### PR TITLE
system: Simplify the line ending option in cle/readline/vi/bas

### DIFF
--- a/interpreters/bas/bas_fs.c
+++ b/interpreters/bas/bas_fs.c
@@ -294,7 +294,7 @@ static int edit(int chn, int nl)
         }
       else if ((f->inCapacity + 1) < sizeof(f->inBuf))
         {
-#ifdef CONFIG_EOL_IS_BOTH_CRLF
+#ifndef CONFIG_EOL_IS_CR
           /* Ignore carriage returns that may accompany a CRLF sequence. */
 
           if (ch != '\r')
@@ -304,10 +304,8 @@ static int edit(int chn, int nl)
 
 #ifdef CONFIG_EOL_IS_CR
               if (ch != '\r')
-#elif defined(CONFIG_EOL_IS_LF)
+#else
               if (ch != '\n')
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-              if (ch != '\n' && ch != '\r')
 #endif
                 {
                   /* No.. escape control characters other than newline and
@@ -341,7 +339,7 @@ static int edit(int chn, int nl)
                       FS_putChar(chn, '\n');
                     }
 
-#if defined(CONFIG_EOL_IS_CR) || defined(CONFIG_EOL_IS_EITHER_CRLF)
+#ifdef CONFIG_EOL_IS_CR
                   /* If the host is talking to us with CR line terminations,
                    * switch to use LF internally.
                    */

--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -45,34 +45,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 /* Control characters */
 
 #undef  CTRL
@@ -1079,12 +1051,9 @@ static int cle_editloop(FAR struct cle_s *priv)
 
         /* Newline terminates editing.  But what is a newline? */
 
-#if defined(CONFIG_EOL_IS_CR) || defined(CONFIG_EOL_IS_EITHER_CRLF)
+#ifdef CONFIG_EOL_IS_CR
         case '\r': /* CR terminates line */
-
-#elif defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF) || \
-      defined(CONFIG_EOL_IS_EITHER_CRLF)
-
+#else
         case '\n': /* LF terminates line */
 #endif
           {
@@ -1097,7 +1066,7 @@ static int cle_editloop(FAR struct cle_s *priv)
           }
           break;
 
-#if defined(CONFIG_EOL_IS_BOTH_CRLF)
+#ifndef CONFIG_EOL_IS_CR
         case '\r': /* Wait for the LF */
           break;
 #endif

--- a/system/readline/readline.h
+++ b/system/readline/readline.h
@@ -31,34 +31,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 /* Helper macros */
 
 #define RL_GETC(v)      ((v)->rl_getc(v))

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -665,12 +665,14 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
        * others both.
        */
 
-#if  defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
-      else if (ch == '\n')
-#elif defined(CONFIG_EOL_IS_CR)
       else if (ch == '\r')
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-      else if (ch == '\n' || ch == '\r')
+#ifndef CONFIG_EOL_IS_CR
+        {
+          /* Wait for the LF */
+
+          continue;
+        }
+      else if (ch == '\n')
 #endif
         {
 #ifdef CONFIG_READLINE_CMD_HISTORY

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -57,34 +57,6 @@
 #  define CONFIG_SYSTEM_VI_COLS 64
 #endif
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 #ifndef CONFIG_SYSTEM_VI_YANK_THRESHOLD
 #define CONFIG_SYSTEM_VI_YANK_THRESHOLD 128
 #endif
@@ -4099,7 +4071,7 @@ static void vi_cmd_mode(FAR struct vi_s *vi)
           }
           break;
 
-#if defined(CONFIG_EOL_IS_CR)
+#ifdef CONFIG_EOL_IS_CR
         case KEY_CMDMODE_NEXTLINE:
         case '\r': /* CR terminates line */
           {
@@ -4108,25 +4080,12 @@ static void vi_cmd_mode(FAR struct vi_s *vi)
           }
           break;
 
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
+#else
        case '\r': /* Wait for the LF */
           break;
-#endif
 
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
         case KEY_CMDMODE_NEXTLINE:
         case '\n': /* LF terminates line */
-          {
-            vi->curpos = vi_nextline(vi, vi->curpos);
-            vi_gotofirstnonwhite(vi);
-          }
-          break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-        case KEY_CMDMODE_NEXTLINE:
-        case '\r': /* Either CR or LF terminates line */
-        case '\n':
           {
             vi->curpos = vi_nextline(vi, vi->curpos);
             vi_gotofirstnonwhite(vi);
@@ -4639,29 +4598,18 @@ static void vi_cmd_submode(FAR struct vi_s *vi)
 
           /* What do we do with carriage returns? line feeds? */
 
-#if defined(CONFIG_EOL_IS_CR)
+#ifdef CONFIG_EOL_IS_CR
           case '\r': /* CR terminates line */
             {
               vi_parsecolon(vi);
             }
             break;
 
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
+#else
           case '\r': /* Wait for the LF */
             break;
-#endif
 
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
-            {
-              vi_parsecolon(vi);
-            }
-            break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
             {
               vi_parsecolon(vi);
             }
@@ -4941,29 +4889,18 @@ static void vi_find_submode(FAR struct vi_s *vi, bool revfind)
 
           /* What do we do with carriage returns? line feeds? */
 
-#if defined(CONFIG_EOL_IS_CR)
+#ifdef CONFIG_EOL_IS_CR
           case '\r': /* CR terminates line */
             {
               vi_parsefind(vi, revfind);
             }
             break;
 
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
+#else
           case '\r': /* Wait for the LF */
             break;
-#endif
 
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
-            {
-              vi_parsefind(vi, revfind);
-            }
-            break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
             {
               vi_parsefind(vi, revfind);
             }
@@ -5089,7 +5026,7 @@ static void vi_replacech_submode(FAR struct vi_s *vi)
 
           /* What do we do with carriage returns? line feeds? */
 
-#if defined(CONFIG_EOL_IS_CR)
+#ifdef CONFIG_EOL_IS_CR
           case '\r': /* CR terminates line */
             {
               ch = '\n';
@@ -5097,24 +5034,12 @@ static void vi_replacech_submode(FAR struct vi_s *vi)
             }
             break;
 
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
+#else
           case '\r': /* Wait for the LF */
             break;
-#endif
 
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
             {
-              found = true;
-            }
-            break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
-            {
-              ch = '\n';
               found = true;
             }
             break;
@@ -5487,7 +5412,7 @@ static void vi_insert_mode(FAR struct vi_s *vi)
 
           /* What do we do with carriage returns? */
 
-#if defined(CONFIG_EOL_IS_CR)
+#ifdef CONFIG_EOL_IS_CR
           case '\r': /* CR terminates line */
             {
               if (vi->mode == MODE_INSERT)
@@ -5503,12 +5428,10 @@ static void vi_insert_mode(FAR struct vi_s *vi)
             }
             break;
 
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
+#else
          case '\r': /* Wait for the LF */
             break;
-#endif
 
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
             {
               if (vi->mode == MODE_INSERT)
@@ -5520,26 +5443,6 @@ static void vi_insert_mode(FAR struct vi_s *vi)
                   vi_replacech(vi, '\n');
                 }
 
-              vi->drawtoeos = true;
-            }
-            break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
-            {
-              if (vi->mode == MODE_INSERT)
-                {
-                  vi_insertch(vi, '\n');
-                }
-              else
-                {
-                  vi_replacech(vi, '\n');
-                }
-
-              vi_putch(vi, ' ');
-              vi_clrtoeol(vi);
               vi->drawtoeos = true;
             }
             break;


### PR DESCRIPTION
## Summary
it's easy to handle \n or \r\n ending correctly,
so let's reduce the possible option to one(EOL_IS_CR).

## Impact
The end line handling

## Testing
Please ignore the follow false style alarm:
```
Error: /home/runner/work/incubator-nuttx-apps/incubator-nuttx-apps/apps/interpreters/bas/bas_fs.c:1872:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx-apps/incubator-nuttx-apps/apps/interpreters/bas/bas_fs.c:1874:2: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx-apps/incubator-nuttx-apps/apps/system/vi/vi.c:512:57: error: Multiple data definitions
Error: /home/runner/work/incubator-nuttx-apps/incubator-nuttx-apps/apps/system/vi/vi.c:513:54: error: Multiple data definitions
```