### PR TITLE
add CMake build system support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+# ##############################################################################
+# apps/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_APPS_DIR)
+  nuttx_add_library(apps)
+  if(NOT EXISTS {NUTTX_APPS_BINDIR}/dummy.c)
+    file(TOUCH ${NUTTX_APPS_BINDIR}/dummy.c)
+  endif()
+  target_sources(apps PRIVATE ${NUTTX_APPS_BINDIR}/dummy.c)
+endif()
+
+file(MAKE_DIRECTORY ${NUTTX_APPS_BINDIR}/include)
+include_directories(include)
+include_directories(${NUTTX_APPS_BINDIR}/include)
+
+add_subdirectory(audioutils)
+add_subdirectory(boot)
+add_subdirectory(canutils)
+add_subdirectory(crypto)
+add_subdirectory(examples)
+add_subdirectory(fsutils)
+add_subdirectory(games)
+add_subdirectory(gpsutils)
+add_subdirectory(graphics)
+add_subdirectory(industry)
+add_subdirectory(interpreters)
+add_subdirectory(math)
+add_subdirectory(mlearning)
+add_subdirectory(modbus)
+add_subdirectory(netutils)
+add_subdirectory(nshlib)
+add_subdirectory(platform)
+add_subdirectory(system)
+add_subdirectory(testing)
+add_subdirectory(wireless)
+
+if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/external)
+  add_subdirectory(external)
+endif()
+
+add_subdirectory(builtin) # must be last
+
+nuttx_generate_kconfig()

--- a/audioutils/CMakeLists.txt
+++ b/audioutils/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/audioutils/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Audio Utility libraries")

--- a/boot/CMakeLists.txt
+++ b/boot/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/boot/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Bootloader Utilities")

--- a/builtin/CMakeLists.txt
+++ b/builtin/CMakeLists.txt
@@ -1,0 +1,59 @@
+# ##############################################################################
+# apps/builtin/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BUILTIN)
+
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+  # generate registry
+  get_property(nuttx_app_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
+  set(builtin_list_string)
+  set(builtin_proto_string)
+  foreach(module ${nuttx_app_libs})
+
+    # builtin_list.h Example: { "hello", SCHED_PRIORITY_DEFAULT, 2048,
+    # hello_main },
+    #
+    get_target_property(APP_MAIN ${module} APP_MAIN)
+    get_target_property(APP_NAME ${module} APP_NAME)
+    get_target_property(APP_PRIORITY ${module} APP_PRIORITY)
+    get_target_property(APP_STACK ${module} APP_STACK)
+    set(builtin_list_string
+        "${builtin_list_string}\{ \"${APP_NAME}\", ${APP_PRIORITY}, ${APP_STACK}, ${APP_MAIN} \},  \n"
+    )
+
+    # builtin_proto.h Example: int hello_main(int argc, char *argv[]);
+    set(builtin_proto_string
+        "${builtin_proto_string}int ${APP_MAIN}(int argc, char *argv[]);\n")
+
+  endforeach()
+
+  configure_file(builtin_proto.h.in builtin_proto.h)
+  configure_file(builtin_list.h.in builtin_list.h)
+
+  set(CSRCS)
+
+  list(APPEND CSRCS builtin_list.c exec_builtin.c builtin_list.h
+       builtin_proto.h)
+
+  # target_sources(apps PRIVATE ${CSRCS})
+  nuttx_add_library(apps_builtin ${CSRCS})
+
+endif()

--- a/builtin/builtin_list.h.in
+++ b/builtin/builtin_list.h.in
@@ -1,0 +1,1 @@
+${builtin_list_string}

--- a/builtin/builtin_proto.h.in
+++ b/builtin/builtin_proto.h.in
@@ -1,0 +1,1 @@
+${builtin_proto_string}

--- a/canutils/CMakeLists.txt
+++ b/canutils/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/canutils/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "CAN Utilities")

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/crypto/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Cryptography Library Support")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ##############################################################################
+# apps/examples/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+nuttx_generate_kconfig(MENUDESC "Examples")

--- a/examples/adc/CMakeLists.txt
+++ b/examples/adc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/adc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ADC)
+  nuttx_add_application(NAME adc)
+endif()

--- a/examples/adxl372_test/CMakeLists.txt
+++ b/examples/adxl372_test/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/adxl372_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ADXL372_TEST)
+  nuttx_add_application(NAME adxl372_test)
+endif()

--- a/examples/ajoystick/CMakeLists.txt
+++ b/examples/ajoystick/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/ajoystick/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_AJOYSTICK)
+  nuttx_add_application(NAME ajoystick)
+endif()

--- a/examples/alarm/CMakeLists.txt
+++ b/examples/alarm/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/alarm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ALARM)
+  nuttx_add_application(
+    NAME
+    alarm
+    SRCS
+    alarm_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_ALARM_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ALARM_PRIORITY})
+endif()

--- a/examples/apa102/CMakeLists.txt
+++ b/examples/apa102/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/apa102/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_APA102)
+  nuttx_add_application(NAME apa102)
+endif()

--- a/examples/apds9960/CMakeLists.txt
+++ b/examples/apds9960/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/apds9960/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_APDS9960)
+  nuttx_add_application(NAME apds9960)
+endif()

--- a/examples/bastest/CMakeLists.txt
+++ b/examples/bastest/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/bastest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BASTEST)
+  nuttx_add_application(NAME bastest)
+endif()

--- a/examples/bmp180/CMakeLists.txt
+++ b/examples/bmp180/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/bmp180/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BMP180)
+  nuttx_add_application(NAME bmp180)
+endif()

--- a/examples/bridge/CMakeLists.txt
+++ b/examples/bridge/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/bridge/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BRIDGE)
+  nuttx_add_application(NAME bridge)
+endif()

--- a/examples/buttons/CMakeLists.txt
+++ b/examples/buttons/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/buttons/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BUTTONS)
+  nuttx_add_application(
+    NAME
+    buttons
+    SRCS
+    buttons_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_BUTTONS_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_BUTTONS_PRIORITY})
+endif()

--- a/examples/calib_udelay/CMakeLists.txt
+++ b/examples/calib_udelay/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/calib_udelay/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CALIB_UDELAY)
+  nuttx_add_application(NAME calib_udelay)
+endif()

--- a/examples/can/CMakeLists.txt
+++ b/examples/can/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/can/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CAN)
+  nuttx_add_application(NAME can)
+endif()

--- a/examples/canard/CMakeLists.txt
+++ b/examples/canard/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/canard/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LIBCANARD)
+  nuttx_add_application(NAME canard)
+endif()

--- a/examples/cctype/CMakeLists.txt
+++ b/examples/cctype/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/cctype/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CCTYPE)
+  nuttx_add_application(NAME cctype)
+endif()

--- a/examples/chat/CMakeLists.txt
+++ b/examples/chat/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/chat/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CHAT)
+  nuttx_add_application(NAME chat)
+endif()

--- a/examples/configdata/CMakeLists.txt
+++ b/examples/configdata/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/configdata/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CONFIGDATA)
+  nuttx_add_application(NAME configdata)
+endif()

--- a/examples/cpuhog/CMakeLists.txt
+++ b/examples/cpuhog/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/cpuhog/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CPUHOG)
+  nuttx_add_application(NAME cpuhog)
+endif()

--- a/examples/cromfs/CMakeLists.txt
+++ b/examples/cromfs/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/cromfs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CROMFS)
+  nuttx_add_application(NAME cromfs)
+endif()

--- a/examples/dac/CMakeLists.txt
+++ b/examples/dac/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/dac/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_DAC)
+  nuttx_add_application(NAME dac)
+endif()

--- a/examples/dhcpd/CMakeLists.txt
+++ b/examples/dhcpd/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ##############################################################################
+# apps/examples/dhcpd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_DHCPD)
+  nuttx_add_application(
+    NAME
+    dhcpd
+    SRCS
+    host.c
+    target.c
+    STACKSIZE
+    2048)
+
+  add_definitions(-DCONFIG_NETUTILS_DHCPD_HOST=1 -DHAVE_SO_REUSEADDR=1
+                  -DHAVE_SO_BROADCAST=1)
+
+endif()

--- a/examples/dhtxx/CMakeLists.txt
+++ b/examples/dhtxx/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/dhtxx/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_DHTXX)
+  nuttx_add_application(NAME dhtxx)
+endif()

--- a/examples/discover/CMakeLists.txt
+++ b/examples/discover/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/discover/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_DISCOVER)
+  nuttx_add_application(NAME discover SRCS discover_main.c)
+endif()

--- a/examples/djoystick/CMakeLists.txt
+++ b/examples/djoystick/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/djoystick/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_DJOYSTICK)
+  nuttx_add_application(NAME djoystick)
+endif()

--- a/examples/elf/CMakeLists.txt
+++ b/examples/elf/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# apps/examples/elf/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ELF)
+  nuttx_add_application(NAME elf INCLUDES ${CMAKE_CURRENT_SOURCE_DIR} SRCS
+                        elf_main.c)
+
+  # TODO: tests
+
+endif()

--- a/examples/fb/CMakeLists.txt
+++ b/examples/fb/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/fb/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FB)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_FB_PROGNAME}
+    SRCS
+    fb_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FB_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_FB_PRIORITY})
+endif()

--- a/examples/fboverlay/CMakeLists.txt
+++ b/examples/fboverlay/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/fboverlay/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FBOVERLAY)
+  nuttx_add_application(NAME fboverlay)
+endif()

--- a/examples/flash_test/CMakeLists.txt
+++ b/examples/flash_test/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/flash_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FLASH_TEST)
+  nuttx_add_application(NAME flash_test)
+endif()

--- a/examples/flowc/CMakeLists.txt
+++ b/examples/flowc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/flowc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FLOWC)
+  nuttx_add_application(NAME flowc)
+endif()

--- a/examples/ft80x/CMakeLists.txt
+++ b/examples/ft80x/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/ft80x/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FT80X)
+  nuttx_add_application(NAME ft80x)
+endif()

--- a/examples/ftpc/CMakeLists.txt
+++ b/examples/ftpc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/ftpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FTPC)
+  nuttx_add_application(NAME ftpc)
+endif()

--- a/examples/ftpd/CMakeLists.txt
+++ b/examples/ftpd/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ##############################################################################
+# apps/examples/ftpd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FTPD)
+  nuttx_add_application(NAME ftpd_start SRCS ftpd_main.c STACKSIZE
+                        ${CONFIG_EXAMPLES_FTPD_STACKSIZE})
+  nuttx_add_application(NAME ftpd_stop STACKSIZE
+                        ${CONFIG_EXAMPLES_FTPD_STACKSIZE})
+endif()

--- a/examples/gpio/CMakeLists.txt
+++ b/examples/gpio/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/gpio/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_GPIO)
+  nuttx_add_application(NAME gpio)
+endif()

--- a/examples/gps/CMakeLists.txt
+++ b/examples/gps/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/gps/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_GPS)
+  nuttx_add_application(NAME gps)
+endif()

--- a/examples/hello/CMakeLists.txt
+++ b/examples/hello/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/hello/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_HELLO)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_HELLO_PROGNAME}
+    SRCS
+    hello_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_HELLO_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_HELLO_PRIORITY})
+endif()

--- a/examples/helloxx/CMakeLists.txt
+++ b/examples/helloxx/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/helloxx/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_HELLOXX)
+  nuttx_add_application(NAME helloxx SRCS helloxx_main.cxx)
+endif()

--- a/examples/hidkbd/CMakeLists.txt
+++ b/examples/hidkbd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/hidkbd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_HIDKBD)
+  nuttx_add_application(NAME hidkbd)
+endif()

--- a/examples/i2schar/CMakeLists.txt
+++ b/examples/i2schar/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/i2schar/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_I2SCHAR)
+  nuttx_add_application(NAME i2schar)
+endif()

--- a/examples/i2sloop/CMakeLists.txt
+++ b/examples/i2sloop/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/i2sloop/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_I2SLOOP)
+  nuttx_add_application(NAME i2sloop)
+endif()

--- a/examples/igmp/CMakeLists.txt
+++ b/examples/igmp/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# apps/examples/igmp/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_IGMP)
+  nuttx_add_application(NAME igmp SRCS igmp.c STACKSIZE
+                        ${CONFIG_DEFAULT_TASK_STACKSIZE})
+endif()

--- a/examples/ina219/CMakeLists.txt
+++ b/examples/ina219/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/ina219/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_INA219)
+  nuttx_add_application(NAME ina219)
+endif()

--- a/examples/ina226/CMakeLists.txt
+++ b/examples/ina226/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/ina226/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_INA226)
+  nuttx_add_application(
+    NAME
+    ina226
+    SRCS
+    ina226_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_INA226_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_INA226_PRIORITY})
+endif()

--- a/examples/ipforward/CMakeLists.txt
+++ b/examples/ipforward/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/ipforward/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_IPFORWARD)
+  nuttx_add_application(NAME ipforward)
+endif()

--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/json/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_JSON)
+  nuttx_add_application(NAME json)
+endif()

--- a/examples/leds/CMakeLists.txt
+++ b/examples/leds/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/leds/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LEDS)
+  nuttx_add_application(NAME leds)
+endif()

--- a/examples/lis3dsh_reader/CMakeLists.txt
+++ b/examples/lis3dsh_reader/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/lis3dsh_reader/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LIS3DSH_READER)
+  nuttx_add_application(NAME lis3dsh_reader)
+endif()

--- a/examples/lsm330spi_test/CMakeLists.txt
+++ b/examples/lsm330spi_test/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/lsm330spi_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LSM330SPI_TEST)
+  nuttx_add_application(NAME lsm330spi_test)
+endif()

--- a/examples/lvgldemo/CMakeLists.txt
+++ b/examples/lvgldemo/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/lvgldemo/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LVGLDEMO)
+  nuttx_add_application(NAME lvgldemo)
+endif()

--- a/examples/max31855/CMakeLists.txt
+++ b/examples/max31855/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/max31855/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MAX31855)
+  nuttx_add_application(NAME max31855)
+endif()

--- a/examples/media/CMakeLists.txt
+++ b/examples/media/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/media/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MEDIA)
+  nuttx_add_application(NAME media)
+endif()

--- a/examples/mld/CMakeLists.txt
+++ b/examples/mld/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/mld/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MLD)
+  nuttx_add_application(NAME mld)
+endif()

--- a/examples/mlx90614/CMakeLists.txt
+++ b/examples/mlx90614/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/mlx90614/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MLX90614)
+  nuttx_add_application(NAME mlx90614)
+endif()

--- a/examples/modbus/CMakeLists.txt
+++ b/examples/modbus/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/modbus/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MODBUS)
+  nuttx_add_application(NAME modbus)
+endif()

--- a/examples/module/CMakeLists.txt
+++ b/examples/module/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/module/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MODULE)
+  nuttx_add_application(NAME module)
+endif()

--- a/examples/mount/CMakeLists.txt
+++ b/examples/mount/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/mount/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MOUNT)
+  nuttx_add_application(
+    NAME
+    mount
+    SRCS
+    mount_main.c
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE})
+
+  target_sources(apps PRIVATE ramdisk.c)
+endif()

--- a/examples/mtdpart/CMakeLists.txt
+++ b/examples/mtdpart/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/mtdpart/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MTDPART)
+  nuttx_add_application(NAME mtdpart)
+endif()

--- a/examples/mtdrwb/CMakeLists.txt
+++ b/examples/mtdrwb/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/mtdrwb/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MTDRWB)
+  nuttx_add_application(NAME mtdrwb)
+endif()

--- a/examples/netloop/CMakeLists.txt
+++ b/examples/netloop/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/netloop/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NETLOOP)
+  nuttx_add_application(NAME netloop)
+endif()

--- a/examples/netpkt/CMakeLists.txt
+++ b/examples/netpkt/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/netpkt/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NETPKT)
+  nuttx_add_application(NAME netpkt)
+endif()

--- a/examples/nettest/CMakeLists.txt
+++ b/examples/nettest/CMakeLists.txt
@@ -1,0 +1,101 @@
+# ##############################################################################
+# apps/examples/nettest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NETTEST)
+
+  set(CSRCS)
+
+  # Basic TCP networking test
+
+  set(SRCS nettest_cmdline.c)
+  if(CONFIG_EXAMPLES_NETTEST_INIT)
+    list(APPEND SRCS nettest_netinit.c)
+  endif()
+
+  # Target 1 Files
+
+  if(CONFIG_EXAMPLES_NETTEST_LOOPBACK)
+    list(APPEND SRCS nettest_server.c nettest_client.c)
+  elseif(CONFIG_EXAMPLES_NETTEST_SERVER)
+    list(APPEND SRCS nettest_server.c)
+  else()
+    list(APPEND SRCS nettest_client.c)
+  endif()
+
+  # Target 1 Application Info
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NETTEST_PROGNAME1}
+    SRCS
+    nettest_target1.c
+    INCLUDE_DIRECTORIES
+    ${CMAKE_BINARY_DIR}/include/nuttx
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NETTEST_STACKSIZE1}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NETTEST_PRIORITY1})
+
+  # Target 2
+
+  if(CONFIG_EXAMPLES_NETTEST_TARGET2)
+
+    if(CONFIG_EXAMPLES_NETTEST_SERVER)
+      list(APPEND SRCS nettest_client.c)
+    else()
+      list(APPEND SRCS nettest_server.c)
+    endif()
+
+    # Target 2 Application Info
+
+    nuttx_add_application(
+      NAME
+      ${CONFIG_EXAMPLES_NETTEST_PROGNAME2}
+      SRCS
+      nettest_target2.c
+      INCLUDE_DIRECTORIES
+      ${CMAKE_BINARY_DIR}/include/nuttx
+      STACKSIZE
+      ${CONFIG_EXAMPLES_NETTEST_STACKSIZE2}
+      PRIORITY
+      ${CONFIG_EXAMPLES_NETTEST_PRIORITY2})
+
+  endif()
+
+  target_include_directories(apps PRIVATE ${CMAKE_BINARY_DIR}/include/nuttx)
+  target_sources(apps PRIVATE ${SRCS})
+
+  # Host
+
+  if(NOT CONFIG_EXAMPLES_NETTEST_TARGET2 AND NOT
+                                             CONFIG_EXAMPLES_NETTEST_LOOPBACK)
+    ExternalProject_Add(
+      nettest
+      SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/host
+      INSTALL_DIR ${CMAKE_BINARY_DIR}/apps/examples/nettest/host
+      CMAKE_ARGS
+        -DNUTTX_DIR=${NUTTX_DIR} -DNUTTX_BINARY_DIR=${CMAKE_BINARY_DIR}
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/apps/examples/nettest/host
+      USES_TERMINAL_CONFIGURE true
+      USES_TERMINAL_BUILD true
+      USES_TERMINAL_INSTALL true)
+  endif()
+
+endif()

--- a/examples/nettest/host/CMakeLists.txt
+++ b/examples/nettest/host/CMakeLists.txt
@@ -1,0 +1,52 @@
+# ##############################################################################
+# apps/examples/nettest/host/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+# Configure project
+cmake_minimum_required(VERSION 3.16)
+project(nuttx_tools LANGUAGES C)
+
+set(NUTTX_ACTIVE_DEFCONFIG ${NUTTX_BINARY_DIR}/.config)
+include(${NUTTX_DIR}/cmake/kconfig.cmake)
+
+set(HOST_SRCS ../nettest_host.c)
+if(CONFIG_EXAMPLES_NETTEST_SERVER)
+  set(HOST_TARGET tcpclient)
+  add_executable(tcpclient ../nettest_client.c ${HOST_SRCS})
+  install(TARGETS tcpclient DESTINATION bin)
+else()
+  set(HOST_TARGET tcpserver)
+  add_executable(tcpserver ../nettest_server.c ${HOST_SRCS})
+  install(TARGETS tcpserver DESTINATION bin)
+endif()
+
+target_compile_definitions(${HOST_TARGET} PRIVATE NETTEST_HOST=1)
+if(CONFIG_EXAMPLES_NETTEST_SERVER)
+  target_compile_definitions(
+    ${HOST_TARGET}
+    PRIVATE
+      CONFIG_EXAMPLES_NETTEST_SERVER=1
+      CONFIG_EXAMPLES_NETTEST_SERVERIP="${CONFIG_EXAMPLES_NETTEST_SERVERIP}")
+endif()
+if(CONFIG_EXAMPLES_NETTEST_PERFORMANCE)
+  target_compile_definitions(${HOST_TARGET}
+                             PRIVATE CONFIG_EXAMPLES_NETTEST_PERFORMANCE=1)
+endif()
+
+target_include_directories(${HOST_TARGET}
+                           PRIVATE ${NUTTX_BINARY_DIR}/include/nuttx)

--- a/examples/nrf24l01_term/CMakeLists.txt
+++ b/examples/nrf24l01_term/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nrf24l01_term/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NRF24L01TERM)
+  nuttx_add_application(NAME nrf24l01_term)
+endif()

--- a/examples/null/CMakeLists.txt
+++ b/examples/null/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/null/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NULL)
+  nuttx_add_application(NAME null)
+endif()

--- a/examples/nunchuck/CMakeLists.txt
+++ b/examples/nunchuck/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nunchuck/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NUNCHUCK)
+  nuttx_add_application(NAME nunchuck)
+endif()

--- a/examples/nx/CMakeLists.txt
+++ b/examples/nx/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nx/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NX)
+  nuttx_add_application(NAME nx)
+endif()

--- a/examples/nxdemo/CMakeLists.txt
+++ b/examples/nxdemo/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nxdemo/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXDEMO)
+  nuttx_add_application(NAME nxdemo)
+endif()

--- a/examples/nxflat/CMakeLists.txt
+++ b/examples/nxflat/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nxflat/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXFLAT)
+  nuttx_add_application(NAME nxflat)
+endif()

--- a/examples/nxhello/CMakeLists.txt
+++ b/examples/nxhello/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nxhello/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXHELLO)
+  nuttx_add_application(NAME nxhello)
+endif()

--- a/examples/nximage/CMakeLists.txt
+++ b/examples/nximage/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nximage/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXIMAGE)
+  nuttx_add_application(NAME nximage)
+endif()

--- a/examples/nxlines/CMakeLists.txt
+++ b/examples/nxlines/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# apps/examples/nxlines/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXLINES)
+  nuttx_add_application(NAME nxlines SRCS nxlines_bkgd.c nxlines_listener.c
+                        nxlines_main.c)
+endif()

--- a/examples/nxterm/CMakeLists.txt
+++ b/examples/nxterm/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nxterm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXTERM)
+  nuttx_add_application(NAME nxterm)
+endif()

--- a/examples/nxtext/CMakeLists.txt
+++ b/examples/nxtext/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/nxtext/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NXTEXT)
+  nuttx_add_application(NAME nxtext)
+endif()

--- a/examples/obd2/CMakeLists.txt
+++ b/examples/obd2/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/obd2/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_OBD2)
+  nuttx_add_application(NAME obd2)
+endif()

--- a/examples/oneshot/CMakeLists.txt
+++ b/examples/oneshot/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/oneshot/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ONESHOT)
+  nuttx_add_application(NAME oneshot)
+endif()

--- a/examples/pca9635/CMakeLists.txt
+++ b/examples/pca9635/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/pca9635/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PCA9635)
+  nuttx_add_application(NAME pca9635)
+endif()

--- a/examples/pdcurses/CMakeLists.txt
+++ b/examples/pdcurses/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/pdcurses/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PDCURSES)
+  nuttx_add_application(NAME pdcurses)
+endif()

--- a/examples/pf_ieee802154/CMakeLists.txt
+++ b/examples/pf_ieee802154/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/pf_ieee802154/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PFIEEE802154)
+  nuttx_add_application(NAME pf_ieee802154)
+endif()

--- a/examples/pipe/CMakeLists.txt
+++ b/examples/pipe/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# apps/examples/pipe/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PIPE)
+  nuttx_add_application(NAME pipe)
+
+endif()

--- a/examples/poll/CMakeLists.txt
+++ b/examples/poll/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/poll/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_POLL)
+  nuttx_add_application(NAME poll)
+endif()

--- a/examples/popen/CMakeLists.txt
+++ b/examples/popen/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/popen/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_POPEN)
+  nuttx_add_application(NAME popen)
+endif()

--- a/examples/posix_spawn/CMakeLists.txt
+++ b/examples/posix_spawn/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/posix_spawn/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_POSIXSPAWN)
+  nuttx_add_application(NAME posix_spawn SRCS spawn_main.c)
+endif()

--- a/examples/powerled/CMakeLists.txt
+++ b/examples/powerled/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/powerled/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_POWERLED)
+  nuttx_add_application(NAME powerled)
+endif()

--- a/examples/powermonitor/CMakeLists.txt
+++ b/examples/powermonitor/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/powermonitor/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_POWERMONITOR)
+  nuttx_add_application(NAME powermonitor)
+endif()

--- a/examples/pppd/CMakeLists.txt
+++ b/examples/pppd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/pppd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PPPD)
+  nuttx_add_application(NAME pppd)
+endif()

--- a/examples/pty_test/CMakeLists.txt
+++ b/examples/pty_test/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/pty_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PTYTEST)
+  nuttx_add_application(NAME pty_test)
+endif()

--- a/examples/pwm/CMakeLists.txt
+++ b/examples/pwm/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/pwm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PWM)
+  nuttx_add_application(NAME pwm)
+endif()

--- a/examples/qencoder/CMakeLists.txt
+++ b/examples/qencoder/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/qencoder/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_QENCODER)
+  nuttx_add_application(NAME qencoder)
+endif()

--- a/examples/random/CMakeLists.txt
+++ b/examples/random/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/random/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RANDOM)
+  nuttx_add_application(NAME random)
+endif()

--- a/examples/relays/CMakeLists.txt
+++ b/examples/relays/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/relays/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RELAYS)
+  nuttx_add_application(NAME relays)
+endif()

--- a/examples/rfid_readuid/CMakeLists.txt
+++ b/examples/rfid_readuid/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/rfid_readuid/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RFID_READUID)
+  nuttx_add_application(NAME rfid_readuid)
+endif()

--- a/examples/rgbled/CMakeLists.txt
+++ b/examples/rgbled/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# apps/examples/rgbled/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RGBLED)
+  nuttx_add_application(NAME rgbled SRCS rgbled.c)
+
+endif()

--- a/examples/romfs/CMakeLists.txt
+++ b/examples/romfs/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/romfs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ROMFS)
+  nuttx_add_application(NAME romfs)
+endif()

--- a/examples/sendmail/CMakeLists.txt
+++ b/examples/sendmail/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/sendmail/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SENDMAIL)
+  nuttx_add_application(NAME sendmail)
+endif()

--- a/examples/serialblaster/CMakeLists.txt
+++ b/examples/serialblaster/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/serialblaster/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SERIALBLASTER)
+  nuttx_add_application(NAME serialblaster)
+endif()

--- a/examples/serialrx/CMakeLists.txt
+++ b/examples/serialrx/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/serialrx/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SERIALRX)
+  nuttx_add_application(NAME serialrx)
+endif()

--- a/examples/serloop/CMakeLists.txt
+++ b/examples/serloop/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/serloop/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SERLOOP)
+  nuttx_add_application(NAME serloop)
+endif()

--- a/examples/slcd/CMakeLists.txt
+++ b/examples/slcd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/slcd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SLCD)
+  nuttx_add_application(NAME slcd)
+endif()

--- a/examples/smps/CMakeLists.txt
+++ b/examples/smps/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/smps/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SMPS)
+  nuttx_add_application(NAME smps)
+endif()

--- a/examples/sotest/CMakeLists.txt
+++ b/examples/sotest/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/sotest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SOTEST)
+  nuttx_add_application(NAME sotest)
+endif()

--- a/examples/stat/CMakeLists.txt
+++ b/examples/stat/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/stat/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_STAT)
+  nuttx_add_application(NAME stat)
+endif()

--- a/examples/system/CMakeLists.txt
+++ b/examples/system/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/system/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SYSTEM)
+  nuttx_add_application(NAME system)
+endif()

--- a/examples/tcpblaster/CMakeLists.txt
+++ b/examples/tcpblaster/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/tcpblaster/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TCPBLASTER)
+  nuttx_add_application(NAME tcpblaster)
+endif()

--- a/examples/tcpecho/CMakeLists.txt
+++ b/examples/tcpecho/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/tcpecho/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TCPECHO)
+  nuttx_add_application(NAME tcpecho)
+endif()

--- a/examples/telnetd/CMakeLists.txt
+++ b/examples/telnetd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/telnetd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TELNETD)
+  nuttx_add_application(NAME telnetd SRCS telnetd.c)
+endif()

--- a/examples/thttpd/CMakeLists.txt
+++ b/examples/thttpd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/thttpd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_THTTPD)
+  nuttx_add_application(NAME thttpd)
+endif()

--- a/examples/tiff/CMakeLists.txt
+++ b/examples/tiff/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/tiff/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TIFF)
+  nuttx_add_application(NAME tiff)
+endif()

--- a/examples/timer/CMakeLists.txt
+++ b/examples/timer/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/timer/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TIMER)
+  nuttx_add_application(NAME timer)
+endif()

--- a/examples/touchscreen/CMakeLists.txt
+++ b/examples/touchscreen/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/touchscreen/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TOUCHSCREEN)
+  nuttx_add_application(NAME touchscreen)
+endif()

--- a/examples/udgram/CMakeLists.txt
+++ b/examples/udgram/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/udgram/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_UDGRAM)
+  nuttx_add_application(NAME udgram)
+endif()

--- a/examples/udp/CMakeLists.txt
+++ b/examples/udp/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/udp/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_UDP)
+  nuttx_add_application(NAME udp)
+endif()

--- a/examples/udpblaster/CMakeLists.txt
+++ b/examples/udpblaster/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/udpblaster/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_UDPBLASTER)
+  nuttx_add_application(NAME udpblaster)
+endif()

--- a/examples/unionfs/CMakeLists.txt
+++ b/examples/unionfs/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/unionfs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_UNIONFS)
+  nuttx_add_application(NAME unionfs)
+endif()

--- a/examples/usbserial/CMakeLists.txt
+++ b/examples/usbserial/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# apps/examples/usbserial/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_USBSERIAL)
+  nuttx_add_application(
+    NAME
+    usbserial
+    STACKSIZE
+    2048
+    SRCS
+    host.c
+    usbserial_main.c)
+endif()

--- a/examples/userfs/CMakeLists.txt
+++ b/examples/userfs/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/userfs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_USERFS)
+  nuttx_add_application(NAME userfs)
+endif()

--- a/examples/usrsocktest/CMakeLists.txt
+++ b/examples/usrsocktest/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/usrsocktest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_USRSOCKTEST)
+  nuttx_add_application(NAME usrsocktest)
+endif()

--- a/examples/ustream/CMakeLists.txt
+++ b/examples/ustream/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/ustream/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_USTREAM)
+  nuttx_add_application(NAME ustream)
+endif()

--- a/examples/veml6070/CMakeLists.txt
+++ b/examples/veml6070/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/veml6070/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_VEML6070)
+  nuttx_add_application(NAME veml6070)
+endif()

--- a/examples/watchdog/CMakeLists.txt
+++ b/examples/watchdog/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/watchdog/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WATCHDOG)
+  nuttx_add_application(NAME watchdog)
+endif()

--- a/examples/webserver/CMakeLists.txt
+++ b/examples/webserver/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/webserver/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WEBSERVER)
+  nuttx_add_application(NAME webserver)
+endif()

--- a/examples/wget/CMakeLists.txt
+++ b/examples/wget/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/wget/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WGET)
+  nuttx_add_application(NAME wget SRCS wget_main.c)
+endif()

--- a/examples/wgetjson/CMakeLists.txt
+++ b/examples/wgetjson/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/wgetjson/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WGETJSON)
+  nuttx_add_application(NAME wgetjson)
+endif()

--- a/examples/xbc_test/CMakeLists.txt
+++ b/examples/xbc_test/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# apps/examples/xbc_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_XBC_TEST)
+  nuttx_add_application(NAME xbc_test)
+endif()

--- a/examples/xmlrpc/CMakeLists.txt
+++ b/examples/xmlrpc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/xmlrpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_XMLRPC)
+  nuttx_add_application(NAME xmlrpc)
+endif()

--- a/examples/zerocross/CMakeLists.txt
+++ b/examples/zerocross/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/examples/zerocross/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ZEROCROSS)
+  nuttx_add_application(NAME zerocross)
+endif()

--- a/fsutils/CMakeLists.txt
+++ b/fsutils/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/fsutils/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "File System Utilities")

--- a/fsutils/flash_eraseall/CMakeLists.txt
+++ b/fsutils/flash_eraseall/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/fsutils/flash_eraseall/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_FLASH_ERASEALL)
+  nuttx_add_application(NAME flash_eraseall SRCS flash_eraseall.c)
+endif()

--- a/fsutils/inifile/CMakeLists.txt
+++ b/fsutils/inifile/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/fsutils/inifile/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_INIFILE)
+  nuttx_add_application(NAME inifile SRCS inifile.c)
+endif()

--- a/fsutils/mkfatfs/CMakeLists.txt
+++ b/fsutils/mkfatfs/CMakeLists.txt
@@ -1,0 +1,29 @@
+# ##############################################################################
+# apps/fsutils/mkfatfs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_MKFATFS)
+  set(SRCS)
+
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+  list(APPEND SRCS mkfatfs.c configfat.c writefat.c)
+
+  target_sources(apps PRIVATE ${SRCS})
+endif()

--- a/fsutils/mksmartfs/CMakeLists.txt
+++ b/fsutils/mksmartfs/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/fsutils/mksmartfs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_MKSMARTFS)
+  nuttx_add_application(NAME mksmartfs SRCS mksmartfs.c)
+endif()

--- a/fsutils/passwd/CMakeLists.txt
+++ b/fsutils/passwd/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# apps/fsutils/passwd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_PASSWD)
+  set(CSRCS)
+
+  list(APPEND CSRCS passwd_verify.c passwd_find.c passwd_encrypt.c)
+
+  if(NOT CONFIG_FSUTILS_PASSWD_READONLY)
+    list(
+      APPEND
+      CSRCS
+      passwd_adduser.c
+      passwd_deluser.c
+      passwd_update.c
+      passwd_append.c
+      passwd_delete.c
+      passwd_lock.c)
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY NUTTX_APPS_LIBRARIES ${TARGET})
+  target_sources(apps PRIVATE ${CSRCS})
+
+endif()

--- a/games/CMakeLists.txt
+++ b/games/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/games/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Games")

--- a/gpsutils/CMakeLists.txt
+++ b/gpsutils/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/gpsutils/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "GPS Utilities")

--- a/graphics/CMakeLists.txt
+++ b/graphics/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/graphics/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Graphics Support")

--- a/industry/CMakeLists.txt
+++ b/industry/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/industry/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Industrial Applications")

--- a/interpreters/CMakeLists.txt
+++ b/interpreters/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/interpreters/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Interpreters")

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/math/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Math Library Support")

--- a/mlearning/CMakeLists.txt
+++ b/mlearning/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ##############################################################################
+# apps/mlearning/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_generate_kconfig(MENUDESC "Machine Learning Support")

--- a/modbus/CMakeLists.txt
+++ b/modbus/CMakeLists.txt
@@ -1,0 +1,114 @@
+# ##############################################################################
+# apps/modbus/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# ##############################################################################
+# apps/modbus/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_MODBUS)
+
+  set(CSRCS)
+
+  if(CONFIG_MODBUS_SLAVE)
+    list(APPEND CSRCS mb.c)
+  endif()
+
+  if(CONFIG_MB_RTU_MASTER)
+    list(APPEND CSRCS mb_m.c)
+  endif()
+
+  # ascii/Make.defs
+
+  if(CONFIG_MB_ASCII_ENABLED)
+    list(APPEND CSRCS ascii/mbascii.c)
+  endif()
+
+  # functions/Make.defs
+
+  list(
+    APPEND
+    CSRCS
+    functions/mbfunccoils.c
+    functions/mbfuncdiag.c
+    functions/mbfuncdisc.c
+    functions/mbfuncholding.c
+    functions/mbfuncinput.c
+    functions/mbfuncother.c
+    functions/mbutils.c)
+
+  if(CONFIG_MB_ASCII_MASTER)
+    list(APPEND CSRCS functions/mbfunccoils_m.c functions/mbfuncdisc_m.c
+         functions/mbfuncholding_m.c functions/mbfuncinput_m.c)
+  elseif(CONFIG_MB_RTU_MASTER)
+    list(APPEND CSRCS functions/mbfunccoils_m.c functions/mbfuncdisc_m.c
+         functions/mbfuncholding_m.c functions/mbfuncinput_m.c)
+  endif()
+
+  # nuttx/Make.defs
+
+  list(APPEND CSRCS nuttx/portother.c)
+
+  if(CONFIG_MODBUS_SLAVE)
+    list(APPEND CSRCS nuttx/portevent.c nuttx/portserial.c nuttx/porttimer.c)
+  endif()
+
+  if(CONFIG_MB_RTU_MASTER)
+    list(APPEND CSRCS nuttx/portother_m.c nuttx/portserial_m.c
+         nuttx/porttimer_m.c nuttx/portevent_m.c)
+  endif()
+
+  # rtu/Make.defs
+
+  if(CONFIG_MB_RTU_ENABLED OR CONFIG_MB_RTU_MASTER)
+    list(APPEND rtu/mbcrc.c)
+    if(CONFIG_MB_RTU_ENABLED)
+      list(APPEND rtu/mbrtu.c)
+    endif()
+
+    if(CONFIG_MB_RTU_MASTER)
+      list(APPEND rtu/mbrtu_m.c)
+    endif()
+  endif()
+
+  # tcp/Make.defs
+
+  if(CONFIG_MB_TCP_ENABLED)
+    list(APPEND tcp/mbtcp.c)
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+
+endif()

--- a/netutils/CMakeLists.txt
+++ b/netutils/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "Network Utilities")

--- a/netutils/chat/CMakeLists.txt
+++ b/netutils/chat/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/chat/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_CHAT)
+  target_sources(apps PRIVATE chat.c)
+endif()

--- a/netutils/cjson/CMakeLists.txt
+++ b/netutils/cjson/CMakeLists.txt
@@ -1,0 +1,70 @@
+# ##############################################################################
+# apps/netutils/cjson/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_CJSON)
+
+  if(NOT CONFIG_NETUTILS_CJSON_URL)
+    set(CONFIG_NETUTILS_CJSON_URL "https://github.com/DaveGamble/cJSON/archive")
+  endif()
+
+  if(NOT CONFIG_NETUTILS_CJSON_VERSION)
+    set(CONFIG_NETUTILS_CJSON_VERSION "1.7.10")
+  endif()
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/cJSON)
+    FetchContent_Declare(
+      cJSON
+      DOWNLOAD_NAME "v${CONFIG_NETUTILS_CJSON_VERSION}.tar.gz"
+      DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
+      URL "${CONFIG_NETUTILS_CJSON_URL}/v${CONFIG_NETUTILS_CJSON_VERSION}.tar.gz"
+          SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/cJSON
+          BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/netutils/cjson/cJSON
+          CONFIGURE_COMMAND
+          ""
+          BUILD_COMMAND
+          ""
+          INSTALL_COMMAND
+          ""
+          TEST_COMMAND
+          ""
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(cJSON)
+
+    if(NOT cJSON_POPULATED)
+      FetchContent_Populate(cJSON)
+    endif()
+  endif()
+
+  if(NOT EXISTS ${CMAKE_BINARY_DIR}/apps/include/netutils/cJSON.h
+     OR NOT EXISTS ${CMAKE_BINARY_DIR}/apps/include/netutils/cJSON_Utils.h)
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/apps/include/netutils)
+    file(CREATE_LINK ${CMAKE_CURRENT_LIST_DIR}/cJSON/cJSON.h
+         ${CMAKE_BINARY_DIR}/apps/include/netutils/cJSON.h SYMBOLIC)
+    file(CREATE_LINK ${CMAKE_CURRENT_LIST_DIR}/cJSON/cJSON_Utils.h
+         ${CMAKE_BINARY_DIR}/apps/include/netutils/cJSON_Utils.h SYMBOLIC)
+  endif()
+
+  target_sources(apps PRIVATE cJSON/cJSON.c cJSON/cJSON_Utils.c)
+
+endif()

--- a/netutils/codecs/CMakeLists.txt
+++ b/netutils/codecs/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/codecs/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_CODECS)
+  target_sources(apps PRIVATE urldecode.c base64.c md5.c)
+endif()

--- a/netutils/dhcp6c/CMakeLists.txt
+++ b/netutils/dhcp6c/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/dhcp6c/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_DHCP6C)
+  target_sources(apps PRIVATE dhcp6c.c)
+endif()

--- a/netutils/dhcpc/CMakeLists.txt
+++ b/netutils/dhcpc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/dhcpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_DHCPC)
+  target_sources(apps PRIVATE dhcpc.c)
+endif()

--- a/netutils/dhcpd/CMakeLists.txt
+++ b/netutils/dhcpd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/dhcpd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_DHCPD AND CONFIG_NET_UDP)
+  target_sources(apps PRIVATE dhcpd.c)
+endif()

--- a/netutils/discover/CMakeLists.txt
+++ b/netutils/discover/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/discover/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_DISCOVER)
+  target_sources(apps PRIVATE discover.c)
+endif()

--- a/netutils/esp8266/CMakeLists.txt
+++ b/netutils/esp8266/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/esp8266/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_ESP8266)
+  target_sources(apps PRIVATE esp8266.c)
+endif()

--- a/netutils/ftpc/CMakeLists.txt
+++ b/netutils/ftpc/CMakeLists.txt
@@ -1,0 +1,64 @@
+# ##############################################################################
+# apps/netutils/ftpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_FTPC)
+  set(CSRCS)
+
+  # FTP connection management
+
+  list(APPEND CSRCS ftpc_connect.c ftpc_disconnect.c)
+
+  # FTP commands
+
+  list(
+    APPEND
+    CSRCS
+    ftpc_cdup.c
+    ftpc_chdir.c
+    ftpc_chmod.c
+    ftpc_filesize.c
+    ftpc_filetime.c
+    ftpc_help.c
+    ftpc_idle.c
+    ftpc_listdir.c
+    ftpc_login.c
+    ftpc_mkdir.c
+    ftpc_noop.c
+    ftpc_rpwd.c
+    ftpc_quit.c
+    ftpc_rename.c
+    ftpc_rmdir.c
+    ftpc_unlink.c
+    ftpc_cmd.c)
+
+  # FTP transfers
+
+  list(APPEND CSRCS ftpc_getfile.c ftpc_putfile.c ftpc_transfer.c)
+
+  # FTP responses
+
+  list(APPEND CSRCS ftpc_response.c ftpc_getreply.c)
+
+  # FTP helpers
+  list(APPEND CSRCS ftpc_utils.c ftpc_socket.c)
+
+  target_sources(apps PRIVATE ${CSRCS})
+
+endif()

--- a/netutils/ftpd/CMakeLists.txt
+++ b/netutils/ftpd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/ftpd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_FTPD)
+  target_sources(apps PRIVATE ftpd.c)
+endif()

--- a/netutils/iperf/CMakeLists.txt
+++ b/netutils/iperf/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/iperf/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_IPERF)
+  nuttx_add_application(NAME iperf SRCS iperf_main.c iperf.c)
+endif()

--- a/netutils/libcurl4nx/CMakeLists.txt
+++ b/netutils/libcurl4nx/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/netutils/libcurl4nx/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_LIBCURL4NX)
+  target_sources(
+    apps
+    PRIVATE curl4nx_easy_init.c
+            curl4nx_easy_cleanup.c
+            curl4nx_easy_reset.c
+            curl4nx_easy_duphandle.c
+            curl4nx_easy_escape.c
+            curl4nx_easy_unescape.c
+            curl4nx_easy_setopt.c
+            curl4nx_easy_perform.c
+            curl4nx_easy_getinfo.c)
+endif()

--- a/netutils/netcat/CMakeLists.txt
+++ b/netutils/netcat/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# apps/netutils/netcat/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_NETCAT)
+  nuttx_add_application(NAME ${CONFIG_NETUTILS_NETCAT_PROGNAME} SRCS
+                        netcat_main.c)
+endif()

--- a/netutils/netinit/CMakeLists.txt
+++ b/netutils/netinit/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# apps/netutils/netinit/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_NETINIT)
+  set(CSRCS)
+  list(APPEND CSRCS netinit.c)
+
+  if(CONFIG_WIRELESS_WAPI AND NOT CONFIG_NETINIT_NETLOCAL)
+    list(APPEND CSRCS netinit_associate.c)
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+endif()

--- a/netutils/netlib/CMakeLists.txt
+++ b/netutils/netlib/CMakeLists.txt
@@ -1,0 +1,129 @@
+# ##############################################################################
+# apps/netutils/netlib/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_NETLIB)
+
+  # Network Library
+
+  set(SRCS netlib_ipv4addrconv.c netlib_ethaddrconv.c netlib_parsehttpurl.c)
+  list(APPEND SRCS netlib_setifstatus.c netlib_getifstatus.c)
+
+  # Generic URL parsing support
+
+  if(CONFIG_NETUTILS_NETLIB_GENERICURLPARSER)
+    list(APPEND SRCS netlib_parseurl.c)
+  endif()
+
+  # IP address support
+
+  if(CONFIG_NET_IPv4)
+    list(APPEND SRCS netlib_setipv4addr.c netlib_getipv4addr.c)
+    list(APPEND SRCS netlib_setdripv4addr.c netlib_setipv4netmask.c)
+    list(APPEND SRCS netlib_getdripv4addr.c netlib_getipv4netmask.c)
+    list(APPEND SRCS netlib_ipv4adaptor.c)
+    if(CONFIG_NET_ARP)
+      list(APPEND SRCS netlib_getarp.c netlib_setarp.c netlib_delarp.c)
+      if(CONFIG_NETLINK_ROUTE)
+        list(APPEND SRCS netlib_getarptab.c)
+      endif()
+    endif()
+    if(CONFIG_NETDB_DNSCLIENT)
+      list(APPEND SRCS netlib_setipv4dnsaddr.c)
+    endif()
+    if(CONFIG_NET_ROUTE)
+      list(APPEND SRCS netlib_ipv4route.c netlib_ipv4router.c)
+    endif()
+    if(CONFIG_NET_IPTABLES)
+      list(APPEND SRCS netlib_iptables.c)
+    endif()
+  endif()
+
+  if(CONFIG_NET_IPv6)
+    list(APPEND SRCS netlib_setipv6addr.c netlib_getipv6addr.c)
+    list(APPEND SRCS netlib_setdripv6addr.c netlib_setipv6netmask.c)
+    list(APPEND SRCS netlib_prefix2ipv6netmask.c netlib_ipv6netmask2prefix.c)
+    list(APPEND SRCS netlib_ipv6adaptor.c)
+    if(CONFIG_NET_ICMPv6_AUTOCONF)
+      list(APPEND SRCS netlib_autoconfig.c)
+    endif()
+    if(CONFIG_NETDB_DNSCLIENT)
+      list(APPEND SRCS netlib_setipv6dnsaddr.c)
+    endif()
+    if(CONFIG_NET_ROUTE)
+      list(APPEND SRCS netlib_ipv6route.c netlib_ipv6router.c)
+    endif()
+    if(CONFIG_NETLINK_ROUTE)
+      list(APPEND SRCS netlib_getnbtab.c)
+    endif()
+  endif()
+
+  # Device support
+
+  if(CONFIG_NETLINK_ROUTE)
+    list(APPEND SRCS netlib_getdevs.c)
+    if(CONFIG_NET_ROUTE)
+      list(APPEND SRCS netlib_getroute.c)
+    endif()
+  endif()
+
+  # These require TCP support
+
+  if(CONFIG_NET_TCP)
+    if(CONFIG_NET_IPv4) # Not yet available for IPv6
+      list(APPEND SRCS netlib_server.c netlib_listenon.c)
+    endif()
+  endif()
+
+  # These require wireless IOCTL support */
+
+  if(CONFIG_NETDEV_WIRELESS_IOCTL)
+    list(APPEND SRCS netlib_getessid.c netlib_setessid.c)
+  endif()
+
+  # MAC address support(Ethernet and 6LoWPAN only)
+
+  if(CONFIG_NET_ETHERNET)
+    list(APPEND SRCS netlib_setmacaddr.c netlib_getmacaddr.c)
+  endif()
+
+  list(APPEND SRCS netlib_setmtu.c)
+
+  if(CONFIG_WIRELESS_IEEE802154)
+    list(APPEND SRCS netlib_seteaddr.c netlib_getpanid.c netlib_saddrconv.c
+         netlib_eaddrconv.c)
+  endif()
+
+  if(CONFIG_WIRELESS_PKTRADIO)
+    list(APPEND SRCS netlib_getproperties.c netlib_getnodeaddr.c
+         netlib_setnodeaddr.c)
+    list(APPEND SRCS netlib_nodeaddrconv.c)
+  endif()
+
+  # IGMP support
+
+  if(CONFIG_NET_IGMP)
+    if(CONFIG_NET_IPv4) # Not yet available for IPv6
+      list(APPEND SRCS netlib_ipmsfilter.c)
+    endif()
+  endif()
+
+  target_sources(apps PRIVATE ${SRCS})
+
+endif()

--- a/netutils/ntpclient/CMakeLists.txt
+++ b/netutils/ntpclient/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/ntpclient/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_NTPCLIENT)
+  target_sources(apps PRIVATE ntpclient.c)
+endif()

--- a/netutils/ping/CMakeLists.txt
+++ b/netutils/ping/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# apps/netutils/ping/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_PING)
+  target_sources(apps PRIVATE icmp_ping.c)
+endif()
+
+if(CONFIG_NETUTILS_PING6)
+  target_sources(apps PRIVATE icmpv6_ping.c)
+endif()

--- a/netutils/pppd/CMakeLists.txt
+++ b/netutils/pppd/CMakeLists.txt
@@ -1,0 +1,37 @@
+# ##############################################################################
+# apps/netutils/pppd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_PPPD)
+  set(CSRCS)
+
+  list(
+    APPEND
+    CSRCS
+    pppd.c
+    ppp.c
+    ahdlc.c
+    lcp.c
+    ipcp.c)
+  if(CONFIG_NETUTILS_PPPD_PAP)
+    list(APPEND CSRCS pap.c)
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+endif()

--- a/netutils/rexec/CMakeLists.txt
+++ b/netutils/rexec/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/rexec/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_REXEC)
+  nuttx_add_application(NAME rexec SRCS rexec.c)
+endif()

--- a/netutils/rexecd/CMakeLists.txt
+++ b/netutils/rexecd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/rexecd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_REXECD)
+  nuttx_add_application(NAME rexecd SRCS rexecd.c)
+endif()

--- a/netutils/smtp/CMakeLists.txt
+++ b/netutils/smtp/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/smtp/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_SMTP)
+  target_sources(apps PRIVATE smtp.c)
+endif()

--- a/netutils/telnetc/CMakeLists.txt
+++ b/netutils/telnetc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/telnetc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_TELNETC)
+  target_sources(apps PRIVATE telnetc.c)
+endif()

--- a/netutils/telnetd/CMakeLists.txt
+++ b/netutils/telnetd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/telnetd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_TELNETD)
+  target_sources(apps PRIVATE telnetd_daemon.c)
+endif()

--- a/netutils/tftpc/CMakeLists.txt
+++ b/netutils/tftpc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/tftpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_TFTPC AND CONFIG_NET_UDP)
+  target_sources(apps PRIVATE tftpc_get.c tftpc_put.c tftpc_packets.c)
+endif()

--- a/netutils/thttpd/CMakeLists.txt
+++ b/netutils/thttpd/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/thttpd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_THTTPD)
+  nuttx_add_application(NAME thttpd)
+endif()

--- a/netutils/usrsock_rpmsg/CMakeLists.txt
+++ b/netutils/usrsock_rpmsg/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# apps/netutils/usrsock_rpmsg/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_USRSOCK_RPMSG)
+  if(CONFIG_NET_USRSOCK)
+    nuttx_add_application(NAME usrsock SRCS usrsock_rpmsg_client.c)
+  else()
+    nuttx_add_application(NAME usrsock SRCS usrsock_rpmsg_server.c)
+  endif()
+endif()

--- a/netutils/wakeonlan/CMakeLists.txt
+++ b/netutils/wakeonlan/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# apps/netutils/wakeonlan/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_WAKEONLAN)
+  nuttx_add_application(NAME ${CONFIG_NETUTILS_WAKEONLAN_PROGNAME} SRCS
+                        wol_main.c)
+endif()

--- a/netutils/webclient/CMakeLists.txt
+++ b/netutils/webclient/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/webclient/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_WEBCLIENT AND CONFIG_NET_TCP)
+  target_sources(apps PRIVATE webclient.c)
+endif()

--- a/netutils/webserver/CMakeLists.txt
+++ b/netutils/webserver/CMakeLists.txt
@@ -1,0 +1,42 @@
+# ##############################################################################
+# apps/netutils/webserver/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_WEBSERVER)
+
+  set(CSRCS)
+
+  # Web server library
+
+  if(CONFIG_NET_TCP)
+    list(APPEND CSRCS httpd.c httpd_cgi.c)
+    if(CONFIG_NETUTILS_HTTPD_SENDFILE)
+      list(APPEND CSRCS httpd_sendfile.c)
+      if(CONFIG_NETUTILS_HTTPD_DIRLIST)
+        list(APPEND CSRCS httpd_dirlist.c)
+      endif()
+    elseif(CONFIG_NETUTILS_HTTPD_MMAP)
+      list(APPEND CSRCS httpd_mmap.c)
+    else()
+      list(APPEND CSRCS httpd_fs.c)
+    endif()
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+endif()

--- a/netutils/xmlrpc/CMakeLists.txt
+++ b/netutils/xmlrpc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/xmlrpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_XMLRPC)
+  target_sources(apps PRIVATE xmlparser.c response.c)
+endif()

--- a/nshlib/CMakeLists.txt
+++ b/nshlib/CMakeLists.txt
@@ -1,0 +1,130 @@
+# ##############################################################################
+# apps/nshlib/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NSH_LIBRARY)
+
+  set(CSRCS)
+
+  list(
+    APPEND
+    CSRCS
+    nsh_init.c
+    nsh_parse.c
+    nsh_console.c
+    nsh_script.c
+    nsh_system.c
+    nsh_command.c
+    nsh_fscmds.c
+    nsh_ddcmd.c
+    nsh_proccmds.c
+    nsh_mmcmds.c
+    nsh_timcmds.c
+    nsh_envcmds.c
+    nsh_syscmds.c
+    nsh_dbgcmds.c)
+
+  list(APPEND CSRCS nsh_session.c)
+
+  if(CONFIG_NSH_CONSOLE_LOGIN)
+    list(APPEND CSRCS nsh_login.c)
+  endif()
+
+  list(APPEND CSRCS nsh_fsutils.c)
+
+  if(CONFIG_NSH_BUILTIN_APPS)
+    list(APPEND CSRCS nsh_builtin.c)
+  endif()
+
+  if(CONFIG_NSH_FILE_APPS)
+    list(APPEND CSRCS nsh_fileapps.c)
+  endif()
+
+  if(CONFIG_NSH_VARS)
+    list(APPEND CSRCS nsh_vars.c)
+  endif()
+
+  if(CONFIG_NSH_ROMFSETC)
+    list(APPEND CSRCS nsh_romfsetc.c)
+  endif()
+
+  if(CONFIG_NET)
+    list(APPEND CSRCS nsh_netcmds.c)
+
+    if(CONFIG_NET_ROUTE)
+      list(APPEND CSRCS nsh_routecmds.c)
+    endif()
+  endif()
+
+  if(NOT CONFIG_DISABLE_MOUNTPOINT)
+    list(APPEND CSRCS nsh_mntcmds.c)
+  endif()
+
+  if(CONFIG_MODULE)
+    if(NOT CONFIG_NSH_DISABLE_MODCMDS)
+      list(APPEND CSRCS nsh_modcmds.c)
+    endif()
+  endif()
+
+  if(CONFIG_NSH_CONSOLE)
+    list(APPEND CSRCS nsh_consolemain.c)
+  endif()
+
+  if(NOT CONFIG_NSH_DISABLE_PRINTF)
+    list(APPEND CSRCS nsh_printf.c)
+  endif()
+
+  if(CONFIG_NSH_TELNET)
+    list(APPEND CSRCS nsh_telnetd.c)
+    if(CONFIG_NSH_TELNET_LOGIN)
+      list(APPEND CSRCS nsh_telnetlogin.c)
+    endif()
+  endif()
+
+  if(NOT CONFIG_NSH_DISABLESCRIPT)
+    list(APPEND CSRCS nsh_test.c)
+  endif()
+
+  if(CONFIG_USBDEV)
+    list(APPEND CSRCS nsh_usbconsole.c)
+  endif()
+
+  if(CONFIG_NSH_ALTCONDEV)
+    list(APPEND CSRCS nsh_altconsole.c)
+  endif()
+
+  if(CONFIG_NSH_USBDEV_TRACE)
+    list(APPEND CSRCS nsh_usbtrace.c)
+  endif()
+
+  if(CONFIG_NETUTILS_CODECS)
+    list(APPEND CSRCS nsh_codeccmd.c)
+  endif()
+
+  if(CONFIG_NSH_LOGIN_PASSWD)
+    list(APPEND CSRCS nsh_passwdcmds.c)
+  endif()
+
+  if(CONFIG_NSH_ALIAS)
+    list(APPEND CSRCS nsh_alias.c)
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+
+endif()

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/platform/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# set(SRCS)
+#
+# list(APPEND SRCS gnu/gnu_cxxinitialize.c)
+#
+# target_sources(apps PRIVATE ${SRCS})

--- a/system/CMakeLists.txt
+++ b/system/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "System Libraries and NSH Add-Ons")

--- a/system/cdcacm/CMakeLists.txt
+++ b/system/cdcacm/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/cdcacm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_CDCACM)
+  nuttx_add_application(NAME cdcacm)
+endif()

--- a/system/cle/CMakeLists.txt
+++ b/system/cle/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/cle/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_CLE)
+  target_sources(apps PRIVATE cle.c)
+endif()

--- a/system/composite/CMakeLists.txt
+++ b/system/composite/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/composite/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_COMPOSITE)
+  nuttx_add_application(NAME composite SRCS composite_main.c)
+endif()

--- a/system/critmon/CMakeLists.txt
+++ b/system/critmon/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/critmon/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_CRITMONITOR)
+  nuttx_add_application(NAME critmon)
+endif()

--- a/system/cu/CMakeLists.txt
+++ b/system/cu/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/cu/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_CUTERM)
+  nuttx_add_application(
+    NAME
+    cu
+    SRCS
+    cu_main.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_CUTERM_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_CUTERM_PRIORITY})
+endif()

--- a/system/dhcpc/CMakeLists.txt
+++ b/system/dhcpc/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/dhcpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_DHCPC_RENEW)
+  nuttx_add_application(
+    NAME
+    dhcpc
+    SRCS
+    renew_main.c
+    STACKSIZE
+    ${CONFIG_DHCPC_RENEW_STACKSIZE}
+    PRIORITY
+    ${CONFIG_DHCPC_RENEW_PRIORITY})
+endif()

--- a/system/dumpstack/CMakeLists.txt
+++ b/system/dumpstack/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/dumpstack/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_DUMPSTACK)
+  nuttx_add_application(
+    NAME
+    dumpstack
+    SRCS
+    dumpstack.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_DUMPSTACK_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_DUMPSTACK_PRIORITY})
+endif()

--- a/system/flash_eraseall/CMakeLists.txt
+++ b/system/flash_eraseall/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/flash_eraseall/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_FLASH_ERASEALL)
+  nuttx_add_application(NAME flash_eraseall)
+endif()

--- a/system/hex2bin/CMakeLists.txt
+++ b/system/hex2bin/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/hex2bin/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_HEX2BIN)
+  nuttx_add_application(NAME hex2bin)
+endif()

--- a/system/hexed/CMakeLists.txt
+++ b/system/hexed/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/hexed/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_HEXED)
+  nuttx_add_application(NAME hexed)
+endif()

--- a/system/hostname/CMakeLists.txt
+++ b/system/hostname/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/hostname/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MM)
+  nuttx_add_application(NAME mm)
+endif()

--- a/system/i2c/CMakeLists.txt
+++ b/system/i2c/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# apps/system/i2c/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_I2CTOOL)
+  set(SRCS i2c_main.c)
+  list(
+    APPEND
+    SRCS
+    i2c_bus.c
+    i2c_common.c
+    i2c_dev.c
+    i2c_get.c
+    i2c_set.c
+    i2c_verf.c
+    i2c_devif.c
+    i2c_dump.c
+    i2c_hexdump.c)
+  if(CONFIG_I2C_RESET)
+    list(APPEND SRCS i2c_reset.c)
+  endif()
+  nuttx_add_application(NAME i2c SRCS ${SRCS} STACKSIZE
+                        ${CONFIG_DEFAULT_TASK_STACKSIZE})
+endif()

--- a/system/lm75/CMakeLists.txt
+++ b/system/lm75/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/lm75/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_LM75)
+  nuttx_add_application(NAME lm75)
+endif()

--- a/system/lzf/CMakeLists.txt
+++ b/system/lzf/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/lzf/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_LZF)
+  nuttx_add_application(NAME lzf)
+endif()

--- a/system/mdio/CMakeLists.txt
+++ b/system/mdio/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/mdio/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_MDIO)
+  nuttx_add_application(NAME mdio)
+endif()

--- a/system/netdb/CMakeLists.txt
+++ b/system/netdb/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ##############################################################################
+# apps/system/netdb/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NETDB)
+  nuttx_add_application(
+    NAME
+    netdb
+    STACKSIZE
+    2048
+    PRIORITY
+    100
+    SRCS
+    netdb_main.c)
+
+endif()

--- a/system/nsh/CMakeLists.txt
+++ b/system/nsh/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ##############################################################################
+# apps/system/nsh/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NSH)
+  nuttx_add_application(NAME nsh SRCS nsh_main.c)
+
+  nuttx_add_application(NAME sh SRCS sh_main.c)
+
+endif()

--- a/system/ntpc/CMakeLists.txt
+++ b/system/ntpc/CMakeLists.txt
@@ -1,0 +1,49 @@
+# ##############################################################################
+# apps/system/ntpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NTPC)
+  nuttx_add_application(
+    NAME
+    ntpcstart
+    SRCS
+    ntpcstart_main.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_NTPC_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_NTPC_PRIORITY})
+  nuttx_add_application(
+    NAME
+    ntpcstop
+    SRCS
+    ntpcstop_main.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_NTPC_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_NTPC_PRIORITY})
+  nuttx_add_application(
+    NAME
+    ntpcstatus
+    SRCS
+    ntpcstatus_main.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_NTPC_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_NTPC_PRIORITY})
+endif()

--- a/system/nxplayer/CMakeLists.txt
+++ b/system/nxplayer/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# apps/system/nxplayer/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NXPLAYER)
+  if(CONFIG_NXPLAYER_COMMAND_LINE)
+    nuttx_add_application(NAME nxplayer SRCS nxplayer_main.c STACKSIZE
+                          ${CONFIG_NXPLAYER_MAINTHREAD_STACKSIZE})
+  endif()
+  target_sources(apps PRIVATE nxplayer.c)
+endif()

--- a/system/nxrecorder/CMakeLists.txt
+++ b/system/nxrecorder/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# apps/system/nxrecorder/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NXRECORDER)
+  if(CONFIG_NXRECORDER_COMMAND_LINE)
+    nuttx_add_application(NAME nxrecorder SRCS nxrecorder_main.c STACKSIZE
+                          ${CONFIG_NXRECORDER_MAINTHREAD_STACKSIZE})
+  endif()
+  target_sources(apps PRIVATE nxrecorder.c)
+endif()

--- a/system/ping/CMakeLists.txt
+++ b/system/ping/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/ping/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_PING)
+  nuttx_add_application(
+    NAME
+    ping
+    SRCS
+    ping.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_PING_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_PING_PRIORITY})
+endif()

--- a/system/ping6/CMakeLists.txt
+++ b/system/ping6/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/ping6/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_PING6)
+  nuttx_add_application(NAME ping6)
+endif()

--- a/system/popen/CMakeLists.txt
+++ b/system/popen/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/popen/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_POPEN)
+  target_sources(apps PRIVATE popen.c)
+endif()

--- a/system/ramtest/CMakeLists.txt
+++ b/system/ramtest/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/ramtest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_RAMTEST)
+  nuttx_add_application(NAME ramtest)
+endif()

--- a/system/readline/CMakeLists.txt
+++ b/system/readline/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/system/readline/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_READLINE)
+
+  target_sources(apps PRIVATE readline.c readline_fd.c readline_common.c)
+
+endif()

--- a/system/sched_note/CMakeLists.txt
+++ b/system/sched_note/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/sched_note/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NOTE)
+  nuttx_add_application(NAME sched_note)
+endif()

--- a/system/setlogmask/CMakeLists.txt
+++ b/system/setlogmask/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/setlogmask/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_SETLOGMASK)
+  nuttx_add_application(
+    NAME
+    setlogmask
+    SRCS
+    setlogmask.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_SETLOGMASK_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_SETLOGMASK_PRIORITY})
+endif()

--- a/system/stackmonitor/CMakeLists.txt
+++ b/system/stackmonitor/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/stackmonitor/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_STACKMONITOR)
+  nuttx_add_application(NAME stackmonitor)
+endif()

--- a/system/system/CMakeLists.txt
+++ b/system/system/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/system/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_SYSTEM)
+  target_sources(apps PRIVATE system.c)
+endif()

--- a/system/taskset/CMakeLists.txt
+++ b/system/taskset/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/taskset/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_TASKSET)
+  nuttx_add_application(NAME taskset)
+endif()

--- a/system/tee/CMakeLists.txt
+++ b/system/tee/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/tee/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_TEE)
+  nuttx_add_application(NAME tee)
+endif()

--- a/system/telnet/CMakeLists.txt
+++ b/system/telnet/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# apps/system/telnet/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_TELNET_CHATD)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_SYSTEM_TELNET_CHATD_PROGNAME}
+    SRCS
+    telnet_chatd.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_TELNET_CHATD_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_TELNET_CHATD_PRIORITY})
+endif()
+
+if(CONFIG_SYSTEM_TELNET_CLIENT)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_SYSTEM_TELNET_CLIENT_PROGNAME}
+    SRCS
+    telnet_client.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_TELNET_CLIENT_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_TELNET_CLIENT_PRIORITY})
+endif()

--- a/system/ubloxmodem/CMakeLists.txt
+++ b/system/ubloxmodem/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/ubloxmodem/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_UBLOXMODEM)
+  nuttx_add_application(NAME ubloxmodem)
+endif()

--- a/system/usbmsc/CMakeLists.txt
+++ b/system/usbmsc/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/usbmsc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_USBMSC)
+  nuttx_add_application(NAME usbmsc STACKSIZE 768 SRCS usbmsc_main.c)
+endif()

--- a/system/vi/CMakeLists.txt
+++ b/system/vi/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/vi/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_VI)
+  nuttx_add_application(NAME vi)
+endif()

--- a/system/zmodem/CMakeLists.txt
+++ b/system/zmodem/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/system/zmodem/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_ZMODEM)
+  nuttx_add_application(NAME zmodem)
+endif()

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ##############################################################################
+# apps/testing/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+nuttx_generate_kconfig(MENUDESC "Testing")

--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -1,0 +1,144 @@
+# ##############################################################################
+# apps/testing/ostest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_OSTEST)
+
+  set(SRCS
+      getopt.c
+      dev_null.c
+      restart.c
+      sigprocmask.c
+      sighand.c
+      signest.c
+      sighelper.c)
+
+  if(CONFIG_SIG_SIGSTOP_ACTION)
+    if(CONFIG_SIG_SIGKILL_ACTION)
+      list(APPEND SRCS suspend.c)
+    endif()
+  endif()
+
+  if(CONFIG_ARCH_FPU)
+    if(NOT CONFIG_TESTING_OSTEST_FPUTESTDISABLE)
+      list(APPEND SRCS fpu.c)
+    endif()
+  endif()
+
+  if(NOT CONFIG_STDIO_DISABLE_BUFFERING)
+    list(APPEND SRCS setvbuf.c)
+  endif()
+
+  if(NOT CONFIG_TLS_NELEM EQUAL 0)
+    list(APPEND SRCS tls.c)
+  endif()
+
+  if(CONFIG_TESTING_OSTEST_AIO)
+    list(APPEND SRCS aio.c)
+  endif()
+
+  if(CONFIG_SCHED_WAITPID)
+    list(APPEND SRCS waitpid.c)
+  endif()
+
+  if(NOT CONFIG_DISABLE_PTHREAD)
+    list(
+      APPEND
+      SRCS
+      cancel.c
+      cond.c
+      mutex.c
+      timedmutex.c
+      sem.c
+      semtimed.c
+      barrier.c)
+    list(APPEND SRCS timedwait.c)
+    list(APPEND SRCS pthread_rwlock.c pthread_rwlock_cancel.c)
+
+    if(CONFIG_SCHED_WAITPID)
+      list(APPEND SRCS pthread_exit.c)
+    endif()
+
+    if(NOT CONFIG_TLS_NELEM EQUAL 0)
+      list(APPEND SRCS specific.c)
+    endif()
+
+    if(NOT CONFIG_PTHREAD_CLEANUP_STACKSIZE EQUAL 0)
+      list(APPEND SRCS pthread_cleanup.c)
+    endif()
+
+    if(NOT CONFIG_PTHREAD_MUTEX_UNSAFE)
+      list(APPEND SRCS robust.c)
+    endif()
+
+    if(CONFIG_PTHREAD_MUTEX_TYPES)
+      list(APPEND SRCS rmutex.c)
+    endif()
+
+    if(CONFIG_FS_NAMED_SEMAPHORES)
+      list(APPEND SRCS nsem.c)
+    endif()
+
+    if(NOT "${CONFIG_RR_INTERVAL}" STREQUAL "0")
+      list(APPEND SRCS roundrobin.c)
+    endif()
+
+    if(CONFIG_SCHED_SPORADIC)
+      list(APPEND SRCS sporadic.c sporadic2.c)
+    endif()
+
+    if(CONFIG_SCHED_WORKQUEUE)
+      list(APPEND SRCS wqueue.c)
+    endif()
+  endif() # CONFIG_DISABLE_PTHREAD
+
+  if(NOT CONFIG_DISABLE_MQUEUE)
+    if(NOT CONFIG_DISABLE_PTHREAD)
+      list(APPEND SRCS mqueue.c timedmqueue.c)
+    endif() # CONFIG_DISABLE_PTHREAD
+  endif() # CONFIG_DISABLE_MQUEUE
+
+  if(NOT CONFIG_DISABLE_POSIX_TIMERS)
+    list(APPEND SRCS posixtimer.c)
+    if(CONFIG_SIG_EVTHREAD)
+      list(APPEND SRCS sigev_thread.c)
+    endif()
+  endif()
+
+  if(CONFIG_ARCH_HAVE_VFORK)
+    if(CONFIG_SCHED_WAITPID)
+      list(APPEND SRCS vfork.c)
+    endif()
+  endif()
+
+  if(NOT CONFIG_DISABLE_PTHREAD)
+    if(CONFIG_PRIORITY_INHERITANCE)
+      list(APPEND SRCS prioinherit.c)
+    endif() # CONFIG_PRIORITY_INHERITANCE
+  endif() # CONFIG_DISABLE_PTHREAD
+
+  if(CONFIG_ARCH_SETJMP_H)
+    list(APPEND SRCS setjmp.c)
+  endif()
+
+  target_sources(apps PRIVATE ${SRCS})
+
+  nuttx_add_application(NAME ostest SRCS ostest_main.c)
+
+endif()

--- a/wireless/CMakeLists.txt
+++ b/wireless/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/wireless/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "Wireless Libraries and NSH Add-Ons")

--- a/wireless/wapi/CMakeLists.txt
+++ b/wireless/wapi/CMakeLists.txt
@@ -1,0 +1,39 @@
+# ##############################################################################
+# wireless/wapi/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_WIRELESS_WAPI)
+
+  set(CSRCS src/network.c src/util.c src/wireless.c src/driver_wext.c)
+
+  if(CONFIG_WIRELESS_WAPI_CMDTOOL)
+    nuttx_add_application(
+      NAME
+      ${CONFIG_WIRELESS_WAPI_PROGNAME}
+      SRCS
+      src/wapi.c
+      STACKSIZE
+      ${CONFIG_WIRELESS_WAPI_STACKSIZE}
+      PRIORITY
+      ${CONFIG_WIRELESS_WAPI_PRIORITY})
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+
+endif()


### PR DESCRIPTION
## Summary

enhance cmake build system (Enhance #3704)

1. Update all CMakeLists.txt to adapt to new layout
2. Fix cmake build break
3. Update all new file license
4. Fully compatible with current compilation environment(use configure.sh or cmake as you choose)

------------------

How to test

```
From within nuttx/. Configure:

$ cmake -B build -DBOARD_CONFIG=sabre-6quad/smp -GNinja
$ cmake -B build -DBOARD_CONFIG=lm3s6965-ek/qemu-flat -GNinja
$ cmake -B build -DBOARD_CONFIG=sim/nsh -GNinja

This uses ninja generator (install with sudo apt install ninja-build). To build:

$ cmake --build build

menuconfig:

$ cmake --build build -t menuconfig
```

------------------

Compilation speed:

```
| lm3s6965-ek/qemu-flat:
| Orignal     : $ time `./tools/configure.sh lm3s6965-ek/qemu-flat > /dev/null && make -j16 > /dev/null`
| CMake       : $ time `cmake -B build -DBOARD_CONFIG=lm3s6965-ek/qemu-flat > /dev/null;cmake --build build -j16 > /dev/null`
| CMake(Ninja): $ time `cmake -B build -DBOARD_CONFIG=lm3s6965-ek/qemu-flat -GNinja > /dev/null;cmake --build build -j16 > /dev/null`
|
|         Orignal        CMake     CMake(Ninja)
| real   0m9.982s     0m4.739s         0m4.475s
| user   1m5.336s    0m41.846s        0m37.434s
| sys   0m16.428s     0m9.239s         0m7.998s
|
|
| Orignal     : $ time `./tools/configure.sh sabre-6quad/smp > /dev/null && make -j16 > /dev/null`
| CMake       : $ time `cmake -B build -DBOARD_CONFIG=sabre-6quad/smp > /dev/null;cmake --build build -j16 > /dev/null`
| CMake(Ninja): $ time `cmake -B build -DBOARD_CONFIG=sabre-6quad/smp -GNinja > /dev/null;cmake --build build -j16 > /dev/null`
|
|         Orignal        CMake     CMake(Ninja)
| real  0m10.921s     0m3.936s         0m3.616s
| user  0m51.603s    0m32.621s        0m29.102s
| sys   0m13.720s     0m8.075s         0m6.460s
```

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

Depends on: https://github.com/apache/nuttx/pull/6718

## Testing

cmake -B build -DBOARD_CONFIG=sim/nsh -GNinja
cmake -B build -DBOARD_CONFIG=sabre-6quad/smp -GNinja
cmake -B build -DBOARD_CONFIG=lm3s6965-ek/qemu-flat -GNinja
