### PR TITLE
Fix various error in Windows native build

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -62,7 +62,8 @@ ifeq ($(BUILD_MODULE),y)
 endif
 
 SUFFIX = $(subst $(DELIM),.,$(CWD))
-PROGNAME := $(shell echo $(PROGNAME))
+
+PROGNAME := $(subst ",,$(PROGNAME))
 
 # Object files
 

--- a/Directory.mk
+++ b/Directory.mk
@@ -22,11 +22,15 @@ include $(APPDIR)/Make.defs
 
 # Sub-directories that have been built or configured.
 
-SUBDIRS       := $(dir $(wildcard *$(DELIM)Makefile))
-CONFIGSUBDIRS := $(filter-out $(dir $(wildcard *$(DELIM)Kconfig)),$(SUBDIRS))
-CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).depend))
-CLEANSUBDIRS  += $(dir $(wildcard *$(DELIM).kconfig))
+SUBDIRS       := $(dir $(wildcard */Makefile))
+CONFIGSUBDIRS := $(filter-out $(dir $(wildcard */Kconfig)),$(SUBDIRS))
+CLEANSUBDIRS  += $(dir $(wildcard */.depend))
+CLEANSUBDIRS  += $(dir $(wildcard */.kconfig))
 CLEANSUBDIRS  := $(sort $(CLEANSUBDIRS))
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+	CONFIGSUBDIRS  := $(subst /,\,$(CONFIGSUBDIRS))
+	CLEANSUBDIRS  := $(subst /,\,$(CLEANSUBDIRS))
+endif
 
 all: nothing
 

--- a/Make.defs
+++ b/Make.defs
@@ -21,27 +21,22 @@
 TOPDIR ?= $(APPDIR)/import
 include $(TOPDIR)/Make.defs
 
-# The GNU make CURDIR will always be a POSIX-like path with forward slashes
-# as path segment separators.  This is fine for the above inclusions but
-# will cause problems later for the native build.  If we know that this is
-# a native build, then we need to fix up the APPDIR path for subsequent
-# use
-
-ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-APPDIR := ${shell echo %CD%}
-endif
-
 # Application Directories
 
 # BUILDIRS is the list of top-level directories containing Make.defs files
 # CLEANDIRS is the list of all top-level directories containing Makefiles.
 #   It is used only for cleaning.
 
-BUILDIRS   := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Make.defs))
-BUILDIRS   := $(filter-out $(APPDIR)$(DELIM)import$(DELIM),$(BUILDIRS))
-CONFIGDIRS := $(filter-out $(APPDIR)$(DELIM)builtin$(DELIM),$(BUILDIRS))
-CONFIGDIRS := $(filter-out $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Kconfig)),$(CONFIGDIRS))
-CLEANDIRS  := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Makefile))
+BUILDIRS   := $(dir $(wildcard $(APPDIR)/*/Make.defs))
+BUILDIRS   := $(filter-out $(APPDIR)/import/,$(BUILDIRS))
+CONFIGDIRS := $(filter-out $(APPDIR)/builtin/,$(BUILDIRS))
+CONFIGDIRS := $(filter-out $(dir $(wildcard $(APPDIR)/*/Kconfig)),$(CONFIGDIRS))
+CLEANDIRS  := $(dir $(wildcard $(APPDIR)/*/Makefile))
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+	BUILDIRS  := $(subst /,\,$(BUILDIRS))
+	CONFIGDIRS  := $(subst /,\,$(CONFIGDIRS))
+	CLEANDIRS  := $(subst /,\,$(CLEANDIRS))
+endif
 
 # CONFIGURED_APPS is the application directories that should be built in
 #   the current configuration.
@@ -85,14 +80,24 @@ endif
 BUILTIN_REGISTRY = $(APPDIR)$(DELIM)builtin$(DELIM)registry
 DEPCONFIG = $(TOPDIR)$(DELIM).config
 
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define REGISTER
 	$(Q) echo Register: $1
-	$(Q) echo { \"$1\", $2, $3, $4 }, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo { "$(subst ",,$(1))", $2, $3, $(subst ",,$(4)) }, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo int $(subst ",,$(4))(int argc, char *argv[]); > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"
+
+	$(Q) touch $(BUILTIN_REGISTRY)$(DELIM).updated"
+endef
+else
+define REGISTER
+	$(Q) echo "Register: $1"
+	$(Q) echo "{ \"$1\", $2, $3, $4 }," > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
 	$(Q) if [ ! -z $4 ]; then \
 	        echo "int $4(int argc, char *argv[]);" > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"; \
 	     fi;
 	$(Q) touch "$(BUILTIN_REGISTRY)$(DELIM).updated"
 endef
+endif
 
 # Standard include path
 

--- a/builtin/Makefile
+++ b/builtin/Makefile
@@ -28,6 +28,10 @@ CSRCS = builtin_list.c exec_builtin.c
 
 PDATLIST = $(strip $(call RWILDCARD, registry, *.pdat))
 BDATLIST = $(strip $(call RWILDCARD, registry, *.bdat))
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+	PDATLIST  := $(subst /,\,$(PDATLIST))
+	BDATLIST  := $(subst /,\,$(BDATLIST))
+endif
 
 builtin_list.c: builtin_list.h builtin_proto.h
 

--- a/platform/Makefile
+++ b/platform/Makefile
@@ -25,7 +25,7 @@ CONFIG_ARCH_BOARD ?= dummy
 # Directories
 
 PLATFORMDIR = board
-DUMMYDIR    = $(APPDIR)/platform/dummy
+DUMMYDIR    = $(APPDIR)$(DELIM)platform$(DELIM)dummy
 
 ifeq ($(CONFIG_ARCH_BOARD_CUSTOM),y)
   LINKDIR   = $(DUMMYDIR)


### PR DESCRIPTION
## Summary
These patch finally raised NuttX Windows native build
## Impact
Windows native build
## Testing
Tested build of stm32f4discovery on Windows XP/7 + GnuW32 + MinGW + kconfig-frontends-win32
![nuttx-win32](https://user-images.githubusercontent.com/10884769/201475892-e2dac509-1dbf-4a42-be59-1a0120e9bc64.jpg)
