### PR TITLE
NuttX graduated the Incubator; update repository links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,13 @@ jobs:
             # Determine the repo and leave that unset to use the normal checkout behavior
             # of using the merge commit instead of HEAD
             case $GITHUB_REPOSITORY in
-              "apache/incubator-nuttx")
+              "apache/nuttx")
                 # OS
                 echo "Triggered by change in OS"
                 APPS_REF=$REF_NAME
                 ;;
 
-              "apache/incubator-nuttx-apps" )
+              "apache/nuttx-apps" )
                 # APPS
                 OS_REF=$REF_NAME
                 echo "Triggered by change in APPS"
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v3
         with:
-          repository: apache/incubator-nuttx
+          repository: apache/nuttx
           ref: ${{ steps.gittargets.outputs.os_ref }}
           path: sources/nuttx
           fetch-depth: 1
@@ -96,7 +96,7 @@ jobs:
       - name: Checkout apps repo
         uses: actions/checkout@v3
         with:
-          repository: apache/incubator-nuttx-apps
+          repository: apache/nuttx-apps
           ref: ${{ steps.gittargets.outputs.apps_ref }}
           path: sources/apps
           fetch-depth: 1
@@ -135,7 +135,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Pull
-        run: docker pull ghcr.io/apache/incubator-nuttx/apache-nuttx-ci-linux
+        run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Run builds

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v3
         with:
-          repository: apache/incubator-nuttx
+          repository: apache/nuttx
           path: nuttx
           fetch-depth: 0
 
       - name: Checkout apps repo
         uses: actions/checkout@v3
         with:
-          repository: apache/incubator-nuttx-apps
+          repository: apache/nuttx-apps
           path: apps
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

NuttX has graduated the Incubator and the repositories will be renamed to remove the `incubator-` prefix.

This PR updates all links, documentation, etc., to the new names.

Note: Please **DO NOT MERGE** until Infra has renamed the repositories!!

See the Infra Jira ticket: https://issues.apache.org/jira/browse/INFRA-23935

## Impact

Affects GitHub workflows.

## Testing

N/A