### PR TITLE
testing/monkey: add auto select uinput

### DIFF
--- a/testing/monkey/Kconfig
+++ b/testing/monkey/Kconfig
@@ -5,6 +5,8 @@
 
 menuconfig TESTING_MONKEY
 	tristate "Monkey test"
+	select UINPUT_TOUCH
+	select UINPUT_BUTTONS
 	default n
 
 if TESTING_MONKEY


### PR DESCRIPTION
## Summary
Automatically enable the uinput device when enable the monkey configuration, simplifying user configuration.

## Impact
Monkey test.

## Testing
Daily test.

