### PR TITLE
luamodules/luv: fix comile warning -Werror=int-to-pointer-cast

### DIFF
--- a/interpreters/luamodules/luv/0001-fix-compile-warnings.patch
+++ b/interpreters/luamodules/luv/0001-fix-compile-warnings.patch
@@ -1,22 +1,16 @@
-From 809314f3c818ddcfdc72e2b3adb4faf350bf201c Mon Sep 17 00:00:00 2001
+From 5ead8fc3a68738c1569ec635f898f50f9476bf4a Mon Sep 17 00:00:00 2001
 From: Xu Xingliang <xuxingliang@xiaomi.com>
-Date: Fri, 2 Dec 2022 13:07:17 +0800
+Date: Mon, 12 Dec 2022 11:56:58 +0800
 Subject: [PATCH] fix compile warnings
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
-
-luv/src/fs.c:431:14: warning: declaration of ‘data’ shadows a previous local [-Wshadow]
-luv/src/private.h:114:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 
 Signed-off-by: Xu Xingliang <xuxingliang@xiaomi.com>
 ---
  src/fs.c      | 14 +++++++-------
  src/luv.h     |  2 +-
  src/private.h |  2 +-
- src/thread.c  |  2 +-
+ src/thread.c  |  4 ++--
  src/work.c    |  6 +++---
- 5 files changed, 13 insertions(+), 13 deletions(-)
+ 5 files changed, 14 insertions(+), 14 deletions(-)
 
 diff --git a/src/fs.c b/src/fs.c
 index 344d602..ea2a80a 100644
@@ -93,7 +87,7 @@ index 1e921a4..b4ea7fb 100644
  /* From process.c */
  static int luv_parse_signal(lua_State* L, int slot);
 diff --git a/src/thread.c b/src/thread.c
-index 36041af..5de5556 100644
+index 36041af..93427d4 100644
 --- a/src/thread.c
 +++ b/src/thread.c
 @@ -24,7 +24,7 @@ typedef struct {
@@ -105,8 +99,17 @@ index 36041af..5de5556 100644
    lua_State* L = luaL_newstate();
  
    // Add in the lua standard libraries
+@@ -262,7 +262,7 @@ static int luv_thread_gc(lua_State* L) {
+ static int luv_thread_tostring(lua_State* L)
+ {
+   luv_thread_t* thd = luv_check_thread(L, 1);
+-  lua_pushfstring(L, "uv_thread_t: %p", (void*)thd->handle);
++  lua_pushfstring(L, "uv_thread_t: %p", (void*)(uintptr_t)thd->handle);
+   return 1;
+ }
+ 
 diff --git a/src/work.c b/src/work.c
-index 7e42641..b51bfd1 100644
+index b6b7561..52d8004 100644
 --- a/src/work.c
 +++ b/src/work.c
 @@ -127,7 +127,7 @@ static int luv_work_cb(lua_State* L) {
@@ -118,7 +121,7 @@ index 7e42641..b51bfd1 100644
  {
    lua_State* L = uv_key_get(&tls_vmkey);
    if (L == NULL)
-@@ -245,7 +245,7 @@ static const luaL_Reg luv_work_ctx_methods[] = {
+@@ -247,7 +247,7 @@ static const luaL_Reg luv_work_ctx_methods[] = {
    {NULL, NULL}
  };
  
@@ -127,7 +130,7 @@ index 7e42641..b51bfd1 100644
  {
    const char* val;
    int status = uv_key_create(&tls_vmkey);
-@@ -287,7 +287,7 @@ static void luv_key_init_once()
+@@ -289,7 +289,7 @@ static void luv_key_init_once()
    idx_vms = 0;
  }
  


### PR DESCRIPTION
## Summary
Fix compile error when reported by CI.

## Impact
No.

## Testing
Local build with Wall Werror passed.
