### PR TITLE
drivers/note: rename /dev/note to /dev/note/ram

### DIFF
--- a/examples/watcher/task_mn.c
+++ b/examples/watcher/task_mn.c
@@ -69,10 +69,10 @@ void task_mn_print_tasks_status(void)
     {
       /* Open the note driver */
 
-      notefd = open("/dev/note", O_RDONLY);
+      notefd = open("/dev/note/ram", O_RDONLY);
       if (notefd < 0)
         {
-          printf("Error: cannot open /dev/note\n");
+          printf("Error: cannot open /dev/note/ram\n");
           return;
         }
 
@@ -243,10 +243,10 @@ void task_mn_get_task_name(struct noteram_get_taskname_s *task)
 {
   int notefd;
 
-  notefd = open("/dev/note", O_RDONLY);
+  notefd = open("/dev/note/ram", O_RDONLY);
   if (notefd < 0)
     {
-      fprintf(stderr, "trace: cannot open /dev/note\n");
+      fprintf(stderr, "trace: cannot open /dev/note/ram\n");
       return;
     }
 

--- a/system/sched_note/note_main.c
+++ b/system/sched_note/note_main.c
@@ -787,12 +787,12 @@ static int note_daemon(int argc, char *argv[])
 
   /* Open the note driver */
 
-  syslog(LOG_INFO, "note_daemon: Opening /dev/note\n");
-  fd = open("/dev/note", O_RDONLY);
+  syslog(LOG_INFO, "note_daemon: Opening /dev/note/ram\n");
+  fd = open("/dev/note/ram", O_RDONLY);
   if (fd < 0)
     {
       int errcode = errno;
-      syslog(LOG_ERR, "note_daemon: ERROR: Failed to open /dev/note: %d\n",
+      syslog(LOG_ERR, "note_daemon: ERROR: Failed to open /dev/note/ram: %d\n",
              errcode);
       goto errout;
     }

--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -128,11 +128,10 @@ static void note_ioctl(int cmd, unsigned long arg)
 {
   int notefd;
 
-  notefd = open("/dev/note", O_RDONLY);
+  notefd = open("/dev/note/ram", O_RDONLY);
   if (notefd < 0)
     {
-      fprintf(stderr,
-             "trace: cannot open /dev/note\n");
+      fprintf(stderr, "trace: cannot open /dev/note/ram\n");
       return;
     }
 
@@ -713,11 +712,10 @@ int trace_dump(trace_dump_t type, FAR FILE *out)
 
   /* Open note for read */
 
-  fd = open("/dev/note", O_RDONLY);
+  fd = open("/dev/note/ram", O_RDONLY);
   if (fd < 0)
     {
-      fprintf(stderr,
-              "trace: cannot open /dev/note\n");
+      fprintf(stderr, "trace: cannot open /dev/note/ram\n");
       return ERROR;
     }
 


### PR DESCRIPTION
## Summary
rename note devices to support multiple note devices

depends on : https://github.com/apache/nuttx/pull/7841

## Impact

## Testing
sim:note
