### PR TITLE
system/camera: fix 'is_image' uninitialized

### DIFF
--- a/system/nxcamera/nxcamera_main.c
+++ b/system/nxcamera/nxcamera_main.c
@@ -266,7 +266,7 @@ static int nxcamera_cmd_output(FAR struct nxcamera_s *pcam, FAR char *parg)
   int      ret;
   char     path[PATH_MAX];
   FAR char *ext;
-  bool     isimage;
+  bool     isimage = false;
 
   /* First try to open the device directly */
 


### PR DESCRIPTION
## Summary
simple fix
## Impact

## Testing

