### PR TITLE
arp: Remove the unnecessary inclusion of nuttx/net/arp

### DIFF
--- a/examples/bridge/bridge_main.c
+++ b/examples/bridge/bridge_main.c
@@ -33,12 +33,10 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 
 #if defined(CONFIG_EXAMPLES_BRIDGE_NET1_DHCPC) || \
     defined(CONFIG_EXAMPLES_BRIDGE_NET2_DHCPC)
-#  include <arpa/inet.h>
 #  include "netutils/dhcpc.h"
 #endif
 

--- a/examples/discover/discover_main.c
+++ b/examples/discover/discover_main.c
@@ -31,7 +31,6 @@
 
 #include <net/if.h>
 #include <netinet/in.h>
-#include <nuttx/net/arp.h>
 
 #include "netutils/netlib.h"
 #include "netutils/discover.h"

--- a/examples/netlink_route/netlink_route_main.c
+++ b/examples/netlink_route/netlink_route_main.c
@@ -34,9 +34,9 @@
 #include <net/if.h>
 #include <net/route.h>
 #include <net/ethernet.h>
+#include <netinet/arp.h>
 #include <netinet/in.h>
 
-#include <nuttx/net/arp.h>
 #include <nuttx/net/neighbor.h>
 
 #include "netutils/netlib.h"

--- a/examples/tcpecho/tcpecho_main.c
+++ b/examples/tcpecho/tcpecho_main.c
@@ -40,12 +40,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
-
-#ifdef CONFIG_EXAMPLES_TCPECHO_DHCPC
-#  include <arpa/inet.h>
-#endif
 
 /* Here we include the header file for the application(s) we use in
  * our project as defined in the config/<board-name>/defconfig file

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -38,7 +38,6 @@
 #include <netinet/in.h>
 #include <netinet/ether.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 #include "netutils/thttpd.h"
 

--- a/examples/webserver/webserver_main.c
+++ b/examples/webserver/webserver_main.c
@@ -56,7 +56,6 @@
 #include <net/if.h>
 #include <netinet/in.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 
 #ifdef CONFIG_EXAMPLES_WEBSERVER_DHCPC

--- a/examples/xmlrpc/xmlrpc_main.c
+++ b/examples/xmlrpc/xmlrpc_main.c
@@ -65,13 +65,8 @@
 #include <net/if.h>
 #include <netinet/in.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 #include "netutils/xmlrpc.h"
-
-#ifdef CONFIG_EXAMPLES_XMLRPC_DHCPC
-#  include <arpa/inet.h>
-#endif
 
 /* Here we include the header file for the application(s) we use in
  * our project as defined in the config/<board-name>/defconfig file

--- a/netutils/netlib/netlib_delarp.c
+++ b/netutils/netlib/netlib_delarp.c
@@ -33,10 +33,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <netinet/arp.h>
 #include <netinet/in.h>
 #include <net/if.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 
 /****************************************************************************

--- a/netutils/netlib/netlib_getarp.c
+++ b/netutils/netlib/netlib_getarp.c
@@ -33,10 +33,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <netinet/arp.h>
 #include <netinet/in.h>
 #include <net/if.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 
 /****************************************************************************

--- a/netutils/netlib/netlib_getarptab.c
+++ b/netutils/netlib/netlib_getarptab.c
@@ -30,9 +30,8 @@
 #include <string.h>
 #include <errno.h>
 
+#include <netinet/arp.h>
 #include <netpacket/netlink.h>
-
-#include <nuttx/net/arp.h>
 
 #include "netutils/netlib.h"
 

--- a/netutils/netlib/netlib_getdevs.c
+++ b/netutils/netlib/netlib_getdevs.c
@@ -33,8 +33,6 @@
 
 #include <netpacket/netlink.h>
 
-#include <nuttx/net/arp.h>
-
 #include "netutils/netlib.h"
 
 #ifdef CONFIG_NETLINK_ROUTE

--- a/netutils/netlib/netlib_setarp.c
+++ b/netutils/netlib/netlib_setarp.c
@@ -33,10 +33,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <netinet/arp.h>
 #include <netinet/in.h>
 #include <net/if.h>
 
-#include <nuttx/net/arp.h>
 #include "netutils/netlib.h"
 
 /****************************************************************************

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -53,6 +53,7 @@
 #include <net/if.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <netinet/arp.h>
 #include <netinet/ether.h>
 
 #include <nuttx/irq.h>
@@ -69,10 +70,6 @@
 #  ifdef CONFIG_WIRELESS_PKTRADIO
 #    include <nuttx/wireless/pktradio.h>
 #  endif
-#endif
-
-#ifdef CONFIG_NETLINK_ROUTE
-#    include <nuttx/net/arp.h>
 #endif
 
 #ifdef CONFIG_NETUTILS_NETLIB

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -44,8 +44,8 @@
 #include <strings.h>
 #include <math.h>
 #include <errno.h>
+#include <netinet/arp.h>
 
-#include <nuttx/net/arp.h>
 #include <nuttx/wireless/wireless.h>
 
 #include "wireless/wapi.h"


### PR DESCRIPTION
## Summary

and change the remain inclusion to netinet/arp.h
depends on https://github.com/apache/nuttx/pull/7889

## Impact

## Testing

