### PR TITLE
luamodules/cjson: add lua cjson module

### DIFF
--- a/interpreters/luamodules/cjson/.gitignore
+++ b/interpreters/luamodules/cjson/.gitignore
@@ -1,0 +1,2 @@
+lua-cjson/
+*.tar.gz

--- a/interpreters/luamodules/cjson/Kconfig
+++ b/interpreters/luamodules/cjson/Kconfig
@@ -1,0 +1,21 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config LUA_CJSON_MODULE
+	bool "Lua cjson module"
+	default n
+	depends on INTERPRETERS_LUA
+	---help---
+		LUA cjson module
+
+if LUA_CJSON_MODULE
+
+config LUA_CJSON_VERSION
+	string "lua csjon version"
+	default "2.1.0.9"
+	---help---
+		Lua cjson module from luarocks.
+
+endif # LUA_CJSON_MODULE

--- a/interpreters/luamodules/cjson/Make.defs
+++ b/interpreters/luamodules/cjson/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/interpreters/luamodules/cjson/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_LUA_CJSON_MODULE),)
+
+CONFIGURED_APPS += $(APPDIR)/interpreters/luamodules/cjson
+
+endif

--- a/interpreters/luamodules/cjson/Makefile
+++ b/interpreters/luamodules/cjson/Makefile
@@ -1,0 +1,62 @@
+############################################################################
+# apps/interpreters/luamodules/cjson/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+LUACJSON_VERSION  = $(patsubst "%",%,$(strip $(CONFIG_LUA_CJSON_VERSION)))
+LUACJSON_TARBALL  = $(LUACJSON_VERSION).tar.gz
+LUACJSON_UNPACK   = lua-cjson
+LUACJSON_URL_BASE = https://github.com/openresty/lua-cjson/archive/refs/tags
+LUACJSON_URL      = $(LUACJSON_URL_BASE)/$(LUACJSON_TARBALL)
+LUACJSON_SRC      = $(LUACJSON_UNPACK)
+
+VPATH += lua-cjson
+CSRCS = lua_cjson.c strbuf.c fpconv.c
+
+$(LUACJSON_TARBALL):
+	$(Q) echo "Downloading $(LUACJSON_TARBALL) from $(LUACJSON_URL)"
+	$(Q) curl -O -L $(LUACJSON_URL)
+
+$(LUACJSON_UNPACK): $(LUACJSON_TARBALL)
+	$(Q) echo "Unpacking $(LUACJSON_TARBALL) to $(LUACJSON_UNPACK)"
+	$(Q) tar -xvzf $(LUACJSON_TARBALL)
+	$(Q) mv lua-cjson-$(LUACJSON_VERSION) $(LUACJSON_UNPACK)
+
+$(LUACJSON_UNPACK)/.patch: $(LUACJSON_UNPACK)
+	touch $(LUACJSON_UNPACK)/.patch
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(LUACJSON_UNPACK)/.git),)
+distclean::
+	$(call DELDIR, $(LUACJSON_UNPACK))
+	$(call DELFILE, $(LUACJSON_TARBALL))
+
+context:: $(LUACJSON_UNPACK)/.patch
+endif
+
+# Set LUAMODNAME and include Module.mk to add this module to the list of
+# builtin modules for the Lua interpreter. LUAMODNAME should match the
+# module's luaopen function.
+
+LUAMODNAME = cjson
+
+include $(APPDIR)/interpreters/lua/Module.mk
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
Add luamodules cjson from https://github.com/openresty/lua-cjson

## Impact
No.

## Testing
Locally tested.
