### PR TITLE
NSH Sysinit optional exec

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -783,9 +783,17 @@ config NSH_ROMFSMOUNTPT
 		can be changed with this setting.  This must be a absolute path
 		beginning with '/'.
 
+config NSH_SYSINITSCRIPT_EXEC
+	bool "Execute sysinit script"
+	default n
+	depends on NSH_CROMFSETC
+	---help---
+		Executes the sysinit script on consolemain startup
+
 config NSH_SYSINITSCRIPT
 	string "Relative path to sysinit script"
 	default "init.d/rc.sysinit"
+	depends on NSH_SYSINITSCRIPT_EXEC
 	---help---
 		This is the relative path to the sysinit script within the mountpoint.
 		The default is init.d/rc.sysinit. This is a relative path and must not

--- a/nshlib/nsh_init.c
+++ b/nshlib/nsh_init.c
@@ -144,7 +144,7 @@ void nsh_initialize(void)
   boardctl(BOARDIOC_INIT, 0);
 #endif
 
-#if defined(CONFIG_NSH_ROMFSETC) && !defined(CONFIG_NSH_DISABLESCRIPT)
+#if defined(CONFIG_NSH_SYSINITSCRIPT_EXEC) && !defined(CONFIG_NSH_DISABLESCRIPT)
   pstate = nsh_newconsole(false);
 
   /* Execute the system init script */

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -191,7 +191,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NSH_ROMFSETC
+#ifdef CONFIG_NSH_SYSINITSCRIPT_EXEC
 int nsh_sysinitscript(FAR struct nsh_vtbl_s *vtbl)
 {
   return nsh_script_redirect(vtbl, "sysinit", NSH_SYSINITPATH);


### PR DESCRIPTION
## Summary
Make the sysinit startup script optional since most existing systems just only use rcS and get this error now.
`nsh: sysinit: fopen failed: No such file or directory`
