### PR TITLE
nshlib/script: delete unnecessary log when missing script file

### DIFF
--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -803,7 +803,7 @@ int nsh_usbconsole(void);
 
 #if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
 int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-               FAR const char *path);
+               FAR const char *path, bool log);
 #ifdef CONFIG_NSH_ROMFSETC
 int nsh_sysinitscript(FAR struct nsh_vtbl_s *vtbl);
 int nsh_initscript(FAR struct nsh_vtbl_s *vtbl);

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1815,7 +1815,7 @@ int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
-  return nsh_script(vtbl, argv[0], argv[1]);
+  return nsh_script(vtbl, argv[0], argv[1], true);
 }
 #endif
 #endif

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -165,7 +165,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 #ifndef CONFIG_NSH_DISABLESCRIPT
           /* Execute the shell script */
 
-          return nsh_script(vtbl, argv[0], argv[1]);
+          return nsh_script(vtbl, argv[0], argv[1], true);
 #else
           return EXIT_FAILURE;
 #endif

--- a/nshlib/nsh_stdsession.c
+++ b/nshlib/nsh_stdsession.c
@@ -167,7 +167,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 #ifndef CONFIG_NSH_DISABLESCRIPT
       /* Execute the shell script */
 
-      return nsh_script(vtbl, argv[0], argv[i]);
+      return nsh_script(vtbl, argv[0], argv[i], true);
 #else
       return EXIT_FAILURE;
 #endif


### PR DESCRIPTION

## Summary
nshlib/script: delete unnecessary log when missing script file.
Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>

## Impact
delete unnecessary log 
## Testing
local test
