### PR TITLE
ifconfig: Be compatible with linux/freebsd and support prefixlen for IPv6

### DIFF
--- a/netutils/netlib/netlib_prefix2ipv6netmask.c
+++ b/netutils/netlib/netlib_prefix2ipv6netmask.c
@@ -69,7 +69,7 @@ void netlib_prefix2ipv6netmask(uint8_t preflen, FAR struct in6_addr *netmask)
    *              1..6 7..2 3..8 9..4  5..0 1..6 7..2 3..8
    */
 
-  for (i = 0; i < 7; i++)
+  for (i = 0; i < 8; i++)
     {
       /* bit = {0, 16, 32, 48, 64, 80, 96, 112} */
 
@@ -88,12 +88,12 @@ void netlib_prefix2ipv6netmask(uint8_t preflen, FAR struct in6_addr *netmask)
           else
             {
               /* Eg. preflen = 38, bit = {32}
-               *     bit - preflen = 6
+               *     preflen - bit = 6
                *     make = 0xffff << (16-6)
                *          = 0xfc00
                */
 
-              mask[i]  = 0xffff << (16 - (bit - preflen));
+              mask[i]  = htons(0xffff << (16 - (preflen - bit)));
             }
         }
       else

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -670,7 +670,7 @@ system image.
 
   Dump data in hexadecimal format from a file or character device.
 
-- `ifconfig [nic_name [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>] [dns <dns-address>] [hw <hw-mac>]`
+- `ifconfig [nic_name [address_family] [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>] [dns <dns-address>] [hw <hw-mac>]`
 
   Show the current configuration of the network, for example:
 

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -670,7 +670,7 @@ system image.
 
   Dump data in hexadecimal format from a file or character device.
 
-- `ifconfig [nic_name [address_family] [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>] [dns <dns-address>] [hw <hw-mac>]`
+- `ifconfig [nic_name [address_family] [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>] [prefixlen <len>] [dns <dns-address>] [hw <hw-mac>]`
 
   Show the current configuration of the network, for example:
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -698,8 +698,18 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
                     }
                 }
 #endif
-              else if (i == 2)
+              else if (!strcmp(tmp, "add"))
                 {
+                  /* Compatible with linux IPv6 command, do nothing. */
+
+                  continue;
+                }
+              else if (hostip == NULL && i <= 4)
+                {
+                  /* Let first non-option be host ip, to support inet/inet6
+                   * options before address.
+                   */
+
                   hostip = tmp;
                 }
               else

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -559,6 +559,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv6
   struct in6_addr addr6;
   struct in6_addr gip6 = IN6ADDR_ANY_INIT;
+  FAR char *preflen = NULL;
 #endif
   int i;
   FAR char *ifname = NULL;
@@ -665,6 +666,21 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #endif
                 }
 
+#ifdef CONFIG_NET_IPv6
+              else if (!strcmp(tmp, "prefixlen"))
+                {
+                  if (argc - 1 >= i + 1)
+                    {
+                      preflen = argv[i + 1];
+                      i++;
+                    }
+                  else
+                    {
+                      badarg = true;
+                    }
+                }
+#endif
+
 #ifdef HAVE_HWADDR
               /* REVISIT: How will we handle Ethernet and SLIP together? */
 
@@ -752,6 +768,15 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (hostip != NULL)
         {
           /* REVISIT: Should DHCPC check be used here too? */
+
+          if ((tmp = strchr(hostip, '/')) != NULL)
+            {
+              *tmp = 0;
+              if (preflen == NULL)
+                {
+                  preflen = tmp + 1;
+                }
+            }
 
           ninfo("Host IP: %s\n", hostip);
           inet_pton(AF_INET6, hostip, &addr6);
@@ -855,6 +880,11 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         {
           ninfo("Netmask: %s\n", mask);
           inet_pton(AF_INET6, mask, &addr6);
+        }
+      else if (preflen != NULL)
+        {
+          ninfo("Prefixlen: %s\n", preflen);
+          netlib_prefix2ipv6netmask(atoi(preflen), &addr6);
         }
       else
         {


### PR DESCRIPTION
## Summary
Patches included:
- ifconfig: Allow hostip on first non-option place after inet/inet6 
- ifconfig: Support prefixlen/CIDR for IPv6 

NuttX previous:
```
ifconfig eth0 10.0.0.1 [inet]
ifconfig eth0 2022::2 inet6
```

Linux:
```
ifconfig eth0 [inet] 10.0.0.1
ifconfig eth0 [inet6] add 2022::2[/96]
```

FreeBSD:
```
ifconfig eth0 inet 10.0.0.1
ifconfig eth0 inet6 2022::2[/96]
ifconfig eth0 inet6 2022::2 [prefixlen 96]
```

NuttX newly supported:
```
ifconfig eth0 [inet] 10.0.0.1
ifconfig eth0 inet6 [add] 2022::2[/96]
ifconfig eth0 inet6 [add] 2022::2 [prefixlen 96]
```

Ref:
https://man7.org/linux/man-pages/man8/ifconfig.8.html
https://www.freebsd.org/cgi/man.cgi?ifconfig

## Impact
Improve ifconfig functionality.

## Testing
Manually tested with commands listed above.