### PR TITLE
Remove the unnecessary NULL fields in global instance definition of file_operations

### DIFF
--- a/examples/module/drivers/chardev/chardev.c
+++ b/examples/module/drivers/chardev/chardev.c
@@ -68,12 +68,6 @@ static const struct file_operations chardev_fops =
   NULL,          /* close */
   chardev_read,  /* read */
   chardev_write, /* write */
-  NULL,          /* seek */
-  NULL,          /* ioctl */
-  NULL           /* poll */
-#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL         /* unlink */
-#endif
 };
 
 /****************************************************************************
@@ -93,7 +87,8 @@ static ssize_t chardev_read(FAR struct file *filep, FAR char *buffer,
   memcpy(buffer, g_read_string, ret);
 
   syslog(LOG_INFO, "chardev_read: Returning %d bytes\n", (int)ret);
-  lib_dumpbuffer("chardev_read: Returning", (FAR const uint8_t *)buffer, ret);
+  lib_dumpbuffer("chardev_read: Returning",
+                 (FAR const uint8_t *)buffer, ret);
   return ret;
 }
 


### PR DESCRIPTION
## Summary
Continue the change in kernel side: https://github.com/apache/nuttx/pull/8016

## Impact
code refactor only

## Testing
Please ignore the nxstyle false alarm:
```
Error: apps/examples/module/drivers/chardev/chardev.c:50:46: error: Multiple data definitions
```