### PR TITLE
netutils/dhcpc:fix dhcp hostname len error in dhcpc_sendmsg

### DIFF
--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -231,7 +231,7 @@ static FAR uint8_t *dhcpc_addend(FAR uint8_t *optptr)
 static int dhcpc_sendmsg(FAR struct dhcpc_state_s *pdhcpc,
                          FAR struct dhcpc_state *presult, int msgtype)
 {
-  char hostname[HOST_NAME_MAX];
+  char hostname[HOST_NAME_MAX + 1];
   struct sockaddr_in addr;
   FAR uint8_t *pend;
   in_addr_t serverid = INADDR_BROADCAST;
@@ -257,7 +257,7 @@ static int dhcpc_sendmsg(FAR struct dhcpc_state_s *pdhcpc,
 
   if (gethostname(hostname, sizeof(hostname)) || (0 == strlen(hostname)))
     {
-      strncpy(hostname, CONFIG_NETUTILS_DHCPC_HOST_NAME, HOST_NAME_MAX);
+      strlcpy(hostname, CONFIG_NETUTILS_DHCPC_HOST_NAME, sizeof(hostname));
     }
 
   /* Handle the message specific settings */


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
Fix len error in dhcpc_sendmsg

## Impact
DHCP

## Testing
Tested on ESP32C3
