### PR TITLE
examples/netlink_route: fix compiler warning

### DIFF
--- a/examples/netlink_route/netlink_route_main.c
+++ b/examples/netlink_route/netlink_route_main.c
@@ -148,11 +148,11 @@ static void dump_neighbor(void)
         {
           if ((j + 1) >= nb->ne_addr.na_llsize)
             {
-              printf("%02x", nb->ne_addr.u.na_addr);
+              printf("%02x", nb->ne_addr.u.na_addr[j]);
             }
           else
             {
-              printf("%02x.", nb->ne_addr.u.na_addr);
+              printf("%02x.", nb->ne_addr.u.na_addr[j]);
             }
         }
 


### PR DESCRIPTION


## Summary
examples/netlink_route: fix compiler warning

```
netlink_route_main.c: In function ‘dump_neighbor’: netlink_route_main.c:151:26: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘uint8_t *’ {aka ‘unsigned char *’} [-Wformat=]
  151 |               printf("%02x", nb->ne_addr.u.na_addr);
      |                       ~~~^   ~~~~~~~~~~~~~~~~~~~~~
      |                          |                |
      |                          unsigned int     uint8_t * {aka unsigned char *}
      |                       %02hhn
netlink_route_main.c:155:26: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘uint8_t *’ {aka ‘unsigned char *’} [-Wformat=]
  155 |               printf("%02x.", nb->ne_addr.u.na_addr);
      |                       ~~~^    ~~~~~~~~~~~~~~~~~~~~~
      |                          |                 |
      |                          unsigned int      uint8_t * {aka unsigned char *}
      |                       %02hhn
```

Signed-off-by: chao an <anchao@xiaomi.com>
## Impact

N/A

## Testing

ci-check