### PR TITLE
wireless/wapi:rework wapi error print in util.h

### DIFF
--- a/wireless/wapi/src/util.h
+++ b/wireless/wapi/src/util.h
@@ -42,73 +42,33 @@
  ****************************************************************************/
 
 #include <string.h>
+#include <debug.h>
 #include <errno.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef DEBUG_WIRELESS_ERROR
-#  ifdef CONFIG_LIBC_STRERROR
-#    define WAPI_IOCTL_STRERROR(cmd,errcode) \
-      fprintf( \
-        stderr, "%s:%d:%s():ioctl(%s): %s\n", \
-        __FILE__, __LINE__, __func__, \
-        wapi_ioctl_command_name(cmd), strerror(errcode))
+#ifdef CONFIG_LIBC_STRERROR
+#  define WAPI_IOCTL_STRERROR(cmd,errcode) \
+    wlerr("ioctl(%s): %s\n", \
+      wapi_ioctl_command_name(cmd), strerror(errcode))
 
-#    define WAPI_STRERROR(fmt, ...) \
-      fprintf( \
-          stderr, "%s:%d:%s():" fmt ": %s\n", \
-        __FILE__, __LINE__, __func__, \
-        ## __VA_ARGS__, strerror(errno))
-#  else
-#    define WAPI_IOCTL_STRERROR(cmd,errcode) \
-      fprintf( \
-        stderr, "%s:%d:%s():ioctl(%s): %d\n", \
-        __FILE__, __LINE__, __func__, \
-        wapi_ioctl_command_name(cmd), errcode)
-
-#    define WAPI_STRERROR(fmt, ...) \
-      fprintf( \
-          stderr, "%s:%d:%s():" fmt ": %d\n", \
-        __FILE__, __LINE__, __func__, \
-        ## __VA_ARGS__, errno)
-#  endif
-
-#  define WAPI_ERROR(fmt, ...) \
-    fprintf( \
-      stderr, "%s:%d:%s(): " fmt , \
-      __FILE__, __LINE__, __func__, ## __VA_ARGS__)
-
+#  define WAPI_STRERROR(fmt, ...) \
+    wlerr(fmt ": %s\n", \
+      ## __VA_ARGS__, strerror(errno))
 #else
-#  ifdef CONFIG_LIBC_STRERROR
-#    define WAPI_IOCTL_STRERROR(cmd,errcode) \
-      fprintf( \
-        stderr, "ioctl(%s): %s\n", \
-        wapi_ioctl_command_name(cmd), strerror(errcode))
+#  define WAPI_IOCTL_STRERROR(cmd,errcode) \
+    wlerr("ioctl(%s): %d\n", \
+      wapi_ioctl_command_name(cmd), errcode)
 
-#    define WAPI_STRERROR(fmt, ...) \
-      fprintf( \
-        stderr, fmt ": %s\n", \
-        ## __VA_ARGS__, strerror(errno))
-#  else
-#    define WAPI_IOCTL_STRERROR(cmd,errcode) \
-      fprintf( \
-        stderr, "ioctl(%s): %d\n", \
-        wapi_ioctl_command_name(cmd), errcode)
-
-#    define WAPI_STRERROR(fmt, ...) \
-      fprintf( \
-        stderr, fmt ": %d\n", \
-        ## __VA_ARGS__, errno)
-#  endif
-
-#  define WAPI_ERROR(fmt, ...) \
-    fprintf( \
-      stderr, fmt , \
-      ## __VA_ARGS__)
-
+#  define WAPI_STRERROR(fmt, ...) \
+    wlerr(fmt ": %d\n", \
+      ## __VA_ARGS__, errno)
 #endif
+
+#define WAPI_ERROR(fmt, ...) \
+  wlerr(fmt , ## __VA_ARGS__)
 
 #define WAPI_VALIDATE_PTR(ptr) \
   if (ptr == NULL) \


### PR DESCRIPTION
## Summary
I want to control print information through setlogmask()，so I changed wapi err print to wlerr.
I don't get why the original wapi util.h defined its own err print, which seems redundant to me.

Please review, I don't know if I am missing anything. 

## Impact
Only on wapi err print message.

## Testing
Tested on ESP32C3.
