### PR TITLE
system/ramspeed: skip cases where time too short

### DIFF
--- a/system/ramspeed/ramspeed_main.c
+++ b/system/ramspeed/ramspeed_main.c
@@ -344,7 +344,7 @@ static void print_rate(FAR const char *name, size_t bytes,
       printf(RAMSPEED_PREFIX
              "Time-consuming is too short,"
              " please increase the <repeat number>\n");
-      exit(EXIT_FAILURE);
+      return;
     }
 
   rate = (uint64_t)bytes * 1000 / cost_time / 1024;
@@ -377,11 +377,12 @@ static void memcpy_speed_test(FAR void *dest, FAR const void *src,
 
       if (step < 1024)
         {
-          printf("______do %" PRIu32 " B operation______\n", step);
+          printf("______Perform %" PRIu32 " Bytes access ______\n", step);
         }
       else
         {
-          printf("______do %" PRIu32  " KB operation______\n", step / 1024);
+          printf("______Perform %" PRIu32  " KBytes access ______\n",
+                 step / 1024);
         }
 
       if (irq_disable)
@@ -441,11 +442,12 @@ static void memset_speed_test(FAR void *dest, uint8_t value,
 
       if (step < 1024)
         {
-          printf("______do %" PRIu32 " B operation______\n", step);
+          printf("______Perform %" PRIu32 " Bytes access______\n", step);
         }
       else
         {
-          printf("______do %" PRIu32  " KB operation______\n", step / 1024);
+          printf("______Perform %" PRIu32  " KBytes access______\n",
+                 step / 1024);
         }
 
       if (irq_disable)


### PR DESCRIPTION
## Summary
Make ramspeed test not terminate.

## Impact
ramspeed test.

## Testing
None.
