### PR TITLE
Add *.su to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.src
 *.swp
 *.sym
+*.su
 *~
 .context
 .depend


### PR DESCRIPTION
## Summary

*.su is generated by gcc/clang when we pass -fstack-usage to them

## Impact

Minor

## Testing

Pass CI