### PR TITLE
benchmarks: Add EEMBC's CoreMark

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+/Kconfig

--- a/benchmarks/Make.defs
+++ b/benchmarks/Make.defs
@@ -1,0 +1,21 @@
+############################################################################
+# apps/benchmarks/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(wildcard $(APPDIR)/benchmarks/*/Make.defs)

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,0 +1,23 @@
+############################################################################
+# apps/benchmarks/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+MENUDESC = "Benchmark Applications"
+
+include $(APPDIR)/Directory.mk

--- a/benchmarks/coremark/.gitignore
+++ b/benchmarks/coremark/.gitignore
@@ -1,0 +1,2 @@
+/coremark
+/*.zip

--- a/benchmarks/coremark/Kconfig
+++ b/benchmarks/coremark/Kconfig
@@ -1,0 +1,53 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig BENCHMARK_COREMARK
+	bool "Coremark Benchmark"
+	default n
+	---help---
+		Enable support for the EEMBC's Coremark benchmark application.
+
+if BENCHMARK_COREMARK
+
+config COREMARK_PROGNAME
+	string "Coremark program name"
+	default "coremark"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config COREMARK_PRIORITY
+	int "Coremark task priority"
+	default 100
+
+config COREMARK_STACKSIZE
+	int "Coremark task stack size"
+	default 4096
+
+config COREMARK_MULTITHREAD_OVERRIDE
+	bool "Override number of threads"
+	default n
+	---help---
+		Override the default number of threads to be executed.
+		The default value is the same as the number of CPU cores.
+
+config COREMARK_MULTITHREAD_COUNT
+	depends on COREMARK_MULTITHREAD_OVERRIDE
+	int "Number of threads to be executed"
+	default 1
+
+config COREMARK_ITERATIONS_OVERRIDE
+	bool "Override number of iterations"
+	default n
+	---help---
+		Override the default number of iterations for the benchmark.
+		The default value is defined by the application based on the system.
+
+config COREMARK_ITERATIONS_COUNT
+	depends on COREMARK_ITERATIONS_OVERRIDE
+	int "Number of iterations"
+	default 100
+
+endif # BENCHMARK_COREMARK

--- a/benchmarks/coremark/Make.defs
+++ b/benchmarks/coremark/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/benchmarks/coremark/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_BENCHMARK_COREMARK),)
+CONFIGURED_APPS += $(APPDIR)/benchmarks/coremark
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/benchmarks/coremark/coremark
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/benchmarks/coremark/coremark/posix
+endif

--- a/benchmarks/coremark/Makefile
+++ b/benchmarks/coremark/Makefile
@@ -1,0 +1,106 @@
+############################################################################
+# apps/benchmarks/coremark/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Coremark application
+
+############################################################################
+# Flags
+############################################################################
+
+COREMARK_URL ?= "https://github.com/eembc/coremark/archive"
+
+COREMARK_VERSION = main
+COREMARK_ZIP = $(COREMARK_VERSION).zip
+
+COREMARK_UNPACKNAME = coremark
+UNPACK ?= unzip -q -o
+
+VPATH += $(COREMARK_UNPACKNAME)
+VPATH += $(COREMARK_UNPACKNAME)$(DELIM)posix
+
+CFLAGS += -Wno-undef
+
+ifeq ($(CONFIG_COREMARK_MULTITHREAD_OVERRIDE),y)
+COREMARK_NTHREADS = $(CONFIG_COREMARK_MULTITHREAD_COUNT)
+else
+ifneq ($(CONFIG_SMP_NCPUS),)
+COREMARK_NTHREADS = $(CONFIG_SMP_NCPUS)
+else
+COREMARK_NTHREADS = 1
+endif
+endif
+
+CFLAGS += ${DEFINE_PREFIX}USE_PTHREAD ${DEFINE_PREFIX}PERFORMANCE_RUN=1
+CFLAGS += ${DEFINE_PREFIX}MULTITHREAD=$(COREMARK_NTHREADS)
+CFLAGS += ${DEFINE_PREFIX}FLAGS_STR="\"Using NuttX compilation options\""
+CFLAGS += ${DEFINE_PREFIX}MEM_LOCATION="\"Defined by the NuttX configuration\""
+
+ifeq ($(CONFIG_COREMARK_ITERATIONS_OVERRIDE),y)
+CFLAGS += ${DEFINE_PREFIX}ITERATIONS=$(CONFIG_COREMARK_ITERATIONS_COUNT)
+endif
+
+CSRCS =  core_list_join.c
+CSRCS += core_matrix.c
+CSRCS += core_state.c
+CSRCS += core_util.c
+CSRCS += core_portme.c
+
+############################################################################
+# Targets
+############################################################################
+
+$(COREMARK_ZIP):
+	@echo "Downloading: $(COREMARK_URL)/$(COREMARK_ZIP)"
+	$(Q) curl -O -L $(COREMARK_URL)/$(COREMARK_ZIP)
+
+$(COREMARK_UNPACKNAME): $(COREMARK_ZIP)
+	@echo "Unpacking: $(COREMARK_ZIP) -> $(COREMARK_UNPACKNAME)"
+	$(Q) $(UNPACK) $(COREMARK_ZIP)
+	$(Q) mv	coremark-$(COREMARK_VERSION) $(COREMARK_UNPACKNAME)
+	$(Q) touch $(COREMARK_UNPACKNAME)
+
+clean::
+	$(call DELFILE, $(OBJS))
+
+# Download and unpack tarball if no git repo found
+
+ifeq ($(wildcard $(COREMARK_UNPACKNAME)/.git),)
+context:: $(COREMARK_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(COREMARK_UNPACKNAME))
+	$(call DELFILE, $(COREMARK_ZIP))
+endif
+
+############################################################################
+# Applications Configuration
+############################################################################
+
+MODULE = $(CONFIG_BENCHMARK_COREMARK)
+
+PROGNAME  += $(CONFIG_COREMARK_PROGNAME)
+PRIORITY  += $(CONFIG_COREMARK_PRIORITY)
+STACKSIZE += $(CONFIG_COREMARK_STACKSIZE)
+
+MAINSRC += $(COREMARK_UNPACKNAME)/core_main.c
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary

Add a benchmark category and EEMBC's CoreMark.

## Impact

An universal benchmark tool to use on NuttX.

## Testing

Tested using an ESP32-DevKItC with SMP enabled.

```
NuttShell (NSH) NuttX-10.4.0
nsh> coremark
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 17440
Total time (secs): 17.440000
Iterations/Sec   : 688.073394
Iterations       : 12000
Compiler version : GCC11.2.0
Compiler flags   : Using NuttX compilation options
Parallel PThreads : 2
Memory location  : Defined by the NuttX configuration
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[1]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[1]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[1]crcstate      : 0x8e3a
[0]crcfinal      : 0xa14c
[1]crcfinal      : 0xa14c
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 688.073394 / GCC11.2.0 Using NuttX compilation options / Defined by the NuttX configuration / 2:PThreads
nsh>
```



