### PR TITLE
ostest: Add initial support for CONFIG_BUILD_KERNEL

### DIFF
--- a/testing/ostest/Kconfig
+++ b/testing/ostest/Kconfig
@@ -82,7 +82,8 @@ if ARCH_FPU && SCHED_WAITPID
 
 config TESTING_OSTEST_FPUTESTDISABLE
 	bool "Disable FPU test"
-	default n
+	default y if !BUILD_FLAT
+	default n if BUILD_FAT
 
 if !TESTING_OSTEST_FPUTESTDISABLE
 

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -123,4 +123,8 @@ ifeq ($(CONFIG_ARCH_SETJMP_H),y)
 CSRCS += setjmp.c
 endif
 
+ifeq ($(CONFIG_BUILD_KERNEL),y)
+CSRCS += task.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -118,11 +118,13 @@ void aio_test(void);
 
 /* restart.c ****************************************************************/
 
+#ifndef CONFIG_BUILD_KERNEL
 void restart_test(void);
+#endif
 
 /* waitpid.c ****************************************************************/
 
-#ifdef CONFIG_SCHED_WAITPID
+#if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_BUILD_KERNEL)
 int waitpid_test(void);
 #endif
 
@@ -257,6 +259,12 @@ int sem_nfreeholders(void);
 #else
 #  define sem_enumholders(sem)
 #  define sem_nfreeholders()
+#endif
+
+#ifdef CONFIG_BUILD_KERNEL
+int task_create(FAR const char *name, int priority,
+                int stack_size, main_t entry, FAR char * const argv[]);
+int task_delete(int pid);
 #endif
 
 #endif /* __APPS_TESTING_OSTEST_OSTEST_H */

--- a/testing/ostest/restart.c
+++ b/testing/ostest/restart.c
@@ -35,6 +35,8 @@
 
 #include "ostest.h"
 
+#ifndef CONFIG_BUILD_KERNEL
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -224,3 +226,5 @@ void restart_test(void)
 
   printf("restart_main: Exiting\n");
 }
+
+#endif /* !CONFIG_BUILD_KERNEL */

--- a/testing/ostest/task.c
+++ b/testing/ostest/task.c
@@ -1,0 +1,218 @@
+/****************************************************************************
+ * apps/testing/ostest/task.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <malloc.h>
+#include <pthread.h>
+#include <spawn.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MAX_EXEC_ARGS 256
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct main_args_s
+{
+  main_t     entry;
+  int        prio;
+  int        argc;
+  FAR char  *argv[];
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: main_trampoline
+ *
+ * Description:
+ *   Trampoline function for pthread to pass argv among other things
+ *
+ ****************************************************************************/
+
+static void *main_trampoline(void *ptr)
+{
+  struct main_args_s *args = (struct main_args_s *) ptr;
+  pthread_setschedprio(pthread_self(), args->prio);
+  pthread_setname_np(pthread_self(), args->argv[0]);
+  args->entry(args->argc, args->argv);
+  free(ptr);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: task_create
+ *
+ * Description:
+ *   Adaptation for CONFIG_BUILD_KERNEL to compile ostest using pthreads
+ *   instead of NuttX tasks.
+ *
+ ****************************************************************************/
+
+int task_create(FAR const char *name, int priority,
+                int stack_size, main_t entry, FAR char * const argv[])
+{
+  FAR struct main_args_s *args;
+  FAR char *ptr;
+  pthread_t pid;
+  pthread_attr_t attr;
+  size_t argvsize = 0;
+  size_t argssize;
+  int argc = 0;
+  int ret;
+  int i;
+
+  /* Get the number of arguments and the size of the argument list */
+
+  if (argv)
+    {
+      while (argv[argc])
+        {
+          argvsize += strlen(argv[argc]) + 1;
+          if (argc >= MAX_EXEC_ARGS)
+            {
+              ret = E2BIG;
+              goto update_errno;
+            }
+
+          argc++;
+        }
+    }
+
+  /* Name is a part of argv */
+
+  argvsize += strlen(name) + 1;
+
+  /* Allocate the struct + memory for argv + name */
+
+  argssize = sizeof(struct main_args_s) + (argc + 2) * sizeof(FAR char *);
+
+  args = (struct main_args_s *)malloc(argssize + argvsize);
+  if (!args)
+    {
+      ret = ENOMEM;
+      goto update_errno;
+    }
+
+  /* Initialize the struct */
+
+  args->entry = entry;
+  args->prio = priority;
+  args->argc = argc + 1; /* +1 for name */
+
+  /* Copy the name */
+
+  ptr = (char *)args + argssize;
+  args->argv[0] = ptr;
+  strcpy(ptr, name);
+  ptr += strlen(name) + 1;
+
+  /* Copy the argv list */
+
+  for (i = 0; i < argc; i++)
+    {
+      args->argv[i + 1] = ptr;
+      strcpy(ptr, argv[i]);
+      ptr += strlen(argv[i]) + 1;
+    }
+
+  /* Terminate the argv[] list */
+
+  args->argv[args->argc] = NULL;
+
+  /* Set the worker parameters */
+
+  pthread_attr_init(&attr);
+  pthread_attr_setschedpolicy(&attr, SCHED_RR);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+  pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+  pthread_attr_setstacksize(&attr, stack_size);
+
+  /* Start the worker */
+
+  ret = pthread_create(&pid, &attr, &main_trampoline, args);
+  if (ret != 0)
+    {
+      printf("ERROR: pthread_create:%d, errno:%s\n", ret, strerror(ret));
+      free(args);
+      pid = ERROR;
+    }
+
+  pthread_attr_destroy(&attr);
+
+update_errno:
+  if (ret != 0)
+    {
+      set_errno(-ret);
+      pid = ERROR;
+    }
+
+  return (int)pid;
+}
+
+/****************************************************************************
+ * Name: task_delete
+ *
+ * Description:
+ *   Adaptation for CONFIG_BUILD_KERNEL to compile ostest using pthreads
+ *   instead of NuttX tasks.
+ *
+ ****************************************************************************/
+
+int task_delete(int pid)
+{
+  int ret;
+
+  if (pid == pthread_self())
+    {
+      ret = pthread_join(pid, NULL);
+      pthread_exit(NULL);
+    }
+  else
+    {
+      ret = pthread_cancel(pid);
+    }
+
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+    }
+
+  return ret;
+}
+

--- a/testing/ostest/waitpid.c
+++ b/testing/ostest/waitpid.c
@@ -32,7 +32,11 @@
 
 #include "ostest.h"
 
-#ifdef CONFIG_SCHED_WAITPID
+/* REVISIT: This could be implemented for CONFIG_BUILD_KERNEL as well, by
+ * starting a new process instead of using task_create()
+ */
+
+#if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_BUILD_KERNEL)
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -389,4 +393,4 @@ int waitpid_test(void)
   return 0;
 }
 
-#endif /* CONFIG_SCHED_WAITPID */
+#endif /* CONFIG_SCHED_WAITPID && !CONFIG_BUILD_KERNEL */


### PR DESCRIPTION
## Summary
Implement task_create and task_delete for use with ostest. The functions are unavailable in kernel build mode but overload them here and create a pthread worker instead. Some tests should be re-visited because the intent is to user another task (in this case another process) to e.g. receive signals. That will require quite a bit of extra work.

Tests that had to be disabled:
- waitpid: pthreads don't work with waitpid, but this can be fixed by starting a dummy process instead and using waitpid on that (NOT IMPLEMENTED)
- restart: task_restart() does not work at all with kernel mode so it is disabled entirely
- fpu: make sure the FPU test is not even attempted, because it will cause ASSERT() and stop the test
- vfork: vfork() does not work for some reason in CONFIG_BUILD_KERNEL, there is something missing on the kernel side, so just disable the test for now

Tests that should be re-visited:
- The signal tests, now they signal the process itself while before the signal was sent to another task. This will require building the part that receives the signal as a separate process
- waitpid: Like stated above, waitpid does not work for pthreads
- user_main: It might be a better idea to just call user_main() because the "test creating a task works"-part has already been tested; if ostest starts, then task starting and creation also works
## Impact
Adds basic support for ostest with CONFIG_BUILD_KERNEL=y
## Testing
icicle:knsh
