### PR TITLE
apps/system/nxplayer&nxlooper:  fix codechecker warning

### DIFF
--- a/system/nxlooper/nxlooper_main.c
+++ b/system/nxlooper/nxlooper_main.c
@@ -264,7 +264,7 @@ static int nxlooper_cmd_volume(FAR struct nxlooper_s *plooper, char *parg)
     {
       /* Get the percentage value from the argument */
 
-      percent = (uint16_t)(atof(parg) * 10.0);
+      percent = (uint16_t)(strtof(parg, NULL) * 10.0f);
       return nxlooper_setvolume(plooper, percent);
     }
 

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -415,7 +415,7 @@ static int nxplayer_cmd_bass(FAR struct nxplayer_s *pplayer, char *parg)
     {
       /* Get the level and range percentage value from the argument */
 
-      level_percent = (uint8_t) atoi(parg);
+      level_percent = (uint8_t)strtoul(parg, NULL, 10);
       nxplayer_setbass(pplayer, level_percent);
     }
 
@@ -445,7 +445,7 @@ static int nxplayer_cmd_treble(FAR struct nxplayer_s *pplayer, char *parg)
     {
       /* Get the level and range percentage value from the argument */
 
-      level_percent = (uint8_t) atoi(parg);
+      level_percent = (uint8_t)strtoul(parg, NULL, 10);
       nxplayer_settreble(pplayer, level_percent);
     }
 
@@ -476,7 +476,7 @@ static int nxplayer_cmd_balance(FAR struct nxplayer_s *pplayer, char *parg)
     {
       /* Get the percentage value from the argument */
 
-      percent = (uint16_t) (atof(parg) * 10.0);
+      percent = (uint16_t)(strtof(parg, NULL) * 10.0f);
       nxplayer_setbalance(pplayer, percent);
     }
 


### PR DESCRIPTION
## Summary

nxplayer_main.c:
code checker warning:
level_percent = (uint8_t) atoi(parg);
     'atoi' used to convert a string to an integer value, but function will not report conversion errors; consider using 'strtol' instead.
nxlooper_main.c:
code checker warning:
percent = (uint16_t)(atof(parg) * 10.0);
     'atof' used to convert a string to a floating-point value, but function will not report conversion errors; consider using 'strtod' instead

## Impact

Minor

## Testing

Pass CI