### PR TITLE
Makefile: adjust compilation flags order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ $(SYMTABSRC): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 $(SYMTABOBJ): %$(OBJEXT): %.c
-	$(call COMPILE, -fno-lto -fno-builtin $<, $@)
+	$(call COMPILE, $<, $@, -fno-lto -fno-builtin)
 
 $(BIN): $(SYMTABOBJ)
 	$(call ARCHIVE_ADD, $(call CONVERT_PATH,$(BIN)), $^)


### PR DESCRIPTION
## Summary
Move compile flags to third argument

## Impact
Depended on by https://github.com/apache/nuttx/pull/8347

## Testing

