### PR TITLE
ifconfig: Support `ifconfig interface` and update arg limit

### DIFF
--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -670,7 +670,7 @@ system image.
 
   Dump data in hexadecimal format from a file or character device.
 
-- `ifconfig [nic_name [address_family] [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>] [prefixlen <len>] [dns <dns-address>] [hw <hw-mac>]`
+- `ifconfig [nic_name [address_family] [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] [dns <dns-address>] [hw <hw-mac>]`
 
   Show the current configuration of the network, for example:
 

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -244,9 +244,10 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifdef CONFIG_NET
 # ifndef CONFIG_NSH_DISABLE_IFCONFIG
-  { "ifconfig", cmd_ifconfig, 1, 11,
-    "[interface [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] "
-    "[netmask <net-mask>] [dns <dns-address>] [hw <hw-mac>]" },
+  { "ifconfig", cmd_ifconfig, 1, 12,
+    "[interface [address_family] [<ip-address>|dhcp]] "
+    "[dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] "
+    "[dns <dns-address>] [hw <hw-mac>]" },
 # endif
 # ifndef CONFIG_NSH_DISABLE_IFUPDOWN
   { "ifdown",   cmd_ifdown,   2, 2, "<interface>" },

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -595,6 +595,11 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   if (argc <= 2)
     {
+      if (argc == 2)
+        {
+          return ifconfig_callback(vtbl, argv[1]);
+        }
+
       ret = nsh_foreach_netdev(ifconfig_callback, vtbl, "ifconfig");
       if (ret < 0)
         {


### PR DESCRIPTION
## Summary
From comment in cmd_ifconfig, it seems that we support `ifconfig [interface]`, but actually not considering the interface param now. After this commit, we only print the information of interface specified in param, just like linux.

Also updates the arg limit of the ifconfig command to meet current function.
## Impact
Support `ifconfig eth0` to only print information on `eth0`

## Testing
Manually on sim.

