### PR TITLE
nxplayer: enqueue streaming data to audio driver.

### DIFF
--- a/include/system/nxplayer.h
+++ b/include/system/nxplayer.h
@@ -522,9 +522,9 @@ int nxplayer_parse_mp3(int fd, FAR uint32_t *samplerate,
 int nxplayer_fill_mp3(int fd, FAR struct ap_buffer_s *apb);
 
 /****************************************************************************
- * Name: nxplayer_fill_pcm
+ * Name: nxplayer_fill_common
  *
- *   Performs read pcm file to apb buffer
+ *   Performs common function to read data to apb buffer
  *
  * Input Parameters:
  *   pplayer   - Pointer to the context to initialize
@@ -534,7 +534,7 @@ int nxplayer_fill_mp3(int fd, FAR struct ap_buffer_s *apb);
  *
  ****************************************************************************/
 
-int nxplayer_fill_pcm(int fd, FAR struct ap_buffer_s *apb);
+int nxplayer_fill_common(int fd, FAR struct ap_buffer_s *apb);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/system/nxplayer/Makefile
+++ b/system/nxplayer/Makefile
@@ -23,8 +23,8 @@ include $(APPDIR)/Make.defs
 # NxPlayer Library
 
 CSRCS     = nxplayer.c
+CSRCS    += nxplayer_common.c
 CSRCS    += nxplayer_mp3.c
-CSRCS    += nxplayer_pcm.c
 
 ifneq ($(CONFIG_NXPLAYER_COMMAND_LINE),)
 PROGNAME  = nxplayer

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -131,12 +131,12 @@ static const struct nxplayer_dec_ops_s g_dec_ops[] =
   {
     AUDIO_FMT_MP3,
     nxplayer_parse_mp3,
-    nxplayer_fill_mp3
+    nxplayer_fill_common
   },
   {
     AUDIO_FMT_PCM,
     NULL,
-    nxplayer_fill_pcm
+    nxplayer_fill_common
   }
 };
 

--- a/system/nxplayer/nxplayer_common.c
+++ b/system/nxplayer/nxplayer_common.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/nxplayer/nxplayer_pcm.c
+ * apps/system/nxplayer/nxplayer_common.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -38,13 +38,13 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxplayer_fill_pcm
+ * Name: nxplayer_fill_common
  *
- *   nxplayer_fill_pcm fill pcm data into apb buffer.
+ *   nxplayer_fill_common fill data into apb buffer.
  *
  ****************************************************************************/
 
-int nxplayer_fill_pcm(int fd, FAR struct ap_buffer_s *apb)
+int nxplayer_fill_common(int fd, FAR struct ap_buffer_s *apb)
 {
   /* Read data into the buffer. */
 


### PR DESCRIPTION
nxplayer: enqueue streaming data to audio driver.

Signed-off-by: qiaohaijiao1 <qiaohaijiao1@xiaomi.com>

## Summary
add support streaming data instead of framed. 

## Impact
N/A

## Testing
Xiaomi Vela

