### PR TITLE
Application.mk: Provide a default ZIGELFFLAGS if not defined

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -93,6 +93,10 @@ ifneq ($(BUILD_MODULE),y)
   OBJS += $(MAINCOBJ) $(MAINCXXOBJ) $(MAINRUSTOBJ) $(MAINZIGOBJ)
 endif
 
+# Compile flags
+
+ZIGELFFLAGS ?= $(ZIGFLAGS)
+
 DEPPATH += --dep-path .
 DEPPATH += --obj-path .
 


### PR DESCRIPTION



## Summary
Avoid add ZIGELFFLAGS to each board level Make.defs by default value.
## Impact
Zig only
## Testing
Local machine
