### PR TITLE
nxplayer: add support which mp3 file which has no ID3 header

### DIFF
--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -520,10 +520,19 @@ int nxplayer_getmidisubformat(int fd)
 }
 #endif
 
+/****************************************************************************
+ * Name: nxplayer_getmp3subformat
+ *
+ *   nxplayer_getmp3subformat() just return AUDIO_SUBFMT_PCM_MP3
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_AUDIO_FORMAT_MP3
 int nxplayer_getmp3subformat(int fd)
 {
   return AUDIO_SUBFMT_PCM_MP3;
 }
+#endif
 
 /****************************************************************************
  * Name: nxplayer_fmtfromextension

--- a/system/nxplayer/nxplayer_mp3.c
+++ b/system/nxplayer/nxplayer_mp3.c
@@ -235,15 +235,22 @@ int nxplayer_parse_mp3(int fd, FAR uint32_t *samplerate,
       return -ENODATA;
     }
 
-  position = (buffer[6] & ID3V2_BIT_MASK) * 0x200000 +
-             (buffer[7] & ID3V2_BIT_MASK) * 0x4000 +
-             (buffer[8] & ID3V2_BIT_MASK) * 0x80 +
-             (buffer[9] & ID3V2_BIT_MASK) +
-             sizeof(buffer);
+  if (!memcmp(buffer, "ID3", 3))
+    {
+      position = (buffer[6] & ID3V2_BIT_MASK) * 0x200000 +
+                 (buffer[7] & ID3V2_BIT_MASK) * 0x4000 +
+                 (buffer[8] & ID3V2_BIT_MASK) * 0x80 +
+                 (buffer[9] & ID3V2_BIT_MASK) +
+                 sizeof(buffer);
 
-  lseek(fd, position, SEEK_SET);
+      lseek(fd, position, SEEK_SET);
+      read(fd, buffer, 4);
+    }
+  else
+    {
+      position = 0;
+    }
 
-  read(fd, buffer, 4);
   mpa_header = buffer[0] << 24 |
                buffer[1] << 16 |
                buffer[2] << 8  |


### PR DESCRIPTION
Signed-off-by: qiaohaijiao1 <qiaohaijiao1@xiaomi.com>

## Summary
Improve compatibility which mp3 file has no ID3V2 header

## Impact
N/A
## Testing
Xiaomi Vela

