### PR TITLE
fix dump_string format error when CONFIG_ALLSYMS is not enabled

### DIFF
--- a/system/trace/trace_dump.c
+++ b/system/trace/trace_dump.c
@@ -643,12 +643,21 @@ static int trace_dump_one(trace_dump_t type, FAR FILE *out, FAR uint8_t *p,
               (nst->nst_data[0] == 'B' ||
                nst->nst_data[0] == 'E'))
             {
+#ifdef CONFIG_ALLSYMS
               fprintf(out, "tracing_mark_write: %c|%d|%pS\n",
                       nst->nst_data[0], pid, (FAR void *)ip);
+#else
+              fprintf(out, "tracing_mark_write: %c|%d|%p\n",
+                      nst->nst_data[0], pid, (FAR void *)ip);
+#endif
             }
           else
             {
+#ifdef CONFIG_ALLSYMS
               fprintf(out, "%pS: %s\n", (FAR void *)ip, nst->nst_data);
+#else
+              fprintf(out, "%p: %s\n", (FAR void *)ip, nst->nst_data);
+#endif
             }
         }
         break;


### PR DESCRIPTION
## Summary
When allsyms is not enabled, using trace dump -a will print one more character 'S'

   hello-7   [0]   4.181600000: tracing_mark_write: B|7|0x56780da8S
   hello-7   [0]   5.181700000: tracing_mark_write: E|7|0x5678113bS

## Impact

## Testing

