### PR TITLE
build: Remove the annoy warning from distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,20 +205,6 @@ clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 	$(call CLEAN)
 
 distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
-ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-	$(Q) ( if exist  external \
-		echo "********************************************************" \
-		echo "* The external directory/link must be removed manually *" \
-		echo "********************************************************" \
-	)
-else
-	$(Q) (if [ -e external ]; then \
-		echo "********************************************************"; \
-		echo "* The external directory/link must be removed manually *"; \
-		echo "********************************************************"; \
-		fi; \
-	)
-endif
 	$(call DELFILE, .depend)
 	$(call DELFILE, $(SYMTABSRC))
 	$(call DELFILE, $(SYMTABOBJ))


### PR DESCRIPTION
## Summary

and nuttx/tools/testbuild.sh already do the same check.

## Impact

Minor

## Testing

CI