### PR TITLE
build/Kconfig: add BINDIR/APPSBINDIR to support out of tree build

### DIFF
--- a/platform/Kconfig
+++ b/platform/Kconfig
@@ -16,6 +16,6 @@ config PLATFORM_CONFIGDATA
 		volatile storage can be used:  A file, EEPROM, hardcoded values in
 		FLASH, etc.
 
-source "$APPSDIR/platform/board/Kconfig"
+source "$APPSBINDIR/platform/board/Kconfig"
 
 endmenu # Platform-specific Support


### PR DESCRIPTION
## Summary

build/Kconfig: add BINDIR/APPSBINDIR to support out of tree build

First decoupling changes from https://github.com/apache/nuttx/pull/6718

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

Depends on: https://github.com/apache/nuttx/pull/6718
N/A

## Testing

cmake (https://github.com/apache/nuttx/pull/6718) 