### PR TITLE
trace: add trace header when dumping

### DIFF
--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -199,6 +199,10 @@ static int trace_cmd_dump(int index, int argc, FAR char **argv,
       changed = notectl_enable(false, notectlfd);
     }
 
+  /* Dump the trace header */
+
+  fputs("# tracer: nop\n#\n", out);
+
   /* Dump the trace data */
 
   ret = trace_dump(type, out);


### PR DESCRIPTION
## Summary
When using the Android trace format, if there is no file header, the file cannot be parsed correctly

## Impact

## Testing
In this case, the file content is the same, but the parsing fails when there is no header
Open these two files respectively in https://ui.perfetto.dev/
![image](https://user-images.githubusercontent.com/33870028/217206502-179dfc77-3f08-409c-b830-f663ad06bebb.png)

[trace_has_header.log](https://github.com/apache/nuttx-apps/files/10673523/trace_has_header.log)
[trace_no_header.log](https://github.com/apache/nuttx-apps/files/10673524/trace_no_header.log)

