### PR TITLE
examples/nxscope: add support for CDCACM dev

### DIFF
--- a/examples/nxscope/Kconfig
+++ b/examples/nxscope/Kconfig
@@ -34,6 +34,11 @@ config EXAMPLES_NXSCOPE_SERIAL_BAUD
 	int "nxscope serial baud"
 	default 115200
 
+config EXAMPLES_NXSCOPE_CDCACM
+	bool "nxscope CDCACM device support"
+	depends on CDCACM
+	default n
+
 endif # LOGGING_NXSCOPE_INTF_SERIAL
 
 config EXAMPLES_NXSCOPE_FORCE_ENABLE

--- a/logging/nxscope/nxscope_iser.c
+++ b/logging/nxscope/nxscope_iser.c
@@ -177,10 +177,35 @@ int nxscope_ser_init(FAR struct nxscope_intf_s *intf,
       flags |= O_NONBLOCK;
     }
 
+#ifdef CONFIG_SERIAL_REMOVABLE
+  do
+    {
+      /* Try to open the console */
+
+      priv->fd = open(priv->cfg->path, flags);
+      if (priv->fd < 0)
+        {
+          /* ENOTCONN means that the USB device is not yet connected.
+           * Anything else is bad.
+           */
+
+          if (errno != ENOTCONN)
+            {
+              break;
+            }
+
+          /* Sleep a bit and try again */
+
+          sleep(1);
+        }
+    }
+  while (priv->fd < 0);
+#else
   priv->fd = open(priv->cfg->path, flags);
+#endif
   if (priv->fd < 0)
     {
-      _err("ERROR: failed to open %s\n", priv->cfg->path);
+      _err("ERROR: failed to open %s %d\n", priv->cfg->path, errno);
       ret = -errno;
       goto errout;
     }


### PR DESCRIPTION
## Summary

- logging/nxscope/nxscope_iser.c: wait for device if CONFIG_SERIAL_REMOVALBE=y
- examples/nxscope: add support for CDCACM dev

## Impact

## Testing
stm32f4discovery
