### PR TITLE
examples/timer_gpio: fix compilation

### DIFF
--- a/examples/timer_gpio/timer_gpio_main.c
+++ b/examples/timer_gpio/timer_gpio_main.c
@@ -184,7 +184,6 @@ static int timer_gpio_daemon(int argc, char *argv[])
   notify.event.sigev_notify = SIGEV_SIGNAL;
   notify.event.sigev_signo  = CONFIG_EXAMPLES_TIMER_GPIO_SIGNO;
   notify.event.sigev_value.sival_ptr = NULL;
-  notify.oneshot = false;
 
   ret = ioctl(fd_timer, TCIOC_NOTIFICATION,
               (unsigned long)((uintptr_t)&notify));


### PR DESCRIPTION
## Summary
examples/timer_gpio: fix compilation

Broken since 9368b659a763faa4e45b657ea71922b651751aa5
## Impact

## Testing
CI
