### PR TITLE
nxscope: use the entire reserved buffer when sending strings

### DIFF
--- a/include/logging/nxscope/nxscope_chan.h
+++ b/include/logging/nxscope/nxscope_chan.h
@@ -224,15 +224,6 @@ int nxscope_put_vub32_m(FAR struct nxscope_s *s, uint8_t ch,
 int nxscope_put_vb32_m(FAR struct nxscope_s *s, uint8_t ch,
                        FAR b32_t *val, uint8_t d,
                        FAR uint8_t *meta, uint8_t mlen);
-
-/****************************************************************************
- * Name: nxscope_put_vchar_m
- *
- * NOTE: if a given string is shorten than initialized channel vdim,
- *       we put only string bytes + '\0'
- *
- ****************************************************************************/
-
 int nxscope_put_vchar_m(FAR struct nxscope_s *s, uint8_t ch,
                         FAR char *val, uint8_t d,
                         FAR uint8_t *meta, uint8_t mlen);
@@ -283,15 +274,6 @@ int nxscope_put_vub32(FAR struct nxscope_s *s, uint8_t ch,
                       FAR ub32_t *val, uint8_t d);
 int nxscope_put_vb32(FAR struct nxscope_s *s, uint8_t ch,
                      FAR b32_t *val, uint8_t d);
-
-/****************************************************************************
- * Name: nxscope_put_vchar
- *
- * NOTE: if a given string is shorten than initialized channel vdim,
- *       we put only string bytes + '\0'
- *
- ****************************************************************************/
-
 int nxscope_put_vchar(FAR struct nxscope_s *s, uint8_t ch,
                       FAR char *val, uint8_t d);
 

--- a/logging/nxscope/nxscope_chan.c
+++ b/logging/nxscope/nxscope_chan.c
@@ -360,13 +360,14 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
 
       case NXSCOPE_TYPE_CHAR:
         {
-          /* Copy only string bytes + '\0' */
+          /* Copy string bytes and fill with '\0' */
 
           DEBUGASSERT(val);
 
           strncpy((FAR char *)buff, (FAR const char *)val, d);
           j += strnlen((FAR char *)buff, d);
-          buff[j++] = '\0';
+          memset(&buff[j], '\0', d - j);
+          j = d;
 
           break;
         }


### PR DESCRIPTION
## Summary
- nxscope: use the entire reserved channel length when sending strings.
The previous version makes stream data parser too complicated and susceptible to errors.

## Impact

## Testing
