### PR TITLE
build/Kconfig: fix warnings detected by kconfiglib

### DIFF
--- a/examples/calib_udelay/Kconfig
+++ b/examples/calib_udelay/Kconfig
@@ -17,11 +17,9 @@ if EXAMPLES_CALIB_UDELAY
 config EXAMPLES_CALIB_UDELAY_NUM_MEASUREMENTS
 	int "Number of measurements to take for each loop iteration count"
 	default 3
-	---help---
 
 config EXAMPLES_CALIB_UDELAY_NUM_RESULTS
 	int "Number of results to generate for calibration slope"
 	default 20
-	---help---
 
 endif

--- a/graphics/twm4nx/Kconfig
+++ b/graphics/twm4nx/Kconfig
@@ -97,7 +97,7 @@ choice
 
 config TWM4NX_MOUSE
 	bool "Mouse"
-	select NX_SWCURSOR
+	depends on NX_SWCURSOR
 
 config TWM4NX_TOUCHSCREEN
 	bool "Touchscreen"

--- a/mlearning/cmsis/Kconfig
+++ b/mlearning/cmsis/Kconfig
@@ -16,7 +16,7 @@ if CMSIS
 
 config CMSIS_VER
 	string "Default CMSIS version"
-	default 5.8.0
+	default "5.8.0"
 
 config CMSIS_DSP
 	bool "CMSIS DSP"

--- a/mlearning/libnnablart/Kconfig
+++ b/mlearning/libnnablart/Kconfig
@@ -15,6 +15,6 @@ if NNABLA_RT
 
 config NNABLA_RT_VER
 	string "Default NNABLA Runtime version"
-	default 1.24.0
+	default "1.24.0"
 
 endif # NNABLA_RT

--- a/netutils/thttpd/Kconfig
+++ b/netutils/thttpd/Kconfig
@@ -314,7 +314,6 @@ config THTTPD_TILDE_MAP2
 config THTTPD_GENERATE_INDICES
 	bool "Generate name indices"
 	default n
-	---help---
 
 config THTTPD_USE_URLPATTERN
 	bool "Use URL pattern"

--- a/netutils/webserver/Kconfig
+++ b/netutils/webserver/Kconfig
@@ -143,8 +143,7 @@ config NETUTILS_HTTPD_PATH
 
 config NETUTILS_HTTPD_KEEPALIVE_DISABLE
 	bool "Keepalive Disable"
-	default y if !NETUTILS_HTTPD_TIMEOUT
-	default n if NETUTILS_HTTPD_TIMEOUT
+	default y
 	---help---
 		Disabled HTTP keep-alive for HTTP clients.  Keep-alive permits a
 		client to make multiple requests over the same connection, rather

--- a/system/dumpstack/Kconfig
+++ b/system/dumpstack/Kconfig
@@ -7,7 +7,6 @@ menuconfig SYSTEM_DUMPSTACK
 	tristate "dumpstack tool for show the task backtrace"
 	default n
 	depends on SCHED_BACKTRACE
-	---help---
 
 if SYSTEM_DUMPSTACK
 


### PR DESCRIPTION
## Summary

build/Kconfig: fix warnings detected by kconfiglib

Part of https://github.com/apache/nuttx/pull/8485

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

before:

$ APPSDIR=../apps/ EXTERNALDIR=dummy menuconfig

```bash
Kconfig:233: warning: the 'modules' option is not supported. Let me know if this is a problem for you, as it wouldn't be that hard to implement. Note that modules are supported -- Kconfiglib just assumes the symbol name MODULES, like older versions of the C implementation did when 'option modules' wasn't used.
arch/arm/Kconfig:1361: warning: style: quotes recommended around 'arch/arm/src/s32k3xx/Kconfig' in 'source arch/arm/src/s32k3xx/Kconfig'
arch/arm/Kconfig:1418: warning: style: quotes recommended around 'arch/arm/src/stm32wb/Kconfig' in 'source arch/arm/src/stm32wb/Kconfig'
arch/sparc/Kconfig:65: warning: style: quotes recommended around 'arch/sparc/src/sparc_v8/Kconfig' in 'source arch/sparc/src/sparc_v8/Kconfig'
arch/sparc/Kconfig:66: warning: style: quotes recommended around 'arch/sparc/src/bm3803/Kconfig' in 'source arch/sparc/src/bm3803/Kconfig'
arch/sparc/Kconfig:67: warning: style: quotes recommended around 'arch/sparc/src/bm3823/Kconfig' in 'source arch/sparc/src/bm3823/Kconfig'
arch/sparc/Kconfig:68: warning: style: quotes recommended around 'arch/sparc/src/s698pm/Kconfig' in 'source arch/sparc/src/s698pm/Kconfig'
warning: ARCH_BOARD_STM32G071B_DISCO (defined at boards/Kconfig:1446) has leading or trailing whitespace in its prompt
warning: DRIVERS_VIRTIO (defined at drivers/virtio/Kconfig:6) has 'help' but empty help text
warning: DRIVERS_VIRTIO_MMIO_NUM (defined at drivers/virtio/Kconfig:13) has 'help' but empty help text
warning: DRIVERS_VIRTIO_MMIO_BASE (defined at drivers/virtio/Kconfig:19) has 'help' but empty help text
warning: DRIVERS_VIRTIO_MMIO_REGSIZE (defined at drivers/virtio/Kconfig:23) has 'help' but empty help text
warning: DRIVERS_VIRTIO_MMIO_IRQ (defined at drivers/virtio/Kconfig:28) has 'help' but empty help text
warning: DRIVERS_VIRTIO_NET (defined at drivers/virtio/Kconfig:34) has 'help' but empty help text
warning: DRIVERS_VIRTIO_NET_QUEUE_LEN (defined at drivers/virtio/Kconfig:42) has 'help' but empty help text
warning: NET_USRSOCK_UDP (defined at net/usrsock/Kconfig:41) has 'help' but empty help text
libs/libc/machine/Kconfig:209: warning: style: quotes recommended around 'libs/libc/machine/sparc/Kconfig' in 'source libs/libc/machine/sparc/Kconfig'
warning: the hex symbol TTY_LAUNCH_STACKSIZE (defined at drivers/serial/Kconfig:201) has a non-hex default INIT_STACKSIZE (defined at sched/Kconfig:338)
warning: the choice symbol ARCH_DEBUG_H (defined at Kconfig:559) is selected by the following symbols, but select/imply has no effect on choice symbols
 - AVR_HAS_MEMX_PTR (defined at arch/avr/src/avr/Kconfig:63)
warning: the choice symbol GD32F4_FLASH_CONFIG_K (defined at arch/arm/src/gd32f4/Kconfig:105) is selected by the following symbols, but select/imply has no effect on choice symbols
 - GD32F450ZK_EVAL_CONSOLE_BOARD (defined at boards/arm/gd32f4/gd32f450zk-eval/Kconfig:35)
warning: the default selection IMXRT_PROVIDES_TXC (undefined) of <choice> (defined at arch/arm/src/imxrt/Kconfig:1777) is not contained in the choice
warning: the choice symbol TIVA_UART2 (defined at arch/arm/src/tiva/Kconfig:798) is selected by the following symbols, but select/imply has no effect on choice symbols
 - TM4C1294_LAUNCHPAD_JUMPERS_CAN (defined at boards/arm/tiva/tm4c1294-launchpad/Kconfig:75)
warning: the choice symbol NRF52_LFCLK_XTAL (defined at arch/arm/src/nrf52/Kconfig:304) is selected by the following symbols, but select/imply has no effect on choice symbols
 - NRF52_SOFTDEVICE_CONTROLLER (defined at arch/arm/src/nrf52/Kconfig:661)
warning: the default selection SAMA5_ADC_PWMTRIG_LINE0 (undefined) of <choice> (defined at arch/arm/src/sama5/Kconfig:4416) is not contained in the choice
warning: the default selection Z180_NO_SERIAL_CONSOLE (undefined) of <choice> (defined at arch/z80/src/z180/Kconfig:534) is not contained in the choice
warning: the default selection EZ80_ZDSII_V522 (undefined) of <choice> (defined at arch/z80/src/z8/Kconfig:53) is not contained in the choice
warning: the choice symbol BOOT_RUNFROMEXTSRAM (defined at arch/Kconfig:1126) is selected by the following symbols, but select/imply has no effect on choice symbols
 - IMX6_BOOT_SRAM (defined at arch/arm/src/imx6/Kconfig:194)
 - IMXRT_BOOT_SRAM (defined at arch/arm/src/imxrt/Kconfig:1907)
 - EZ80_PROGRAM (defined at arch/z80/src/ez80/Kconfig:96)
 - Z20X_COPYTORAM (defined at boards/z80/ez80/z20x/Kconfig:47)
warning: the choice symbol BOOT_RUNFROMFLASH (defined at arch/Kconfig:1131) is selected by the following symbols, but select/imply has no effect on choice symbols
 - IMX6_BOOT_NOR (defined at arch/arm/src/imx6/Kconfig:190)
 - IMXRT_BOOT_NOR (defined at arch/arm/src/imxrt/Kconfig:1902)
 - EZ80_BOOTLOADER (defined at arch/z80/src/ez80/Kconfig:88)
 - SAME54_XPLAINED_PRO_RUNFROMFLASH (defined at boards/arm/samd5e5/same54-xplained-pro/Kconfig:12)
 - METRO_M4_RUNFROMFLASH (defined at boards/arm/samd5e5/metro-m4/Kconfig:12)
 - Z20X_STANDALONE (defined at boards/z80/ez80/z20x/Kconfig:40)
warning: the choice symbol BOOT_RUNFROMISRAM (defined at arch/Kconfig:1137) is selected by the following symbols, but select/imply has no effect on choice symbols
 - IMX6_BOOT_OCRAM (defined at arch/arm/src/imx6/Kconfig:182)
 - IMXRT_BOOT_OCRAM (defined at arch/arm/src/imxrt/Kconfig:1893)
 - SAME54_XPLAINED_PRO_RUNFROMSRAM (defined at boards/arm/samd5e5/same54-xplained-pro/Kconfig:19)
 - METRO_M4_RUNFROMSRAM (defined at boards/arm/samd5e5/metro-m4/Kconfig:18)
warning: the choice symbol BOOT_RUNFROMSDRAM (defined at arch/Kconfig:1142) is selected by the following symbols, but select/imply has no effect on choice symbols
 - ARCH_CHIP_A1X (defined at arch/arm/Kconfig:55)
 - ARCH_CHIP_AM335X (defined at arch/arm/Kconfig:69)
 - ARCH_CHIP_IMX6 (defined at arch/arm/Kconfig:137)
 - IMX6_BOOT_SDRAM (defined at arch/arm/src/imx6/Kconfig:186)
 - IMXRT_BOOT_SDRAM (defined at arch/arm/src/imxrt/Kconfig:1897)
warning: the default selection LX_CPU_BOOT_APP (undefined) of <choice> (defined at boards/arm/lpc17xx_40xx/lx_cpu/Kconfig:8) is not contained in the choice
warning: the choice symbol SAMA5D27_GIANT_BOARD_492MHZ (defined at boards/arm/sama5/giant-board/Kconfig:12) is selected by the following symbols, but select/imply has no effect on choice symbols
 - ARCH_BOARD_GIANT_BOARD (defined at boards/Kconfig:1797)
warning: the default selection BOARD_STM32_BG431BESC1_HSI (undefined) of <choice> (defined at boards/arm/stm32/b-g431b-esc1/Kconfig:8) is not contained in the choice
warning: the default selection BOARD_NUCLEO_G431RB_HSI (undefined) of <choice> (defined at boards/arm/stm32/nucleo-g431rb/Kconfig:8) is not contained in the choice
warning: the default selection ARCH_BOARD_FLASH_PART1_FS_RAW (undefined) of <choice> (defined at boards/arm/stm32wl5/nucleo-wl55jc/Kconfig:239) is not contained in the choice
warning: the default selection ARCH_BOARD_FLASH_PART2_FS_RAW (undefined) of <choice> (defined at boards/arm/stm32wl5/nucleo-wl55jc/Kconfig:305) is not contained in the choice
warning: the default selection ARCH_BOARD_FLASH_PART3_FS_RAW (undefined) of <choice> (defined at boards/arm/stm32wl5/nucleo-wl55jc/Kconfig:348) is not contained in the choice
warning: the default selection ARCH_BOARD_FLASH_PART4_FS_RAW (undefined) of <choice> (defined at boards/arm/stm32wl5/nucleo-wl55jc/Kconfig:391) is not contained in the choice
warning: the choice symbol Z20X_W25_CHARDEV (defined at boards/z80/ez80/z20x/Kconfig:76) is selected by the following symbols, but select/imply has no effect on choice symbols
 - Z20X_W25BOOT (defined at boards/z80/ez80/z20x/Kconfig:22)
warning: the choice symbol LCD_PORTRAIT (defined at drivers/lcd/Kconfig:1086) is selected by the following symbols, but select/imply has no effect on choice symbols
 - ARCH_BOARD_TTGO_T5V2_ESP32 (defined at boards/Kconfig:308)
warning: the choice symbol LCD_SSD1680_2_90 (defined at drivers/lcd/Kconfig:1567) is selected by the following symbols, but select/imply has no effect on choice symbols
 - ARCH_BOARD_TTGO_T5V2_ESP32 (defined at boards/Kconfig:308)
warning: the choice symbol USART0_SERIAL_CONSOLE (defined at drivers/serial/Kconfig:354) is selected by the following symbols, but select/imply has no effect on choice symbols
 - GD32F450ZK_EVAL_CONSOLE_BOARD (defined at boards/arm/gd32f4/gd32f450zk-eval/Kconfig:35)
warning: the choice symbol USART3_SERIAL_CONSOLE (defined at drivers/serial/Kconfig:384) is selected by the following symbols, but select/imply has no effect on choice symbols
 - GD32F450ZK_EVAL_CONSOLE_VIRTUAL (defined at boards/arm/gd32f4/gd32f450zk-eval/Kconfig:42)
 - NUCLEO_CONSOLE_VIRTUAL (defined at boards/arm/stm32f7/nucleo-144/Kconfig:86)
 - NUCLEO_F429ZI_CONSOLE_VIRTUAL (defined at boards/arm/stm32/nucleo-f429zi/Kconfig:41)
warning: the choice symbol UART4_SERIAL_CONSOLE (defined at drivers/serial/Kconfig:389) is selected by the following symbols, but select/imply has no effect on choice symbols
 - NUCLEO_CONSOLE_MORPHO_UART4 (defined at boards/arm/stm32f7/nucleo-144/Kconfig:98)
warning: the choice symbol USART6_SERIAL_CONSOLE (defined at drivers/serial/Kconfig:414) is selected by the following symbols, but select/imply has no effect on choice symbols
 - NUCLEO_CONSOLE_ARDUINO (defined at boards/arm/stm32f7/nucleo-144/Kconfig:80)
 - NUCLEO_F429ZI_CONSOLE_ARDUINO (defined at boards/arm/stm32/nucleo-f429zi/Kconfig:35)
warning: the choice symbol UART8_SERIAL_CONSOLE (defined at drivers/serial/Kconfig:429) is selected by the following symbols, but select/imply has no effect on choice symbols
 - NUCLEO_CONSOLE_MORPHO (defined at boards/arm/stm32f7/nucleo-144/Kconfig:92)
warning: the choice symbol OTHER_SERIAL_CONSOLE (defined at drivers/serial/Kconfig:589) is selected by the following symbols, but select/imply has no effect on choice symbols
 - LEUART0_SERIAL_CONSOLE (defined at arch/arm/src/efm32/Kconfig:308)
 - LEUART1_SERIAL_CONSOLE (defined at arch/arm/src/efm32/Kconfig:315)
warning: the choice symbol MATH_CORDIC_USE_Q31 (defined at drivers/math/Kconfig:21) is selected by the following symbols, but select/imply has no effect on choice symbols
 - STM32_CORDIC (defined at arch/arm/src/stm32/Kconfig:2759)
Loaded configuration '.config'
No changes to save (for '.config')
```

after:

$ APPSDIR=../apps/ EXTERNALDIR=dummy menuconfig

```
Kconfig:233: warning: the 'modules' option is not supported. Let me know if this is a problem for you, as it wouldn't be that hard to implement. Note that modules are supported -- Kconfiglib just assumes the symbol name MODULES, like older versions of the C implementation did when 'option modules' wasn't used.
Loaded configuration '.config'
No changes to save (for '.config')
```