### PR TITLE
Kconfig: Make indent consistent with TABS

### DIFF
--- a/canutils/candump/Kconfig
+++ b/canutils/candump/Kconfig
@@ -7,7 +7,7 @@ config CANUTILS_CANDUMP
 	tristate "SocketCAN candump tool"
 	default n
 	depends on NET_CAN
-        select CANUTILS_LIBCANUTILS
+		select CANUTILS_LIBCANUTILS
 	---help---
 		Enable the SocketCAN candump tool ported from
 		https://github.com/linux-can/can-utils

--- a/canutils/cansend/Kconfig
+++ b/canutils/cansend/Kconfig
@@ -7,7 +7,7 @@ config CANUTILS_CANSEND
 	tristate "SocketCAN cansend tool"
 	default n
 	depends on NET_CAN
-        select CANUTILS_LIBCANUTILS
+		select CANUTILS_LIBCANUTILS
 	---help---
 		Enable the SocketCAN cansend tool ported from
 		https://github.com/linux-can/can-utils

--- a/examples/nrf24l01_btle/Kconfig
+++ b/examples/nrf24l01_btle/Kconfig
@@ -39,6 +39,6 @@ config NRF24L01_BTLE_DHT11
 	default n
 	depends on SENSORS_DHTXX
 	---help---
-	    Enable driver support for the DHTxx humidity/temperature sensor.
+		Enable driver support for the DHTxx humidity/temperature sensor.
 
 endif

--- a/examples/pty_test/Kconfig
+++ b/examples/pty_test/Kconfig
@@ -41,11 +41,11 @@ config EXAMPLES_PTYTEST_DAEMONPRIO
 	default 100
 
 config EXAMPLES_PTYTEST_WAIT_CONNECTED
-  bool "Keep retrying open serial device"
-  ---help---
-     For USB based serial devices, open will fail
-     if the other end is not connected (USB cable unplugged).
-     Enabling this option will retry the open() call every second
-     until connected.
+	bool "Keep retrying open serial device"
+	---help---
+		For USB based serial devices, open will fail
+		if the other end is not connected (USB cable unplugged).
+		Enabling this option will retry the open() call every second
+		until connected.
 
 endif

--- a/games/shift/Kconfig
+++ b/games/shift/Kconfig
@@ -38,7 +38,7 @@ config GAMES_SHIFT_STACKSIZE
 #
 
 choice
-        prompt "Input Device (Joystick, Gesture Sensor, etc)"
+	prompt "Input Device (Joystick, Gesture Sensor, etc)"
 	default GAMES_SHIFT_USE_CONSOLEKEY
 
 config GAMES_SHIFT_USE_CONSOLEKEY

--- a/math/libtommath/Kconfig
+++ b/math/libtommath/Kconfig
@@ -25,100 +25,100 @@ menuconfig LIBTOMMATH_DEMOS
 if LIBTOMMATH_DEMOS
 
 config LIBTOMMATH_TEST
-        tristate "LibTomMath Test"
-        default n
-        ---help---
-                Demo test application for LibTomMath
+	tristate "LibTomMath Test"
+	default n
+	---help---
+		Demo test application for LibTomMath
 
 if LIBTOMMATH_TEST
 
 config LIBTOMMATH_TEST_PROGNAME
-        string "Test program name"
-        default "tommath_test"
-        ---help---
-                LibTomMath test application name
+	string "Test program name"
+	default "tommath_test"
+	---help---
+		LibTomMath test application name
 
 config LIBTOMMATH_TEST_PRIORITY
-        int "Test application priority"
-        default 100
+	int "Test application priority"
+	default 100
 
 config LIBTOMMATH_TEST_STACKSIZE
-        int "Test application stack size"
-        default DEFAULT_TASK_STACKSIZE
+	int "Test application stack size"
+	default DEFAULT_TASK_STACKSIZE
 
 endif # LIBTOMMATH_TEST
 
 config LIBTOMMATH_MTEST_OPPONENT
-        tristate "LibTomMath MTest opponent"
-        default n
-        ---help---
-                Demo mtest opponent application for LibTomMath
+	tristate "LibTomMath MTest opponent"
+	default n
+	---help---
+		Demo mtest opponent application for LibTomMath
 
 if LIBTOMMATH_MTEST_OPPONENT
 
 config LIBTOMMATH_MTEST_OPPONENT_PROGNAME
-        string "MTest opponent program name"
-        default "tommath_mtest_opponent"
-        ---help---
-                LibTomMath mtest opponent application name
+	string "MTest opponent program name"
+	default "tommath_mtest_opponent"
+	---help---
+		LibTomMath mtest opponent application name
 
 config LIBTOMMATH_MTEST_OPPONENT_PRIORITY
-        int "MTest opponent application priority"
-        default 100
+	int "MTest opponent application priority"
+	default 100
 
 config LIBTOMMATH_MTEST_OPPONENT_STACKSIZE
-        int "MTest opponent application stack size"
-        default DEFAULT_TASK_STACKSIZE
+	int "MTest opponent application stack size"
+	default DEFAULT_TASK_STACKSIZE
 
 endif # LIBTOMMATH_MTEST_OPPONENT
 
 config LIBTOMMATH_TIMING
-        tristate "LibTomMath Timing"
-        default n
-        ---help---
-                Demo timing test application for LibTomMath
+	tristate "LibTomMath Timing"
+	default n
+	---help---
+		Demo timing test application for LibTomMath
 
 if LIBTOMMATH_TIMING
 
 config LIBTOMMATH_TIMING_PROGNAME
-        string "Timing program name"
-        default "tommath_timing"
-        ---help---
-                LibTomMath test application name
+	string "Timing program name"
+	default "tommath_timing"
+	---help---
+		LibTomMath test application name
 
 config LIBTOMMATH_TIMING_PRIORITY
-        int "Timing application priority"
-        default 100
+	int "Timing application priority"
+	default 100
 
 config LIBTOMMATH_TIMING_STACKSIZE
-        int "Timing application stack size"
-        default DEFAULT_TASK_STACKSIZE
+	int "Timing application stack size"
+	default DEFAULT_TASK_STACKSIZE
 
 endif # LIBTOMMATH_TIMING
 
 endif # LIBTOMMATH_DEMOS
 
 config LIBTOMMATH_MTEST
-        tristate "LibTomMath MPI Math Library Mtest"
-        default n
-        ---help---
-                LibTomMath mtest applications for LibTomMath
+	tristate "LibTomMath MPI Math Library Mtest"
+	default n
+	---help---
+		LibTomMath mtest applications for LibTomMath
 
 if LIBTOMMATH_MTEST
 
 config LIBTOMMATH_MTEST_PROGNAME
-        string "Mtest program name"
-        default "tommath_mtest"
-        ---help---
-                LibTomMath test application name
+	string "Mtest program name"
+	default "tommath_mtest"
+	---help---
+		LibTomMath test application name
 
 config LIBTOMMATH_MTEST_PRIORITY
-        int "Mtest application priority"
-        default 100
+	int "Mtest application priority"
+	default 100
 
 config LIBTOMMATH_MTEST_STACKSIZE
-        int "Mtest application stack size"
-        default DEFAULT_TASK_STACKSIZE
+	int "Mtest application stack size"
+	default DEFAULT_TASK_STACKSIZE
 
 endif # LIBTOMMATH_MTEST
 

--- a/mlearning/cmsis/Kconfig
+++ b/mlearning/cmsis/Kconfig
@@ -41,11 +41,11 @@ config CMSIS_DSP_ARM_MATH_ROUNDING
 endif # CMSIS_DSP
 
 config CMSIS_NN
-        bool "CMSIS NN"
-        default y
-        depends on CMSIS_DSP
-        ---help---
-                Enable CMSIS-NN: Efficient neural network kernels.
+	bool "CMSIS NN"
+	default y
+	depends on CMSIS_DSP
+	---help---
+		Enable CMSIS-NN: Efficient neural network kernels.
 
 
 endif # CMSIS

--- a/mlearning/darknet/Kconfig
+++ b/mlearning/darknet/Kconfig
@@ -8,7 +8,7 @@ config DARKNET_YOLO
 	default n
 	---help---
 		You only look once (YOLO) is a state-of-the-art,
-                real-time object detection system
+		real-time object detection system
 
 if DARKNET_YOLO
 

--- a/netutils/codecs/Kconfig
+++ b/netutils/codecs/Kconfig
@@ -26,7 +26,7 @@ config CODECS_HASH_MD5
 	---help---
 		Enables support for the following interfaces: md5_init(),
 		md5_update(), md5_final(), md5_transform(), md5_sum() and
-                md5_hash()
+		md5_hash()
 
 		Contributed NuttX by Darcy Gong.
 

--- a/netutils/dhcp6c/Kconfig
+++ b/netutils/dhcp6c/Kconfig
@@ -4,15 +4,15 @@
 #
 
 config NETUTILS_DHCP6C
-    bool "DHCPv6 client"
-    default n
-    depends on NET_IPv6
-    depends on NET_UDP && NET_UDP_CHECKSUMS
+	bool "DHCPv6 client"
+	default n
+	depends on NET_IPv6
+	depends on NET_UDP && NET_UDP_CHECKSUMS
 
 if NETUTILS_DHCP6C
 
 config NETUTILS_DHCP6C_REQUEST_TIMEOUT
-    int "Default single request timeout in second"
-    default 6
+	int "Default single request timeout in second"
+	default 6
 
 endif

--- a/netutils/thttpd/Kconfig
+++ b/netutils/thttpd/Kconfig
@@ -16,7 +16,7 @@ config THTTPD_NFILE_DESCRIPTORS
 	int "the maximum number of file descriptors for thttpd webserver"
 	default 16
 	---help---
-	        The maximum number of file descriptors for thttpd webserver
+		The maximum number of file descriptors for thttpd webserver
 
 config THTTPD_PORT
 	int "THTTPD port number"

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -1267,37 +1267,37 @@ config NSH_LOGIN_FAILCOUNT
 		Number of login retry attempts.
 
 config NSH_PLATFORM_CHALLENGE
-        bool "Platform challenge"
-        default n
-        depends on NSH_LOGIN_PLATFORM
-        ---help---
-                If this option is selected, the NSH will call into platform-specific
-                logic in order to get the challenge.  The function prototype for this
-                call is:
+	bool "Platform challenge"
+	default n
+	depends on NSH_LOGIN_PLATFORM
+	---help---
+		If this option is selected, the NSH will call into platform-specific
+		logic in order to get the challenge.  The function prototype for this
+		call is:
 
-                        void platform_challenge(FAR char *buffer, size_t buflen);
+			void platform_challenge(FAR char *buffer, size_t buflen);
 
-                Where buffer is the location to return the challenge and buflen is the
-                length of that buffer.  The maximum size of the buffer is determined
-                by NSH_FILEIOSIZE.  An appropriate location for the
-                implementation of platform_challenge would be within apps/platform/<board>.
+		Where buffer is the location to return the challenge and buflen is the
+		length of that buffer.  The maximum size of the buffer is determined
+		by NSH_FILEIOSIZE.  An appropriate location for the
+		implementation of platform_challenge would be within apps/platform/<board>.
 
-                One newline will be inserted after the platform-supplied message.
+		One newline will be inserted after the platform-supplied message.
 
-                platform_challenge() is prototyped and described in apps/include/nshlib/nshlib.h
-                which may be included like:
+		platform_challenge() is prototyped and described in apps/include/nshlib/nshlib.h
+		which may be included like:
 
-                        #include "nshlib/nshlib.h"
+			#include "nshlib/nshlib.h"
 
 config NSH_PLATFORM_SKIP_LOGIN
-        bool "Platform skip login"
-        default n
-        ---help---
-                If this option is selected, the NSH will call into platform-specific
-                logic in order to skip login.  The function prototype for this
-                call is:
+	bool "Platform skip login"
+	default n
+	---help---
+		If this option is selected, the NSH will call into platform-specific
+		logic in order to skip login.  The function prototype for this
+		call is:
 
-                        int platform_skip_login(void);
+			int platform_skip_login(void);
 
 endif # NSH_LOGIN
 endif # NSH_LIBRARY

--- a/system/uniqueid/Kconfig
+++ b/system/uniqueid/Kconfig
@@ -4,11 +4,11 @@
 #
 
 config SYSTEM_UNIQUEID
-       tristate "'uniqueid' command"
-       default n
-       depends on BOARDCTL_UNIQUEID
-       ---help---
-               Enable the uniqueid tool
+	tristate "'uniqueid' command"
+	default n
+	depends on BOARDCTL_UNIQUEID
+	---help---
+		Enable the uniqueid tool
 
 if SYSTEM_UNIQUEID
 endif

--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -1,10 +1,10 @@
 config NIMBLE
-  bool "Apache nimBLE (BLE host-layer)"
-  default n
-  depends on !WIRELESS_BLUETOOTH_HOST
-  ---help---
-    Enable Apache nimBLE Bluetooth Low Energy
-    host-layer stack.
+	bool "Apache nimBLE (BLE host-layer)"
+	default n
+	depends on !WIRELESS_BLUETOOTH_HOST
+	---help---
+		Enable Apache nimBLE Bluetooth Low Energy
+		host-layer stack.
 
 if NIMBLE
 config NIMBLE_STACKSIZE
@@ -12,8 +12,8 @@ config NIMBLE_STACKSIZE
 	default DEFAULT_TASK_STACKSIZE
 
 config NIMBLE_REF
-  string "Version"
-  default "cd8ab38c3da91b71dd428979153a408f38d3b02e"
-  ---help---
-    Git ref name to use when downloading from nimBLE repo
+	string "Version"
+	default "cd8ab38c3da91b71dd428979153a408f38d3b02e"
+	---help---
+		Git ref name to use when downloading from nimBLE repo
 endif


### PR DESCRIPTION
## Summary

Throughout Kconfig, we indent with TABS. However, some Kconfig files had areas indented with spaces. Making these consistent with the rest.

## Impact

Consistent style.

## Testing

N/A