### PR TITLE
Wolfssl code back

### DIFF
--- a/crypto/wolfssl/.gitignore
+++ b/crypto/wolfssl/.gitignore
@@ -1,0 +1,2 @@
+/wolfssl
+/wolfssl-examples

--- a/crypto/wolfssl/Kconfig
+++ b/crypto/wolfssl/Kconfig
@@ -1,0 +1,111 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+if ALLOW_GPL_COMPONENTS
+
+menuconfig CRYPTO_WOLFSSL
+	bool "wolfSSL SSL/TLS Cryptography Library"
+	default n
+	---help---
+		Enable support for wolfSSL
+
+if CRYPTO_WOLFSSL
+
+config WOLFSSL_VERSION
+	string "wolfSSL Version"
+	default "5.5.4"
+
+menuconfig WOLFCRYPT_APPS
+	tristate "wolfCrypt applications"
+	default n
+	---help---
+		Enable wolfCrypt applications
+
+if WOLFCRYPT_APPS
+
+config WOLFSSL_DEFAULT_TASK_STACKSIZE
+	int "wolfSSL app default stack size"
+	default 16384
+
+config WOLFCRYPT_APP_BENCHMARK
+	bool "wolfCrypt Benchmark application"
+	default n
+	---help---
+		Enable the wolfCrypt benchmark application
+
+if WOLFCRYPT_APP_BENCHMARK
+
+config WOLFCRYPT_APP_BENCHMARK_PROGNAME
+	string "Program name"
+	default "wolfcrypt_benchmark"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config WOLFCRYPT_APP_BENCHMARK_PRIORITY
+	int "wolfcrypt benchmark task priority"
+	default 100
+
+config WOLFCRYPT_APP_BENCHMARK_STACKSIZE
+	int "wolfcrypt benchmark stack size"
+	default WOLFSSL_DEFAULT_TASK_STACKSIZE
+
+endif
+
+config WOLFCRYPT_APP_SELFTEST
+	bool "wolfCrypt Self Test application"
+	default n
+	---help---
+		Enable the wolfCrypt self-test app
+
+if WOLFCRYPT_APP_SELFTEST
+
+config WOLFCRYPT_APP_SELFTEST_PROGNAME
+	string "Program name"
+	default "wolfcrypt_test"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config WOLFCRYPT_APP_SELFTEST_PRIORITY
+	int "wolfcrypt self-test task priority"
+	default 100
+
+config WOLFCRYPT_APP_SELFTEST_STACKSIZE
+	int "wolfcrypt self-test stack size"
+	default WOLFSSL_DEFAULT_TASK_STACKSIZE
+
+endif
+
+config WOLFSSL_APP_CLIENT_SERVER
+	bool "wolfSSL client and server example"
+	default n
+	---help---
+		runs both a tls client and server in the same task that connect to one
+		another, requires local loopback
+
+if WOLFSSL_APP_CLIENT_SERVER
+
+config WOLFSSL_APP_CLIENT_SERVER_PROGNAME
+	string "Program name"
+	default "wolfssl_client_server"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config WOLFSSL_APP_CLIENT_SERVER_PRIORITY
+	int "wolfssl client server task priority"
+	default 100
+
+config WOLFSSL_APP_CLIENT_SERVER_STACKSIZE
+	int "wolfssl client server stack size"
+	default WOLFSSL_DEFAULT_TASK_STACKSIZE
+
+endif
+
+endif
+
+endif # CRYPTO_WOLFSSL
+
+endif # ALLOW_GPL_COMPONENTS

--- a/crypto/wolfssl/Make.defs
+++ b/crypto/wolfssl/Make.defs
@@ -1,0 +1,12 @@
+ifeq ($(CONFIG_CRYPTO_WOLFSSL),y)
+CONFIGURED_APPS += $(APPDIR)/crypto/wolfssl
+
+CFLAGS += ${INCDIR_PREFIX}${APPDIR}/crypto/wolfssl
+CFLAGS += ${INCDIR_PREFIX}${APPDIR}/crypto/wolfssl/wolfssl
+CFLAGS += ${DEFINE_PREFIX}WOLFSSL_CONFIG_FILE="<crypto/wolfssl_config.h>"
+
+CXXFLAGS += ${INCDIR_PREFIX}${APPDIR}/crypto/wolfssl
+CXXFLAGS += ${INCDIR_PREFIX}${APPDIR}/crypto/wolfssl/wolfssl
+CXXFLAGS += ${DEFINE_PREFIX}WOLFSSL_CONFIG_FILE="<crypto/wolfssl_config.h>"
+
+endif

--- a/crypto/wolfssl/Makefile
+++ b/crypto/wolfssl/Makefile
@@ -1,0 +1,153 @@
+include $(APPDIR)/Make.defs
+
+# wolfSSL SSL/TLS crypto library
+
+WOLFSSL_VERSION = $(patsubst "%",%,$(strip $(CONFIG_WOLFSSL_VERSION)))
+
+WOLFSSL_UNPACKNAME = wolfssl
+WOLFSSL_EXAMPLESNAME = wolfssl-examples
+
+# WOLFSSL TLS FILES
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/crl.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/internal.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/keys.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/ocsp.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/sniffer.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/ssl.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/tls.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/tls13.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/src/wolfio.c
+
+# wolfCrypt Core (FIPS validated crypto available contact fips@wolfssl.com)
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/aes.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/cmac.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/des3.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/dh.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ecc.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/hmac.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/random.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/rsa.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sha.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sha256.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sha512.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sha3.c
+
+# wolfCrypt Additional
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/asm.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/asn.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/blake2s.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/chacha.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/chacha20_poly1305.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/coding.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/compress.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/cpuid.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/cryptocb.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/curve25519.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/curve448.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ecc_fp.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/eccsi.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ed25519.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ed448.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/error.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/fe_448.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/fe_low_mem.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/fe_operations.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ge_448.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ge_low_mem.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/ge_operations.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/hash.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/kdf.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/integer.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/logging.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/md5.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/memory.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/pkcs12.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/pkcs7.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/poly1305.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/pwdbased.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/rc2.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sakke.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/signature.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/srp.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_arm32.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_arm64.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_armthumb.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_c32.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_c64.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_cortexm.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_dsp32.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_int.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/sp_x86_64.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/tfm.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/wc_dsp.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/wc_encrypt.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/wc_pkcs11.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/wc_port.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/wolfevent.c
+CSRCS += $(WOLFSSL_UNPACKNAME)/wolfcrypt/src/wolfmath.c
+
+CFLAGS += -DWOLFSSL_USER_SETTINGS
+
+ifneq ($(CONFIG_WOLFCRYPT_APPS),)
+
+MODULE = $(CONFIG_WOLFSSL_APPS)
+
+ifeq ($(CONFIG_WOLFCRYPT_APP_BENCHMARK),y)
+
+PROGNAME  += $(CONFIG_WOLFCRYPT_APP_BENCHMARK_PROGNAME)
+PRIORITY  += $(CONFIG_WOLFCRYPT_APP_BENCHMARK_PRIORITY)
+STACKSIZE += $(CONFIG_WOLFCRYPT_APP_BENCHMARK_STACKSIZE)
+
+CFLAGS += -I$(WOLFSSL_UNPACKNAME)
+CFLAGS += -I$(WOLFSSL_UNPACKNAME)/../ # To reach user_settings.h
+MAINSRC += $(WOLFSSL_UNPACKNAME)/wolfcrypt/benchmark/benchmark.c
+
+endif
+
+ifeq ($(CONFIG_WOLFCRYPT_APP_SELFTEST),y)
+
+PROGNAME  += $(CONFIG_WOLFCRYPT_APP_SELFTEST_PROGNAME)
+PRIORITY  += $(CONFIG_WOLFCRYPT_APP_SELFTEST_PRIORITY)
+STACKSIZE += $(CONFIG_WOLFCRYPT_APP_SELFTEST_STACKSIZE)
+
+CFLAGS += -I$(WOLFSSL_UNPACKNAME)
+CFLAGS += -I$(WOLFSSL_UNPACKNAME)/../ # To reach user_settings.h
+MAINSRC += $(WOLFSSL_UNPACKNAME)/wolfcrypt/test/test.c
+
+endif
+
+ifeq ($(CONFIG_WOLFSSL_APP_CLIENT_SERVER),y)
+
+PROGNAME  += $(CONFIG_WOLFSSL_APP_CLIENT_SERVER_PROGNAME)
+PRIORITY  += $(CONFIG_WOLFSSL_APP_CLIENT_SERVER_PRIORITY)
+STACKSIZE += $(CONFIG_WOLFSSL_APP_CLIENT_SERVER_STACKSIZE)
+
+CFLAGS += -I$(WOLFSSL_UNPACKNAME)
+CFLAGS += -I$(WOLFSSL_UNPACKNAME)/../ # To reach user_settings.h
+MAINSRC += $(WOLFSSL_EXAMPLESNAME)/embedded/tls-client-server.c
+
+endif
+
+endif
+
+ifeq ($(CONFIG_WOLFSSL_APP_CLIENT_SERVER),y)
+wolfssl:
+	git clone git@github.com:wolfSSL/wolfssl.git $(WOLFSSL_UNPACKNAME)
+	git clone git@github.com:wolfSSL/wolfssl-examples.git $(WOLFSSL_EXAMPLESNAME)
+else
+wolfssl:
+	git clone git@github.com:wolfSSL/wolfssl.git $(WOLFSSL_UNPACKNAME)
+endif
+
+context:: wolfssl
+
+ifeq ($(CONFIG_WOLFSSL_APP_CLIENT_SERVER),y)
+distclean::
+	$(call DELDIR, $(WOLFSSL_UNPACKNAME))
+	$(call DELDIR, $(WOLFSSL_EXAMPLESNAME))
+else
+distclean:
+	$(call DELDIR, $(WOLFSSL_UNPACKNAME))
+endif
+
+include $(APPDIR)/Application.mk

--- a/crypto/wolfssl/README.md
+++ b/crypto/wolfssl/README.md
@@ -1,0 +1,92 @@
+# NuttX + wolfSSL
+
+## Installation
+
+### Installing from nuttx-apps
+
+Skip to step 6
+
+### Installing from wolfssl
+
+1) Create working directory (e.g. ~/nuttxspace):
+    ```
+    $ cd ~
+    $ mkdir nuttxspace
+    ```
+2) Install dependencies:
+    ```
+    $ cd ~/nuttxspace
+    $ sudo apt install -y bison flex gettext texinfo libncurses5-dev libncursesw5-dev gperf automake libtool pkg-config build-essential gperf genromfs libgmp-dev libmpc-dev libmpfr-dev libisl-dev binutils-dev libelf-dev libexpat-dev gcc-multilib g++-multilib picocom u-boot-tools util-linux
+    $ sudo apt install -y kconfig-frontends
+    $ sudo apt install -y gcc-arm-none-eabi binutils-arm-none-eabi
+    ```
+3) Clone nuttx and nuttx-apps into working directory:
+    ```
+    $ git clone https://github.com/apache/nuttx.git nuttx
+    $ git clone https://github.com/apache/nuttx-apps apps
+    ```
+4) Copy this directory into the working directory applications:
+    ```
+    $ cp -R RTOS/nuttx/wolfssl ~/nuttxspace/apps/crypto/wolfssl
+    ```
+5) Setup wolfSSL in preparation for the build, `WOLFSSL_DIR` must be the path to the original wolfssl repo:
+    ```
+    $ cd ~/nuttxspace/apps/crypto/wolfssl
+    $ WOLFSSL_DIR=<path-to-wolfssl-repo> ./setup-wolfssl.sh
+    ```
+6) Setup baseline NuttX configuration (board + NuttX Shell):
+    ```
+    $ cd ~/nuttxspace/nuttx
+    $ ./tools/configure.sh -l <board>:nsh
+    ```
+   If you are using wolfSSL for TLS you should use the `netnsh` target if your board supports it
+   ```
+    $ ./tools/configure.sh -l <board>:netnsh
+   ```
+> **EXAMPLES:**
+>   - For NuttX Simulator: `$ ./tools/configure.sh sim:nsh`
+>   - For BL602 (RISC-V): `$ ./tools/configure.sh -l bl602evb:nsh`
+>   - For NUCLEO-L552ZE-Q (Cortex-M33): `$ ./tools/configure.sh -l nucleo-l552ze:nsh`
+>   - For NUCLEO-H753ZI: `$ ./tools/configure.sh -l nucleo-h743zi:nsh`
+>   - For NUCLEO-F756ZG: `./tools/configure.sh -l nucleo-144:f746-nsh`
+
+7) Start custom configuration system:
+    ```
+    $ make menuconfig
+    ```
+8) Configure NuttX to enable the wolfSSL crypto library test applications:
+    - From main menu select: **Application Configuration > Cryptography Library Support**
+    - Enable and then select **wolfSSL SSL/TLS Cryptography Library**
+    - Enable and then select **wolfSSL applications**
+    - Enable applications:
+        - **wolfCrypt Benchmark application**
+        - **wolfCrypt Test application**
+        - **wolfSSL client and server example**
+    - Select Save from bottom menu, saving to `.config` file
+    - Exit configuration tool
+
+    If you are using wolfSSL for TLS you should use the `netnsh` target and should enable an NTP or some for of system time keeping so that wolfSSL has the current date to check certificates. You will also need to set the right networking settings for NuttX to connect to the internet.
+9) Build NuttX and wolfSSL:
+    ```
+    $ make
+    ```
+10) Flash the target
+    ### Simulator
+      ./nuttx
+    ### STM32 Targets (address may vary)
+      STM32_Programmer_CLI -c port=swd -d ./nuttx.bin 0x08000000
+11) Connect to the target with a serial monitoring tool, the device on linux is usually /dev/ttyACM0 but it may vary
+    - minicom -D /dev/ttyACM0
+12) Run the wolfcrypt benchmark and/or test in the NuttX Shell:
+    ```
+    nsh> wolfcrypt_test
+    nsh> wolfcrypt_benchmark
+    nsh> wolfssl_client_server
+    ```
+## Notes
+- Developed using the following targets:
+    - STM NUCLEO-L552ZE-Q (Cortex-M33)
+    - STM NUCLEO-H753ZI
+    - STM NUCLEO-F756ZG
+    - DT-BL10 / BL602 (RISC-V)
+    - NuttX simulator

--- a/crypto/wolfssl/user_settings.h
+++ b/crypto/wolfssl/user_settings.h
@@ -1,0 +1,53 @@
+#include <nuttx/config.h>
+
+/* Library */
+#define SINGLE_THREADED
+#define WOLFSSL_SMALL_STACK
+
+/* Environment */
+#define NO_FILESYSTEM
+#define HAVE_STRINGS_H
+#define WOLF_C99
+
+/* Math */
+#define WOLFSSL_SP_MATH_ALL
+
+/* Crypto */
+#define HAVE_ECC
+#define ECC_TIMING_RESISTANT
+#define WC_RSA_BLINDING
+#undef  RSA_LOW_MEM
+#define NO_MD4
+#define NO_DSA
+
+/* RNG */
+#define WOLFSSL_GENSEED_FORTEST
+
+/* Applications */
+#define NO_MAIN_FUNCTION
+#define BENCH_EMBEDDED
+#define WOLFSSL_BENCHMARK_FIXED_UNITS_MB
+
+/* Development */
+/*#define DEBUG_WOLFSSL*/
+
+#define HAVE_TLS_EXTENSIONS
+#define HAVE_SUPPORTED_CURVES
+#define HAVE_ENCRYPT_THEN_MAC
+#define HAVE_EXTENDED_MASTER
+#define WOLFSSL_TLS13
+#define HAVE_AESGCM
+#define HAVE_HKDF
+#define HAVE_DH
+#define HAVE_FFDHE_2048
+#define HAVE_DH_DEFAULT_PARAMS
+#define WC_RSA_PSS
+#define HAVE_AEAD
+#define WOLFSSL_SHA224
+#define WOLFSSL_SHA384
+#define WOLFSSL_SHA512
+#define WOLFSSL_SHA3
+#define HAVE_POLY1305
+#define HAVE_CHACHA
+#define HAVE_ENCRYPT_THEN_MAC
+#define NO_OLD_TLS


### PR DESCRIPTION
## Summary
Add wolfSSL build files, allows wolfSSL to be cloned in and used quickly

## Impact
Allows wolfSSL to be built into NuttX

## Testing
Tested using wolfSSL tests in the NuttX simulator and on the STM32F746ZG, STM32H753 and STM32L552ZE