### PR TITLE
system/cle.c: Fix configuration for CONFIG_EOL_IS_EITHER_CRLF=y

### DIFF
--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -1077,12 +1077,12 @@ static int cle_editloop(FAR struct cle_s *priv)
 
         /* Newline terminates editing.  But what is a newline? */
 
-#if defined(CONFIG_EOL_IS_CR) || defined(CONFIG_EOL_IS_EITHER_CRLF)
+#if defined(CONFIG_EOL_IS_EITHER_CRLF)
         case '\r': /* CR terminates line */
-
-#elif defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF) || \
-      defined(CONFIG_EOL_IS_EITHER_CRLF)
-
+        case '\n': /* LF terminates line */
+#elif defined(CONFIG_EOL_IS_CR)
+        case '\r': /* CR terminates line */
+#elif defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
         case '\n': /* LF terminates line */
 #endif
           {


### PR DESCRIPTION
## Summary
The old flagging was insufficient, only '\r' was accepted as a line terminator if CONFIG_EOL_IS_EITHER_CRLF was set.

I noticed this regression after:
https://github.com/apache/nuttx/pull/8454
## Impact
Now that CR is bucketed into LF, this patches the nsh terminal, if the PC terminal uses CR
## Testing
icicle:nsh
