### PR TITLE
Bug fix on repeated lvgl downloads from git

### DIFF
--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -95,7 +95,7 @@ UNPACK ?= unzip -o
 
 LVGL_UNPACKDIR =  $(WD)/$(LVGL_UNPACKNAME)
 
-ifneq($(wildcard $(LVGL_UNPACKDIR)/CMakeLists.txt),)
+ifneq ($(wildcard $(LVGL_UNPACKNAME)/CMakeLists.txt),)
 
 $(LVGL_TARBALL):
 	$(Q) echo "Downloading: lvgl $(LVGL_TARBALL)"
@@ -108,7 +108,7 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
 #Download and unpack tarball if no git repo found
-	ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
+ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 	context:: $(LVGL_UNPACKNAME)
 
 	distclean::

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -108,6 +108,7 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
 #Download and unpack tarball if no git repo found
+
 ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 	context:: $(LVGL_UNPACKNAME)
 

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -95,8 +95,7 @@ UNPACK ?= unzip -o
 
 LVGL_UNPACKDIR =  $(WD)/$(LVGL_UNPACKNAME)
 
-ifneq ($(wildcard $(LVGL_UNPACKNAME)/CMakeLists.txt),)
-
+ifneq ($(wildcard $(LVGL_UNPACKNAME)/lvgl.h),)
 $(LVGL_TARBALL):
 	$(Q) echo "Downloading: lvgl $(LVGL_TARBALL)"
 	$(Q) curl -O -L $(CONFIG_GRAPH_LVGL_URL)/$(LVGL_TARBALL)

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -106,7 +106,7 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) mv	lvgl-$(LVGL_VERSION) $(LVGL_UNPACKNAME)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
-#Download and unpack tarball if no git repo found
+# Download and unpack tarball if no git repo found
 
 ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 	context:: $(LVGL_UNPACKNAME)

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -95,8 +95,10 @@ UNPACK ?= unzip -o
 
 LVGL_UNPACKDIR =  $(WD)/$(LVGL_UNPACKNAME)
 
+ifneq($(wildcard $(LVGL_UNPACKDIR)/CMakeLists.txt),)
+
 $(LVGL_TARBALL):
-	$(Q) echo "Downloading: $(LVGL_TARBALL)"
+	$(Q) echo "Downloading: lvgl $(LVGL_TARBALL)"
 	$(Q) curl -O -L $(CONFIG_GRAPH_LVGL_URL)/$(LVGL_TARBALL)
 
 $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
@@ -105,13 +107,14 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(Q) mv	lvgl-$(LVGL_VERSION) $(LVGL_UNPACKNAME)
 	$(Q) touch $(LVGL_UNPACKNAME)
 
-# Download and unpack tarball if no git repo found
-ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
-context:: $(LVGL_UNPACKNAME)
+#Download and unpack tarball if no git repo found
+	ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
+	context:: $(LVGL_UNPACKNAME)
 
-distclean::
-	$(call DELDIR, $(LVGL_UNPACKNAME))
-	$(call DELFILE, $(LVGL_TARBALL))
+	distclean::
+		$(call DELDIR, $(LVGL_UNPACKNAME))
+		$(call DELFILE, $(LVGL_TARBALL))
+endif
 endif
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
While building lvgl for nuttx, each time lvgl is downloaded from the source repository. The Changes includes:
* The Make file checks if lvgl Make files are already present to prevent re-download.

## Summary
While building LVGL #include<lvgl/lvgl.h> the make build system downloads every time from the repository even when the file is present. Tweaked the build to skip downloading again if LVGL makefiles are already Present.
## Impact
 When building using "make clean" and "make", everytime lvgl is downloaded irrespective of whether the source is present.
## Testing
Unit Tests on With lvgl Source and without lvgl source was done.
