### PR TITLE
testing/cmocka: update cmocka version and add patch

### DIFF
--- a/testing/cmocka/0001-cmocka.c-Reduce-the-call-stack-consumption-of-printf.patch
+++ b/testing/cmocka/0001-cmocka.c-Reduce-the-call-stack-consumption-of-printf.patch
@@ -1,0 +1,59 @@
+From a5e95907fbf6921668abc4a61641d28a16a88c81 Mon Sep 17 00:00:00 2001
+From: Xiang Xiao <xiaoxiang@xiaomi.com>
+Date: Fri, 6 Jan 2023 10:09:20 +0800
+Subject: [PATCH 1/2] cmocka.c: Reduce the call stack consumption of printf
+
+Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
+Change-Id: Idf179ad5eb81bbc63eea4f71980857831668e7a8
+---
+ src/cmocka.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/cmocka.c cmocka/src/cmocka.c
+index ef8fbd9..ff59b53 100644
+--- a/src/cmocka.c
++++ cmocka/src/cmocka.c
+@@ -2086,7 +2086,7 @@ static void vcmocka_print_error(const char* const format,
+  */
+ static void vcmocka_print_error(const char* const format, va_list args)
+ {
+-    char buffer[1024];
++    char buffer[256];
+     size_t msg_len = 0;
+     va_list ap;
+     int len;
+@@ -2427,12 +2427,12 @@ void cmocka_print_error(const char * const format, ...)
+ /* Standard output and error print methods. */
+ void vprint_message(const char* const format, va_list args)
+ {
++    vprintf(format, args);
++    fflush(stdout);
++#ifdef _WIN32
+     char buffer[4096];
+ 
+     vsnprintf(buffer, sizeof(buffer), format, args);
+-    printf("%s", buffer);
+-    fflush(stdout);
+-#ifdef _WIN32
+     OutputDebugString(buffer);
+ #endif /* _WIN32 */
+ }
+@@ -2440,12 +2440,12 @@ void vprint_message(const char* const format, va_list args)
+ 
+ void vprint_error(const char* const format, va_list args)
+ {
++    vfprintf(stderr, format, args);
++    fflush(stderr);
++#ifdef _WIN32
+     char buffer[4096];
+ 
+     vsnprintf(buffer, sizeof(buffer), format, args);
+-    fprintf(stderr, "%s", buffer);
+-    fflush(stderr);
+-#ifdef _WIN32
+     OutputDebugString(buffer);
+ #endif /* _WIN32 */
+ }
+-- 
+2.25.1
+

--- a/testing/cmocka/0002-cmocka-feature-to-forwarding-cmocka-log-message-to-c.patch
+++ b/testing/cmocka/0002-cmocka-feature-to-forwarding-cmocka-log-message-to-c.patch
@@ -1,0 +1,74 @@
+From b4069b535e94c74481bc78ae4363d7741def5e4a Mon Sep 17 00:00:00 2001
+From: chao an <anchao@xiaomi.com>
+Date: Mon, 16 Jan 2023 15:19:59 +0800
+Subject: [PATCH 2/2] cmocka: feature to forwarding cmocka log message to
+ custom channel
+
+Add custom log message implementation to support different backend output, such as linux (vsyslog):
+
+https://www.gnu.org/software/libc/manual/html_node/syslog_003b-vsyslog.html
+
+redefine the vprint output function to native implement:
+
+1. Enable platfrom include: -DCMOCKA_PLATFORM_INCLUDE
+2. Add cmocka platform header to forwarding the log message to custom channel
+
+cmocka_platform.h:
+
+| #ifndef CMOCKA_PLATFORM_H_
+| #define CMOCKA_PLATFORM_H_
+|
+| #include <syslog.h>
+|
+| #define cmocka_vprint_message(f,a) vsyslog(LOG_INFO,f,a)
+| #define cmocka_vprint_error(f,a) vsyslog(LOG_ERR,f,a)
+|
+| #endif /* CMOCKA_PLATFORM_H_ */
+
+Change-Id: I0959c3d1fc372de842b63d9e220561d3df62beb2
+Signed-off-by: chao an <anchao@xiaomi.com>
+---
+ src/cmocka.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/cmocka.c cmocka/src/cmocka.c
+index ff59b53..1cc9eac 100644
+--- a/src/cmocka.c
++++ cmocka/src/cmocka.c
+@@ -2427,6 +2427,7 @@ void cmocka_print_error(const char * const format, ...)
+ /* Standard output and error print methods. */
+ void vprint_message(const char* const format, va_list args)
+ {
++#ifndef cmocka_vprint_message
+     vprintf(format, args);
+     fflush(stdout);
+ #ifdef _WIN32
+@@ -2435,11 +2436,15 @@ void vprint_message(const char* const format, va_list args)
+     vsnprintf(buffer, sizeof(buffer), format, args);
+     OutputDebugString(buffer);
+ #endif /* _WIN32 */
++#else
++    cmocka_vprint_message(format, args);
++#endif
+ }
+ 
+ 
+ void vprint_error(const char* const format, va_list args)
+ {
++#ifndef cmocka_vprint_error
+     vfprintf(stderr, format, args);
+     fflush(stderr);
+ #ifdef _WIN32
+@@ -2448,6 +2453,9 @@ void vprint_error(const char* const format, va_list args)
+     vsnprintf(buffer, sizeof(buffer), format, args);
+     OutputDebugString(buffer);
+ #endif /* _WIN32 */
++#else
++    cmocka_vprint_error(format, args);
++#endif
+ }
+ 
+ 
+-- 
+2.25.1
+

--- a/testing/cmocka/Makefile
+++ b/testing/cmocka/Makefile
@@ -36,9 +36,11 @@ MAINSRC = $(CURDIR)/cmocka_main.c
 ifeq ($(wildcard cmocka/.git),)
 VERSION ?= 1.1.5
 cmocka.zip:
-	$(Q) curl -L https://github.com/clibs/cmocka/archive/cmocka-$(VERSION).zip -o cmocka.zip
+	$(Q) curl -L https://github.com/clibs/cmocka/archive/$(VERSION).zip -o cmocka.zip
 	$(Q) unzip -o cmocka.zip
-	$(Q) mv cmocka-cmocka-$(VERSION) cmocka
+	$(Q) mv cmocka-$(VERSION) cmocka
+	$(Q) patch -p0 < 0001-cmocka.c-Reduce-the-call-stack-consumption-of-printf.patch
+	$(Q) patch -p0 < 0002-cmocka-feature-to-forwarding-cmocka-log-message-to-c.patch
 
 context:: cmocka.zip
 


### PR DESCRIPTION
Specify cmocka as the latest version 1.15
add patch to enable cmocka to output with syslog

## Summary
Update cmocka version and add patch
## Impact
None
## Testing
Pass vela CI
