### PR TITLE
fsutils/passwd: fix warning: leak of ‘iobuffer’ [CWE-401] [-Wanalyzer-malloc-leak]

### DIFF
--- a/fsutils/passwd/passwd_find.c
+++ b/fsutils/passwd/passwd_find.c
@@ -73,6 +73,10 @@ int passwd_find(FAR const char *username, FAR struct passwd_s *passwd)
   stream = fopen(CONFIG_FSUTILS_PASSWD_PATH, "r");
   if (stream == NULL)
     {
+      /* Free an I/O buffer for the transfer */
+
+      free(iobuffer);
+
       int errcode = errno;
       DEBUGASSERT(errcode > 0);
       return -errcode;


### PR DESCRIPTION
## Summary

I manually added the `-fanalyzer` compile option on the simulation (Ubuntu 20.04 with GCC 10.3.0) to check my application for potential memory leaks. Then, I found this problem.

```
In function ‘passwd_find’:
passwd_find.c:82:14: warning: leak of ‘iobuffer’ [CWE-401] [-Wanalyzer-malloc-leak]
   82 |       return -errcode;
      |              ^~~~~~~~
  ‘passwd_find’: events 1-5
    |
    |   65 |   iobuffer = (FAR char *)malloc(CONFIG_FSUTILS_PASSWD_IOBUFFER_SIZE);
    |      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                          |
    |      |                          (1) allocated here
    |   66 |   if (iobuffer == NULL)
    |      |      ~
    |      |      |
    |      |      (2) assuming ‘iobuffer’ is non-NULL
    |      |      (3) following ‘false’ branch (when ‘iobuffer’ is non-NULL)...
    |......
    |   73 |   stream = fopen(CONFIG_FSUTILS_PASSWD_PATH, "r");
    |      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |            |
    |      |            (4) ...to here
    |   74 |   if (stream == NULL)
    |      |      ~
    |      |      |
    |      |      (5) following ‘true’ branch (when ‘stream’ is NULL)...
    |
  ‘passwd_find’: event 6
    |
    |   80 |       int errcode = errno;
    |      |                     ^~~~~
    |      |                     |
    |      |                     (6) ...to here
    |
  ‘passwd_find’: event 7
    |
    |   82 |       return -errcode;
    |      |              ^~~~~~~~
    |      |              |
    |      |              (7) ‘iobuffer’ leaks here; was allocated at (1)
    |
```
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
N/A

## Testing
Manually checked the fixes.
