### PR TITLE
Add NSH lomtd command

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -377,6 +377,10 @@ config NSH_DISABLE_LOSMART
 	bool "Disable losmart"
 	default DEFAULT_SMALL || !MTD_SMART
 
+config NSH_DISABLE_LOMTD
+	bool "Disable lomtd"
+	default DEFAULT_SMALL || !MTD_LOOP
+
 config NSH_DISABLE_LN
 	bool "Disable ln"
 	default DEFAULT_SMALL

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1018,6 +1018,9 @@ int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  if defined(CONFIG_SMART_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSMART)
   int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
+#  if defined(CONFIG_MTD_LOOP) && !defined(CONFIG_NSH_DISABLE_LOMTD)
+  int cmd_lomtd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#  endif
 #  if defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0 && \
       !defined(CONFIG_NSH_DISABLE_MKFIFO)
   int cmd_mkfifo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -283,6 +283,14 @@ static const struct cmdmap_s g_cmdmap[] =
 # endif
 #endif
 
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+# if defined(CONFIG_MTD_LOOP) && !defined(CONFIG_NSH_DISABLE_LOMTD)
+  { "lomtd",   cmd_lomtd, 3, 9,
+    "[-d <dev-path>] | [[-o <offset>] [-e <erase-size>] "
+    "[-s <sect-size>] <dev-path> <file-path>]]" },
+# endif
+#endif
+
 #if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
   { "ln",       cmd_ln,       3, 4, "[-s] <target> <link>" },
 #endif


### PR DESCRIPTION
## Summary
Create MTD loop device from command line (lomtd, similar to losetup, losmart)

## Impact
No impact

## Testing
Testing should be performed when related code will be added to nuttx repository (pr. #8573)

Preparing:
config: Simulator, enable littlfs, spiffs, filemtd + mtd loop
apps: nsh component lomtd is not disabled
host: create files, e.g., littlefs.dat, spiffs.dat

./nuttx
nsh>mount -t hostfs -o fs=/home/oreh /host
nsh>lomtd -s 1024 -e 4096 -o 0 /dev/mtd0 /host/littlefs.dat
nsh>mount -t littlefs -f "forceformat" /dev/mtd0 /mnt0
nsh>ls /mnt0

nsh>lomtd -s 1024 -e 4096 -o 0 /dev/mtd1 /host/spiffs.dat
nsh>mount -t spiffs -o "forceformat" /dev/mtd1 /mnt1
nsh>ls /mnt1
