### PR TITLE
system/libuv: check GCC version before set special flags

### DIFF
--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -49,9 +49,13 @@ CFLAGS += -I$(LIBUV_UNPACK)/src
 CFLAGS += -I$(LIBUV_UNPACK)/src/unix
 CFLAGS += -I$(LIBUV_UNPACK)/test
 CFLAGS += -Wno-shadow
-CFLAGS += -Wno-dangling-pointer
 CFLAGS += -DDEF_THREADPOOL_SIZE=CONFIG_LIBUV_THREADPOOL_SIZE
 CFLAGS += -DDEF_THREADPOOL_STACKSIZE=CONFIG_LIBUV_THREAD_STACKSIZE
+
+GCCVER = $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+ifeq ($(GCCVER),12.2.1)
+  CFLAGS += -Wno-dangling-pointer
+endif
 
 VPATH += $(LIBUV_UNPACK)/src
 VPATH += $(LIBUV_UNPACK)/src/unix


### PR DESCRIPTION
## Summary

system/libuv: check GCC version before set special flags

## Impact

GCC-12.2

## Testing

GCC-12.2