### PR TITLE
lvgl/port: add libuv porting

### DIFF
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -36,6 +36,11 @@
 #include <port/lv_port.h>
 #include <lvgl/demos/lv_demos.h>
 
+#ifdef CONFIG_LIBUV
+#  include <uv.h>
+#  include <port/lv_port_libuv.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -175,6 +180,10 @@ int main(int argc, FAR char *argv[])
   const int func_key_pair_len = sizeof(func_key_pair) /
                                 sizeof(func_key_pair[0]);
 
+#ifdef CONFIG_LIBUV
+  uv_loop_t ui_loop;
+#endif
+
   /* If no arguments are specified and only 1 demo exists, select the demo */
 
   if (argc == 1 && func_key_pair_len == 2)  /* 2 because of NULL sentinel */
@@ -225,6 +234,11 @@ int main(int argc, FAR char *argv[])
 
   /* Handle LVGL tasks */
 
+#ifdef CONFIG_LIBUV
+  uv_loop_init(&ui_loop);
+  lv_port_libuv_init(&ui_loop);
+  uv_run(&ui_loop, UV_RUN_DEFAULT);
+#else
   while (1)
     {
       uint32_t idle;
@@ -235,6 +249,7 @@ int main(int argc, FAR char *argv[])
       idle = idle ? idle : 1;
       usleep(idle * 1000);
     }
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/graphics/lvgl/Kconfig
+++ b/graphics/lvgl/Kconfig
@@ -54,6 +54,11 @@ config LV_PORT_FBDEV_DEFAULT_DEVICEPATH
 	default "/dev/fb0"
 	depends on LV_PORT_USE_FBDEV
 
+config LV_PORT_UV_POLL_DEVICEPATH
+	string "Display poll device path"
+	depends on LIBUV
+	default "/dev/fb0"
+
 config LV_PORT_USE_TOUCHPAD
 	bool "Enable touchpad port"
 	default n

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -34,6 +34,9 @@ CFLAGS += -Wno-format -Wno-unused-variable
 CSRCS += port/lv_port.c
 CSRCS += port/lv_port_tick.c
 
+ifeq ($(CONFIG_LIBUV),y)
+CSRCS += port/lv_port_libuv.c
+endif
 
 ifeq ($(CONFIG_LV_PORT_USE_LCDDEV),y)
 CSRCS += port/lv_port_lcddev.c

--- a/graphics/lvgl/port/lv_port_libuv.c
+++ b/graphics/lvgl/port/lv_port_libuv.c
@@ -1,0 +1,186 @@
+/****************************************************************************
+ * apps/graphics/lvgl/port/lv_port_libuv.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <uv.h>
+#include <stdlib.h>
+#include <lvgl/lvgl.h>
+#include "lv_port_libuv.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Type Declarations
+ ****************************************************************************/
+
+struct lv_uv_ctx_s
+{
+  int fd;
+  uv_timer_t ui_timer;
+  uv_poll_t ui_refr;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ui_timer_cb
+ ****************************************************************************/
+
+static void ui_timer_cb(FAR uv_timer_t *handle)
+{
+  uint32_t sleep_ms;
+  LV_LOG_TRACE("start");
+
+  sleep_ms = lv_timer_handler();
+
+  /* Prevent busy loops. */
+
+  if (sleep_ms == 0)
+    {
+      sleep_ms = 1;
+    }
+
+  uv_timer_start(handle, ui_timer_cb, sleep_ms, 0);
+  LV_LOG_TRACE("stop, sleep %" PRIu32 " ms", sleep_ms);
+}
+
+/****************************************************************************
+ * Name: ui_refr_cb
+ ****************************************************************************/
+
+static void ui_refr_cb(FAR uv_poll_t *handle, int status, int events)
+{
+  LV_LOG_TRACE("start");
+  _lv_disp_refr_timer(NULL);
+  LV_LOG_TRACE("stop");
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lv_port_libuv_init
+ *
+ * Description:
+ *   Add the UI event loop to the uv_loop.
+ *
+ * Input Parameters:
+ *   loop - Pointer to uv_loop.
+ *
+ * Returned Value:
+ *   Pointer to UI event context.
+ *
+ ****************************************************************************/
+
+FAR void *lv_port_libuv_init(FAR void *loop)
+{
+  int fd;
+  FAR uv_loop_t *ui_loop = loop;
+  FAR lv_disp_t *disp;
+  FAR struct lv_uv_ctx_s *uv_ctx;
+
+  LV_LOG_INFO("dev: " CONFIG_LV_PORT_UV_POLL_DEVICEPATH " opening...");
+  fd = open(CONFIG_LV_PORT_UV_POLL_DEVICEPATH, O_WRONLY);
+  if (fd < 0)
+    {
+      LV_LOG_ERROR(CONFIG_LV_PORT_UV_POLL_DEVICEPATH
+                   " open failed: %d", errno);
+      return NULL;
+    }
+
+  disp = lv_disp_get_default();
+  LV_ASSERT_NULL(disp);
+
+  if (disp->refr_timer == NULL)
+    {
+      LV_LOG_ERROR("disp->refr_timer is NULL");
+      close(fd);
+      return NULL;
+    }
+
+  /* Remove default refr timer. */
+
+  lv_timer_del(disp->refr_timer);
+  disp->refr_timer = NULL;
+
+  uv_ctx = malloc(sizeof(struct lv_uv_ctx_s));
+  LV_ASSERT_MALLOC(uv_ctx);
+
+  memset(uv_ctx, 0, sizeof(struct lv_uv_ctx_s));
+  uv_ctx->fd = fd;
+
+  LV_LOG_INFO("init ui_timer...");
+  uv_timer_init(ui_loop, &uv_ctx->ui_timer);
+  uv_timer_start(&uv_ctx->ui_timer, ui_timer_cb, 1, 1);
+
+  LV_LOG_INFO("init ui_refr...");
+  uv_poll_init(ui_loop, &uv_ctx->ui_refr, fd);
+  uv_poll_start(&uv_ctx->ui_refr, UV_WRITABLE, ui_refr_cb);
+
+  LV_LOG_INFO("ui loop start OK");
+  return uv_ctx;
+}
+
+/****************************************************************************
+ * Name: lv_port_libuv_uninit
+ *
+ * Description:
+ *   Remove the UI event loop.
+ *
+ * Input Parameters:
+ *   Pointer to UI event context.
+ *
+ ****************************************************************************/
+
+void lv_port_libuv_uninit(FAR void *ctx)
+{
+  FAR struct lv_uv_ctx_s *uv_ctx = ctx;
+
+  if (uv_ctx == NULL)
+    {
+      LV_LOG_WARN("uv_ctx is NULL");
+      return;
+    }
+
+  uv_close((FAR uv_handle_t *)&uv_ctx->ui_timer, NULL);
+  uv_close((FAR uv_handle_t *)&uv_ctx->ui_refr, NULL);
+  close(uv_ctx->fd);
+  free(ctx);
+  LV_LOG_INFO("ui loop close OK");
+}

--- a/graphics/lvgl/port/lv_port_libuv.h
+++ b/graphics/lvgl/port/lv_port_libuv.h
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * apps/graphics/lvgl/port/lv_port_libuv.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_GRAPHICS_LVGL_PORT_LV_PORT_LIBUV_H
+#define __APPS_GRAPHICS_LVGL_PORT_LV_PORT_LIBUV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_LIBUV)
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lv_port_libuv_init
+ *
+ * Description:
+ *   Add the UI event loop to the uv_loop.
+ *
+ * Input Parameters:
+ *   loop - Pointer to uv_loop.
+ *
+ * Returned Value:
+ *   Pointer to UI event context.
+ *
+ ****************************************************************************/
+
+FAR void *lv_port_libuv_init(FAR void *loop);
+
+/****************************************************************************
+ * Name: lv_port_libuv_uninit
+ *
+ * Description:
+ *   Remove the UI event loop.
+ *
+ * Input Parameters:
+ *   Pointer to UI event context.
+ *
+ ****************************************************************************/
+
+void lv_port_libuv_uninit(FAR void *ctx);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_LIBUV */
+
+#endif /* __APPS_GRAPHICS_LVGL_PORT_LV_PORT_LIBUV_H */


### PR DESCRIPTION
## Summary

Add LVGL libuv porting to replace traditional UI polling.

## Impact

LVGL application.

## Testing

```bash
./tools/configure.sh -l sim:lvgl_fb
```

libuv config:
```
CONFIG_LIBUV=y
CONFIG_DISABLE_ENVIRON=n
CONFIG_PTHREAD_MUTEX_TYPES=y
CONFIG_TLS_TASK_NELEM=32
```
