### PR TITLE
graphics/lvgl: fix build due to no-format-security

### DIFF
--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -27,7 +27,7 @@ LVGL_DIR_NAME = lvgl
 
 # Relax LVGL's format checking and unused variable checking to avoid errors
 
-CFLAGS += -Wno-format -Wno-unused-variable
+CFLAGS += -Wno-format -Wno-format-security -Wno-unused-variable
 
 -include ./lvgl/lvgl.mk
 


### PR DESCRIPTION
Without this change the build produces error:
  error: ‘-Wformat-security’ ignored without ‘-Wformat’
