### PR TITLE
lvgldemo: use nitems instead of sizeof

### DIFF
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <sys/boardctl.h>
+#include <sys/param.h>
 #include <unistd.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -108,8 +109,7 @@ static const struct func_key_pair_s func_key_pair[] =
 static void show_usage(void)
 {
   int i;
-  const int len = sizeof(func_key_pair)
-                  / sizeof(struct func_key_pair_s) - 1;
+  const int len = nitems(func_key_pair) - 1;
 
   if (len == 0)
     {
@@ -136,8 +136,7 @@ static void show_usage(void)
 static demo_create_func_t find_demo_create_func(FAR const char *name)
 {
   int i;
-  const int len = sizeof(func_key_pair)
-                  / sizeof(struct func_key_pair_s) - 1;
+  const int len = nitems(func_key_pair) - 1;
 
   for (i = 0; i < len; i++)
     {
@@ -172,8 +171,7 @@ int main(int argc, FAR char *argv[])
 {
   demo_create_func_t demo_create_func;
   FAR const char *demo = NULL;
-  const int func_key_pair_len = sizeof(func_key_pair) /
-                                sizeof(func_key_pair[0]);
+  const int func_key_pair_len = nitems(func_key_pair);
 
   /* If no arguments are specified and only 1 demo exists, select the demo */
 


### PR DESCRIPTION
## Summary
Use nitems to get the length of the array, simplify the code.

## Impact
lvgldemo

## Testing
None

