### PR TITLE
nshlib: Remove the remaining CONFIG_FILE_STREAM dependence

### DIFF
--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -29,7 +29,6 @@
 
 #include <sys/types.h>
 
-#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
@@ -53,11 +52,6 @@
 #  ifndef CONFIG_NSH_DISABLEBG
 #    define CONFIG_NSH_DISABLEBG 1
 #  endif
-#endif
-
-#ifndef CONFIG_FILE_STREAM
-#  undef CONFIG_NSH_FILE_APPS
-#  undef CONFIG_NSH_CMDPARMS
 #endif
 
 /* rmdir, mkdir, rm, and mv are only available if mountpoints are enabled
@@ -988,11 +982,9 @@ int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
   int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
-#if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
-#  ifndef CONFIG_NSH_DISABLE_SOURCE
+#if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_SOURCE)
   int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
-#  endif
-#endif /* CONFIG_FILE_STREAM && !CONFIG_NSH_DISABLESCRIPT */
+#endif
 
 #ifdef NSH_HAVE_DIROPTS
 #  ifndef CONFIG_NSH_DISABLE_MKDIR

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -150,8 +149,7 @@ static int nsh_wait_inputdev(FAR struct console_stdio_s *pstate,
                * to open the keyboard device.
                */
 
-              puts(msg);
-              fflush(stdout);
+              write(STDOUT_FILENO, msg, strlen(msg));
               msg = NULL;
             }
 

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -31,6 +31,7 @@
 
 #include <stdbool.h>
 #include <errno.h>
+#include <sched.h>
 #include <string.h>
 
 #include <nuttx/lib/builtin.h>

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -136,7 +136,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
             {
               /* Setup up to receive SIGINT if control-C entered. */
 
-              tc = ioctl(STDOUT_FILENO, TIOCSCTTY, ret);
+              tc = nsh_ioctl(vtbl, TIOCSCTTY, ret);
             }
 
           /* Wait for the application to exit.  We did lock the scheduler
@@ -201,7 +201,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
           if (vtbl->isctty && tc == 0)
             {
-              ioctl(STDOUT_FILENO, TIOCNOTTY);
+              nsh_ioctl(vtbl, TIOCNOTTY, 0);
             }
         }
 #  ifndef CONFIG_NSH_DISABLEBG

--- a/nshlib/nsh_codeccmd.c
+++ b/nshlib/nsh_codeccmd.c
@@ -28,7 +28,6 @@
 #include <sys/stat.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -87,10 +87,8 @@ static int  cmd_unrecognized(FAR struct nsh_vtbl_s *vtbl, int argc,
 
 static const struct cmdmap_s g_cmdmap[] =
 {
-#if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
-# ifndef CONFIG_NSH_DISABLE_SOURCE
+#if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_SOURCE)
   { ".",        cmd_source,   2, 2, "<script-path>" },
-# endif
 #endif
 
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_TEST)
@@ -515,10 +513,8 @@ static const struct cmdmap_s g_cmdmap[] =
   { "sleep",    cmd_sleep,    2, 2, "<sec>" },
 #endif
 
-#if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
-# ifndef CONFIG_NSH_DISABLE_SOURCE
+#if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_SOURCE)
   { "source",   cmd_source,   2, 2, "<script-path>" },
-# endif
 #endif
 
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_TEST)

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <sys/ioctl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -70,7 +71,7 @@ static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd,
 static void nsh_consoleundirect(FAR struct nsh_vtbl_s *vtbl,
                                 FAR uint8_t *save);
 static void nsh_consoleexit(FAR struct nsh_vtbl_s *vtbl,
-                            int exitstatus) anoreturn_function;
+                            int exitstatus) noreturn_function;
 
 /****************************************************************************
  * Private Functions

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -57,18 +57,20 @@ static FAR struct nsh_vtbl_s *nsh_consoleclone(FAR struct nsh_vtbl_s *vtbl);
 #endif
 static void nsh_consolerelease(FAR struct nsh_vtbl_s *vtbl);
 static ssize_t nsh_consolewrite(FAR struct nsh_vtbl_s *vtbl,
-  FAR const void *buffer, size_t nbytes);
+                                FAR const void *buffer, size_t nbytes);
+static int nsh_consoleioctl(FAR struct nsh_vtbl_s *vtbl,
+                            int cmd, unsigned long arg);
 static int nsh_consoleoutput(FAR struct nsh_vtbl_s *vtbl,
-  FAR const char *fmt, ...) printf_like(2, 3);
+                             FAR const char *fmt, ...) printf_like(2, 3);
 static int nsh_erroroutput(FAR struct nsh_vtbl_s *vtbl,
-  FAR const char *fmt, ...) printf_like(2, 3);
+                           FAR const char *fmt, ...) printf_like(2, 3);
 static FAR char *nsh_consolelinebuffer(FAR struct nsh_vtbl_s *vtbl);
 static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd,
-  FAR uint8_t *save);
+                                FAR uint8_t *save);
 static void nsh_consoleundirect(FAR struct nsh_vtbl_s *vtbl,
-  FAR uint8_t *save);
-static void nsh_consoleexit(FAR struct nsh_vtbl_s *vtbl, int exitstatus)
-  noreturn_function;
+                                FAR uint8_t *save);
+static void nsh_consoleexit(FAR struct nsh_vtbl_s *vtbl,
+                            int exitstatus) anoreturn_function;
 
 /****************************************************************************
  * Private Functions
@@ -125,6 +127,22 @@ static ssize_t nsh_consolewrite(FAR struct nsh_vtbl_s *vtbl,
     }
 
   return ret;
+}
+
+/****************************************************************************
+ * Name: nsh_consolewrite
+ *
+ * Description:
+ *   Issue ioctl to the currently selected stream.
+ *
+ ****************************************************************************/
+
+static int nsh_consoleioctl(FAR struct nsh_vtbl_s *vtbl,
+                            int cmd, unsigned long arg)
+{
+  FAR struct console_stdio_s *pstate = (FAR struct console_stdio_s *)vtbl;
+
+  return ioctl(OUTFD(pstate), cmd, arg);
 }
 
 /****************************************************************************
@@ -347,6 +365,7 @@ FAR struct console_stdio_s *nsh_newconsole(bool isctty)
 #endif
       pstate->cn_vtbl.release     = nsh_consolerelease;
       pstate->cn_vtbl.write       = nsh_consolewrite;
+      pstate->cn_vtbl.ioctl       = nsh_consoleioctl;
       pstate->cn_vtbl.output      = nsh_consoleoutput;
       pstate->cn_vtbl.error       = nsh_erroroutput;
       pstate->cn_vtbl.linebuffer  = nsh_consolelinebuffer;

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -29,7 +29,6 @@
 
 #include <sys/types.h>
 
-#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -61,7 +60,7 @@
  * See struct serialsave_s in nsh_console.c
  */
 
-#define SAVE_SIZE (2 * sizeof(int) + 2 * sizeof(FILE*))
+#define SAVE_SIZE (2 * sizeof(int))
 
 /* Are we using the NuttX console for I/O?  Or some other character device? */
 

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -43,6 +43,7 @@
 #define nsh_clone(v)           (v)->clone(v)
 #define nsh_release(v)         (v)->release(v)
 #define nsh_write(v,b,n)       (v)->write(v,b,n)
+#define nsh_ioctl(v,c,a)       (v)->ioctl(v,c,a)
 #define nsh_linebuffer(v)      (v)->linebuffer(v)
 #define nsh_redirect(v,f,s)    (v)->redirect(v,f,s)
 #define nsh_undirect(v,s)      (v)->undirect(v,s)
@@ -103,6 +104,7 @@ struct nsh_vtbl_s
   void (*release)(FAR struct nsh_vtbl_s *vtbl);
   ssize_t (*write)(FAR struct nsh_vtbl_s *vtbl, FAR const void *buffer,
                    size_t nbytes);
+  int (*ioctl)(FAR struct nsh_vtbl_s *vtbl, int cmd, unsigned long arg);
   int (*error)(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...)
       printf_like(2, 3);
   int (*output)(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...)

--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -24,10 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <assert.h>
-
-#include <sys/boardctl.h>
 
 #include "nsh.h"
 #include "nsh_console.h"

--- a/nshlib/nsh_dbgcmds.c
+++ b/nshlib/nsh_dbgcmds.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>

--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -24,6 +24,8 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/clock.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -204,7 +204,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
             {
               /* Setup up to receive SIGINT if control-C entered. */
 
-              tc = ioctl(stdout->fs_fd, TIOCSCTTY, pid);
+              tc = nsh_ioctl(vtbl, TIOCSCTTY, pid);
             }
 
           /* Wait for the application to exit.  We did lock the scheduler
@@ -260,7 +260,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
           if (vtbl->isctty && tc == 0)
             {
-              ioctl(stdout->fs_fd, TIOCNOTTY);
+              nsh_ioctl(vtbl, TIOCNOTTY, 0);
             }
         }
 #  ifndef CONFIG_NSH_DISABLEBG

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -1976,15 +1976,13 @@ int cmd_rmdir(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
  * Name: cmd_source
  ****************************************************************************/
 
-#if defined(CONFIG_FILE_STREAM) && !defined(CONFIG_NSH_DISABLESCRIPT)
-#ifndef CONFIG_NSH_DISABLE_SOURCE
+#if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_SOURCE)
 int cmd_source(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
 
   return nsh_script(vtbl, argv[0], argv[1], true);
 }
-#endif
 #endif
 
 /****************************************************************************

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/nshlib/nsh_login.c
+++ b/nshlib/nsh_login.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>

--- a/nshlib/nsh_mmcmds.c
+++ b/nshlib/nsh_mmcmds.c
@@ -24,6 +24,8 @@
 
 #include <nuttx/config.h>
 
+#include <string.h>
+
 #include "nsh.h"
 #include "nsh_console.h"
 

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -24,11 +24,14 @@
 
 #include <nuttx/config.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
 #include <debug.h>
+#include <pthread.h>
+#include <sched.h>
 #include <unistd.h>
 
 #ifdef CONFIG_NSH_CMDPARMS
@@ -1958,7 +1961,7 @@ static int nsh_loop(FAR struct nsh_vtbl_s *vtbl, FAR char **ppcmd,
                           SEEK_SET);
               if (ret < 0)
                 {
-                  nsh_error(vtbl, g_fmtcmdfailed, "done", "fseek",
+                  nsh_error(vtbl, g_fmtcmdfailed, "done", "lseek",
                             NSH_ERRNO);
                 }
 

--- a/nshlib/nsh_printf.c
+++ b/nshlib/nsh_printf.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -115,7 +115,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
         {
           if (log)
             {
-              nsh_error(vtbl, g_fmtcmdfailed, cmd, "fopen", NSH_ERRNO);
+              nsh_error(vtbl, g_fmtcmdfailed, cmd, "open", NSH_ERRNO);
             }
 
           /* Free the allocated path */
@@ -138,7 +138,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
           /* Get the current file position.  This is used to control
            * looping.  If a loop begins in the next line, then this file
            * offset will be needed to locate the top of the loop in the
-           * script file.  Note that ftell will return -1 on failure.
+           * script file.  Note that lseek will return -1 on failure.
            */
 
           vtbl->np.np_foffs = lseek(vtbl->np.np_fd, 0, SEEK_CUR);
@@ -146,7 +146,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
 
           if (vtbl->np.np_foffs < 0 && log)
             {
-              nsh_error(vtbl, g_fmtcmdfailed, "loop", "ftell", NSH_ERRNO);
+              nsh_error(vtbl, g_fmtcmdfailed, "loop", "lseek", NSH_ERRNO);
             }
 #endif
 

--- a/nshlib/nsh_system.c
+++ b/nshlib/nsh_system.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/nshlib/nsh_telnetlogin.c
+++ b/nshlib/nsh_telnetlogin.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>

--- a/nshlib/nsh_usbconsole.c
+++ b/nshlib/nsh_usbconsole.c
@@ -26,7 +26,6 @@
 
 #include <sys/boardctl.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -62,11 +61,6 @@
 
 static void nsh_configstdio(int fd)
 {
-  /* Make sure the stdout, and stderr are flushed */
-
-  fflush(stdout);
-  fflush(stderr);
-
   /* Dup the fd to create standard fd 0-2 */
 
   dup2(fd, 0);

--- a/nshlib/nsh_usbtrace.c
+++ b/nshlib/nsh_usbtrace.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
+#include <stdarg.h>
 #include <debug.h>
 
 #include <nuttx/usb/usbdev_trace.h>


### PR DESCRIPTION
## Summary

continue the change from https://github.com/apache/nuttx-apps/pull/1559, found by https://github.com/apache/nuttx/pull/4819.

## Impact

nshlib

## Testing

CI