### PR TITLE
crypto/mbedtls: disable optimize on sim platform 

### DIFF
--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -38,6 +38,12 @@ MBEDTLS_UNPACKPROGDIR = $(MBEDTLS_UNPACKNAME)$(DELIM)programs
 # This lets Mbed TLS better use some of the POSIX features we have
 CFLAGS += ${DEFINE_PREFIX}__unix__
 
+library/bignum.c_CFLAGS += -fno-lto
+
+ifeq ($(CONFIG_ARCH_SIM),y)
+  CFLAGS += -O0
+endif
+
 CSRCS = $(wildcard $(MBEDTLS_UNPACKLIBDIR)$(DELIM)*.c)
 
 $(MBEDTLS_ZIP):


### PR DESCRIPTION
## Summary

crypto/mbedtls: disable optimize on sim platform 

## Impact

mbedtls

## Testing

build break if enable MBEDTLS_HAVE_ASM && CONFIG_DEBUG_FULLOPT on sim platform


```bash
In file included from mbedtls/library/bignum.c:41:
mbedtls/library/bignum.c: In function ‘mpi_mul_hlp’:
mbedtls/library/bn_mul.h:86:13: error: ‘asm’ operand has impossible constraints
   86 | #define asm __asm
      |             ^~~~~
mbedtls/library/bn_mul.h:102:5: note: in expansion of macro ‘asm’
  102 |     asm(                                    \
      |     ^~~
mbedtls/library/bignum.c:1669:9: note: in expansion of macro ‘MULADDC_INIT’
 1669 |         MULADDC_INIT
      |         ^~~~~~~~~~~~
mbedtls/library/bn_mul.h:86:13: error: ‘asm’ operand has impossible constraints
   86 | #define asm __asm
      |             ^~~~~
mbedtls/library/bn_mul.h:102:5: note: in expansion of macro ‘asm’
  102 |     asm(                                    \
      |     ^~~
mbedtls/library/bignum.c:1684:9: note: in expansion of macro ‘MULADDC_INIT’
 1684 |         MULADDC_INIT
      |         ^~~~~~~~~~~~
mbedtls/library/bn_mul.h:86:13: error: ‘asm’ operand has impossible constraints
   86 | #define asm __asm
      |             ^~~~~
mbedtls/library/bn_mul.h:102:5: note: in expansion of macro ‘asm’
  102 |     asm(                                    \
      |     ^~~
mbedtls/library/bignum.c:1695:9: note: in expansion of macro ‘MULADDC_INIT’
 1695 |         MULADDC_INIT
      |         ^~~~~~~~~~~~

```