### PR TITLE
stdio: Remove CONFIG_EOL_IS_XXX

### DIFF
--- a/interpreters/bas/bas_fs.c
+++ b/interpreters/bas/bas_fs.c
@@ -435,9 +435,12 @@ int FS_opendev(int chn, int infd, int outfd)
 
 int FS_openin(const char *name)
 {
-  int chn, fd;
+  int chn;
+  int fd;
 
-  if ((fd = open(name, O_RDONLY)) == -1)
+  fd = open(name, O_RDONLY);
+
+  if (fd < 0)
     {
       FS_errmsg = strerror(errno);
       return -1;
@@ -526,9 +529,12 @@ int FS_openinChn(int chn, const char *name, int mode)
 
 int FS_openout(const char *name)
 {
-  int chn, fd;
+  int chn;
+  int fd;
 
-  if ((fd = open(name, O_WRONLY | O_TRUNC | O_CREAT, 0666)) == -1)
+  fd = open(name, O_WRONLY | O_TRUNC | O_CREAT, 0666);
+
+  if (fd < 0)
     {
       FS_errmsg = strerror(errno);
       return -1;
@@ -911,7 +917,8 @@ void FS_xonxoff(int chn, int on)
 
 int FS_put(int chn)
 {
-  ssize_t offset, written;
+  ssize_t offset;
+  size_t written;
 
   if (opened(chn, 2) == -1)
     {
@@ -1397,7 +1404,8 @@ int FS_getChar(int dev)
 
 int FS_get(int chn)
 {
-  ssize_t offset, rd;
+  ssize_t offset;
+  size_t rd;
 
   if (opened(chn, 2) == -1)
     {
@@ -1523,7 +1531,8 @@ int FS_eof(int chn)
 long int FS_loc(int chn)
 {
   int fd;
-  off_t cur, offset = 0;
+  off_t cur;
+  off_t offset = 0;
 
   if (opened(chn, -1) == -1)
     {
@@ -1773,9 +1782,11 @@ int FS_charpos(int chn)
 
 int FS_copy(const char *from, const char *to)
 {
-  int infd, outfd;
+  int infd;
+  int outfd;
   char buf[4096];
-  ssize_t inlen, outlen = -1;
+  ssize_t inlen;
+  ssize_t outlen = -1;
 
   if ((infd = open(from, O_RDONLY)) == -1)
     {

--- a/interpreters/bas/bas_fs.c
+++ b/interpreters/bas/bas_fs.c
@@ -294,64 +294,43 @@ static int edit(int chn, int nl)
         }
       else if ((f->inCapacity + 1) < sizeof(f->inBuf))
         {
-#ifdef CONFIG_EOL_IS_BOTH_CRLF
-          /* Ignore carriage returns that may accompany a CRLF sequence. */
+          /* Is this a new line character */
 
-          if (ch != '\r')
-#endif
+          if (ch != '\n')
             {
-              /* Is this a new line character */
+              /* No.. escape control characters other than newline and
+               * carriage return
+               */
 
-#ifdef CONFIG_EOL_IS_CR
-              if (ch != '\r')
-#elif defined(CONFIG_EOL_IS_LF)
-              if (ch != '\n')
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-              if (ch != '\n' && ch != '\r')
-#endif
+              if (ch >= '\0' && ch < ' ')
                 {
-                  /* No.. escape control characters other than newline and
-                   * carriage return
-                   */
-
-                  if (ch >= '\0' && ch < ' ')
-                    {
-                      FS_putChar(chn, '^');
-                      FS_putChar(chn, ch ? (ch + 'a' - 1) : '@');
-                    }
-
-                  /* Output normal, printable characters */
-
-                  else
-                    {
-                      FS_putChar(chn, ch);
-                    }
+                  FS_putChar(chn, '^');
+                  FS_putChar(chn, ch ? (ch + 'a' - 1) : '@');
                 }
 
-              /* It is a newline */
+              /* Output normal, printable characters */
 
               else
                 {
-                  /* Echo the newline (or not).  We always use newline
-                   * termination when talking to the host.
-                   */
-
-                  if (nl)
-                    {
-                      FS_putChar(chn, '\n');
-                    }
-
-#if defined(CONFIG_EOL_IS_CR) || defined(CONFIG_EOL_IS_EITHER_CRLF)
-                  /* If the host is talking to us with CR line terminations,
-                   * switch to use LF internally.
-                   */
-
-                  ch = '\n';
-#endif
+                  FS_putChar(chn, ch);
                 }
-
-              f->inBuf[f->inCapacity++] = ch;
             }
+
+          /* It is a newline */
+
+          else
+            {
+              /* Echo the newline (or not).  We always use newline
+               * termination when talking to the host.
+               */
+
+              if (nl)
+                {
+                  FS_putChar(chn, '\n');
+                }
+            }
+
+          f->inBuf[f->inCapacity++] = ch;
         }
     }
   while (ch != '\n');

--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -45,34 +45,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 /* Control characters */
 
 #undef  CTRL
@@ -1077,14 +1049,7 @@ static int cle_editloop(FAR struct cle_s *priv)
 
         /* Newline terminates editing.  But what is a newline? */
 
-#if defined(CONFIG_EOL_IS_EITHER_CRLF)
-        case '\r': /* CR terminates line */
         case '\n': /* LF terminates line */
-#elif defined(CONFIG_EOL_IS_CR)
-        case '\r': /* CR terminates line */
-#elif defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
-        case '\n': /* LF terminates line */
-#endif
           {
             /* Add the newline to the buffer at the end of the line */
 
@@ -1094,11 +1059,6 @@ static int cle_editloop(FAR struct cle_s *priv)
             return OK;
           }
           break;
-
-#if defined(CONFIG_EOL_IS_BOTH_CRLF)
-        case '\r': /* Wait for the LF */
-          break;
-#endif
 
         /* Text to insert or unimplemented/invalid keypresses */
 

--- a/system/readline/readline.h
+++ b/system/readline/readline.h
@@ -31,34 +31,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 /* Helper macros */
 
 #define RL_GETC(v)      ((v)->rl_getc(v))

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -667,13 +667,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
        * others both.
        */
 
-#if  defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
       else if (ch == '\n')
-#elif defined(CONFIG_EOL_IS_CR)
-      else if (ch == '\r')
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-      else if (ch == '\n' || ch == '\r')
-#endif
         {
 #ifdef CONFIG_READLINE_CMD_HISTORY
           /* Save history of command, only if there was something

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -57,34 +57,6 @@
 #  define CONFIG_SYSTEM_VI_COLS 64
 #endif
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 #ifndef CONFIG_SYSTEM_VI_YANK_THRESHOLD
 #define CONFIG_SYSTEM_VI_YANK_THRESHOLD 128
 #endif
@@ -4099,21 +4071,6 @@ static void vi_cmd_mode(FAR struct vi_s *vi)
           }
           break;
 
-#if defined(CONFIG_EOL_IS_CR)
-        case KEY_CMDMODE_NEXTLINE:
-        case '\r': /* CR terminates line */
-          {
-            vi->curpos = vi_nextline(vi, vi->curpos);
-            vi_gotofirstnonwhite(vi);
-          }
-          break;
-
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-       case '\r': /* Wait for the LF */
-          break;
-#endif
-
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
         case KEY_CMDMODE_NEXTLINE:
         case '\n': /* LF terminates line */
           {
@@ -4121,18 +4078,6 @@ static void vi_cmd_mode(FAR struct vi_s *vi)
             vi_gotofirstnonwhite(vi);
           }
           break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-        case KEY_CMDMODE_NEXTLINE:
-        case '\r': /* Either CR or LF terminates line */
-        case '\n':
-          {
-            vi->curpos = vi_nextline(vi, vi->curpos);
-            vi_gotofirstnonwhite(vi);
-          }
-          break;
-#endif
 
         case KEY_CMDMODE_PREVLINE:
           {
@@ -4639,34 +4584,11 @@ static void vi_cmd_submode(FAR struct vi_s *vi)
 
           /* What do we do with carriage returns? line feeds? */
 
-#if defined(CONFIG_EOL_IS_CR)
-          case '\r': /* CR terminates line */
-            {
-              vi_parsecolon(vi);
-            }
-            break;
-
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-          case '\r': /* Wait for the LF */
-            break;
-#endif
-
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
             {
               vi_parsecolon(vi);
             }
             break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
-            {
-              vi_parsecolon(vi);
-            }
-            break;
-#endif
 
           default:
             {
@@ -4941,34 +4863,11 @@ static void vi_find_submode(FAR struct vi_s *vi, bool revfind)
 
           /* What do we do with carriage returns? line feeds? */
 
-#if defined(CONFIG_EOL_IS_CR)
-          case '\r': /* CR terminates line */
-            {
-              vi_parsefind(vi, revfind);
-            }
-            break;
-
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-          case '\r': /* Wait for the LF */
-            break;
-#endif
-
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
             {
               vi_parsefind(vi, revfind);
             }
             break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
-            {
-              vi_parsefind(vi, revfind);
-            }
-            break;
-#endif
 
           default:
             {
@@ -5089,36 +4988,11 @@ static void vi_replacech_submode(FAR struct vi_s *vi)
 
           /* What do we do with carriage returns? line feeds? */
 
-#if defined(CONFIG_EOL_IS_CR)
-          case '\r': /* CR terminates line */
-            {
-              ch = '\n';
-              found = true;
-            }
-            break;
-
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-          case '\r': /* Wait for the LF */
-            break;
-#endif
-
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
             {
               found = true;
             }
             break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
-            {
-              ch = '\n';
-              found = true;
-            }
-            break;
-#endif
 
           default:
             {
@@ -5487,28 +5361,6 @@ static void vi_insert_mode(FAR struct vi_s *vi)
 
           /* What do we do with carriage returns? */
 
-#if defined(CONFIG_EOL_IS_CR)
-          case '\r': /* CR terminates line */
-            {
-              if (vi->mode == MODE_INSERT)
-                {
-                  vi_insertch(vi, '\n');
-                }
-              else
-                {
-                  vi_replacech(vi, '\n');
-                }
-
-              vi->drawtoeos = true;
-            }
-            break;
-
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-         case '\r': /* Wait for the LF */
-            break;
-#endif
-
-#if defined(CONFIG_EOL_IS_LF) || defined(CONFIG_EOL_IS_BOTH_CRLF)
           case '\n': /* LF terminates line */
             {
               if (vi->mode == MODE_INSERT)
@@ -5523,27 +5375,6 @@ static void vi_insert_mode(FAR struct vi_s *vi)
               vi->drawtoeos = true;
             }
             break;
-#endif
-
-#ifdef CONFIG_EOL_IS_EITHER_CRLF
-          case '\r': /* Either CR or LF terminates line */
-          case '\n':
-            {
-              if (vi->mode == MODE_INSERT)
-                {
-                  vi_insertch(vi, '\n');
-                }
-              else
-                {
-                  vi_replacech(vi, '\n');
-                }
-
-              vi_putch(vi, ' ');
-              vi_clrtoeol(vi);
-              vi->drawtoeos = true;
-            }
-            break;
-#endif
 
           case KEY_UP:         /* Move the cursor up one line */
             {


### PR DESCRIPTION
## Summary
Remove CONFIG_EOL_IS_XXX relative logic since serial driver will do the convertion.

Please ignore nxstyle error from `bas_fs.c`.
## Impact
Should be none.
## Testing
cle/vi/bas/readline
