### PR TITLE
wireless/wapi: correct check of return value

### DIFF
--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -991,7 +991,7 @@ static int wapi_save_config_cmd(int sock, int argc, FAR char **argv)
                                     &conf.alg,
                                     psk,
                                     &psk_len);
-  if (ret == 0)
+  if (ret >= 0)
     {
       conf.passphrase = psk;
       conf.phraselen = psk_len;


### PR DESCRIPTION
## Summary

----------------------
 * Name: ioctl ...
 * Returned Value:
 *   >=0 on success (positive non-zero values are cmd-specific)
 *   -1 on failure with errno set properly:

## Impact

wapi

## Testing

CI