### PR TITLE
add "hello_nim" example application written in Nim.

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,126 @@
+############################################################################
+# apps/config.nims
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+import std/os
+import std/strutils
+
+switch "os", "nuttx"
+switch "mm", "orc"
+
+switch "arm.nuttx.gcc.exe", "arm-none-eabi-gcc"
+switch "arm64.nuttx.gcc.exe", "aarch64-none-elf-gcc"
+switch "riscv32.nuttx.gcc.exe", "riscv64-unknown-elf-gcc"
+switch "amd64.nuttx.gcc.exe", "x86_64-linux-gnu-gcc"
+
+switch "nimcache", ".nimcache"
+switch "d", "useStdLib"
+switch "d", "useMalloc"
+switch "d", "nimAllocPagesViaMalloc"
+switch "d", "noSignalHandler"
+switch "threads", "off"
+switch "noMain", "on"
+switch "compileOnly", "on"
+switch "noLinking", "on"
+# TODO: need OpenSSL-mbedTLS wrapper library.
+#switch "d", "ssl"
+#swich "dynlibOverride", "ssl"
+
+type
+  OptFlag = enum
+    oNone
+    oSize
+  DotConfig = object
+    arch: string
+    opt: OptFlag
+    debugSymbols: bool
+    ramSize: int
+    isSim: bool
+
+proc killoBytes(bytes: int): int =
+  result = (bytes / 1024).int
+
+proc read_config(cfg: string): DotConfig =
+  for line in cfg.readFile.splitLines:
+    if not line.startsWith("CONFIG_"):
+      continue
+    let keyval = line.replace("CONFIG_", "").split("=")
+    if keyval.len != 2:
+      continue
+    case keyval[0]
+    of "ARCH":
+      let arch = keyval[1].strip(chars = {'"'})
+      case arch
+      of "arm", "arm64":
+        result.arch = arch
+      of "riscv":
+        result.arch = "riscv32"
+      of "sim":
+        if defined(amd64):
+          result.arch = "amd64"
+        elif defined(aarch64):
+          result.arch = "arm64"
+        result.isSim = true
+    of "DEBUG_NOOPT":
+      result.opt = oNone
+    of "DEBUG_FULLOPT":
+      result.opt = oSize
+    of "DEBUG_SYMBOLS":
+      result.debugSymbols = true
+    of "RAM_SIZE":
+      result.ramSize = keyval[1].parseInt
+  echo "* arch:    " & result.arch
+  echo "* opt:     " & $result.opt
+  echo "* debug:   " & $result.debugSymbols
+  echo "* ramSize: " & $result.ramSize
+
+func bool2onoff(b: bool): string =
+  result = if b: "on" else: "off"
+
+proc setup_cfg(cfg: DotConfig) =
+  switch("cpu", cfg.arch)
+  if cfg.opt == oSize:
+    switch("define", "release")
+    switch("define", "danger")
+    switch("opt", "size")
+  if cfg.debugSymbols:
+    # use native debugger (gdb)
+    switch("debugger", "native")
+  let debug_onoff = cfg.debugSymbols.bool2onoff
+  switch("lineDir", debug_onoff)
+  switch("stackTrace", debug_onoff)
+  switch("lineTrace", debug_onoff)
+  if not cfg.isSim:
+    # Adjust the page size for Nim's GC allocator.
+    let ramKilloBytes = cfg.ramSize.killoBytes
+    if ramKilloBytes < 32:
+      switch("define", "nimPage256")
+    elif ramKilloBytes < 512:
+      switch("define", "nimPage512")
+    elif ramKilloBytes < 2048:
+      switch("define", "nimPage1k")
+    if ramKilloBytes < 512:
+      # Sets MemAlign to 4 bytes which reduces the memory alignment
+      # to better match some embedded devices.
+      switch("define", "nimMemAlignTiny")
+
+
+let topdir = getEnv("TOPDIR")
+let cfg = read_config(topdir & "/.config")
+cfg.setup_cfg()

--- a/examples/hello_nim/.gitignore
+++ b/examples/hello_nim/.gitignore
@@ -1,0 +1,2 @@
+.nimcache/
+.nimc

--- a/examples/hello_nim/Kconfig
+++ b/examples/hello_nim/Kconfig
@@ -1,0 +1,29 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_HELLO_NIM
+	tristate "\"Hello, World!\" example (Nim)"
+	default n
+	---help---
+		Enable the \"Hello, World!\" example
+
+if EXAMPLES_HELLO_NIM
+
+config EXAMPLES_HELLO_NIM_PROGNAME
+	string "Program name"
+	default "hello_nim"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_HELLO_NIM_PRIORITY
+	int "Hello task priority"
+	default 100
+
+config EXAMPLES_HELLO_NIM_STACKSIZE
+	int "Hello stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/hello_nim/Make.defs
+++ b/examples/hello_nim/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/hello_nim/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_HELLO_NIM),)
+CONFIGURED_APPS += $(APPDIR)/examples/hello_nim
+endif

--- a/examples/hello_nim/Makefile
+++ b/examples/hello_nim/Makefile
@@ -1,0 +1,50 @@
+############################################################################
+# apps/examples/hello_nim/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Hello, World! (Nim) built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_HELLO_NIM_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_HELLO_NIM_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_HELLO_NIM_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_HELLO_NIM)
+
+# Hello, World! Example
+
+NIMPATH = $(shell choosenim show path)
+CFLAGS += -I $(NIMPATH)/lib -I ./.nimcache
+CSRCS += $(wildcard .nimcache/*.c)
+
+MAINSRC = hello_nim_main.c
+
+.nimc: hello_nim_async.nim
+	nim c --header $<
+	touch .nimc
+
+$(MAINSRC): .nimc
+
+clean::
+	$(call DELDIR, .nimcache)
+	$(call DELFILE, .nimc)
+
+all:: .nimc $(MAINSRC)
+
+include $(APPDIR)/Application.mk

--- a/examples/hello_nim/hello_nim_async.nim
+++ b/examples/hello_nim/hello_nim_async.nim
@@ -1,0 +1,18 @@
+import std/asyncdispatch
+import std/strformat
+
+proc task(id: int): Future[void] {.async.} =
+  for loop in 0..2:
+    echo &"Hello from task {id}! loops: {loop}"
+    if loop < 2:
+      await sleepAsync(1000)
+
+proc launch() {.async.} =
+  for id in 1..2:
+    asyncCheck task(id)
+    await sleepAsync(200)
+  await task(3)
+
+proc hello_nim() {.exportc, cdecl.} =
+  waitFor launch()
+  GC_runOrc()

--- a/examples/hello_nim/hello_nim_main.c
+++ b/examples/hello_nim/hello_nim_main.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * apps/examples/hello_nim/hello_nim_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include "hello_nim_async.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * hello_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  NimMain();
+  hello_nim();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Added sample application in Nim language

## Impact

It allows you to create applications in the Nim language, which can be easily integrated with the C language so that you can use NuttX features in Nim right away.

1.  No need to create HAL, binding modules.
2.  Can use Nim standard libraries, external libraries.

## Testing

Tested on sim, arm Cortex-A5, Cortex-M4.

1.  install choosenim, latest Nim language.

> https://nim-lang.org/install_unix.html
>  `$ choosenim devel --latest`

2. configure NuttX.

This example uses async/await, which requires the following items to be enabled

>CONFIG_SCHED_CHILD_STATUS=y
>CONFIG_NET=y
>CONFIG_NET_SOCKOPTS=y

important:
I am sending out a pull request to clear Nim's asyncdispatch module global dispatcher at the end of the task.

https://github.com/nim-lang/Nim/pull/21432

Until this accepted, the second and subsequent runs will fail.
