### PR TITLE
Fix nsh_builtin.c:91:22: error: 'SA_NOCLDWAIT' undeclared

### DIFF
--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <sched.h>
+#include <signal.h>
 #include <string.h>
 
 #include <nuttx/lib/builtin.h>


### PR DESCRIPTION
## Summary

## Impact

nshlib

## Testing

CI