### PR TITLE
logging/nxscope: add a mention of available client tools for NxScope

### DIFF
--- a/logging/nxscope/README.md
+++ b/logging/nxscope/README.md
@@ -30,3 +30,9 @@ Supported interfaces:
 
 A default serial protocol is implemented in `apps/logging/nxscope/nxscope_pser.c`
 It just packs NxScope data into simple frames with a CRC-16 checksum.
+
+## External tools
+
+- [Nxslib](https://github.com/railab/nxslib) - a Python (3.10+) client library for NxScope devices,
+- [Nxscli](https://github.com/railab/nxscli) - a Python (3.10+) command-line interface for NxScope,
+supporting data capture and visualization


### PR DESCRIPTION
## Summary
logging/nxscope: add a mention of available client tools for NxScope.
- nsxlib - a client library for NxScope devices
- nxscli - a command-line interface tool with 'pythonic' plugin architecture

I also started working on a GUI tool with embedded Matplotlib plots, but abandoned it for now. The command-line interface is easier to use (and more fun to write).

