### PR TITLE
readline: Don't echo input except VT100 command

### DIFF
--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -708,11 +708,6 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           buf[nch++] = '\n';
           buf[nch]   = '\0';
 
-#ifdef CONFIG_READLINE_ECHO
-          /* Echo the newline to the console */
-
-          RL_PUTC(vtbl, '\n');
-#endif
           return nch;
         }
 
@@ -724,11 +719,6 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
         {
           buf[nch++] = ch;
 
-#ifdef CONFIG_READLINE_ECHO
-          /* Echo the character to the console */
-
-          RL_PUTC(vtbl, ch);
-#endif
           /* Check if there is room for another character and the line's
            * null terminator.  If not then we have to end the line now.
            */


### PR DESCRIPTION
## Summary
Let's echo character by serial driver, this will imporve the experience of telnetd, which will display input command and newline twice.
And also enhance the compatiblity with some third party linux readline based application (like WAMR repl).
## Impact
nsh
## Testing
nsh over serial and telnetd
