### PR TITLE
bluetooth/nimble: update to bc7828341226d860429c63994065f8f1b8b8d7b0

### DIFF
--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -13,7 +13,7 @@ config NIMBLE_STACKSIZE
 
 config NIMBLE_REF
 	string "Version"
-	default "17a8e61fdec48d579df3bc5af59a9cff5edee674"
+	default "bc7828341226d860429c63994065f8f1b8b8d7b0"
 	---help---
 		Git ref name to use when downloading from nimBLE repo
 endif


### PR DESCRIPTION
## Summary
bluetooth/nimble: update to bc7828341226d860429c63994065f8f1b8b8d7b0
which fix https://github.com/apache/mynewt-nimble/pull/1472

## Impact

## Testing

