### PR TITLE
wamr: Fix `INTERPRETERS_WAMR_LIBC_WASI` dependency on `PSEUDOFS_SOFTLINKS`

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -72,6 +72,7 @@ config INTERPRETERS_WAMR_LIBC_BUILTIN
 
 config INTERPRETERS_WAMR_LIBC_WASI
 	bool "Enable WASI libc"
+	select PSEUDOFS_SOFTLINKS
 	default n
 	---help---
 	Note: As of writing this, this works only with main branch of


### PR DESCRIPTION
## Summary
This PR intends to fix a hidden dependency issue with the `INTERPRETERS_WAMR_LIBC_WASI` config, which requires `PSEUDOFS_SOFTLINKS` to be enabled to properly build.

Not including it results in linker errors due to missing symbols:
```
LD: nuttx
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o):(.literal.readlinkat_dup+0x0): undefined reference to `readlinkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o):(.literal.wasmtime_ssp_path_link+0x0): undefined reference to `linkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o):(.literal.wasmtime_ssp_path_link+0x4): undefined reference to `symlinkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o): in function `readlinkat_dup':
/home/nihei/Projects/NuttX/apps/interpreters/wamr/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:1512: undefined reference to `readlinkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o): in function `rwlock_unlock':
/home/nihei/Projects/NuttX/apps/interpreters/wamr/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/locking.h:111: undefined reference to `linkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o): in function `wasmtime_ssp_path_link':
/home/nihei/Projects/NuttX/apps/interpreters/wamr/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:1885: undefined reference to `symlinkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o): in function `wasmtime_ssp_path_readlink':
/home/nihei/Projects/NuttX/apps/interpreters/wamr/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2172: undefined reference to `readlinkat'
xtensa-esp32s3-elf-ld: /home/nihei/Projects/NuttX/nuttx/staging/libapps.a(posix.c.home.nihei.Projects.NuttX.apps.interpreters.wamr.o): in function `wasmtime_ssp_path_symlink':
/home/nihei/Projects/NuttX/apps/interpreters/wamr/wamr/core/iwasm/libraries/libc-wasi/sandboxed-system-primitives/src/posix.c:2455: undefined reference to `symlinkat'
```

## Impact
Affects defconfigs that enable `INTERPRETERS_WAMR_LIBC_WASI` and need to explicitly select `PSEUDOFS_SOFTLINKS`.

## Testing
Custom defconfig based on `esp32s3-devkit:nsh` for enabling WAMR support.
