### PR TITLE
system/cle: Don't echo extra '\n'

### DIFF
--- a/system/cle/cle.c
+++ b/system/cle/cle.c
@@ -1055,7 +1055,6 @@ static int cle_editloop(FAR struct cle_s *priv)
 
             priv->curpos = priv->nchars;
             cle_insertch(priv, '\n');
-            cle_putch(priv, '\n');
             return OK;
           }
           break;


### PR DESCRIPTION
## Summary
Before:
```
NuttShell (NSH) NuttX-12.0.0
nsh> free
# Extra line here
                   total       used       free    largest  nused  nfree
        Umem:   33154512      33584   33120928   33120928     96      1
```

After:
```
NuttShell (NSH) NuttX-12.0.0
nsh> free
                   total       used       free    largest  nused  nfree
        Umem:   33154512      33584   33120928   33120928     96      1
```



## Impact
nsh with cle
## Testing
QEMU
