### PR TITLE
Replace the unsafe function(strcat, sprintf) with the safe one(strlcat, snprintf)

### DIFF
--- a/canutils/slcan/slcan.c
+++ b/canutils/slcan/slcan.c
@@ -270,22 +270,23 @@ int main(int argc, char *argv[])
                       /* 29 bit address */
 
                       frame.can_id = frame.can_id & ~CAN_EFF_FLAG;
-                      sprintf(sbuf, "T%08" PRIx32 "%d",
-                              frame.can_id, frame.len);
+                      snprintf(sbuf, sizeof(sbuf), "T%08" PRIx32 "%d",
+                               frame.can_id, frame.len);
                       sbp = &sbuf[10];
                     }
                   else
                     {
                       /* 11 bit address */
 
-                      sprintf(sbuf, "t%03" PRIx32 "%d",
-                              frame.can_id, frame.len);
+                      snprintf(sbuf, sizeof(sbuf), "t%03" PRIx32 "%d",
+                               frame.can_id, frame.len);
                       sbp = &sbuf[5];
                     }
 
                   for (i = 0; i < frame.len; i++)
                     {
-                      sprintf(sbp, "%02X", frame.data[i]);
+                      snprintf(sbp, sizeof(sbuf) - (sbp - sbuf),
+                               "%02X", frame.data[i]);
                       sbp += 2;
                     }
 

--- a/examples/chat/chat_main.c
+++ b/examples/chat/chat_main.c
@@ -256,9 +256,7 @@ static int chat_parse_args(FAR struct chat_app *priv)
 
               /* set the TTY device node */
 
-              strncpy(priv->tty,
-                      (FAR char *)priv->argv[i] + 2,
-                      CHAT_TTYNAME_SIZE - 1);
+              strlcpy(priv->tty, priv->argv[i] + 2, CHAT_TTYNAME_SIZE);
               break;
 
             case 'e':
@@ -266,13 +264,11 @@ static int chat_parse_args(FAR struct chat_app *priv)
               break;
 
             case 'f':
-              ret = chat_script_read(priv,
-                                     (FAR char *)priv->argv[i] + 2);
+              ret = chat_script_read(priv, priv->argv[i] + 2);
               break;
 
             case 'p':
-              numarg = strtol((FAR char *)priv->argv[i] + 2,
-                              NULL, 10);
+              numarg = strtol(priv->argv[i] + 2, NULL, 10);
               if (errno < 0)
                 {
                   ret = -EINVAL;
@@ -283,8 +279,7 @@ static int chat_parse_args(FAR struct chat_app *priv)
               break;
 
             case 't':
-              numarg = strtol((FAR char *)priv->argv[i] + 2,
-                              NULL, 10);
+              numarg = strtol(priv->argv[i] + 2, NULL, 10);
 
               if (errno < 0 || numarg < 0)
                 {
@@ -336,7 +331,7 @@ int main(int argc, FAR char **argv)
   priv.ctl.timeout = CONFIG_EXAMPLES_CHAT_TIMEOUT_SECONDS;
   priv.script = NULL;
   priv.script_dynalloc = false;
-  strncpy(priv.tty, CONFIG_EXAMPLES_CHAT_TTY_DEVNODE, CHAT_TTYNAME_SIZE - 1);
+  strlcpy(priv.tty, CONFIG_EXAMPLES_CHAT_TTY_DEVNODE, CHAT_TTYNAME_SIZE);
 
   _info("parsing the arguments\n");
   ret = chat_parse_args((FAR struct chat_app *)&priv);

--- a/examples/embedlog/embedlog_main.c
+++ b/examples/embedlog/embedlog_main.c
@@ -219,7 +219,7 @@ static void el_print_file(const char *workdir)
 
   /* Create full path to log file embedlog will use */
 
-  sprintf(log_path, "%s/log-rotate", workdir);
+  snprintf(log_path, sizeof(log_path), "%s/log-rotate", workdir);
 
   /* Enable file rotation, maximum 5 files will be created, none of the log
    * files size shall exceed 512 bytes. Rotate size is low to present how

--- a/examples/flash_test/flash_test.c
+++ b/examples/flash_test/flash_test.c
@@ -156,13 +156,14 @@ int main(int argc, FAR char *argv[])
 
       /* Save the sector in our array */
 
-      sectors[x] = (uint16_t) logsector;
+      sectors[x] = (uint16_t)logsector;
       seqs[x] = seq++;
 
       /* Now write some data to the sector */
 
-      sprintf(buffer, "Logical sector %d sequence %d\n",
-              sectors[x], seqs[x]);
+      snprintf(buffer, fmt.availbytes,
+               "Logical sector %d sequence %d\n",
+               sectors[x], seqs[x]);
 
       readwrite.logsector = sectors[x];
       readwrite.offset = 0;
@@ -202,8 +203,9 @@ int main(int argc, FAR char *argv[])
 
       printf("\r%d     ", sectors[x]);
 
-      sprintf(&buffer[100], "Logical sector %d sequence %d\n",
-              sectors[x], seqs[x]);
+      snprintf(&buffer[100], fmt.availbytes - 100,
+               "Logical sector %d sequence %d\n",
+               sectors[x], seqs[x]);
 
       if (strcmp(buffer, &buffer[100]) != 0)
         {
@@ -224,8 +226,9 @@ int main(int argc, FAR char *argv[])
       /* Now write over the sector data with new data, causing a relocation.
        */
 
-      sprintf(buffer, "Logical sector %d sequence %d\n",
-              sectors[x], seqs[x]);
+      snprintf(buffer, fmt.availbytes,
+               "Logical sector %d sequence %d\n",
+               sectors[x], seqs[x]);
       readwrite.logsector = sectors[x];
       readwrite.offset = 0;
       readwrite.count = strlen(buffer) + 1;
@@ -252,7 +255,8 @@ int main(int argc, FAR char *argv[])
        * causing a relocation.
        */
 
-      sprintf(buffer, "Appended data in sector %d\n", sectors[x]);
+      snprintf(buffer, fmt.availbytes,
+               "Appended data in sector %d\n", sectors[x]);
       readwrite.logsector = sectors[x];
       readwrite.offset = 64;
       readwrite.count = strlen(buffer) + 1;

--- a/examples/flowc/flowc_receiver.c
+++ b/examples/flowc/flowc_receiver.c
@@ -107,7 +107,7 @@ static int flowc_cmdline(int argc, char **argv)
 
   if (argc == 2)
     {
-      strncpy(g_tty_devname, argv[1], MAX_DEVNAME);
+      strlcpy(g_tty_devname, argv[1], MAX_DEVNAME);
     }
   else if (argc != 1)
     {

--- a/examples/flowc/flowc_sender.c
+++ b/examples/flowc/flowc_sender.c
@@ -69,7 +69,7 @@ static int flowc_cmdline(int argc, char **argv)
 
   if (argc == 2)
     {
-      strncpy(g_tty_devname, argv[1], MAX_DEVNAME);
+      strlcpy(g_tty_devname, argv[1], MAX_DEVNAME);
     }
   else if (argc != 1)
     {

--- a/examples/foc/foc_device.c
+++ b/examples/foc/foc_device.c
@@ -50,7 +50,8 @@ int foc_device_init(FAR struct foc_device_s *dev, int id)
 
   /* Get FOC devpath */
 
-  sprintf(devpath, "%s%d", CONFIG_EXAMPLES_FOC_DEVPATH, id);
+  snprintf(devpath, sizeof(devpath), "%s%d",
+           CONFIG_EXAMPLES_FOC_DEVPATH, id);
 
   /* Open FOC device */
 

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -887,10 +887,10 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
 
   /* Get qenco devpath */
 
-  sprintf(motor->qedpath,
-          "%s%d",
-          CONFIG_EXAMPLES_FOC_QENCO_DEVPATH,
-          motor->envp->id);
+  snprintf(motor->qedpath, sizeof(motor->qedpath),
+           "%s%d",
+           CONFIG_EXAMPLES_FOC_QENCO_DEVPATH,
+           motor->envp->id);
 
   /* Configure qenco angle handler */
 
@@ -918,10 +918,10 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
 
   /* Get hall devpath */
 
-  sprintf(motor->hldpath,
-          "%s%d",
-          CONFIG_EXAMPLES_FOC_HALL_DEVPATH,
-          motor->envp->id);
+  snprintf(motor->hldpath, sizeof(motor->hldpath),
+           "%s%d",
+           CONFIG_EXAMPLES_FOC_HALL_DEVPATH,
+           motor->envp->id);
 
   /* Configure hall angle handler */
 

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -871,10 +871,10 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
 
   /* Get qenco devpath */
 
-  sprintf(motor->qedpath,
-          "%s%d",
-          CONFIG_EXAMPLES_FOC_QENCO_DEVPATH,
-          motor->envp->id);
+  snprintf(motor->qedpath, sizeof(motor->qedpath),
+           "%s%d",
+           CONFIG_EXAMPLES_FOC_QENCO_DEVPATH,
+           motor->envp->id);
 
   /* Configure qenco angle handler */
 
@@ -902,10 +902,10 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
 
   /* Get hall devpath */
 
-  sprintf(motor->hldpath,
-          "%s%d",
-          CONFIG_EXAMPLES_FOC_HALL_DEVPATH,
-          motor->envp->id);
+  snprintf(motor->hldpath, sizeof(motor->hldpath),
+           "%s%d",
+           CONFIG_EXAMPLES_FOC_HALL_DEVPATH,
+           motor->envp->id);
 
   /* Configure hall angle handler */
 

--- a/examples/foc/foc_thr.c
+++ b/examples/foc/foc_thr.c
@@ -107,7 +107,7 @@ static FAR void *foc_control_thr(FAR void *arg)
 
   /* Get queue name */
 
-  sprintf(mqname, "%s%d", CONTROL_MQ_MQNAME, envp->id);
+  snprintf(mqname, sizeof(mqname), "%s%d", CONTROL_MQ_MQNAME, envp->id);
 
   /* Open queue */
 
@@ -299,7 +299,7 @@ int foc_ctrlthr_init(FAR struct foc_ctrl_env_s *foc, int i, FAR mqd_t *mqd,
 
   /* Get queue name */
 
-  sprintf(mqname, "%s%d", CONTROL_MQ_MQNAME, foc->id);
+  snprintf(mqname, sizeof(mqname), "%s%d", CONTROL_MQ_MQNAME, foc->id);
 
   /* Initialize thread recv queue */
 

--- a/examples/ipforward/ipforward.c
+++ b/examples/ipforward/ipforward.c
@@ -228,7 +228,7 @@ static int ipfwd_tun_configure(FAR struct ipfwd_tun_s *tun)
       return -errcode;
     }
 
-  strncpy(tun->it_devname, ifr.ifr_name, MAX_DEVNAME);
+  strlcpy(tun->it_devname, ifr.ifr_name, MAX_DEVNAME);
   printf("Created TUN device: %s\n", tun->it_devname);
   return 0;
 }

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -192,8 +192,9 @@ void parse_and_callback(cJSON *item, const char *prefix)
 {
     while (item)
     {
-        char *newprefix = malloc(strlen(prefix) + strlen(item->name) + 2);
-        sprintf(newprefix, "%s/%s", prefix, item->name);
+        size_t len = strlen(prefix) + strlen(item->name) + 2;
+        char *newprefix = malloc(len);
+        snprintf(newprefix, len, "%s/%s", prefix, item->name);
         int dorecurse = callback(newprefix, item->type, item);
         if (item->child && dorecurse) parse_and_callback(item->child, newprefix);
         item = item->next;

--- a/examples/mcuboot/update_agent/mcuboot_agent_main.c
+++ b/examples/mcuboot/update_agent/mcuboot_agent_main.c
@@ -207,7 +207,8 @@ static int download_firmware_image(FAR const char *url)
 
   for (i = 0; i < MD5_DIGEST_LENGTH; i++)
     {
-      sprintf(&hash[i * 2], "%02x", digest[i]);
+      snprintf(&hash[i * 2], sizeof(hash) - i * 2,
+               "%02x", digest[i]);
     }
 
   hash[MD5_HASH_LENGTH] = '\0';

--- a/examples/mount/mount_main.c
+++ b/examples/mount/mount_main.c
@@ -212,7 +212,8 @@ static void show_directories(const char *path, int indent)
         {
           char *subdir;
           printf("%s/\n", direntry->d_name);
-          sprintf(g_namebuffer, "%s/%s", path, direntry->d_name);
+          snprintf(g_namebuffer, sizeof(g_namebuffer),
+                   "%s/%s", path, direntry->d_name);
           subdir = strdup(g_namebuffer);
           show_directories(subdir, indent + 1);
           free(subdir);

--- a/examples/netloop/lo_main.c
+++ b/examples/netloop/lo_main.c
@@ -152,7 +152,7 @@ static int lo_client(void)
 
   for (i = 0; ; i++)
     {
-      sprintf(outbuf, "Loopback message %d", i);
+      snprintf(outbuf, sizeof(outbuf), "Loopback message %d", i);
       len = strlen(outbuf);
 
       printf("lo_client: Sending '%s' (%d bytes)\n", outbuf, len);

--- a/examples/pdcurses/newdemo_main.c
+++ b/examples/pdcurses/newdemo_main.c
@@ -316,8 +316,8 @@ int main(int argc, FAR char *argv[])
   curs_set(0);
   noecho();
 
-  /* Refresh stdscr so that reading from it will not cause it to overwrite the
-   * other windows that are being created.
+  /* Refresh stdscr so that reading from it will not cause it to overwrite
+   * the other windows that are being created.
    */
 
   refresh();
@@ -335,7 +335,7 @@ int main(int argc, FAR char *argv[])
       return 1;
     }
 
-  for (;;)
+  for (; ; )
     {
       init_pair(1, COLOR_WHITE, COLOR_BLUE);
       wbkgd(win, COLOR_PAIR(1));

--- a/examples/pdcurses/newdemo_main.c
+++ b/examples/pdcurses/newdemo_main.c
@@ -433,7 +433,7 @@ int main(int argc, FAR char *argv[])
           for (i = w + msg_len; i > 0; i--)
             {
               memset(visbuf, ' ', w);
-              strncpy(scrollbuf + i, message, msg_len);
+              strlcpy(scrollbuf + i, message, msg_len);
               mvwaddnstr(win, height / 2, 1, visbuf, w);
               wrefresh(win);
 

--- a/examples/pdcurses/tui.c
+++ b/examples/pdcurses/tui.c
@@ -92,8 +92,9 @@ static char *padstr(char *s, int length)
   static char buf[MAXSTRLEN];
   char fmt[10];
 
-  sprintf(fmt, (int)strlen(s) > length ? "%%.%ds" : "%%-%ds", length);
-  sprintf(buf, fmt, s);
+  snprintf(fmt, sizeof(fmt),
+           (int)strlen(s) > length ? "%%.%ds" : "%%-%ds", length);
+  snprintf(buf, sizeof(buf), fmt, s);
 
   return buf;
 }
@@ -206,7 +207,7 @@ static void idle(void)
     }
 
   tp = localtime(&t);
-  sprintf(buf, " %.2d-%.2d-%.4d  %.2d:%.2d:%.2d",
+  snprintf(buf, sizeof(buf), " %.2d-%.2d-%.4d  %.2d:%.2d:%.2d",
           tp->tm_mday, tp->tm_mon + 1, tp->tm_year + 1900,
           tp->tm_hour, tp->tm_min, tp->tm_sec);
 

--- a/examples/pdcurses/tui_main.c
+++ b/examples/pdcurses/tui_main.c
@@ -204,7 +204,7 @@ static void showfile(char *fname)
     }
   else
     {
-      sprintf(buf, "ERROR: file '%s' not found", fname);
+      snprintf(buf, sizeof(buf), "ERROR: file '%s' not found", fname);
       errormsg(buf);
     }
 }

--- a/examples/poll/host.c
+++ b/examples/poll/host.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv, char **envp)
 
   for (i = 0; ; i++)
     {
-      sprintf(outbuf, "Remote message %d", i);
+      snprintf(outbuf, sizeof(outbuf), "Remote message %d", i);
       len = strlen(outbuf);
 
       printf("client: Sending '%s' (%d bytes)\n", outbuf, len);

--- a/examples/poll/poll_main.c
+++ b/examples/poll/poll_main.c
@@ -134,7 +134,8 @@ int main(int argc, FAR char *argv[])
   ret = pthread_create(&tid2, NULL, select_listener, NULL);
   if (ret != 0)
     {
-      printf("poll_main: Failed to create select_listener thread: %d\n", ret);
+      printf("poll_main: Failed to create select_listener thread: %d\n",
+             ret);
       exitcode = 6;
       goto errout;
     }

--- a/examples/poll/poll_main.c
+++ b/examples/poll/poll_main.c
@@ -163,7 +163,7 @@ int main(int argc, FAR char *argv[])
        * from the poll.
        */
 
-      sprintf(buffer, "Message %d", count);
+      snprintf(buffer, sizeof(buffer), "Message %d", count);
       nbytes = write(fd1, buffer, strlen(buffer));
       if (nbytes < 0)
         {

--- a/examples/rgbled/rgbled.c
+++ b/examples/rgbled/rgbled.c
@@ -92,7 +92,7 @@ int main(int argc, FAR char *argv[])
           sgreen = 1;
         }
 
-      sprintf(buffer, "#%02X%02X%02X", red, green, blue);
+      snprintf(buffer, sizeof(buffer), "#%02X%02X%02X", red, green, blue);
       write(fd, buffer, 8);
       usleep(5000);
     }

--- a/examples/romfs/romfs_main.c
+++ b/examples/romfs/romfs_main.c
@@ -389,7 +389,8 @@ static void readdirectories(const char *path, struct node_s *entry)
 
       /* Get the full path to the entry */
 
-      sprintf(g_scratchbuffer, "%s/%s", path, direntry->d_name);
+      snprintf(g_scratchbuffer, sizeof(g_scratchbuffer),
+               "%s/%s", path, direntry->d_name);
       fullpath = strdup(g_scratchbuffer);
 
       if (DIRENT_ISDIRECTORY(direntry->d_type))

--- a/examples/rpmsgsocket/rpsock_client.c
+++ b/examples/rpmsgsocket/rpsock_client.c
@@ -274,8 +274,8 @@ static int rpsock_stream_client(int argc, char *argv[])
   /* Connect the socket to the server */
 
   myaddr.rp_family = AF_RPMSG;
-  strncpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
-  strncpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
+  strlcpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
+  strlcpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
 
   printf("client: Connecting to %s,%s...\n", myaddr.rp_cpu, myaddr.rp_name);
   ret = connect(sockfd, (struct sockaddr *)&myaddr, sizeof(myaddr));
@@ -468,8 +468,8 @@ static int rpsock_dgram_client(int argc, char *argv[])
   /* Connect the socket to the server */
 
   myaddr.rp_family = AF_RPMSG;
-  strncpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
-  strncpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
+  strlcpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
+  strlcpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
 
   printf("client: Connecting to %s,%s...\n", myaddr.rp_cpu, myaddr.rp_name);
   ret = connect(sockfd, (struct sockaddr *)&myaddr, sizeof(myaddr));

--- a/examples/rpmsgsocket/rpsock_server.c
+++ b/examples/rpmsgsocket/rpsock_server.c
@@ -187,10 +187,10 @@ static int rpsock_stream_server(int argc, char *argv[])
   /* Bind the socket to a local address */
 
   myaddr.rp_family = AF_RPMSG;
-  strncpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
+  strlcpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
   if (argc == 5)
     {
-      strncpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
+      strlcpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
     }
   else
     {
@@ -300,10 +300,10 @@ static int rpsock_dgram_server(int argc, char *argv[])
   /* Bind the socket to a local address */
 
   myaddr.rp_family = AF_RPMSG;
-  strncpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
+  strlcpy(myaddr.rp_name, argv[3], RPMSG_SOCKET_NAME_SIZE);
   if (argc == 5)
     {
-      strncpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
+      strlcpy(myaddr.rp_cpu, argv[4], RPMSG_SOCKET_CPU_SIZE);
     }
   else
     {

--- a/examples/udgram/udgram_client.c
+++ b/examples/udgram/udgram_client.c
@@ -52,6 +52,7 @@ static inline void fill_buffer(unsigned char *buf, int offset)
         {
           j = 1;
         }
+
       buf[j] = ch;
     }
 }

--- a/examples/udgram/udgram_client.c
+++ b/examples/udgram/udgram_client.c
@@ -88,15 +88,14 @@ int main(int argc, FAR char *argv[])
 
       /* Set up the server address */
 
-      addrlen = strlen(CONFIG_EXAMPLES_UDGRAM_ADDR);
-      if (addrlen > UNIX_PATH_MAX - 1)
+      addrlen = strlen(CONFIG_EXAMPLES_UDGRAM_ADDR) + 1;
+      if (addrlen > UNIX_PATH_MAX)
         {
-          addrlen = UNIX_PATH_MAX - 1;
+          addrlen = UNIX_PATH_MAX;
         }
 
       server.sun_family = AF_LOCAL;
-      strncpy(server.sun_path, CONFIG_EXAMPLES_UDGRAM_ADDR, addrlen);
-      server.sun_path[addrlen] = '\0';
+      strlcpy(server.sun_path, CONFIG_EXAMPLES_UDGRAM_ADDR, addrlen);
 
       addrlen += sizeof(sa_family_t) + 1;
 

--- a/examples/udgram/udgram_server.c
+++ b/examples/udgram/udgram_server.c
@@ -53,9 +53,11 @@ static inline int check_buffer(unsigned char *buf)
         {
           j = 1;
         }
+
       if (buf[j] != ch)
         {
-          printf("server: Buffer content error for offset=%d, index=%d\n", offset, j);
+          printf("server: Buffer content error for offset=%d, index=%d\n",
+                 offset, j);
           ret = 0;
         }
     }
@@ -100,7 +102,7 @@ int main(int argc, FAR char *argv[])
 
   addrlen += sizeof(sa_family_t) + 1;
 
-  if (bind(sockfd, (struct sockaddr*)&server, addrlen) < 0)
+  if (bind(sockfd, (struct sockaddr *)&server, addrlen) < 0)
     {
       printf("server: ERROR bind failure: %d\n", errno);
       return 1;
@@ -113,7 +115,7 @@ int main(int argc, FAR char *argv[])
       printf("server: %d. Receiving up 1024 bytes\n", offset);
       recvlen = addrlen;
       nbytes = recvfrom(sockfd, inbuf, 1024, 0,
-                        (struct sockaddr*)&client, &recvlen);
+                        (struct sockaddr *)&client, &recvlen);
 
       if (nbytes < 0)
         {
@@ -122,10 +124,11 @@ int main(int argc, FAR char *argv[])
           return 1;
         }
 
-      if (recvlen < sizeof(sa_family_t) || recvlen > sizeof(struct sockaddr_un))
+      if (recvlen < sizeof(sa_family_t) ||
+          recvlen > sizeof(struct sockaddr_un))
         {
-          printf("server: %d. ERROR Received %d bytes from client with invalid length %d\n",
-                 offset, nbytes, recvlen);
+          printf("server: %d. ERROR Received %d bytes from client with "
+                 "invalid length %d\n", offset, nbytes, recvlen);
         }
       else if (recvlen == sizeof(sa_family_t))
         {
@@ -142,8 +145,8 @@ int main(int argc, FAR char *argv[])
               printf("server:  ERROR path not NUL terminated\n");
             }
         }
-      else /* if (recvlen > sizeof(sa_family_t)+1 &&
-                  recvlen <= sizeof(struct sockaddr_un)) */
+      else /* if (recvlen > sizeof(sa_family_t) + 1 &&
+            *     recvlen <= sizeof(struct sockaddr_un)) */
         {
           int pathlen = recvlen - sizeof(sa_family_t) - 1;
 

--- a/examples/udgram/udgram_server.c
+++ b/examples/udgram/udgram_server.c
@@ -89,15 +89,14 @@ int main(int argc, FAR char *argv[])
 
   /* Bind the socket to a local address */
 
-  addrlen = strlen(CONFIG_EXAMPLES_UDGRAM_ADDR);
-  if (addrlen > UNIX_PATH_MAX - 1)
+  addrlen = strlen(CONFIG_EXAMPLES_UDGRAM_ADDR) + 1;
+  if (addrlen > UNIX_PATH_MAX)
     {
-      addrlen = UNIX_PATH_MAX - 1;
+      addrlen = UNIX_PATH_MAX;
     }
 
   server.sun_family = AF_LOCAL;
-  strncpy(server.sun_path, CONFIG_EXAMPLES_UDGRAM_ADDR, addrlen);
-  server.sun_path[addrlen] = '\0';
+  strlcpy(server.sun_path, CONFIG_EXAMPLES_UDGRAM_ADDR, addrlen);
 
   addrlen += sizeof(sa_family_t) + 1;
 

--- a/examples/userfs/userfs_main.c
+++ b/examples/userfs/userfs_main.c
@@ -522,7 +522,7 @@ static int ufstest_rename(FAR void *volinfo, FAR const char *oldrelpath,
   file = ufstest_findbyname(oldrelpath);
   if (file != NULL)
     {
-      strncpy(file->entry.d_name, newrelpath, NAME_MAX + 1);
+      strlcpy(file->entry.d_name, newrelpath, NAME_MAX);
       return OK;
     }
 

--- a/examples/ustream/ustream_client.c
+++ b/examples/ustream/ustream_client.c
@@ -78,14 +78,14 @@ int main(int argc, FAR char *argv[])
 
   /* Connect the socket to the server */
 
-  addrlen = strlen(CONFIG_EXAMPLES_USTREAM_ADDR);
-  if (addrlen > UNIX_PATH_MAX - 1)
+  addrlen = strlen(CONFIG_EXAMPLES_USTREAM_ADDR) + 1;
+  if (addrlen > UNIX_PATH_MAX)
     {
-      addrlen = UNIX_PATH_MAX - 1;
+      addrlen = UNIX_PATH_MAX;
     }
 
   myaddr.sun_family = AF_LOCAL;
-  strncpy(myaddr.sun_path, CONFIG_EXAMPLES_USTREAM_ADDR, addrlen);
+  strlcpy(myaddr.sun_path, CONFIG_EXAMPLES_USTREAM_ADDR, addrlen);
   myaddr.sun_path[addrlen] = '\0';
 
   printf("client: Connecting to %s...\n", CONFIG_EXAMPLES_USTREAM_ADDR);

--- a/examples/ustream/ustream_server.c
+++ b/examples/ustream/ustream_server.c
@@ -78,14 +78,14 @@ int main(int argc, FAR char *argv[])
 
   /* Bind the socket to a local address */
 
-  addrlen = strlen(CONFIG_EXAMPLES_USTREAM_ADDR);
-  if (addrlen > UNIX_PATH_MAX - 1)
+  addrlen = strlen(CONFIG_EXAMPLES_USTREAM_ADDR) + 1;
+  if (addrlen > UNIX_PATH_MAX)
     {
-      addrlen = UNIX_PATH_MAX - 1;
+      addrlen = UNIX_PATH_MAX;
     }
 
   myaddr.sun_family = AF_LOCAL;
-  strncpy(myaddr.sun_path, CONFIG_EXAMPLES_USTREAM_ADDR, addrlen);
+  strlcpy(myaddr.sun_path, CONFIG_EXAMPLES_USTREAM_ADDR, addrlen);
   myaddr.sun_path[addrlen] = '\0';
 
   addrlen += sizeof(sa_family_t) + 1;

--- a/examples/ustream/ustream_server.c
+++ b/examples/ustream/ustream_server.c
@@ -41,14 +41,14 @@
  * Public Functions
  ****************************************************************************/
 
-int main(int argc, FAR char *argv[])
+int main(int argc, char *argv[])
 {
 #ifdef CONFIG_EXAMPLES_USTREAM_USE_POLL
   struct pollfd pfd;
 #endif
   struct sockaddr_un myaddr;
   socklen_t addrlen;
-  FAR char *buffer;
+  char *buffer;
   int listensd;
   int acceptsd;
   int nbytesread;
@@ -60,7 +60,7 @@ int main(int argc, FAR char *argv[])
 
   /* Allocate a BIG buffer */
 
-  buffer = (char*)malloc(2*SENDSIZE);
+  buffer = (char *)malloc(2 * SENDSIZE);
   if (!buffer)
     {
       printf("server: failed to allocate buffer\n");
@@ -89,7 +89,7 @@ int main(int argc, FAR char *argv[])
   myaddr.sun_path[addrlen] = '\0';
 
   addrlen += sizeof(sa_family_t) + 1;
-  ret = bind(listensd, (struct sockaddr*)&myaddr, addrlen);
+  ret = bind(listensd, (struct sockaddr *)&myaddr, addrlen);
   if (ret < 0)
     {
       printf("server: bind failure: %d\n", errno);
@@ -98,7 +98,8 @@ int main(int argc, FAR char *argv[])
 
   /* Listen for connections on the bound socket */
 
-  printf("server: Accepting connections on %s ...\n", CONFIG_EXAMPLES_USTREAM_ADDR);
+  printf("server: Accepting connections on %s ...\n",
+         CONFIG_EXAMPLES_USTREAM_ADDR);
 
   if (listen(listensd, 5) < 0)
     {
@@ -131,7 +132,7 @@ int main(int argc, FAR char *argv[])
     }
 #endif
 
-  acceptsd = accept(listensd, (struct sockaddr*)&myaddr, &addrlen);
+  acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
   if (acceptsd < 0)
     {
       printf("server: accept failure: %d\n", errno);
@@ -169,7 +170,8 @@ int main(int argc, FAR char *argv[])
 #endif
 
       printf("server: Reading...\n");
-      nbytesread = recv(acceptsd, &buffer[totalbytesread], 2*SENDSIZE - totalbytesread, 0);
+      nbytesread = recv(acceptsd, &buffer[totalbytesread],
+                        2 * SENDSIZE - totalbytesread, 0);
       if (nbytesread < 0)
         {
           printf("server: recv failed: %d\n", errno);
@@ -189,7 +191,8 @@ int main(int argc, FAR char *argv[])
 
   if (totalbytesread != SENDSIZE)
     {
-      printf("server: Received %d / Expected %d bytes\n", totalbytesread, SENDSIZE);
+      printf("server: Received %d / Expected %d bytes\n",
+             totalbytesread, SENDSIZE);
       goto errout_with_acceptsd;
     }
 
@@ -198,7 +201,8 @@ int main(int argc, FAR char *argv[])
     {
       if (buffer[i] != ch)
         {
-          printf("server: Byte %d is %02x / Expected %02x\n", i, buffer[i], ch);
+          printf("server: Byte %d is %02x / Expected %02x\n",
+                 i, buffer[i], ch);
           goto errout_with_acceptsd;
         }
 

--- a/examples/wgetjson/wgetjson_main.c
+++ b/examples/wgetjson/wgetjson_main.c
@@ -249,8 +249,9 @@ static void wgetjson_json_item_scan(cJSON *item, const char *prefix)
   while (item)
     {
       const char *string = item->string ? item->string : "(null)";
-      newprefix = malloc(strlen(prefix) + strlen(string) + 2);
-      sprintf(newprefix, "%s/%s", prefix, string);
+      size_t len = strlen(prefix) + strlen(string) + 2;
+      newprefix = malloc(len);
+      snprintf(newprefix, len, "%s/%s", prefix, string);
 
       dorecurse = wgetjson_json_item_callback(newprefix, item->type, item);
       if (item->child && dorecurse)

--- a/fsutils/passwd/passwd_find.c
+++ b/fsutils/passwd/passwd_find.c
@@ -153,8 +153,7 @@ int passwd_find(FAR const char *username, FAR struct passwd_s *passwd)
             }
 
           passwd->offset = offset;
-          strncpy(passwd->encrypted, encrypted, MAX_ENCRYPTED);
-          passwd->encrypted[MAX_ENCRYPTED] = '\0';
+          strlcpy(passwd->encrypted, encrypted, MAX_ENCRYPTED);
 
           ret = OK;
           break;

--- a/graphics/pdcurs34/pdcurses/pdc_initscr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_initscr.c
@@ -262,7 +262,8 @@ WINDOW *Xinitscr(int argc, char *argv[])
 
   def_shell_mode();
 
-  sprintf(ttytype, "pdcurses|PDCurses for %s", PDC_sysname());
+  snprintf(ttytype, sizeof(ttytype),
+           "pdcurses|PDCurses for %s", PDC_sysname());
 
   return stdscr;
 }

--- a/graphics/pdcurs34/pdcurses/pdc_panel.c
+++ b/graphics/pdcurs34/pdcurses/pdc_panel.c
@@ -184,7 +184,7 @@ static void dstack(char *fmt, int num, PANEL *pan)
 {
   char s80[80];
 
-  sprintf(s80, fmt, num, pan);
+  snprintf(s80, sizeof(s80), fmt, num, pan);
   PDC_LOG(("%s b=%s t=%s", s80, _bottom_panel ? _bottom_panel->user : "--",
            _top_panel ? _top_panel->user : "--"));
 
@@ -220,7 +220,7 @@ static void dtouchline(PANEL *pan, int start, int count)
 {
   char s80[80];
 
-  sprintf(s80, "dtouchline s=%d c=%d", start, count);
+  snprintf(s80, sizeof(s80), "dtouchline s=%d c=%d", start, count);
   dpanel(s80, pan);
   touchline(pan->win, start, count);
 }

--- a/graphics/pdcurs34/pdcurses/pdc_panel.c
+++ b/graphics/pdcurs34/pdcurses/pdc_panel.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/graphics/pdcurses/pdc_panel.c
+ * apps/graphics/pdcurs34/pdcurses/pdc_panel.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -149,9 +149,12 @@
  ****************************************************************************/
 
 #ifndef CONFIG_PDCURSES_MULTITHREAD
-PANEL *_bottom_panel = (PANEL *) 0;
-PANEL *_top_panel = (PANEL *) 0;
-PANEL _stdscr_pseudo_panel = { (WINDOW *) 0 };
+PANEL *_bottom_panel = (PANEL *)0;
+PANEL *_top_panel = (PANEL *)0;
+PANEL _stdscr_pseudo_panel =
+{
+  (WINDOW *)0
+};
 #else
 typedef struct panel_ctx_s
 {
@@ -177,7 +180,8 @@ static void dpanel(char *text, PANEL *pan)
 {
   PDC_LOG(("%s id=%s b=%s a=%s y=%d x=%d", text, pan->user,
            pan->below ? pan->below->user : "--",
-           pan->above ? pan->above->user : "--", pan->wstarty, pan->wstartx));
+           pan->above ? pan->above->user : "--",
+           pan->wstarty, pan->wstartx));
 }
 
 static void dstack(char *fmt, int num, PANEL *pan)
@@ -686,7 +690,8 @@ WINDOW *panel_window(const PANEL *pan)
 
 int replace_panel(PANEL *pan, WINDOW *win)
 {
-  int maxy, maxx;
+  int maxy;
+  int maxx;
 
   if (!pan)
     {

--- a/graphics/screenshot/screenshot_main.c
+++ b/graphics/screenshot/screenshot_main.c
@@ -85,8 +85,8 @@ static void replace_extension(FAR const char *filename, FAR const char *newext,
       len = size - strlen(newext);
     }
 
-  strncpy(dest, filename, size);
-  strncpy(dest + len, newext, size - len);
+  strlcpy(dest, filename, size);
+  strlcpy(dest + len, newext, size - len);
 }
 
 /****************************************************************************

--- a/graphics/screenshot/screenshot_main.c
+++ b/graphics/screenshot/screenshot_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/screenshot/screenshot_main.c
+ * apps/graphics/screenshot/screenshot_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -69,7 +69,8 @@
  * Private Functions
  ****************************************************************************/
 
-static void replace_extension(FAR const char *filename, FAR const char *newext,
+static void replace_extension(FAR const char *filename,
+                              FAR const char *newext,
                               FAR char *dest, size_t size)
 {
   FAR char *p = strrchr(filename, '.');
@@ -104,8 +105,15 @@ static void replace_extension(FAR const char *filename, FAR const char *newext,
 int save_screenshot(FAR const char *filename)
 {
   struct tiff_info_s info;
-  struct nx_callback_s cb = {};
-  struct nxgl_size_s size = {CONFIG_SCREENSHOT_WIDTH, CONFIG_SCREENSHOT_HEIGHT};
+  struct nx_callback_s cb =
+  {
+  };
+
+  struct nxgl_size_s size =
+  {
+    CONFIG_SCREENSHOT_WIDTH, CONFIG_SCREENSHOT_HEIGHT
+  };
+
 #ifdef CONFIG_VNCSERVER
   struct boardioc_vncstart_s vnc;
 #endif
@@ -130,18 +138,18 @@ int save_screenshot(FAR const char *filename)
     }
 
 #ifdef CONFIG_VNCSERVER
-   /* Setup the VNC server to support keyboard/mouse inputs */
+  /* Setup the VNC server to support keyboard/mouse inputs */
 
-   vnc.display = 0;
-   vnc.handle  = server;
+  vnc.display = 0;
+  vnc.handle  = server;
 
-   ret = boardctl(BOARDIOC_VNC_START, (uintptr_t)&vnc);
-   if (ret < 0)
-     {
-       printf("boardctl(BOARDIOC_VNC_START) failed: %d\n", ret);
-       nx_disconnect(server);
-       return 1;
-     }
+  ret = boardctl(BOARDIOC_VNC_START, (uintptr_t)&vnc);
+  if (ret < 0)
+    {
+      printf("boardctl(BOARDIOC_VNC_START) failed: %d\n", ret);
+      nx_disconnect(server);
+      return 1;
+    }
 #endif
 
   /* Wait for "connected" event */
@@ -157,11 +165,11 @@ int save_screenshot(FAR const char *filename)
 
   window = nx_openwindow(server, 0, &cb, NULL);
   if (!window)
-  {
-    perror("nx_openwindow");
-    nx_disconnect(server);
-    return 1;
-  }
+    {
+      perror("nx_openwindow");
+      nx_disconnect(server);
+      return 1;
+    }
 
   nx_setsize(window, &size);
 
@@ -192,17 +200,26 @@ int save_screenshot(FAR const char *filename)
   strip = malloc(size.w * 3);
 
   for (row = 0; row < size.h; row++)
-  {
-    struct nxgl_rect_s rect = {{0, row}, {size.w - 1, row}};
-    nx_getrectangle(window, &rect, 0, strip, 0);
-
-    ret = tiff_addstrip(&info, strip);
-    if (ret < 0)
+    {
+      struct nxgl_rect_s rect =
       {
-        printf("tiff_addstrip() #%d failed: %d\n", row, ret);
-        break;
-      }
-  }
+        {
+          0, row
+        },
+        {
+          size.w - 1, row
+        }
+      };
+
+      nx_getrectangle(window, &rect, 0, strip, 0);
+
+      ret = tiff_addstrip(&info, strip);
+      if (ret < 0)
+        {
+          printf("tiff_addstrip() #%d failed: %d\n", row, ret);
+          break;
+        }
+    }
 
   free(strip);
 

--- a/interpreters/bas/bas_global.c
+++ b/interpreters/bas/bas_global.c
@@ -179,7 +179,7 @@ static struct Value *hex(struct Value *v, long int value, long int digits)
 {
   char buf[sizeof(long int) * 2 + 1];
 
-  sprintf(buf, "%0*lx", (int)digits, value);
+  snprintf(buf, sizeof(buf), "%0*lx", (int)digits, value);
   Value_new_STRING(v);
   String_appendChars(&v->u.string, buf);
   return v;
@@ -686,8 +686,9 @@ static struct Value *fn_date(struct Value *v, struct Auto *stack)
   String_size(&v->u.string, 10);
   time(&t);
   now = localtime(&t);
-  sprintf(v->u.string.character, "%02d-%02d-%04d", now->tm_mon + 1,
-          now->tm_mday, now->tm_year + 1900);
+  snprintf(v->u.string.character, v->u.string.length + 1,
+           "%02d-%02d-%04d", now->tm_mon + 1,
+           now->tm_mday, now->tm_year + 1900);
   return v;
 }
 
@@ -964,7 +965,7 @@ static struct Value *fn_hexi(struct Value *v, struct Auto *stack)
 {
   char buf[sizeof(long int) * 2 + 1];
 
-  sprintf(buf, "%lx", intValue(stack, 0));
+  snprintf(buf, sizeof(buf), "%lx", intValue(stack, 0));
   Value_new_STRING(v);
   String_appendChars(&v->u.string, buf);
   return v;
@@ -982,7 +983,7 @@ static struct Value *fn_hexd(struct Value *v, struct Auto *stack)
       return Value_new_ERROR(v, OUTOFRANGE, _("number"));
     }
 
-  sprintf(buf, "%lx", n);
+  snprintf(buf, sizeof(buf), "%lx", n);
   Value_new_STRING(v);
   String_appendChars(&v->u.string, buf);
   return v;
@@ -1639,7 +1640,7 @@ static struct Value *fn_oct(struct Value *v, struct Auto *stack)
 {
   char buf[sizeof(long int) * 3 + 1];
 
-  sprintf(buf, "%lo", intValue(stack, 0));
+  snprintf(buf, sizeof(buf), "%lo", intValue(stack, 0));
   Value_new_STRING(v);
   String_appendChars(&v->u.string, buf);
   return v;
@@ -1910,8 +1911,9 @@ static struct Value *fn_times(struct Value *v, struct Auto *stack)
   String_size(&v->u.string, 8);
   time(&t);
   now = localtime(&t);
-  sprintf(v->u.string.character, "%02d:%02d:%02d", now->tm_hour, now->tm_min,
-          now->tm_sec);
+  snprintf(v->u.string.character, v->u.string.length + 1,
+           "%02d:%02d:%02d", now->tm_hour, now->tm_min,
+           now->tm_sec);
   return v;
 }
 

--- a/interpreters/bas/bas_program.c
+++ b/interpreters/bas/bas_program.c
@@ -67,7 +67,8 @@ struct Xref
       {
         struct Pc line;
         struct LineNumber *next;
-      } *lines;
+      }
+    *lines;
     struct Xref *l;
     struct Xref *r;
   };
@@ -175,8 +176,8 @@ static void Xref_print(struct Xref *root,
 
 static int cmpLine(const void *a, const void *b)
 {
-  const register struct Pc *pcA = (const struct Pc *)a, *pcB =
-    (const struct Pc *)b;
+  const register struct Pc *pcA = (const struct Pc *)a;
+  const register struct Pc *pcB = (const struct Pc *)b;
 
   return pcA->line - pcB->line;
 }
@@ -192,7 +193,8 @@ static void printLine(const void *k, struct Program *p, int chn)
 
 static int cmpName(const void *a, const void *b)
 {
-  const register char *funcA = (const char *)a, *funcB = (const char *)b;
+  const register char *funcA = (const char *)a;
+  const register char *funcB = (const char *)b;
 
   return strcmp(funcA, funcB);
 }
@@ -317,7 +319,9 @@ void Program_store(struct Program *this, struct Token *line, long int where)
 void Program_delete(struct Program *this, const struct Pc *from,
                     const struct Pc *to)
 {
-  int i, first, last;
+  int i;
+  int first;
+  int last;
 
   this->runnable = 0;
   this->unsaved = 1;
@@ -696,13 +700,16 @@ struct Value *Program_merge(struct Program *this, int dev,
 
 int Program_lineNumberWidth(struct Program *this)
 {
-  int i, w = 0;
+  int i;
+  int w = 0;
 
   for (i = 0; i < this->size; ++i)
     {
       if (this->code[i]->type == T_INTEGER)
         {
-          int nw, ln;
+          int nw;
+          int ln;
+
           for (ln = this->code[i]->u.integer, nw = 1; ln /= 10; ++nw);
           if (nw > w)
             {
@@ -718,7 +725,8 @@ struct Value *Program_list(struct Program *this, int dev, int watchIntr,
                            struct Pc *from, struct Pc *to,
                            struct Value *value)
 {
-  int i, w;
+  int i;
+  int w;
   int indent = 0;
   struct String s;
 
@@ -940,7 +948,10 @@ int Program_setname(struct Program *this, const char *filename)
 void Program_xref(struct Program *this, int chn)
 {
   struct Pc pc;
-  struct Xref *func, *var, *gosub, *goto_;
+  struct Xref *func;
+  struct Xref *var;
+  struct Xref *gosub;
+  struct Xref *goto_;
   int nl = 0;
 
   assert(this->runnable);

--- a/interpreters/bas/bas_program.c
+++ b/interpreters/bas/bas_program.c
@@ -162,7 +162,8 @@ static void Xref_print(struct Xref *root,
               FS_putChars(chn, "\n        ");
             }
 
-          sprintf(buf, " %ld", Program_lineNumber(p, &cur->line));
+          snprintf(buf, sizeof(buf), " %ld",
+                   Program_lineNumber(p, &cur->line));
           FS_putChars(chn, buf);
         }
       while (cur != tail);
@@ -184,7 +185,8 @@ static void printLine(const void *k, struct Program *p, int chn)
 {
   char buf[80];
 
-  sprintf(buf, "%8ld", Program_lineNumber(p, (const struct Pc *)k));
+  snprintf(buf, sizeof(buf), "%8ld",
+           Program_lineNumber(p, (const struct Pc *)k));
   FS_putChars(chn, buf);
 }
 
@@ -603,7 +605,8 @@ void Program_trace(struct Program *this, struct Pc *pc, int dev, int tr)
     {
       char buf[40];
 
-      sprintf(buf, "<%ld>\n", this->code[pc->line]->u.integer);
+      snprintf(buf, sizeof(buf), "<%ld>\n",
+               this->code[pc->line]->u.integer);
       FS_putChars(dev, buf);
     }
 }

--- a/interpreters/minibasic/basic.c
+++ b/interpreters/minibasic/basic.c
@@ -2913,8 +2913,7 @@ static FAR char *midstring(void)
       return str;
     }
 
-  strncpy(answer, temp, len);
-  answer[len] = 0;
+  strlcpy(answer, temp, len + 1);
   free(str);
   return answer;
 }

--- a/interpreters/minibasic/basic.c
+++ b/interpreters/minibasic/basic.c
@@ -2746,7 +2746,7 @@ static FAR char *strstring(void)
   x = expr();
   match(CPAREN);
 
-  sprintf(g_iobuffer, "%g", x);
+  snprintf(g_iobuffer, sizeof(g_iobuffer), "%g", x);
   answer = mystrdup(g_iobuffer);
   if (!answer)
     {

--- a/interpreters/minibasic/basic.c
+++ b/interpreters/minibasic/basic.c
@@ -4036,7 +4036,7 @@ static FAR char *mystrconcat(FAR const char *str, FAR const char *cat)
   if (answer)
     {
       strlcpy(answer, str, len);
-      strcat(answer, cat);
+      strlcat(answer, cat, len);
     }
 
   return answer;

--- a/logging/nxscope/nxscope_chan.c
+++ b/logging/nxscope/nxscope_chan.c
@@ -364,8 +364,8 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
 
           DEBUGASSERT(val);
 
-          strncpy((FAR char *)buff, (FAR const char *)val, d);
-          j += strnlen((FAR char *)buff, d);
+          strlcpy((FAR char *)buff, (FAR const char *)val, d);
+          j += strlen((FAR char *)buff);
           memset(&buff[j], '\0', d - j);
           j = d;
 

--- a/netutils/chat/chat.c
+++ b/netutils/chat/chat.c
@@ -332,7 +332,7 @@ static int chat_internalise(FAR struct chat *priv,
 
       if (rhs)
         {
-          len = strlen(tok->string);
+          len = strlen(tok->string) + 1;
           if (!tok->no_termin)
             {
               /* Add space for the line terminator */
@@ -340,13 +340,13 @@ static int chat_internalise(FAR struct chat *priv,
               len += 2;
             }
 
-          line->rhs = malloc(len + 1);
+          line->rhs = malloc(len);
           if (line->rhs)
             {
               /* Copy the token and add the line terminator as appropriate */
 
-              sprintf(line->rhs, tok->no_termin ? "%s" : "%s\r\n",
-                      tok->string);
+              snprintf(line->rhs, len,
+                       tok->no_termin ? "%s" : "%s\r\n", tok->string);
             }
           else
             {

--- a/netutils/codecs/md5.c
+++ b/netutils/codecs/md5.c
@@ -399,7 +399,7 @@ char *md5_hash(const uint8_t * addr, const size_t len)
   md5_sum(addr, len, digest);
   for (i = 0; i < 16; i++)
     {
-      sprintf(&hash[i * 2], "%02x", digest[i]);
+      snprintf(&hash[i * 2], 33 - i * 2, "%02x", digest[i]);
     }
 
   hash[32] = 0;

--- a/netutils/dhcp6c/dhcp6c.c
+++ b/netutils/dhcp6c/dhcp6c.c
@@ -1724,7 +1724,7 @@ static FAR void *dhcp6c_precise_open(FAR const char *ifname,
 
   /* Detect interface */
 
-  strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+  strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
   if (ioctl(pdhcp6c->sockfd, SIOCGIFINDEX, &ifr))
     {
       close(pdhcp6c->urandom_fd);

--- a/netutils/discover/discover.c
+++ b/netutils/discover/discover.c
@@ -144,8 +144,8 @@ static inline void discover_initresponse(void)
   g_state.response[0] = DISCOVER_PROTO_ID;
   g_state.response[1] = DISCOVER_RESPONSE;
 
-  strncpy((char *)&g_state.response[2], g_state.info.description,
-          DISCOVER_RESPONSE_SIZE - 3);
+  strlcpy((char *)&g_state.response[2], g_state.info.description,
+          DISCOVER_RESPONSE_SIZE - 2);
 
   for (i = 0; i < DISCOVER_RESPONSE_SIZE - 1; i++)
     {

--- a/netutils/esp8266/esp8266.c
+++ b/netutils/esp8266/esp8266.c
@@ -1059,8 +1059,7 @@ static int lesp_parse_cwjap_ans_line(char *ptr, lesp_ap_t *ap)
           case 1:
               ptr++; /* Remove first '"' */
               *(ptr_next - 1) = '\0';
-              strncpy(ap->ssid, ptr, LESP_SSID_SIZE);
-              ap->ssid[LESP_SSID_SIZE] = '\0';
+              strlcpy(ap->ssid, ptr, LESP_SSID_SIZE + 1);
               break;
 
           case 2:
@@ -1185,8 +1184,7 @@ static int lesp_parse_cwlap_ans_line(char *ptr, lesp_ap_t *ap)
           case 2:
               ptr++; /* Remove first '"' */
               *(ptr_next - 1) = '\0';
-              strncpy(ap->ssid, ptr, LESP_SSID_SIZE);
-              ap->ssid[LESP_SSID_SIZE] = '\0';
+              strlcpy(ap->ssid, ptr, LESP_SSID_SIZE + 1);
               break;
 
           case 3:

--- a/netutils/ftpc/ftpc_getreply.c
+++ b/netutils/ftpc/ftpc_getreply.c
@@ -238,7 +238,7 @@ int fptc_getreply(struct ftpc_session_s *session)
     {
       /* Multi-line response */
 
-      strncpy(tmp, session->reply, 3);
+      strlcpy(tmp, session->reply, sizeof(tmp));
       do
         {
           if (ftpc_gets(session) == -1)

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -1383,8 +1383,9 @@ static FAR char *ftpd_node2path(FAR struct ftpd_pathnode_s *node,
   FAR struct ftpd_pathnode_s *node1;
   FAR struct ftpd_pathnode_s *node2;
   FAR char *path;
-  FAR size_t allocsize;
-  FAR size_t namelen;
+  size_t allocsize;
+  size_t namelen;
+  size_t next;
 
   if (node == NULL)
     {
@@ -1424,7 +1425,7 @@ static FAR char *ftpd_node2path(FAR struct ftpd_pathnode_s *node,
             }
           else
             {
-              allocsize += namelen +1;
+              allocsize += namelen + 1;
             }
         }
       else
@@ -1441,7 +1442,7 @@ static FAR char *ftpd_node2path(FAR struct ftpd_pathnode_s *node,
       return NULL;
     }
 
-  allocsize = 0;
+  next = 0;
   node1 = node;
   while (node1 != NULL)
     {
@@ -1471,19 +1472,20 @@ static FAR char *ftpd_node2path(FAR struct ftpd_pathnode_s *node,
         {
           if (namelen <= 0)
             {
-              allocsize += sprintf(&path[allocsize], "/");
+              snprintf(&path[next], allocsize - next, "/");
             }
           else
             {
-              allocsize += sprintf(&path[allocsize], "%s", node1->name);
+              snprintf(&path[next], allocsize - next, "%s", node1->name);
             }
         }
       else
         {
-          allocsize += sprintf(&path[allocsize], "%s%s", node1->name, "/");
+          snprintf(&path[next], allocsize - next, "%s%s", node1->name, "/");
         }
 
       node1 = node1->flink;
+      next += strlen(&path[next]);
     }
 
   return path;

--- a/netutils/libcurl4nx/curl4nx_easy_reset.c
+++ b/netutils/libcurl4nx/curl4nx_easy_reset.c
@@ -78,9 +78,9 @@ void curl4nx_easy_reset(FAR struct curl4nx_s *handle)
   /* Setup default options */
 
   handle->port = 80;
-  strncpy(handle->useragent, CONFIG_LIBCURL4NX_USERAGENT,
+  strlcpy(handle->useragent, CONFIG_LIBCURL4NX_USERAGENT,
           sizeof(handle->useragent));
-  strncpy(handle->method, "GET", sizeof(handle->method));
+  strlcpy(handle->method, "GET", sizeof(handle->method));
   handle->version = CURL4NX_HTTP_VERSION_1_1;
   handle->writefunc = curl4nx_default_writefunc;
 

--- a/netutils/rexec/rexec.c
+++ b/netutils/rexec/rexec.c
@@ -165,8 +165,8 @@ int main(int argc, FAR char **argv)
   cmd[0] = '\0';
   for (i = optind; i < argc; i++)
     {
-      strcat(cmd, argv[i]);
-      strcat(cmd, " ");
+      strlcat(cmd, argv[i], sizeof(cmd));
+      strlcat(cmd, " ", sizeof(cmd));
     }
 
   arg.command = cmd;

--- a/netutils/tftpc/tftpc_get.c
+++ b/netutils/tftpc/tftpc_get.c
@@ -153,8 +153,8 @@ int tftpget_cb(FAR const char *remote, in_addr_t addr, bool binary,
 
           if (blockno == 1)
             {
-              len             = tftp_mkreqpacket(packet, TFTP_RRQ, remote,
-                                                 binary);
+              len             = tftp_mkreqpacket(packet, TFTP_IOBUFSIZE,
+                                                 TFTP_RRQ, remote, binary);
               server.sin_port = HTONS(CONFIG_NETUTILS_TFTP_PORT);
               ret             = tftp_sendto(sd, packet, len, &server);
               if (ret != len)

--- a/netutils/tftpc/tftpc_internal.h
+++ b/netutils/tftpc/tftpc_internal.h
@@ -158,7 +158,7 @@
 /* Defined in tftp_packet.c *************************************************/
 
 extern int tftp_sockinit(struct sockaddr_in *server, in_addr_t addr);
-extern int tftp_mkreqpacket(uint8_t *buffer, int opcode,
+extern int tftp_mkreqpacket(uint8_t *buffer, size_t len, int opcode,
                             const char *path, bool binary);
 extern int tftp_mkackpacket(uint8_t *buffer, uint16_t blockno);
 extern int tftp_mkerrpacket(uint8_t *buffer, uint16_t errorcode,

--- a/netutils/tftpc/tftpc_packets.c
+++ b/netutils/tftpc/tftpc_packets.c
@@ -122,13 +122,16 @@ int tftp_sockinit(struct sockaddr_in *server, in_addr_t addr)
  *
  ****************************************************************************/
 
-int tftp_mkreqpacket(uint8_t *buffer, int opcode, const char *path,
-                     bool binary)
+int tftp_mkreqpacket(uint8_t *buffer, size_t len, int opcode,
+                     const char *path, bool binary)
 {
+  int ret;
+
   buffer[0] = opcode >> 8;
   buffer[1] = opcode & 0xff;
-  return sprintf((char *)&buffer[2], "%s%c%s", path, 0,
+  ret = snprintf((char *)&buffer[2], len - 2, "%s%c%s", path, 0,
                  tftp_mode(binary)) + 3;
+  return ret < len ? ret : len;
 }
 
 /****************************************************************************

--- a/netutils/tftpc/tftpc_put.c
+++ b/netutils/tftpc/tftpc_put.c
@@ -302,7 +302,8 @@ int tftpput_cb(FAR const char *remote, in_addr_t addr, bool binary,
   retry   = 0;
   for (; ; )
     {
-      packetlen = tftp_mkreqpacket(packet, TFTP_WRQ, remote, binary);
+      packetlen = tftp_mkreqpacket(packet, TFTP_IOBUFSIZE,
+                                   TFTP_WRQ, remote, binary);
       ret = tftp_sendto(sd, packet, packetlen, &server);
       if (ret != packetlen)
         {

--- a/netutils/thttpd/cgi-src/redirect.c
+++ b/netutils/thttpd/cgi-src/redirect.c
@@ -236,7 +236,8 @@ int main(int argc, char *argv[])
                     {
                       /* Got it; put together the full name. */
 
-                      strcat(g_url, script_name + (star - g_file));
+                      strlcat(g_url, script_name + (star - g_file),
+                              sizeof(g_url));
 
                       /* XXX Whack the script_name, too? */
 

--- a/netutils/thttpd/cgi-src/redirect.c
+++ b/netutils/thttpd/cgi-src/redirect.c
@@ -179,14 +179,15 @@ int main(int argc, char *argv[])
   path_info = getenv("PATH_INFO");
   if (path_info)
     {
-      cp = (char *)malloc(strlen(script_name) + strlen(path_info) + 1);
+      size_t len = strlen(script_name) + strlen(path_info) + 1;
+      cp = (char *)malloc(len);
       if (!cp)
         {
           internal_error("Out of memory.");
           return 2;
         }
 
-      sprintf(cp, "%s%s", script_name, path_info);
+      snprintf(cp, len, "%s%s", script_name, path_info);
       script_name = cp;
     }
 

--- a/netutils/thttpd/cgi-src/ssi.c
+++ b/netutils/thttpd/cgi-src/ssi.c
@@ -324,7 +324,8 @@ static int check_filename(char *filename)
       *cp = '\0';
     }
 
-  authname = malloc(strlen(dirname) + 1 + sizeof(CONFIG_AUTH_FILE));
+  fnl = strlen(dirname) + 1 + sizeof(CONFIG_AUTH_FILE);
+  authname = malloc(fnl);
   if (!authname)
     {
       /* out of memory */
@@ -333,7 +334,7 @@ static int check_filename(char *filename)
       return 0;
     }
 
-  sprintf(authname, "%s/%s", dirname, CONFIG_AUTH_FILE);
+  snprintf(authname, fnl, "%s/%s", dirname, CONFIG_AUTH_FILE);
   r = stat(authname, &sb);
 
   free(dirname);
@@ -907,6 +908,7 @@ int main(int argc, char *argv[])
   char *script_name;
   char *path_info;
   char *path_translated;
+  size_t len;
   int errcode = 0;
 
   /* Default formats. */
@@ -935,14 +937,15 @@ int main(int argc, char *argv[])
       path_info = "";
     }
 
-  g_url = (char *)malloc(strlen(script_name) + strlen(path_info) + 1);
+  len = strlen(script_name) + strlen(path_info) + 1;
+  g_url = (char *)malloc(len);
   if (!g_url)
     {
       internal_error("Out of memory.");
       return 2;
     }
 
-  sprintf(g_url, "%s%s", script_name, path_info);
+  snprintf(g_url, len, "%s%s", script_name, path_info);
 
   /* Get the name of the file to parse. */
 

--- a/netutils/thttpd/cgi-src/ssi.c
+++ b/netutils/thttpd/cgi-src/ssi.c
@@ -216,7 +216,7 @@ static int get_filename(char *vfilename, char *filename,
           return -1;
         }
 
-      strncpy(fn, filename, size);
+      strlcpy(fn, filename, fnsize);
       strlcpy(&fn[size], val, fnsize - size);
     }
   else if (strcmp(tag, "file") == 0)
@@ -419,8 +419,7 @@ static void do_config(FILE *instream, char *vfilename, char *filename,
 
   if (strcmp(tag, "g_timeformat") == 0)
     {
-      strncpy(g_timeformat, val, TIMEFMT_SIZE - 1);
-      g_timeformat[TIMEFMT_SIZE - 1] = '\0';
+      strlcpy(g_timeformat, val, TIMEFMT_SIZE);
     }
   else if (strcmp(tag, "g_sizefmt") == 0)
     {

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -924,10 +924,10 @@ static int httpd_tilde_map1(httpd_conn *hc)
 
   if (prefix[0] != '\0')
     {
-      strcat(hc->expnfilename, "/");
+      strlcat(hc->expnfilename, "/", hc->maxexpnfilename + 1);
     }
 
-  strcat(hc->expnfilename, temp);
+  strlcat(hc->expnfilename, temp, hc->maxexpnfilename + 1);
   return 1;
 }
 #endif /* CONFIG_THTTPD_TILDE_MAP1 */
@@ -975,8 +975,8 @@ static int httpd_tilde_map2(httpd_conn *hc)
   strlcpy(hc->altdir, pw->pw_dir, hc->maxaltdir + 1);
   if (postfix[0] != '\0')
     {
-      strcat(hc->altdir, "/");
-      strcat(hc->altdir, postfix);
+      strlcat(hc->altdir, "/", hc->maxaltdir + 1);
+      strlcat(hc->altdir, postfix, hc->maxaltdir + 1);
     }
 
   alt = expand_filename(hc->altdir, &rest, true);
@@ -1116,8 +1116,8 @@ static int vhost_map(httpd_conn *hc)
   httpd_realloc_str(&hc->expnfilename, &hc->maxexpnfilename,
                     strlen(hc->hostdir) + 1 + len);
   strlcpy(hc->expnfilename, hc->hostdir, hc->maxexpnfilename + 1);
-  strcat(hc->expnfilename, "/");
-  strcat(hc->expnfilename, tempfilename);
+  strlcat(hc->expnfilename, "/", hc->maxexpnfilename + 1);
+  strlcat(hc->expnfilename, tempfilename, hc->maxexpnfilename + 1);
   return 1;
 }
 #endif
@@ -2875,14 +2875,14 @@ int httpd_parse_request(httpd_conn *hc)
 
                   httpd_realloc_str(&hc->accept, &hc->maxaccept,
                                     strlen(hc->accept) + 2 + strlen(cp));
-                  strcat(hc->accept, ", ");
+                  strlcat(hc->accept, ", ", hc->maxaccepte + 1);
                 }
               else
                 {
                   httpd_realloc_str(&hc->accept, &hc->maxaccept, strlen(cp));
                 }
 
-              strcat(hc->accept, cp);
+              strlcat(hc->accept, cp, hc->maxaccepte + 1);
             }
           else if (strncasecmp(buf, "Accept-Encoding:", 16) == 0)
             {
@@ -2899,7 +2899,7 @@ int httpd_parse_request(httpd_conn *hc)
 
                   httpd_realloc_str(&hc->accepte, &hc->maxaccepte,
                                     strlen(hc->accepte) + 2 + strlen(cp));
-                  strcat(hc->accepte, ", ");
+                  strlcat(hc->accepte, ", ", hc->maxaccepte + 1);
                 }
               else
                 {
@@ -3296,7 +3296,7 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowp)
           indxlen = strlen(indexname);
           if (indxlen == 0 || indexname[indxlen - 1] != '/')
             {
-              strcat(indexname, "/");
+              strlcat(indexname, "/", maxindexname + 1);
             }
 
           if (strcmp(indexname, "./") == 0)
@@ -3304,7 +3304,7 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowp)
               indexname[0] = '\0';
             }
 
-          strcat(indexname, index_names[i]);
+          strlcat(indexname, index_names[i], maxindexname + 1);
           if (stat(indexname, &hc->sb) >= 0)
             {
               goto got_one;

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -92,8 +92,6 @@
 #  define STDERR_FILENO 2
 #endif
 
-#define NAMLEN(dirent) strlen((dirent)->d_name)
-
 extern CODE char *crypt(const char *key, const char *setting);
 
 /* Conditional macro to allow two alternate forms for use in the built-in
@@ -1240,7 +1238,7 @@ static char *expand_filename(char *path, char **restp, bool tildemapped)
               /* Special case for absolute paths. */
 
               httpd_realloc_str(&checked, &maxchecked, checkedlen + 1);
-              strncpy(&checked[checkedlen], r, 1);
+              checked[checkedlen] = '/';
               checkedlen += 1;
             }
           else if (strncmp(r, "..", MAX(i, 2)) == 0)
@@ -1660,15 +1658,15 @@ static void ls_child(int argc, char **argv)
           if (maxnames == 0)
             {
               maxnames = 100;
-              names    = NEW(char, maxnames * (PATH_MAX + 1));
+              names    = NEW(char, maxnames * PATH_MAX);
               nameptrs = NEW(char *, maxnames);
             }
           else
             {
               oldmax    = maxnames;
               maxnames *= 2;
-              names     = RENEW(names, char, oldmax * (PATH_MAX + 1),
-                                maxnames * (PATH_MAX + 1));
+              names     = RENEW(names, char, oldmax * PATH_MAX,
+                                maxnames * PATH_MAX);
               nameptrs  = RENEW(nameptrs, char *, oldmax, maxnames);
             }
 
@@ -1680,13 +1678,11 @@ static void ls_child(int argc, char **argv)
 
           for (i = 0; i < maxnames; ++i)
             {
-              nameptrs[i] = &names[i * (PATH_MAX + 1)];
+              nameptrs[i] = &names[i * PATH_MAX];
             }
         }
 
-      namlen = NAMLEN(de);
-      strncpy(nameptrs[nnames], de->d_name, namlen);
-      nameptrs[nnames][namlen] = '\0';
+      strlcpy(nameptrs[nnames], de->d_name, PATH_MAX);
       ++nnames;
     }
 

--- a/netutils/thttpd/thttpd_strings.c
+++ b/netutils/thttpd/thttpd_strings.c
@@ -178,7 +178,7 @@ void httpd_strencode(char *to, int tosize, char *from)
         }
       else
         {
-          sprintf(to, "%%%02x", (int)*from & 0xff);
+          snprintf(to, tosize - tolen, "%%%02x", (int)*from & 0xff);
           to += 3;
           tolen += 3;
         }

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -1770,7 +1770,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
               char post_size[sizeof("18446744073709551615")];
 
               dest = append(dest, ep, g_httpcontsize);
-              sprintf(post_size, "%zu", ctx->bodylen);
+              snprintf(post_size, sizeof(post_size), "%zu", ctx->bodylen);
               dest = append(dest, ep, post_size);
               dest = append(dest, ep, g_httpcrnl);
             }

--- a/netutils/webclient/webclient.c
+++ b/netutils/webclient/webclient.c
@@ -457,10 +457,9 @@ static inline int wget_parsestatus(struct webclient_context *ctx,
               ninfo("Got HTTP status %lu\n", http_status);
               if (ctx->http_reason != NULL)
                 {
-                  strncpy(ctx->http_reason,
+                  strlcpy(ctx->http_reason,
                           ep + 1,
-                          ctx->http_reason_len - 1);
-                  ctx->http_reason[ctx->http_reason_len - 1] = 0;
+                          ctx->http_reason_len);
                 }
 
               /* Check for 2xx (Successful) */
@@ -693,7 +692,7 @@ static inline int wget_parseheaders(struct webclient_context *ctx,
                       *dest = 0;
                     }
 
-                  strncpy(ws->mimetype, ws->line + strlen(g_httpcontenttype),
+                  strlcpy(ws->mimetype, ws->line + strlen(g_httpcontenttype),
                           sizeof(ws->mimetype));
                   found = true;
                 }
@@ -1564,7 +1563,7 @@ int webclient_perform(FAR struct webclient_context *ctx)
                 {
                   memset(&server_un, 0, sizeof(server_un));
                   server_un.sun_family = AF_LOCAL;
-                  strncpy(server_un.sun_path, ctx->unix_socket_path,
+                  strlcpy(server_un.sun_path, ctx->unix_socket_path,
                           sizeof(server_un.sun_path));
 #if !defined(__NuttX__) && !defined(__linux__)
                   server_un.sun_len = SUN_LEN(&server_un);

--- a/netutils/xmlrpc/response.c
+++ b/netutils/xmlrpc/response.c
@@ -164,6 +164,7 @@ int xmlrpc_getstring(struct xmlrpc_s *xmlcall, char *arg)
 int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
 {
   va_list argp;
+  int next = 0;
   int index = 0;
   int close = 0;
   int isstruct = 0;
@@ -195,6 +196,7 @@ int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
               sizeof(xmlcall->response));
     }
 
+  next = strlen(xmlcall->response);
   va_start(argp, args);
 
   while (args[index])
@@ -203,10 +205,15 @@ int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
         {
           if ((args[index] != '{') && (args[index] != '}'))
             {
-              sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                      "  <member>\n");
-              sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                      "    <name>%s</name>\n", va_arg(argp, char *));
+              snprintf(&xmlcall->response[next],
+                       sizeof(xmlcall->response) - next,
+                       "  <member>\n");
+              next += strlen(&xmlcall->response[next]);
+              snprintf(&xmlcall->response[next],
+                       sizeof(xmlcall->response) - next,
+                       "    <name>%s</name>\n",
+                       va_arg(argp, char *));
+              next += strlen(&xmlcall->response[next]);
               close = 1;
             }
         }
@@ -214,39 +221,45 @@ int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
       switch (args[index])
         {
         case '{':
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                  "  <value><struct>\n");
+          snprintf(&xmlcall->response[next],
+                   sizeof(xmlcall->response) - next,
+                   "  <value><struct>\n");
           isstruct = 1;
           break;
 
         case '}':
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                  "  </struct></value>\n");
+          snprintf(&xmlcall->response[next],
+                   sizeof(xmlcall->response) - next,
+                   "  </struct></value>\n");
           isstruct = 0;
           break;
 
         case 'i':
           i = va_arg(argp, int);
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                  "    <value><int>%d</int></value>\r\n", i);
+          snprintf(&xmlcall->response[next],
+                   sizeof(xmlcall->response) - next,
+                   "    <value><int>%d</int></value>\r\n", i);
           break;
 
         case 'b':
           i = va_arg(argp, int);
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
+          snprintf(&xmlcall->response[next],
+                  sizeof(xmlcall->response) - next,
                   "    <value><boolean>%d</boolean></value>\r\n", i);
           break;
 
         case 'd':
           d = va_arg(argp, double);
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                  "    <value><double>%f</double></value>\r\n", d);
+          snprintf(&xmlcall->response[next],
+                   sizeof(xmlcall->response) - next,
+                   "    <value><double>%f</double></value>\r\n", d);
           break;
 
         case 's':
           s = va_arg(argp, char *);
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                  "    <value><string>%s</string></value>\r\n", s);
+          snprintf(&xmlcall->response[next],
+                   sizeof(xmlcall->response) - next,
+                   "    <value><string>%s</string></value>\r\n", s);
           break;
 
         default:
@@ -254,10 +267,13 @@ int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
           break;
         }
 
+      next += strlen(&xmlcall->response[next]);
       if (close)
         {
-          sprintf(&xmlcall->response[strlen(xmlcall->response)],
-                  "  </member>\n");
+          snprintf(&xmlcall->response[next],
+                   sizeof(xmlcall->response) - next,
+                   "  </member>\n");
+          next += strlen(&xmlcall->response[next]);
           close = 0;
         }
 

--- a/netutils/xmlrpc/response.c
+++ b/netutils/xmlrpc/response.c
@@ -164,7 +164,6 @@ int xmlrpc_getstring(struct xmlrpc_s *xmlcall, char *arg)
 int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
 {
   va_list argp;
-  int ret = 0;
   int index = 0;
   int close = 0;
   int isstruct = 0;
@@ -187,12 +186,13 @@ int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
 
   if (xmlcall->error)
     {
-      strcat(&xmlcall->response[strlen(xmlcall->response)], "  <fault>\n");
+      strlcat(xmlcall->response, "  <fault>\n",
+              sizeof(xmlcall->response));
     }
   else
     {
-      strcat(&xmlcall->response[strlen(xmlcall->response)],
-             "  <params><param>\n");
+      strlcat(xmlcall->response, "  <params><param>\n",
+              sizeof(xmlcall->response));
     }
 
   va_start(argp, args);
@@ -268,26 +268,18 @@ int xmlrpc_buildresponse(struct xmlrpc_s *xmlcall, char *args, ...)
 
   if (xmlcall->error)
     {
-      strcat(&xmlcall->response[strlen(xmlcall->response)],
-             "  </fault>\r\n");
+      strlcat(xmlcall->response, "  </fault>\r\n",
+              sizeof(xmlcall->response));
     }
   else
     {
-      strcat(&xmlcall->response[strlen(xmlcall->response)],
-             "  </param></params>\r\n");
+      strlcat(xmlcall->response, "  </param></params>\r\n",
+              sizeof(xmlcall->response));
     }
 
-  if (ret == 0)
-    {
-      strcat(&xmlcall->response[strlen(xmlcall->response)],
-             "</methodResponse>\r\n");
+  strlcat(xmlcall->response, "</methodResponse>\r\n",
+          sizeof(xmlcall->response));
 
-      xmlrpc_insertlength(xmlcall);
-    }
-  else
-    {
-      xmlcall->response[0] = 0;
-    }
-
-  return ret;
+  xmlrpc_insertlength(xmlcall);
+  return 0;
 }

--- a/nshlib/nsh_dbgcmds.c
+++ b/nshlib/nsh_dbgcmds.c
@@ -297,19 +297,22 @@ void nsh_dumpbuffer(FAR struct nsh_vtbl_s *vtbl, FAR const char *msg,
   nsh_output(vtbl, "%s:\n", msg);
   for (i = 0; i < nbytes; i += 16)
     {
-      sprintf(line, "%04x: ", i);
+      snprintf(line, sizeof(line), "%04x: ", i);
+      size = strlen(line);
 
       for (j = 0; j < 16; j++)
         {
-          size = strlen(line);
           if (i + j < nbytes)
             {
-              sprintf(&line[size], "%02x ", buffer[i + j]);
+              snprintf(&line[size], sizeof(line) - size,
+                       "%02x ", buffer[i + j]);
             }
           else
             {
               strlcpy(&line[size], "   ", sizeof(line) - size);
             }
+
+          size += strlen(&line[size]);
         }
 
       for (j = 0; j < 16; j++)
@@ -317,8 +320,9 @@ void nsh_dumpbuffer(FAR struct nsh_vtbl_s *vtbl, FAR const char *msg,
           if (i + j < nbytes)
             {
               ch = buffer[i + j];
-              sprintf(&line[strlen(line)], "%c",
-                      ch >= 0x20 && ch <= 0x7e ? ch : '.');
+              snprintf(&line[size], sizeof(line) - size,
+                       "%c", ch >= 0x20 && ch <= 0x7e ? ch : '.');
+              size += strlen(&line[size]);
             }
         }
 

--- a/nshlib/nsh_login.c
+++ b/nshlib/nsh_login.c
@@ -126,7 +126,7 @@ static void nsh_token(FAR struct console_stdio_s *pstate,
 
   /* Copied the token into the buffer */
 
-  strncpy(buffer, start, buflen);
+  strlcpy(buffer, start, buflen);
 }
 
 /****************************************************************************

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -1106,7 +1106,7 @@ static FAR char *nsh_strcat(FAR struct nsh_vtbl_s *vtbl, FAR char *s1,
   else
     {
       argument[s1size] = '\0';  /* (In case s1 was NULL) */
-      strcat(argument, s2);
+      strlcat(argument, s2, allocsize);
     }
 
   return argument;

--- a/nshlib/nsh_telnetlogin.c
+++ b/nshlib/nsh_telnetlogin.c
@@ -134,7 +134,7 @@ static void nsh_telnettoken(FAR struct console_stdio_s *pstate,
 
   /* Copied the token into the buffer */
 
-  strncpy(buffer, start, buflen);
+  strlcpy(buffer, start, buflen);
 }
 
 /****************************************************************************

--- a/nshlib/nsh_vars.c
+++ b/nshlib/nsh_vars.c
@@ -283,7 +283,7 @@ int nsh_setvar(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
 
   /* Now, put the new name=value string into the NSH variable buffer */
 
-  sprintf(pair, "%s=%s", name, value);
+  snprintf(pair, varlen, "%s=%s", name, value);
   return OK;
 }
 #endif

--- a/system/cfgdata/cfgdata_main.c
+++ b/system/cfgdata/cfgdata_main.c
@@ -248,7 +248,7 @@ static void cfgdatacmd_set(int argc, char *argv[])
 
   /* Copy the name to the cfg struct */
 
-  strncpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
+  strlcpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
 
 #else
 
@@ -377,7 +377,7 @@ static void cfgdatacmd_unset(int argc, char *argv[])
 #ifdef CONFIG_MTD_CONFIG_NAMED
   /* Copy the name to the cfg struct */
 
-  strncpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
+  strlcpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
 
 #else
   int                   x;
@@ -443,7 +443,7 @@ static void cfgdatacmd_print(int argc, char *argv[])
 
   /* Copy the name to the cfg struct */
 
-  strncpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
+  strlcpy(cfg.name, argv[2], CONFIG_MTD_CONFIG_NAME_LEN);
 
 #else
 

--- a/system/cfgdata/cfgdata_main.c
+++ b/system/cfgdata/cfgdata_main.c
@@ -562,9 +562,11 @@ static void cfgdatacmd_show_all_config_items(void)
   /* Print header */
 
 #ifdef CONFIG_MTD_CONFIG_NAMED
-  sprintf(fmtstr, "%%-%ds%%-6sData\n", CONFIG_MTD_CONFIG_NAME_LEN);
+  snprintf(fmtstr, sizeof(fmtstr),
+           "%%-%ds%%-6sData\n", CONFIG_MTD_CONFIG_NAME_LEN);
   printf(fmtstr, "Name", "Len");
-  sprintf(fmtstr, "%%-%ds%%-6d", CONFIG_MTD_CONFIG_NAME_LEN);
+  snprintf(fmtstr, sizeof(fmtstr),
+           "%%-%ds%%-6d", CONFIG_MTD_CONFIG_NAME_LEN);
 #else
   strlcpy(fmtstr, "%-6s%-6s%-6sData\n", sizeof(fmtstr));
   printf(fmtstr, "ID", "Inst", "Len");
@@ -618,7 +620,8 @@ static void cfgdatacmd_show_all_config_items(void)
           char fmtstr2[10];
 
 #ifdef CONFIG_MTD_CONFIG_NAMED
-          sprintf(fmtstr2, "\n%ds", CONFIG_MTD_CONFIG_NAME_LEN + 6);
+          snprintf(fmtstr2, sizeof(fmtstr2),
+                   "\n%ds", CONFIG_MTD_CONFIG_NAME_LEN + 6);
 #else
           strlcpy(fmtstr2, "\n%18s", sizeof(fmtstr2));
 #endif

--- a/system/lzf/lzf_main.c
+++ b/system/lzf/lzf_main.c
@@ -333,14 +333,14 @@ static int compose_name(FAR const char *fname, FAR char *oname, int namelen)
           return -1;
         }
 
-      strncpy(oname, fname, namelen);
+      strlcpy(oname, fname, namelen);
       p = strchr(oname, '.');
       if (p != NULL)
         {
           *p = '_';  /* _ for dot */
         }
 
-       strcat (oname, ".lzf");
+       strlcat(oname, ".lzf", namelen);
     }
   else
     {
@@ -372,13 +372,12 @@ static int compose_name(FAR const char *fname, FAR char *oname, int namelen)
 static int run_file(FAR const char *fname)
 {
   struct stat mystat;
-  char oname[PATH_MAX + 1];
+  char oname[PATH_MAX];
   int fd;
   int fd2;
   int ret;
 
-  memset(oname, 0, sizeof(oname));
-  if (compose_name(fname, oname, PATH_MAX + 1))
+  if (compose_name(fname, oname, sizeof(oname)))
     {
       return -1;
     }

--- a/system/ntpc/ntpcstatus_main.c
+++ b/system/ntpc/ntpcstatus_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/system/ntpc/ntpc_status.c
+ * apps/system/ntpc/ntpcstatus_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/system/ntpc/ntpcstatus_main.c
+++ b/system/ntpc/ntpcstatus_main.c
@@ -45,7 +45,7 @@
 #define	NTP_TIME_STR_MAX_LEN (1 + 21 + 1 + 9 + 1)
 
 static void
-format_ntptimestamp(int64_t ts, FAR char *buf)
+format_ntptimestamp(int64_t ts, FAR char *buf, size_t len)
 {
   FAR const char *sign;
   uint64_t absts;
@@ -61,9 +61,9 @@ format_ntptimestamp(int64_t ts, FAR char *buf)
       absts = ts;
     }
 
-  sprintf(buf, "%s%" PRIu64 ".%09" PRIu64,
-          sign, absts >> 32,
-          ((absts & 0xffffffff) * NSEC_PER_SEC) >> 32);
+  snprintf(buf, len, "%s%" PRIu64 ".%09" PRIu64,
+           sign, absts >> 32,
+           ((absts & 0xffffffff) * NSEC_PER_SEC) >> 32);
 }
 
 /****************************************************************************
@@ -115,8 +115,10 @@ int main(int argc, FAR char *argv[])
         }
 #endif
 
-      format_ntptimestamp(status.samples[i].offset, offset_buf);
-      format_ntptimestamp(status.samples[i].delay, delay_buf);
+      format_ntptimestamp(status.samples[i].offset,
+                          offset_buf, sizeof(offset_buf));
+      format_ntptimestamp(status.samples[i].delay,
+                          delay_buf, sizeof(delay_buf));
       printf("[%u] srv %s offset %s delay %s\n",
              i, name, offset_buf, delay_buf);
     }

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -2167,8 +2167,8 @@ FAR struct nxplayer_s *nxplayer_create(void)
 #endif
 
 #ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
-  strncpy(pplayer->mediadir, CONFIG_NXPLAYER_DEFAULT_MEDIADIR,
-      sizeof(pplayer->mediadir));
+  strlcpy(pplayer->mediadir, CONFIG_NXPLAYER_DEFAULT_MEDIADIR,
+          sizeof(pplayer->mediadir));
 #endif
 
   pthread_mutex_init(&pplayer->mutex, NULL);

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -335,8 +335,7 @@ static void tab_completion(FAR struct rl_common_s *vtbl, char *buf,
             }
 
 #endif
-          strncpy(buf, tmp_name, buflen - 1);
-
+          strlcpy(buf, tmp_name, buflen);
           name_len = strlen(tmp_name);
 
           /* Output the original prompt */

--- a/system/sched_note/note_main.c
+++ b/system/sched_note/note_main.c
@@ -729,7 +729,9 @@ static void dump_notes(size_t nread)
 
                     for (i = 0; i < count; i++)
                       {
-                        ret += sprintf(&out[ret], " 0x%x", note_binary->nbi_data[i]);
+                        snprintf(&out[ret], sizeof(out) - ret,
+                                 " 0x%x", note_binary->nbi_data[i]);
+                        ret += strlen(&out[ret]);
                       }
 
                     trace_dump_unflatten(&ip, note_binary->nbi_ip,

--- a/system/taskset/taskset.c
+++ b/system/taskset/taskset.c
@@ -88,8 +88,7 @@ int main(int argc, FAR char *argv[])
   int rc;
   int i;
 
-  memset(command, 0, sizeof(command));
-
+  command[0] = '\0';
   CPU_ZERO(&cpuset);
 
   /* Parse command line options */
@@ -156,8 +155,8 @@ int main(int argc, FAR char *argv[])
 
           for (i = 0; i < argc - 2; i++)
             {
-              strcat(command, argv[i + 2]);
-              strcat(command, " ");
+              strlcat(command, argv[i + 2], sizeof(command));
+              strlcat(command, " ", sizeof(command));
             }
 
           sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpuset);

--- a/system/termcurses/tcurses_vt100.c
+++ b/system/termcurses/tcurses_vt100.c
@@ -1091,23 +1091,23 @@ static int tcurses_vt100_setattributes(FAR struct termcurses_s *dev,
 
   if (attrib & TCURS_ATTRIB_BLINK)
     {
-      strcat(str, g_setblink);
+      strlcat(str, g_setblink, sizeof(str));
     }
   else
     {
-      strcat(str, g_setnoblink);
+      strlcat(str, g_setnoblink, sizeof(str));
     }
 
   if (attrib & TCURS_ATTRIB_UNDERLINE)
     {
-      strcat(str, g_setunderline);
+      strlcat(str, g_setunderline, sizeof(str));
     }
   else
     {
-      strcat(str, g_setnounderline);
+      strlcat(str, g_setnounderline, sizeof(str));
     }
 
-  strcat(str, "m");
+  strlcat(str, "m", sizeof(str));
 
   ret = write(fd, str, strlen(str));
 

--- a/system/termcurses/tcurses_vt100.c
+++ b/system/termcurses/tcurses_vt100.c
@@ -917,9 +917,9 @@ static int tcurses_vt100_setcolors(FAR struct termcurses_s *dev,
 
   if ((colors->color_mask & TCURS_COLOR_FG) != 0)
     {
-      sprintf(str, g_setfgcolor,
-              tcurses_vt100_getcolorindex(colors->fg_red, colors->fg_green,
-                                          colors->fg_blue));
+      snprintf(str, sizeof(str), g_setfgcolor,
+               tcurses_vt100_getcolorindex(colors->fg_red, colors->fg_green,
+                                           colors->fg_blue));
       ret = write(fd, str, strlen(str));
     }
 
@@ -932,9 +932,9 @@ static int tcurses_vt100_setcolors(FAR struct termcurses_s *dev,
           colors->bg_red = 0;
         }
 
-      sprintf(str, g_setbgcolor,
-              tcurses_vt100_getcolorindex(colors->bg_red, colors->bg_green,
-                                          colors->bg_blue));
+      snprintf(str, sizeof(str), g_setbgcolor,
+               tcurses_vt100_getcolorindex(colors->bg_red, colors->bg_green,
+                                           colors->bg_blue));
       ret = write(fd, str, strlen(str));
     }
 

--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -261,11 +261,11 @@ static int trace_cmd_cmd(int index, int argc, FAR char **argv, int notectlfd)
       return ERROR;
     }
 
-  memset(command, 0, sizeof(command));
+  command[0] = '\0';
   while (index < argc)
     {
-      strcat(command, argv[index]);
-      strcat(command, " ");
+      strlcat(command, argv[index], sizeof(command));
+      strlcat(command, " ", sizeof(command));
       index++;
     }
 

--- a/system/ubloxmodem/ubloxmodem_main.c
+++ b/system/ubloxmodem/ubloxmodem_main.c
@@ -313,8 +313,6 @@ static int ubloxmodem_status(FAR struct ubloxmodem_cxt *cxt)
   FAR struct ubxmdm_regval register_values[UBLOXMODEM_MAX_REGISTERS];
   char regname[4];   /* Null-terminated string buffer */
 
-  regname[3] = '\0'; /* Set the null string terminator */
-
   /* Set the maximum value, to be updated by driver */
 
   status.register_values_size = UBLOXMODEM_MAX_REGISTERS;
@@ -332,7 +330,7 @@ static int ubloxmodem_status(FAR struct ubloxmodem_cxt *cxt)
        i < status.register_values_size && i < UBLOXMODEM_MAX_REGISTERS;
        i++)
     {
-      strncpy(regname, status.register_values[i].name, 3);
+      strlcpy(regname, status.register_values[i].name, sizeof(regname));
       printf("%s=%d ",
              regname,
              (int) status.register_values[i].val);

--- a/system/uniqueid/uniqueid_main.c
+++ b/system/uniqueid/uniqueid_main.c
@@ -228,6 +228,7 @@ int main(int argc, FAR char *argv[])
 {
   uint8_t uniqueid[CONFIG_BOARDCTL_UNIQUEID_SIZE];
   FAR char *formatter;
+  size_t len;
   int i;
 
   struct cfg_s cfg =
@@ -258,8 +259,9 @@ int main(int argc, FAR char *argv[])
       return -1;
     }
 
-  formatter = malloc(strlen(cfg.format) + 2);
-  sprintf(formatter, "%%%s", cfg.format);
+  len = strlen(cfg.format) + 2;
+  formatter = malloc(len);
+  snprintf(formatter, len, "%%%s", cfg.format);
 
   if (cfg.prefix != NULL)
     {

--- a/system/uorb/test/unit_test.c
+++ b/system/uorb/test/unit_test.c
@@ -128,8 +128,8 @@ static int pubsubtest_thread_entry(int argc, FAR char *argv[])
       char fname[32];
       FAR FILE *f;
 
-      sprintf(fname, CONFIG_UORB_SRORAGE_DIR"/uorb_timings%u.txt",
-              timingsgroup);
+      snprintf(fname, sizeof(fname),
+               CONFIG_UORB_SRORAGE_DIR"/uorb_timings%u.txt", timingsgroup);
 
       f = fopen(fname, "w");
       if (f == NULL)

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -5631,9 +5631,9 @@ int main(int argc, FAR char *argv[])
         {
           /* Make file relative to current working directory */
 
-          getcwd(vi->filename, MAX_STRING - 1);
-          strncat(vi->filename, "/", MAX_STRING - 1);
-          strncat(vi->filename, argv[optind], MAX_STRING - 1);
+          getcwd(vi->filename, MAX_STRING);
+          strlcat(vi->filename, "/", MAX_STRING);
+          strlcat(vi->filename, argv[optind], MAX_STRING);
         }
 
       /* Make sure the (possibly truncated) file name is NUL terminated */

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -4432,13 +4432,7 @@ static void vi_parsecolon(FAR struct vi_s *vi)
                * as unmodified.
                */
 
-              strncpy(vi->filename, filename, MAX_FILENAME - 1);
-
-             /* Make sure that the (possibly truncated) file name is NUL
-              * terminated
-              */
-
-              vi->filename[MAX_FILENAME - 1] = '\0';
+              strlcpy(vi->filename, filename, MAX_FILENAME);
               vi->modified = false;
             }
           else
@@ -4462,13 +4456,7 @@ static void vi_parsecolon(FAR struct vi_s *vi)
 
       if (filename)
         {
-          strncpy(vi->filename, filename, MAX_FILENAME - 1);
-
-         /* Make sure that the (possibly truncated) file name is NUL
-          * terminated
-          */
-
-          vi->filename[MAX_FILENAME - 1] = '\0';
+          strlcpy(vi->filename, filename, MAX_FILENAME);
         }
 
       /* If it is not a new file and if there are no changes to the text
@@ -4783,13 +4771,7 @@ static void vi_parsefind(FAR struct vi_s *vi, bool revfind)
     {
       /* Copy the new search string from the scratch to the find buffer */
 
-      strncpy(vi->findstr, vi->scratch, MAX_STRING - 1);
-
-      /* Make sure that the (possibly truncated) search string is NUL
-       * terminated
-       */
-
-      vi->findstr[MAX_STRING - 1] = '\0';
+      strlcpy(vi->findstr, vi->scratch, MAX_STRING);
     }
 
   /* Then attempt to find the string */
@@ -5643,7 +5625,7 @@ int main(int argc, FAR char *argv[])
 
       if (argv[optind][0] == '/')
         {
-          strncpy(vi->filename, argv[optind], MAX_STRING - 1);
+          strlcpy(vi->filename, argv[optind], MAX_STRING);
         }
       else
         {

--- a/system/zmodem/zm_send.c
+++ b/system/zmodem/zm_send.c
@@ -705,7 +705,7 @@ static int zms_sendzsinit(FAR struct zm_state_s *pzm)
 static int zms_sendfilename(FAR struct zm_state_s *pzm)
 {
   FAR struct zms_state_s *pzms = (FAR struct zms_state_s *)pzm;
-  FAR uint8_t *ptr = pzm->scratch;
+  FAR char *ptr = (FAR char *)pzm->scratch;
   int len;
   int ret;
 
@@ -768,19 +768,19 @@ static int zms_sendfilename(FAR struct zm_state_s *pzm)
    */
 
 #ifdef CONFIG_SYSTEM_ZMODEM_TIMESTAMPS
-  sprintf((FAR char *)ptr, "%ld %lo 0 %d 1 %ld 0",
-          (unsigned long)pzms->filesize, (unsigned long)pzms->timestamp,
-          CONFIG_SYSTEM_ZMODEM_SERIALNO, (unsigned long)pzms->filesize);
+  snprintf(ptr, sizeof(pzm->scratch), "%ld %lo 0 %d 1 %ld 0",
+           (unsigned long)pzms->filesize, (unsigned long)pzms->timestamp,
+           CONFIG_SYSTEM_ZMODEM_SERIALNO, (unsigned long)pzms->filesize);
 #else
-  sprintf((FAR char *)ptr, "%ld 0 0 %d 1 %ld 0",
-          (unsigned long)pzms->filesize, CONFIG_SYSTEM_ZMODEM_SERIALNO,
-          (unsigned long)pzms->filesize);
+  snprintf(ptr, sizeof(pzm->scratch), "%ld 0 0 %d 1 %ld 0",
+           (unsigned long)pzms->filesize, CONFIG_SYSTEM_ZMODEM_SERIALNO,
+           (unsigned long)pzms->filesize);
 #endif
 
-  ptr += strlen((FAR char *)ptr);
+  ptr += strlen(ptr);
   *ptr++ = '\0';
 
-  len =  ptr - pzm->scratch;
+  len = ptr - (FAR char *)pzm->scratch;
   DEBUGASSERT(len < CONFIG_SYSTEM_ZMODEM_SNDBUFSIZE);
   return zm_senddata(pzm, pzm->scratch, len);
 }

--- a/testing/drivertest/drivertest_pwm.c
+++ b/testing/drivertest/drivertest_pwm.c
@@ -145,8 +145,7 @@ static void parse_commandline(FAR struct pwm_state_s *pwm_state, int argc,
       switch (ch)
         {
           case 'p':
-            strncpy(pwm_state->devpath, optarg, sizeof(pwm_state->devpath));
-            pwm_state->devpath[sizeof(pwm_state->devpath) - 1] = '\0';
+            strlcpy(pwm_state->devpath, optarg, sizeof(pwm_state->devpath));
             break;
           case 'd':
             OPTARG_TO_VALUE(converted, uint8_t, 10);

--- a/testing/drivertest/drivertest_rtc.c
+++ b/testing/drivertest/drivertest_rtc.c
@@ -88,8 +88,7 @@ static void parse_commandline(FAR struct rtc_state_s *rtc_state, int argc,
       switch (ch)
         {
           case 'd':
-            strncpy(rtc_state->devpath, optarg, sizeof(rtc_state->devpath));
-            rtc_state->devpath[sizeof(rtc_state->devpath) - 1] = '\0';
+            strlcpy(rtc_state->devpath, optarg, sizeof(rtc_state->devpath));
             break;
 
           case '?':

--- a/testing/drivertest/drivertest_timer.c
+++ b/testing/drivertest/drivertest_timer.c
@@ -142,9 +142,8 @@ static void parse_commandline(FAR struct timer_state_s *timer_state,
       switch (ch)
         {
           case 'd':
-            strncpy(timer_state->devpath, optarg,
+            strlcpy(timer_state->devpath, optarg,
                     sizeof(timer_state->devpath));
-            timer_state->devpath[sizeof(timer_state->devpath) - 1] = '\0';
             break;
 
           case 'i':

--- a/testing/drivertest/drivertest_watchdog.c
+++ b/testing/drivertest/drivertest_watchdog.c
@@ -246,14 +246,12 @@ static void parse_commandline(FAR struct wdg_state_s *wdg_state, int argc,
       switch (ch)
         {
           case 'd':
-            strncpy(wdg_state->devpath, optarg, sizeof(wdg_state->devpath));
-            wdg_state->devpath[sizeof(wdg_state->devpath) - 1] = '\0';
+            strlcpy(wdg_state->devpath, optarg, sizeof(wdg_state->devpath));
             break;
 
           case 'p':
-            strncpy(wdg_state->infopath, optarg,
+            strlcpy(wdg_state->infopath, optarg,
                     sizeof(wdg_state->infopath));
-            wdg_state->infopath[sizeof(wdg_state->infopath) - 1] = '\0';
             break;
 
           case 't':

--- a/testing/fatutf8/fatutf8_main.c
+++ b/testing/fatutf8/fatutf8_main.c
@@ -108,7 +108,7 @@ int main(int argc, FAR char *argv[])
 
   printf("\n");
 
-  strcat(path, FILE_NAME);
+  strlcat(path, FILE_NAME, sizeof(path));
 
   printf("open(%s)\n", path);
   fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0777);

--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -1021,7 +1021,7 @@ int main(int argc, FAR char *argv[])
 
   if (ctx->mountdir[strlen(ctx->mountdir)-1] != '/')
     {
-      strcat(ctx->mountdir, "/");
+      strlcat(ctx->mountdir, "/", sizeof(ctx->mountdir));
     }
 
   ctx->fileimage = calloc(ctx->max_file, 1);

--- a/testing/mtd_config_fs/mtd_config_fs_test_main.c
+++ b/testing/mtd_config_fs/mtd_config_fs_test_main.c
@@ -859,7 +859,7 @@ static void test_nvs_gc(struct mtdnvs_ctx_s *ctx)
 
       /* 4 byte key */
 
-      sprintf(data.name, "k%02d", id);
+      snprintf(data.name, sizeof(data.name), "k%02d", id);
       data.configdata = buf;
       data.len = sizeof(buf);
 
@@ -876,7 +876,7 @@ static void test_nvs_gc(struct mtdnvs_ctx_s *ctx)
     {
       /* 4 byte key */
 
-      sprintf(data.name, "k%02d", id);
+      snprintf(data.name, sizeof(data.name), "k%02d", id);
       data.configdata = rd_buf;
       data.len = sizeof(rd_buf);
 
@@ -929,7 +929,7 @@ static void test_nvs_gc(struct mtdnvs_ctx_s *ctx)
     {
       /* 4 byte key */
 
-      sprintf(data.name, "k%02d", id);
+      snprintf(data.name, sizeof(data.name), "k%02d", id);
       data.configdata = rd_buf;
       data.len = sizeof(rd_buf);
 
@@ -1006,7 +1006,7 @@ static int write_content(uint16_t max_id, uint16_t begin, uint16_t end)
 
       /* 4 byte key */
 
-      sprintf(data.name, "k%02d", id);
+      snprintf(data.name, sizeof(data.name), "k%02d", id);
       data.configdata = buf;
       data.len = sizeof(buf);
 
@@ -1054,7 +1054,7 @@ static int check_content(uint16_t max_id)
     {
       /* 4 byte key */
 
-      sprintf(data.name, "k%02d", id);
+      snprintf(data.name, sizeof(data.name), "k%02d", id);
       data.configdata = rd_buf;
       data.len = sizeof(rd_buf);
 
@@ -1512,7 +1512,7 @@ static void test_nvs_full_sector(struct mtdnvs_ctx_s *ctx)
 
   while (1)
     {
-      sprintf(data.name, "k%04x", filling_id);
+      snprintf(data.name, sizeof(data.name), "k%04x", filling_id);
       data.configdata = (FAR uint8_t *)&filling_id;
       data.len = sizeof(filling_id);
 
@@ -1533,7 +1533,7 @@ static void test_nvs_full_sector(struct mtdnvs_ctx_s *ctx)
 
   /* check whether can delete whatever from full storage */
 
-  sprintf(data.name, "k%04x", 1);
+  snprintf(data.name, sizeof(data.name), "k%04x", 1);
   data.configdata = NULL;
   data.len = 0;
 
@@ -1565,7 +1565,7 @@ static void test_nvs_full_sector(struct mtdnvs_ctx_s *ctx)
       goto test_fail;
     }
 
-  sprintf(data.name, "k%04x", filling_id);
+  snprintf(data.name, sizeof(data.name), "k%04x", filling_id);
   data.configdata = (FAR uint8_t *)&filling_id;
   data.len = sizeof(filling_id);
 
@@ -1581,7 +1581,7 @@ static void test_nvs_full_sector(struct mtdnvs_ctx_s *ctx)
 
   for (i = 0; i <= filling_id; i++)
     {
-      sprintf(data.name, "k%04x", i);
+      snprintf(data.name, sizeof(data.name), "k%04x", i);
       data.configdata = (FAR uint8_t *)&data_read;
       data.len = sizeof(data_read);
 
@@ -1997,7 +1997,7 @@ static void test_nvs_gc_touched_deleted_ate(struct mtdnvs_ctx_s *ctx)
 
   while (1)
     {
-      sprintf(data.name, "k%04x", filling_id);
+      snprintf(data.name, sizeof(data.name), "k%04x", filling_id);
       data.configdata = (FAR uint8_t *)&filling_id;
       data.len = sizeof(filling_id);
 
@@ -2032,7 +2032,7 @@ static void test_nvs_gc_touched_deleted_ate(struct mtdnvs_ctx_s *ctx)
    *           B(deleted)       A            gc
    */
 
-  sprintf(data.name, "k%04x", filling_id - 1);
+  snprintf(data.name, sizeof(data.name), "k%04x", filling_id - 1);
   data.configdata = NULL;
   data.len = 0;
   ret = ioctl(fd, CFGDIOC_DELCONFIG, &data);
@@ -2049,7 +2049,7 @@ static void test_nvs_gc_touched_deleted_ate(struct mtdnvs_ctx_s *ctx)
    */
 
   filling_id -= 1;
-  sprintf(data.name, "k%04x", filling_id);
+  snprintf(data.name, sizeof(data.name), "k%04x", filling_id);
   data.configdata = (FAR uint8_t *)&filling_id;
   data.len = sizeof(filling_id);
   ret = ioctl(fd, CFGDIOC_SETCONFIG, &data);
@@ -2064,7 +2064,7 @@ static void test_nvs_gc_touched_deleted_ate(struct mtdnvs_ctx_s *ctx)
 
   for (i = 0; i <= filling_id; i++)
     {
-      sprintf(data.name, "k%04x", i);
+      snprintf(data.name, sizeof(data.name), "k%04x", i);
       data.configdata = (FAR uint8_t *)&data_read;
       data.len = sizeof(data_read);
 
@@ -2146,7 +2146,7 @@ static void test_nvs_gc_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
 
   while (1)
     {
-      sprintf(data.name, "k%04x", filling_id);
+      snprintf(data.name, sizeof(data.name), "k%04x", filling_id);
       data.configdata = (FAR uint8_t *)&filling_id;
       data.len = sizeof(filling_id);
       ret = ioctl(fd, CFGDIOC_SETCONFIG, &data);
@@ -2170,7 +2170,7 @@ static void test_nvs_gc_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
    *           B                A(deleted)   gc
    */
 
-  sprintf(data.name, "k%04x", 1);
+  snprintf(data.name, sizeof(data.name), "k%04x", 1);
   data.configdata = NULL;
   data.len = 0;
   ret = ioctl(fd, CFGDIOC_DELCONFIG, &data);
@@ -2207,7 +2207,7 @@ static void test_nvs_gc_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
    */
 
   update_id = 3;
-  sprintf(data.name, "k%04x", 2);
+  snprintf(data.name, sizeof(data.name), "k%04x", 2);
   data.configdata = (FAR uint8_t *)&update_id;
   data.len = sizeof(update_id);
   ret = ioctl(fd, CFGDIOC_SETCONFIG, &data);
@@ -2222,7 +2222,7 @@ static void test_nvs_gc_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
 
   for (i = 0; i <= filling_id - 1; i++)
     {
-      sprintf(data.name, "k%04x", i);
+      snprintf(data.name, sizeof(data.name), "k%04x", i);
       data.configdata = (FAR uint8_t *)&data_read;
       data.len = sizeof(data_read);
       ret = ioctl(fd, CFGDIOC_GETCONFIG, &data);
@@ -2323,7 +2323,7 @@ static void test_nvs_gc_not_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
 
   while (1)
     {
-      sprintf(data.name, "k%04x", filling_id);
+      snprintf(data.name, sizeof(data.name), "k%04x", filling_id);
       data.configdata = (FAR uint8_t *)&filling_id;
       data.len = sizeof(filling_id);
       ret = ioctl(fd, CFGDIOC_SETCONFIG, &data);
@@ -2347,7 +2347,7 @@ static void test_nvs_gc_not_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
    *           B(deleted)       A            gc
    */
 
-  sprintf(data.name, "k%04x", filling_id - 1);
+  snprintf(data.name, sizeof(data.name), "k%04x", filling_id - 1);
   data.configdata = NULL;
   data.len = 0;
   ret = ioctl(fd, CFGDIOC_DELCONFIG, &data);
@@ -2364,7 +2364,7 @@ static void test_nvs_gc_not_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
    */
 
   update_id = 3;
-  sprintf(data.name, "k%04x", 2);
+  snprintf(data.name, sizeof(data.name), "k%04x", 2);
   data.configdata = (FAR uint8_t *)&update_id;
   data.len = sizeof(update_id);
   ret = ioctl(fd, CFGDIOC_SETCONFIG, &data);
@@ -2379,7 +2379,7 @@ static void test_nvs_gc_not_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
 
   for (i = 0; i <= filling_id - 1; i++)
     {
-      sprintf(data.name, "k%04x", i);
+      snprintf(data.name, sizeof(data.name), "k%04x", i);
       data.configdata = (FAR uint8_t *)&data_read;
       data.len = sizeof(data_read);
       ret = ioctl(fd, CFGDIOC_GETCONFIG, &data);

--- a/testing/scanftest/scanftest_main.c
+++ b/testing/scanftest/scanftest_main.c
@@ -1126,7 +1126,7 @@ int main(int argc, FAR char *argv[])
                 {
                   fscanf(fp, "%s", s2);
                   fscanf(fp, "%2c", s3);
-                  sprintf(s1, "%s%s", s2, s3);
+                  snprintf(s1, sizeof(s1), "%s%s", s2, s3);
 
                   if (strcmp(s1, teststring) != 0)
                     {

--- a/testing/smart_test/smart_test.c
+++ b/testing/smart_test/smart_test.c
@@ -91,7 +91,8 @@ static int smart_create_test_file(char *filename)
     {
       g_line_pos[x] = ftell(fd);
 
-      sprintf(string, "This is line %d at offset %d\n", x, g_line_pos[x]);
+      snprintf(string, sizeof(string),
+               "This is line %d at offset %d\n", x, g_line_pos[x]);
       g_line_len[x] = strlen(string);
       fprintf(fd, "%s", string);
 
@@ -148,8 +149,9 @@ static int smart_seek_test(char *filename)
       fread(readstring, 1, g_line_len[index], fd);
       readstring[g_line_len[index]] = '\0';
 
-      sprintf(cmpstring, "This is line %d at offset %d\n",
-              index, g_line_pos[index]);
+      snprintf(cmpstring, sizeof(cmpstring),
+               "This is line %d at offset %d\n",
+               index, g_line_pos[index]);
 
       if (strcmp(readstring, cmpstring) != 0)
         {


### PR DESCRIPTION
## Summary

- Replace all strcat with strlcat
- Replace all sprintf with snprintf
- Replace all strncpy with strlcpy 
- system/vi: Replace strncat with strlcat

## Impact

Make the coe more safe

## Testing

Please ignore "error: Mixed case identifier found"