### PR TITLE
Include missing headers

### DIFF
--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <fcntl.h>
+#include <sched.h>
 #include <unistd.h>
 
 #include "nsh.h"

--- a/system/nsh/nsh_main.c
+++ b/system/nsh/nsh_main.c
@@ -24,12 +24,13 @@
 
 #include <nuttx/config.h>
 
-#include <sys/stat.h>
-#include <sys/boardctl.h>
+#include <errno.h>
+#include <sched.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <sched.h>
-#include <errno.h>
+#include <sys/boardctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "nshlib/nshlib.h"
 


### PR DESCRIPTION
## Summary
This PR intends to add missing headers to files from `nshlib` and `system/nsh` .
These were being transitively included by the `userspace.h` header from `kmalloc.h`, which will be removed for not being required at the current point of inclusion.

## Impact
No functional change, should have no impact.

## Testing
CI build pass.

