### PR TITLE
Revert "Don't run preconfig, clean or distclean when it's not necessary."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 *~
 .context
 .depend
-.kconfig
 /bin
 /boot_romfsimg.h
 /external

--- a/Application.mk
+++ b/Application.mk
@@ -105,7 +105,7 @@ VPATH += :.
 # Targets follow
 
 all:: $(OBJS)
-.PHONY: clean depend distclean
+.PHONY: clean preconfig depend distclean
 .PRECIOUS: $(BIN)
 
 define ELFASSEMBLE

--- a/Directory.mk
+++ b/Directory.mk
@@ -20,42 +20,41 @@
 
 include $(APPDIR)/Make.defs
 
-# Sub-directories that have been built or configured.
+# Sub-directories
 
-SUBDIRS       := $(dir $(wildcard */Makefile))
-CONFIGSUBDIRS := $(filter-out $(dir $(wildcard */Kconfig)),$(SUBDIRS))
-CLEANSUBDIRS  += $(dir $(wildcard */.depend))
-CLEANSUBDIRS  += $(dir $(wildcard */.kconfig))
-CLEANSUBDIRS  := $(sort $(CLEANSUBDIRS))
+SUBDIRS = $(dir $(wildcard */Makefile))
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-	CONFIGSUBDIRS  := $(subst /,\,$(CONFIGSUBDIRS))
-	CLEANSUBDIRS  := $(subst /,\,$(CLEANSUBDIRS))
+  SUBDIRS := $(subst /,\,$(SUBDIRS))
 endif
 
 all: nothing
 
-.PHONY: nothing clean distclean
+.PHONY: nothing context depend clean distclean
 
-$(foreach SDIR, $(CONFIGSUBDIRS), $(eval $(call SDIR_template,$(SDIR),preconfig)))
-$(foreach SDIR, $(CLEANSUBDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
-$(foreach SDIR, $(CLEANSUBDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),preconfig)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),context)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),depend)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
+$(foreach SDIR, $(SUBDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 
 nothing:
 
 install:
 
-preconfig: $(foreach SDIR, $(CONFIGSUBDIRS), $(SDIR)_preconfig)
+preconfig: $(foreach SDIR, $(SUBDIRS), $(SDIR)_preconfig)
 ifneq ($(MENUDESC),)
 	$(Q) $(MKKCONFIG) -m $(MENUDESC)
-	$(Q) touch .kconfig
 endif
 
-clean: $(foreach SDIR, $(CLEANSUBDIRS), $(SDIR)_clean)
+context: $(foreach SDIR, $(SUBDIRS), $(SDIR)_context)
 
-distclean: $(foreach SDIR, $(CLEANSUBDIRS), $(SDIR)_distclean)
+depend: $(foreach SDIR, $(SUBDIRS), $(SDIR)_depend)
+
+clean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_clean)
+
+distclean: $(foreach SDIR, $(SUBDIRS), $(SDIR)_distclean)
 ifneq ($(MENUDESC),)
 	$(call DELFILE, Kconfig)
-	$(call DELFILE, .kconfig)
 endif
 
 -include Make.dep

--- a/Make.defs
+++ b/Make.defs
@@ -27,16 +27,9 @@ include $(TOPDIR)/Make.defs
 # CLEANDIRS is the list of all top-level directories containing Makefiles.
 #   It is used only for cleaning.
 
-BUILDIRS   := $(dir $(wildcard $(APPDIR)/*/Make.defs))
-BUILDIRS   := $(filter-out $(APPDIR)/import/,$(BUILDIRS))
-CONFIGDIRS := $(filter-out $(APPDIR)/builtin/,$(BUILDIRS))
-CONFIGDIRS := $(filter-out $(dir $(wildcard $(APPDIR)/*/Kconfig)),$(CONFIGDIRS))
-CLEANDIRS  := $(dir $(wildcard $(APPDIR)/*/Makefile))
-ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-	BUILDIRS  := $(subst /,\,$(BUILDIRS))
-	CONFIGDIRS  := $(subst /,\,$(CONFIGDIRS))
-	CLEANDIRS  := $(subst /,\,$(CLEANDIRS))
-endif
+BUILDIRS  := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Make.defs))
+BUILDIRS  := $(filter-out $(APPDIR)$(DELIM)import$(DELIM),$(BUILDIRS))
+CLEANDIRS := $(dir $(wildcard $(APPDIR)$(DELIM)*$(DELIM)Makefile))
 
 # CONFIGURED_APPS is the application directories that should be built in
 #   the current configuration.
@@ -44,7 +37,7 @@ endif
 CONFIGURED_APPS :=
 
 define Add_Application
-	include $(1)Make.defs
+  include $(1)Make.defs
 endef
 
 $(foreach BDIR, $(BUILDIRS), $(eval $(call Add_Application,$(BDIR))))

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ context: | staging
 	$(Q) $(MAKE) register_all
 
 Kconfig:
-	$(foreach SDIR, $(CONFIGDIRS), $(call MAKE_template,$(SDIR),preconfig))
+	$(foreach SDIR, $(BUILDIRS), $(call MAKE_template,$(SDIR),preconfig))
 	$(Q) $(MKKCONFIG)
 
 preconfig: Kconfig


### PR DESCRIPTION
## Summary

to ensure all clean/distclean get run.
This reverts commit 1dae12ba05d30933253afbafccb67cb6ca8b4544.

## Impact

clean/distclean

## Testing

CI