### PR TITLE
system/cu: Disable echo if it's enabled to avoid double input character

### DIFF
--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -179,6 +179,10 @@ static int set_termios(int fd, int rate, enum parity_mode parity,
       tio.c_oflag |= ONLCR;
     }
 
+  /* disable echo if it's enabled to avoid double input character */
+
+  tio.c_iflag &= ~ECHO;
+
   ret = tcsetattr(fd, TCSANOW, &tio);
   if (ret)
     {


### PR DESCRIPTION
## Summary
Disable echo if it's enabled to avoid double input character
## Impact
cu
## Testing
VELA
