### PR TITLE
wasm: increase WASM_INITIAL_MEMORY if stack size is great than initial memory

### DIFF
--- a/interpreters/Wasm.mk
+++ b/interpreters/Wasm.mk
@@ -21,9 +21,14 @@
 ifeq ($(WASM_BUILD),y)
   ifneq ($(CONFIG_INTERPRETERS_WAMR)$(CONFIG_INTERPRETERS_WAMR3),)
 
-WASM_INITIAL_MEMORY ?= 65536
-STACKSIZE           ?= $(CONFIG_DEFAULT_TASK_STACKSIZE)
-PRIORITY            ?= SCHED_PRIORITY_DEFAULT
+STACKSIZE  ?= $(CONFIG_DEFAULT_TASK_STACKSIZE)
+PRIORITY   ?= SCHED_PRIORITY_DEFAULT
+
+ifneq ($(INITMEMORY),)
+  ifeq ($(shell test $(INITMEMORY) -lt $(STACKSIZE); echo $$?),0)
+    INITMEMORY := $(shell expr $(STACKSIZE) + $(INITMEMORY))
+  endif
+endif
 
 # Wamr mode:
 # INT: Interpreter (Default)
@@ -56,7 +61,7 @@ $(WBIN): $(WOBJS)
 	  $(eval mainindex=$(strip $(call GETINDEX,$(main),$(MAINSRC)))) \
 	  $(eval dstname=$(shell echo $(main:%.c=%.wo) | sed -e 's/\//_/g')) \
 	  $(shell cp -rf $(strip $(main:%.c=%.wo)) \
-	    $(strip $(APPDIR)/wasm/$(word $(mainindex),$(PROGNAME))#$(WASM_INITIAL_MEMORY)#$(STACKSIZE)#$(PRIORITY)#$(WAMR_MODE)#$(dstname)) \
+	    $(strip $(APPDIR)/wasm/$(word $(mainindex),$(PROGNAME))#$(INITMEMORY)#$(STACKSIZE)#$(PRIORITY)#$(WAMR_MODE)#$(dstname)) \
 	   ) \
 	 )
 

--- a/interpreters/wamr/Toolchain.defs
+++ b/interpreters/wamr/Toolchain.defs
@@ -32,7 +32,7 @@ CFLAGS_STRIP += $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(A
 WCFLAGS += $(filter-out $(CFLAGS_STRIP),$(CFLAGS))
 WCFLAGS += --sysroot=$(WSYSROOT) -nostdlib -D__NuttX__
 
-WLDFLAGS = -z stack-size=$(STACKSIZE) -Wl,--initial-memory=$(INITIAL_MEMORY)
+WLDFLAGS = -z stack-size=$(STACKSIZE)
 WLDFLAGS += -Wl,--export=main -Wl,--export=__main_argc_argv
 WLDFLAGS += -Wl,--export=__heap_base -Wl,--export=__data_end
 WLDFLAGS += -Wl,--no-entry -Wl,--strip-all -Wl,--allow-undefined
@@ -126,11 +126,13 @@ RCFLAGS += --target=$(WTARGET) $(WCPU)
 define LINK_WAMR
 	$(if $(wildcard $(APPDIR)$(DELIM)wasm$(DELIM)*.wo), \
 	  $(foreach bin,$(wildcard $(APPDIR)$(DELIM)wasm$(DELIM)*.wo), \
-	    $(eval INITIAL_MEMORY=$(shell echo $(notdir $(bin)) | cut -d'#' -f2)) \
+	    $(eval INITMEMORY=$(shell echo $(notdir $(bin)) | cut -d'#' -f2)) \
 	    $(eval STACKSIZE=$(shell echo $(notdir $(bin)) | cut -d'#' -f3)) \
 	    $(eval PROGNAME=$(shell echo $(notdir $(bin)) | cut -d'#' -f1)) \
 	    $(eval WAMRMODE=$(shell echo $(notdir $(bin)) | cut -d'#' -f5)) \
-	    $(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm) \
+	    $(if $(INITMEMORY),
+	    $(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) -Wl,--initial-memory=$(INITMEMORY) -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm), \
+	    $(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm)) \
 	    $(if $(CONFIG_INTERPRETERS_WAMR_AOT), \
 	      $(if $(filter AOT,$(WAMRMODE)), \
 	        $(info Wamrc Generate AoT: $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).aot) \


### PR DESCRIPTION
## Summary

wasm: increase INITMEMORY if stack size is great than initial memory

1. increase INITMEMORY if stack size is great than initial memory
2. Do not pass initial-memory if caller does not specific

Signed-off-by: chao an <anchao@xiaomi.com>



## Impact

N/A

## Testing

sim/wamr