### PR TITLE
apps/interpreters: Add missing Apache Foundation copyright header

### DIFF
--- a/interpreters/bas/Make.defs
+++ b/interpreters/bas/Make.defs
@@ -1,3 +1,23 @@
+############################################################################
+# apps/interpreters/bas/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
 ifneq ($(CONFIG_INTERPRETERS_BAS),)
 CONFIGURED_APPS += $(APPDIR)/interpreters/bas
 endif

--- a/interpreters/bas/Makefile
+++ b/interpreters/bas/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/bas/Makefile
+# apps/interpreters/bas/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/interpreters/ficl/Make.defs
+++ b/interpreters/ficl/Make.defs
@@ -1,3 +1,23 @@
+############################################################################
+# apps/interpreters/ficl/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
 ifneq ($(CONFIG_INTERPRETERS_FICL),)
 CONFIGURED_APPS += $(APPDIR)/interpreters/ficl
 endif


### PR DESCRIPTION
## Summary
Add missing Apache Foundation copyright header
Fix mistakes in comments
## Impact
none
## Testing

