### PR TITLE
nsh: Fix a potential buffer overflow in cmd help

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -813,7 +813,11 @@ static inline void help_builtins(FAR struct nsh_vtbl_s *vtbl)
   unsigned int j;
   unsigned int k;
   unsigned int offset;
-  char line[HELP_LINELEN];
+
+  /* Extra 5 bytes for tab before newline and '\0' */
+
+  char line[HELP_LINELEN + HELP_TABSIZE + 1];
+
   static const char *g_builtin_prompt = "\nBuiltin Apps:\n";
 
   /* Count the number of built-in commands and get the optimal column width */


### PR DESCRIPTION
## Summary
Forget to fix another place in https://github.com/apache/nuttx-apps/pull/1621, fix issue of builtin command list.
## Impact
cmd help
## Testing
VELA
