### PR TITLE
nsh: Added conditional include of netinit.

### DIFF
--- a/nshlib/nsh_init.c
+++ b/nshlib/nsh_init.c
@@ -28,11 +28,14 @@
 #include <nuttx/symtab.h>
 
 #include "system/readline.h"
-#include "netutils/netinit.h"
 #include "nshlib/nshlib.h"
 
 #include "nsh.h"
 #include "nsh_console.h"
+
+#ifdef CONFIG_NSH_NETINIT
+#  include "netutils/netinit.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

`netutils/netinit.h` was always included unconditionaly, regardless whether it was needed or not.

This causes some problems with projects without the need of netinit, or networking whatsoever.  
Sometimes, the apps repo is used partially, netutils may not even be available.

This PR makes sure that this file is included only when needed.

## Impact

NSH can be build without dependency on netutils.

## Testing

Build test.
