### PR TITLE
Using poll instead of epoll in NNG library

### DIFF
--- a/netutils/nng/Kconfig
+++ b/netutils/nng/Kconfig
@@ -17,4 +17,25 @@ config NETUTILS_NNG_VERSION
 	string "NNG Version"
 	default "1.5.2"
 
+config NETUTILS_NNG_HAVE_EPOLL
+	bool "Build with epoll"
+	default n
+	---help---
+		If this option is selected, an epoll based poll gueue
+		is included in the build. Otherwise poll based queue
+		is included in the build.
+
+choice
+	prompt "TLS engine"
+	default NETUTILS_NNG_USE_NONE
+
+config NETUTILS_NNG_USE_NONE
+	bool "None"
+
+config NETUTILS_NNG_USE_MBEDTLS
+	bool "MbedTLS"
+	select CRYPTO_MBEDTLS
+
+endchoice # TLS engine
+
 endif

--- a/netutils/nng/Makefile
+++ b/netutils/nng/Makefile
@@ -36,12 +36,19 @@ CFLAGS += -DNNG_TRANSPORT_WS
 CFLAGS += -DNNG_TRANSPORT_WSS
 
 CFLAGS += -DNNG_USE_EVENTFD
+ifeq ($(CONFIG_NETUTILS_NNG_HAVE_EPOLL),y)
 CFLAGS += -DNNG_HAVE_EPOLL
 CFLAGS += -DNNG_HAVE_EPOLL_CREATE1
+endif
+
+ifeq ($(CONFIG_NETUTILS_NNG_USE_MBEDTLS),y)
+CFLAGS += -DNNG_TLS_ENGINE_INIT=nng_tls_engine_init_mbed
+CFLAGS += -DNNG_TLS_ENGINE_FINI=nng_tls_engine_fini_mbed
+CFLAGS += -DNNG_SUPP_TLS
+endif
 
 DEPPATH += --dep-path $(NNG_SRCDIR)
 VPATH   += :$(NNG_SRCDIR)
-
 
 CSRCS  = $(NNG_SRCDIR)/nng.c 
 CSRCS += $(NNG_SRCDIR)/nng_legacy.c
@@ -88,9 +95,12 @@ CSRCS += $(NNG_SRCDIR)/platform/posix/posix_tcpdial.c
 CSRCS += $(NNG_SRCDIR)/platform/posix/posix_tcplisten.c
 CSRCS += $(NNG_SRCDIR)/platform/posix/posix_thread.c
 CSRCS += $(NNG_SRCDIR)/platform/posix/posix_udp.c
+ifeq ($(CONFIG_NETUTILS_NNG_HAVE_EPOLL),y)
 CSRCS += $(NNG_SRCDIR)/platform/posix/posix_pollq_epoll.c
+else
+CSRCS += $(NNG_SRCDIR)/platform/posix/posix_pollq_poll.c
+endif
 CSRCS += $(NNG_SRCDIR)/platform/posix/posix_rand_getrandom.c
-#CSRCS += $(NNG_SRCDIR)/platform/posix/posix_rand_urandom.c
 
 CSRCS += $(NNG_SRCDIR)/sp/transport.c
 CSRCS += $(NNG_SRCDIR)/sp/protocol/bus0/bus.c
@@ -126,8 +136,9 @@ CSRCS += $(NNG_SRCDIR)/supplemental/http/http_schemes.c
 CSRCS += $(NNG_SRCDIR)/supplemental/http/http_server.c
 CSRCS += $(NNG_SRCDIR)/supplemental/sha1/sha1.c
 CSRCS += $(NNG_SRCDIR)/supplemental/tls/tls_common.c
-#CSRCS += $(NNG_SRCDIR)/supplemental/tls/mbedtls/tls.c
-#CSRCS += $(NNG_SRCDIR)/supplemental/util/options.c
+ifeq ($(CONFIG_NETUTILS_NNG_USE_MBEDTLS),y)
+CSRCS += $(NNG_SRCDIR)/supplemental/tls/mbedtls/tls.c
+endif
 CSRCS += $(NNG_SRCDIR)/supplemental/util/platform.c
 CSRCS += $(NNG_SRCDIR)/supplemental/websocket/websocket.c
 


### PR DESCRIPTION
## Summary

Switching to poll instead of epoll mechanism in NNG library, because PUB/SUB example doesn't work when epoll is used. This was not an issue a few months ago, thus regression testing on epoll and local socket implementation need to be done.
DIsabled mbedtls functionality in Makefile can be enabled, but then MBEDTLS_X509_CRL_PARSE_C macro must be defined in mbedtls_config.h also.

## Impact

NNG library only.

## Testing

Pub/Sub example

