### PR TITLE
nxplayer: read file completely until 0 bytes are returned

### DIFF
--- a/system/nxplayer/nxplayer_common.c
+++ b/system/nxplayer/nxplayer_common.c
@@ -53,9 +53,6 @@ int nxplayer_fill_common(int fd, FAR struct ap_buffer_s *apb)
   apb->curbyte = 0;
   apb->flags   = 0;
 
-#ifdef CONFIG_NXPLAYER_HTTP_STREAMING_SUPPORT
-  /* read data up to nmaxbytes from network */
-
   while (0 < apb->nbytes && apb->nbytes < apb->nmaxbytes)
     {
       int n   = apb->nmaxbytes - apb->nbytes;
@@ -68,7 +65,6 @@ int nxplayer_fill_common(int fd, FAR struct ap_buffer_s *apb)
 
       apb->nbytes += ret;
     }
-#endif
 
   if (apb->nbytes < apb->nmaxbytes)
     {


### PR DESCRIPTION
## Summary

Previously, if the read bytes were less than the requested, the file was closed immediately. This behavior, however, does not consider the fact that the read operation may be blocking when no bytes are available at the moment. That is true for a named pipe (FIFO), for instance. Thus, reading it again lets to the underlying file system the decision of 1) blocking until bytes become available or 2) return 0 immediately (the case for actual files) or 3) read available bytes.

## Impact

No impact on actual files: if the file has reached its end, the second `read` operation will return `0` and the file will be closed. 
It enables, however, using files that `read` may block to wait for new bytes to become available. That is the case for named pipes (FIFO).

## Testing

Tested on ESP32-LyraT board using an actual file (`romfs`), a HTTP streamed file, and a continuously fed named pipe (`mkfifo` + [rtpdump](https://github.com/apache/nuttx-apps/pull/1651)). 
