### PR TITLE
nsh/alias: Add shell alias support for NSH

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -185,6 +185,24 @@ config NSH_DISABLEBG
 		where a minimal footprint is a necessity and background command
 		execution is not.
 
+config NSH_ALIAS
+	bool "Enable alias support"
+	default !DEFAULT_SMALL
+	---help---
+		Enable alias support for nsh. This enables command substitution from
+		a table of alias strings for individual commands. The maximum amount
+		of alias strings is configurable with NSH_ALIAS_MAX_AMOUNT.
+
+if NSH_ALIAS
+
+config NSH_ALIAS_MAX_AMOUNT
+	int "Maximum amount of aliases"
+	default 1
+	---help---
+		Set the maximum amount of alias entries.
+
+endif # NSH_ALIAS
+
 endmenu # Command Line Configuration
 
 config NSH_BUILTIN_APPS

--- a/nshlib/Makefile
+++ b/nshlib/Makefile
@@ -106,4 +106,8 @@ ifeq ($(CONFIG_NSH_LOGIN_PASSWD),y)
 CSRCS += nsh_passwdcmds.c
 endif
 
+ifeq ($(CONFIG_NSH_ALIAS),y)
+CSRCS += nsh_alias.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -715,6 +715,25 @@ struct nsh_parser_s
 #endif
 };
 
+#ifdef CONFIG_NSH_ALIAS
+struct nsh_alias_s
+{
+  FAR struct nsh_alias_s *next;    /* Single link list for traversing */
+  FAR char               *name;    /* Name of the alias */
+  FAR char               *value;   /* Value behind the name */
+  union
+  {
+    struct
+    {
+      uint8_t             exp : 1; /* Already expanded ? */
+      uint8_t             rem : 1; /* Marked for deletion */
+    };
+
+    uint8_t               flags;   /* Raw value */
+  };
+};
+#endif
+
 /* This is the general form of a command handler */
 
 struct nsh_vtbl_s; /* Defined in nsh_console.h */
@@ -791,6 +810,13 @@ int nsh_romfsetc(void);
 int nsh_usbconsole(void);
 #else
 #  define nsh_usbconsole() (-ENOSYS)
+#endif
+
+#ifdef CONFIG_NSH_ALIAS
+FAR struct nsh_alias_s *nsh_aliasfind(FAR struct nsh_vtbl_s *vtbl,
+                                      FAR const char *token);
+void nsh_aliasfree(FAR struct nsh_vtbl_s *vtbl,
+                   FAR struct nsh_alias_s *alias);
 #endif
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
@@ -1191,6 +1217,11 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  ifndef CONFIG_NSH_DISABLE_URLENCODE
   int cmd_urldecode(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #  endif
+#endif
+
+#ifdef CONFIG_NSH_ALIAS
+int cmd_alias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 /****************************************************************************

--- a/nshlib/nsh_alias.c
+++ b/nshlib/nsh_alias.c
@@ -1,0 +1,440 @@
+/****************************************************************************
+ * apps/nshlib/nsh_alias.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <nuttx/queue.h>
+
+#include "nsh.h"
+#include "nsh_console.h"
+
+#ifdef CONFIG_NSH_ALIAS
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Macro to get head of alias list */
+
+#define alias_head(list)        (FAR struct nsh_alias_s *)sq_peek(list)
+#define alias_remfirst(list)    (FAR struct nsh_alias_s *)sq_remfirst(list)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Alias message format */
+
+static const char g_aliasfmt[]    = "alias %s='%s'\n";
+static const char g_savefailfmt[] = "alias %s='%s' failed\n";
+
+/* Common for both alias / unalias */
+
+static const char g_noaliasfmt[]  = "%s: %s not found\n";
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: alias_init
+ ****************************************************************************/
+
+void alias_init(FAR struct nsh_vtbl_s *vtbl)
+{
+  int i;
+
+  if (!sq_empty(&vtbl->alist) || !sq_empty(&vtbl->afreelist))
+    {
+      /* If either list is non-empty, we are initialized already */
+
+      return;
+    }
+
+  sq_init(&vtbl->alist);
+  sq_init(&vtbl->afreelist);
+
+  for (i = 0; i < CONFIG_NSH_ALIAS_MAX_AMOUNT; i++)
+    {
+      sq_addlast((FAR struct sq_entry_s *)&vtbl->atab[i], &vtbl->afreelist);
+    }
+
+  return;
+}
+
+/****************************************************************************
+ * Name: alias_find
+ ****************************************************************************/
+
+static FAR struct nsh_alias_s *alias_find(FAR struct nsh_vtbl_s *vtbl,
+                                          FAR const char *name)
+{
+  FAR struct nsh_alias_s *alias;
+
+  for (alias = alias_head(&vtbl->alist); alias; alias = alias->next)
+    {
+      if (strcmp(alias->name, name) == 0)
+        {
+          return alias;
+        }
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: alias_delete
+ ****************************************************************************/
+
+static void alias_delete(FAR struct nsh_vtbl_s *vtbl,
+                         FAR struct nsh_alias_s *alias)
+{
+  if (alias)
+    {
+      if (alias->exp)
+        {
+          /* Mark it for removal, but keep the data intact */
+
+          alias->rem = 1;
+          return;
+        }
+
+      if (alias->name)
+        {
+          free(alias->name);
+        }
+
+      if (alias->value)
+        {
+          free(alias->value);
+        }
+
+      alias->name = NULL;
+      alias->value = NULL;
+      alias->flags = 0;
+
+      sq_rem((FAR sq_entry_t *)alias, &vtbl->alist);
+      sq_addfirst((FAR sq_entry_t *)alias, &vtbl->afreelist);
+    }
+}
+
+/****************************************************************************
+ * Name: alias_save
+ ****************************************************************************/
+
+static int alias_save(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
+                      FAR const char *value)
+{
+  FAR struct nsh_alias_s *alias;
+  int ret = OK;
+
+  if (!name || *name == '\0' || !value)
+    {
+      return -EINVAL;
+    }
+
+  if ((alias = alias_find(vtbl, name)) != NULL)
+    {
+      /* Update the value */
+
+      free(alias->value);
+      alias->value = strdup(value);
+    }
+  else if ((alias = alias_remfirst(&vtbl->afreelist)) != NULL)
+    {
+      /* Create new value */
+
+      alias->name = strdup(name);
+      alias->value = strdup(value);
+      sq_addlast((FAR sq_entry_t *)alias, &vtbl->alist);
+    }
+
+  if (!alias || !alias->name || !alias->value)
+    {
+      /* Something went wrong, clean up after ourselves */
+
+      alias_delete(vtbl, alias);
+      ret = -ENOMEM;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: alias_printall
+ ****************************************************************************/
+
+static void alias_printall(FAR struct nsh_vtbl_s *vtbl)
+{
+  FAR struct nsh_alias_s *alias;
+
+  for (alias = alias_head(&vtbl->alist); alias; alias = alias->next)
+    {
+      nsh_output(vtbl, g_aliasfmt, alias->name, alias->value);
+    }
+}
+
+/****************************************************************************
+ * Name: alias_removeall
+ ****************************************************************************/
+
+static void alias_removeall(FAR struct nsh_vtbl_s *vtbl)
+{
+  FAR struct nsh_alias_s *alias;
+  FAR struct nsh_alias_s *next;
+
+  alias = alias_head(&vtbl->alist);
+
+  while (alias)
+    {
+      next = alias->next;
+      alias_delete(vtbl, alias);
+      alias = next;
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nsh_aliasfind
+ *
+ * Description:
+ *   Find alias for token. Returns the alias structure or NULL if not found.
+ *
+ * Input Parameters:
+ *   vtbl  - NSH session data.
+ *   token - The argument string to find.
+ *
+ * Returned Value:
+ *   The alias is returned, if one found, otherwise NULL.
+ *
+ ****************************************************************************/
+
+FAR struct nsh_alias_s *nsh_aliasfind(FAR struct nsh_vtbl_s *vtbl,
+                                      FAR const char *token)
+{
+  FAR struct nsh_alias_s *alias;
+
+  /* Init, if necessary */
+
+  alias_init(vtbl);
+
+  if (token)
+    {
+      /* See if such an alias exists ? */
+
+      alias = alias_find(vtbl, token);
+      if (alias && !alias->exp && alias->value)
+        {
+          /* Yes, return the alias */
+
+          return alias;
+        }
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: nsh_aliasfree
+ *
+ * Description:
+ *   Free memory for any deleted alias, aliases are kept in memory until all
+ *   references to it have been freed.
+ *
+ * Input Parameters:
+ *   vtbl  - NSH session data.
+ *   alias - Pointer to alias data that is freed.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void nsh_aliasfree(FAR struct nsh_vtbl_s *vtbl,
+                   FAR struct nsh_alias_s *alias)
+{
+  alias_delete(vtbl, alias);
+}
+
+/****************************************************************************
+ * Name: cmd_alias
+ *
+ * Description:
+ *   Handle 'alias' command from terminal. Multiple alias values can be given
+ *   by a single command.
+ *
+ *   Command does one of three things:
+ *   1) If no arguments are given, every alias is printed to terminal.
+ *   2) If a known alias name is given, the value is printed to terminal.
+ *   3) If a "name=value" pair is given, a new alias is created, if there is
+ *      room.
+ *
+ * Input Parameters:
+ *   vtbl - The NSH console.
+ *   argc - Amount of argument strings in command.
+ *   argv - The argument strings.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int cmd_alias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
+{
+  FAR struct nsh_alias_s *alias;
+  FAR char **arg;
+  FAR char *value;
+  int ret = OK;
+
+  /* Init, if necessary */
+
+  alias_init(vtbl);
+
+  if (argc < 2)
+    {
+      /* Print the alias list */
+
+      alias_printall(vtbl);
+      return ret;
+    }
+
+  /* Traverse through the argument vector */
+
+  for (arg = argv + 1; *arg; arg++)
+    {
+      /* Look for name=value */
+
+      if ((value = strchr(*arg, '=')) != NULL)
+        {
+          /* Save new / modify existing alias */
+
+          *value++ = '\0';
+
+          ret = alias_save(vtbl, *arg, value);
+          if (ret < 0)
+            {
+              nsh_error(vtbl, g_savefailfmt, *arg, value);
+            }
+        }
+      else if ((alias = alias_find(vtbl, *arg)) != NULL)
+        {
+          /* Found it */
+
+          nsh_output(vtbl, g_aliasfmt, alias->name, alias->value);
+        }
+      else
+        {
+          /* Nothing found */
+
+          nsh_error(vtbl, g_noaliasfmt, "alias", *arg);
+          ret = -ENOENT;
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: cmd_unalias
+ *
+ * Description:
+ *   Handle 'cmd_unalias' command from terminal.
+ *
+ *   Command does one of two things:
+ *   1) If the '-a' argument is given, all aliases are destroyed.
+ *   2) If a known alias name is given, the name=value pair is destroyed.
+ *
+ * Input Parameters:
+ *   vtbl - The NSH console.
+ *   argc - Amount of argument strings in command.
+ *   argv - The argument strings.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
+{
+  FAR struct nsh_alias_s *alias;
+  FAR char **arg;
+  int option;
+  int ret = OK;
+
+  /* Init, if necessary */
+
+  alias_init(vtbl);
+
+  if (argc < 2)
+    {
+      /* No arguments given, this is an error */
+
+      return -EINVAL;
+    }
+
+  /* If '-a' is provided, then just wipe them all */
+
+  if ((option = getopt(argc, argv, "a")) != ERROR)
+    {
+      alias_removeall(vtbl);
+      return ret;
+    }
+
+  /* Traverse through the argument vector */
+
+  for (arg = argv + 1; *arg; arg++)
+    {
+      if ((alias = alias_find(vtbl, *arg)) != NULL)
+        {
+          /* Found it */
+
+          alias_delete(vtbl, alias);
+        }
+      else
+        {
+          /* Nothing found */
+
+          nsh_error(vtbl, g_noaliasfmt, "unalias", *arg);
+          ret = -ENOENT;
+        }
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_NSH_ALIAS */

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -104,6 +104,13 @@ static const struct cmdmap_s g_cmdmap[] =
   { "addroute", cmd_addroute, 3, 4, "<target> [<netmask>] <router>" },
 #endif
 
+#ifdef CONFIG_NSH_ALIAS
+  { "alias",    cmd_alias,   1, CONFIG_NSH_MAXARGUMENTS,
+    "[name[=value] ... ]" },
+  { "unalias",  cmd_unalias, 1, CONFIG_NSH_MAXARGUMENTS,
+    "[-a] name [name ... ]" },
+#endif
+
 #if defined(CONFIG_NET) && defined(CONFIG_NET_ARP) && !defined(CONFIG_NSH_DISABLE_ARP)
   { "arp",      cmd_arp,      1, 6,
     "[-i <ifname>] [-a <ipaddr>|-d <ipaddr>|-s <ipaddr> <hwaddr>]" },

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -33,6 +33,8 @@
 #include <stdbool.h>
 #include <errno.h>
 
+#include <nuttx/queue.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -117,6 +119,14 @@ struct nsh_vtbl_s
   /* Common buffer for file I/O. */
 
   char iobuffer[IOBUFFERSIZE];
+#endif
+
+#ifdef CONFIG_NSH_ALIAS
+  /* Shell alias support */
+
+  struct nsh_alias_s atab[CONFIG_NSH_ALIAS_MAX_AMOUNT];
+  struct sq_queue_s  alist;
+  struct sq_queue_s  afreelist;
 #endif
 
   /* Parser state data */

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -1809,7 +1809,7 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
 #ifdef CONFIG_NSH_ALIAS
       /* Expand aliases (if applicable) first, quoting prevents this */
 
-      if (!quoted)
+      if (alist && !quoted)
         {
           pbegin = nsh_aliasexpand(vtbl, pbegin, alist);
         }
@@ -2427,7 +2427,7 @@ static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
   argv[0] = cmd;
   for (argc = 1; argc < MAX_ARGV_ENTRIES - 1; argc++)
     {
-      argv[argc] = nsh_argument(vtbl, &saveptr, &memlist, &alist, NULL);
+      argv[argc] = nsh_argument(vtbl, &saveptr, &memlist, NULL, NULL);
       if (!argv[argc])
         {
           break;
@@ -2571,7 +2571,7 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
     {
       int isenvvar = 0; /* flag for if an environment variable gets expanded */
 
-      argv[argc] = nsh_argument(vtbl, &saveptr, &memlist, &alist, &isenvvar);
+      argv[argc] = nsh_argument(vtbl, &saveptr, &memlist, NULL, &isenvvar);
 
       if (!argv[argc])
         {


### PR DESCRIPTION
## Summary
Add support for shell aliases into NSH. As a pre-requisite add support for single ('') and double ("") quotes as well. Note, this changes the parser behavior quite significantly so if ANY issues please let me know ASAP and I'll fix them at once.
## Impact
Quite significant on the parser (the code is simplified somewhat IMO), adds new POSIX feature to the shell.
## Testing
icicle:nsh, tried several happy cases and error cases. Everything seemingly works.
