### PR TITLE
nshlib/nsh_vars.c: Add missing stdio.h

### DIFF
--- a/nshlib/nsh_vars.c
+++ b/nshlib/nsh_vars.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
## Summary
nsh_vars.c: In function 'nsh_setvar':
nsh_vars.c:285:3: error: incompatible implicit declaration of built-in function 'sprintf' [-Werror]
  285 |   sprintf(pair, "%s=%s", name, value);
## Impact
Fix build issue
## Testing
CI pass
