### PR TITLE
apps: remove unnecessary sem_setprotocol code

### DIFF
--- a/graphics/nxwidgets/src/ccallback.cxx
+++ b/graphics/nxwidgets/src/ccallback.cxx
@@ -83,7 +83,6 @@ CCallback::CCallback(CWidgetControl *widgetControl)
   m_synchronized       = false;
 
   sem_init(&m_semevent, 0, 0);
-  sem_setprotocol(&m_semevent, SEM_PRIO_NONE);
 
 #ifdef CONFIG_NXTERM_NXKBDIN
   // Keyboard input is initially directed to the widgets within the window

--- a/graphics/twm4nx/apps/ccalibration.cxx
+++ b/graphics/twm4nx/apps/ccalibration.cxx
@@ -126,7 +126,6 @@ CCalibration::CCalibration(FAR CTwm4Nx *twm4nx)
 
   sem_init(&m_exclSem, 0, 1);
   sem_init(&m_synchSem, 0, 0);
-  sem_setprotocol(&m_synchSem, SEM_PRIO_NONE);
 }
 
 /**

--- a/graphics/twm4nx/apps/cclock.cxx
+++ b/graphics/twm4nx/apps/cclock.cxx
@@ -297,7 +297,6 @@ bool CClock::run(void)
   // start the new Clock task
 
   sem_init(&GClockVars.waitSem, 0, 0);
-  sem_setprotocol(&GClockVars.waitSem, SEM_PRIO_NONE);
 
   GClockVars.that    = this;
   GClockVars.success = false;

--- a/graphics/twm4nx/src/cinput.cxx
+++ b/graphics/twm4nx/src/cinput.cxx
@@ -97,7 +97,6 @@ CInput::CInput(CTwm4Nx *twm4nx)
   // Initialize the semaphore used to synchronize with the listener thread
 
   sem_init(&m_waitSem, 0, 0);
-  sem_setprotocol(&m_waitSem, SEM_PRIO_NONE);
 
 #ifdef CONFIG_TWM4NX_TOUCHSCREEN
   // Calibration

--- a/testing/ostest/roundrobin.c
+++ b/testing/ostest/roundrobin.c
@@ -192,7 +192,6 @@ void rr_test(void)
 
   sched_lock();
   sem_init(&g_rrsem, 0, 0);
-  sem_setprotocol(&g_rrsem, SEM_PRIO_NONE);
 
   /* Start the threads */
 

--- a/wireless/ieee802154/i8sak/i8sak_main.c
+++ b/wireless/ieee802154/i8sak/i8sak_main.c
@@ -682,10 +682,8 @@ static int i8sak_setup(FAR struct i8sak_s *i8sak, FAR const char *ifname)
   sem_init(&i8sak->exclsem, 0, 1);
 
   sem_init(&i8sak->updatesem, 0, 0);
-  sem_setprotocol(&i8sak->updatesem, SEM_PRIO_NONE);
 
   sem_init(&i8sak->sigsem, 0, 0);
-  sem_setprotocol(&i8sak->sigsem, SEM_PRIO_NONE);
 
   sem_init(&i8sak->eventsem, 0, 1);
 


### PR DESCRIPTION
## Summary

Semaphore does not need set protocol, so remove sem_setprotocol code for semaphore.

## Impact

NA

## Testing

CI Pass