### PR TITLE
ostest: Introduce basic work queue test

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -92,6 +92,10 @@ endif
 ifeq ($(CONFIG_SCHED_SPORADIC),y)
 CSRCS += sporadic.c sporadic2.c
 endif
+
+ifeq ($(CONFIG_SCHED_WORKQUEUE),y)
+CSRCS += wqueue.c
+endif
 endif # CONFIG_DISABLE_PTHREAD
 
 ifneq ($(CONFIG_DISABLE_MQUEUE),y)

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -126,6 +126,12 @@ void restart_test(void);
 int waitpid_test(void);
 #endif
 
+/* wqueue.c *****************************************************************/
+
+#if defined(CONFIG_SCHED_LPWORK) || defined(CONFIG_SCHED_HPWORK)
+void wqueue_test(void);
+#endif
+
 /* mutex.c ******************************************************************/
 
 void mutex_test(void);

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -359,6 +359,15 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
+#if !defined(CONFIG_DISABLE_PTHREAD) && \
+    (defined(CONFIG_SCHED_LPWORK) || defined(CONFIG_SCHED_HPWORK))
+      /* Check work queues */
+
+      printf("\nuser_main: wqueue test\n");
+      wqueue_test();
+      check_test_memory_usage();
+#endif
+
 #ifndef CONFIG_DISABLE_PTHREAD
       /* Verify pthreads and pthread mutex */
 

--- a/testing/ostest/wqueue.c
+++ b/testing/ostest/wqueue.c
@@ -1,0 +1,190 @@
+/****************************************************************************
+ * apps/testing/ostest/wqueue.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <nuttx/wqueue.h>
+
+#if defined(CONFIG_SCHED_LPWORK) || defined(CONFIG_SCHED_HPWORK)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SLEEP_TIME   (100 * 1000)
+#define TEST_COUNT   (100)
+#define VERIFY_COUNT (100)
+
+#ifdef CONFIG_SCHED_LPWORK
+#  define TEST_QUEUE           LPWORK
+#  define TEST_QUEUE_PRIORITY  CONFIG_SCHED_LPWORKPRIORITY
+#else
+#  define TEST_QUEUE           HPWORK
+#  define TEST_QUEUE_PRIORITY  CONFIG_SCHED_HPWORKPRIORITY
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void empty_worker(FAR void *arg)
+{
+}
+
+static void sleep_worker(FAR void *arg)
+{
+  FAR sem_t *sem = arg;
+  usleep(SLEEP_TIME);
+  sem_post(sem);
+}
+
+static void count_worker(FAR void *arg)
+{
+  FAR sem_t *sem = arg;
+  sem_post(sem);
+}
+
+static FAR void *tester(FAR void *arg)
+{
+  int interval = (intptr_t)arg;
+  int i;
+  struct work_s work;
+
+  memset(&work, 0, sizeof(work));
+  for (i = 0; i < TEST_COUNT; i++)
+    {
+      work_queue(TEST_QUEUE, &work, empty_worker, NULL, 0);
+      work_cancel(TEST_QUEUE, &work);
+      usleep(interval);
+    }
+
+  usleep(SLEEP_TIME); /* Wait for workers to run. */
+  return NULL;
+}
+
+static FAR void *verifier(FAR void *arg)
+{
+  sem_t sem;
+  sem_t call_sem;
+  int call_count;
+  int i;
+  struct work_s work[VERIFY_COUNT + 1];
+
+  sem_init(&sem, 0, 0);
+  sem_init(&call_sem, 0, 0);
+  memset(&work, 0, sizeof(work));
+
+  /* Queue sleep worker. */
+
+  work_queue(TEST_QUEUE, &work[0], sleep_worker, &sem, 0);
+
+  /* Queue count workers when TEST_QUEUE is busy. */
+
+  for (i = 1; i <= VERIFY_COUNT; i++)
+    {
+      work_queue(TEST_QUEUE, &work[i], count_worker, &call_sem, 0);
+    }
+
+  /* Wait for sleep worker to run. */
+
+  sem_wait(&sem);
+
+  /* Wait for count workers to run. */
+
+  usleep(SLEEP_TIME);
+
+  sem_getvalue(&call_sem, &call_count);
+  printf("wqueue_test: call = %d, expect = %d\n", call_count, VERIFY_COUNT);
+
+  for (i = 0; i < VERIFY_COUNT; i++)
+    {
+      ASSERT(work[i].worker == NULL);
+    }
+
+  ASSERT(call_count == VERIFY_COUNT);
+  return NULL;
+}
+
+static void run_once(int interval, int priority_test, int priority_verify)
+{
+  pthread_t thread;
+  pthread_attr_t attr;
+  struct sched_param sparam;
+
+  pthread_attr_init(&attr);
+  memset(&sparam, 0, sizeof(sparam));
+
+  /* Tester: try race conditions. */
+
+  sparam.sched_priority = priority_test;
+  pthread_attr_setschedparam(&attr, &sparam);
+
+  pthread_create(&thread, &attr, tester, (FAR void *)(intptr_t)interval);
+  pthread_join(thread, NULL);
+
+  /* Verifier: make sure queue is still working properly. */
+
+  sparam.sched_priority = priority_verify;
+  pthread_attr_setschedparam(&attr, &sparam);
+  pthread_attr_setstacksize(&attr,
+        VERIFY_COUNT * sizeof(struct work_s) + CONFIG_PTHREAD_STACK_DEFAULT);
+
+  pthread_create(&thread, &attr, verifier, NULL);
+  pthread_join(thread, NULL);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void wqueue_test(void)
+{
+  int interval;
+  int priority_test;
+  int priority_verify;
+
+  for (interval = 0; interval <= 1; interval++)
+    {
+      for (priority_test  = TEST_QUEUE_PRIORITY - 1;
+           priority_test <= TEST_QUEUE_PRIORITY + 1;
+           priority_test++)
+        {
+          for (priority_verify  = TEST_QUEUE_PRIORITY - 1;
+               priority_verify <= TEST_QUEUE_PRIORITY + 1;
+               priority_verify++)
+            {
+              run_once(interval, priority_test, priority_verify);
+            }
+        }
+    }
+}
+
+#endif /* CONFIG_SCHED_LPWORK || CONFIG_SCHED_HPWORK */


### PR DESCRIPTION
## Summary
An ostest for https://github.com/apache/nuttx/pull/8832

The test consists of two parts:
- A tester that tries to trigger wrong states of work queue
- A verifier that checks whether the wqueue is still working properly

The tester is trying to queue and cancel work several times with priority lower/same/higher than the work queue.
Most wrong cases are likely to happen with high priority like:
- https://github.com/apache/nuttx/pull/8321
  - If `cancel` never decreases semcount, the count may keep growing and finally overflow
- https://github.com/apache/nuttx/pull/8832
  - If `cancel` is decreasing semcount too much, the `work_thread` may be waken up less times than expected

The lower/same priority testers are just added for covering other unexpected situations.

The verifier is trying to queue some works and check they are called as expected:
- Frist queue a 'sleep' worker, to let a work queue thread be in busy status and not waiting on sem, while other work queue thread(s) (if any) still waiting for sem. If sem is in wrong state, it may cause wrong behavior in either thread waiting/not waiting on the sem.
- Then queue a few count works, if the work queue(s) are still working properly, these works should finally be all called once.

## Impact
Add an ostest for work queue.

## Testing
Without https://github.com/apache/nuttx/pull/8832, this would fail, but may success after it is fixed.