### PR TITLE
interpreters/wamr: New option to dump call stack

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -141,6 +141,10 @@ config INTERPRETERS_WAMR_MEMORY_TRACING
 	bool "Enable memory tracing"
 	default n
 
+config INTERPRETERS_WAMR_DUMP_CALL_STACK
+	bool "Enable dump call stack (on exception)"
+	default n
+
 config INTERPRETERS_WAMR_DISABLE_HW_BOUND_CHECK
 	bool "Disable hardware bound check"
 	default n


### PR DESCRIPTION
## Summary
 New option to dump call stack
## Impact
WAMR only
## Testing
QEMU