### PR TITLE
netutils/ftpc: Cancel wdog on error state in ftpc_reconnect.

### DIFF
--- a/netutils/ftpc/ftpc_connect.c
+++ b/netutils/ftpc/ftpc_connect.c
@@ -276,5 +276,10 @@ int ftpc_reconnect(FAR struct ftpc_session_s *session)
 errout_with_socket:
   ftpc_sockclose(&session->cmd);
 errout:
+  if (WDOG_ISACTIVE(&session->wdog))
+    {
+      wd_cancel(&session->wdog);
+    }
+
   return ERROR;
 }


### PR DESCRIPTION
## Summary
The timer is for connect timeout, but is not cancelled on connect error, then it may be triggered after ftpc quit and cause heap-use-after-free.

## Impact
ftpc won't trigger heap-use-after-free on connect failure now.

## Testing
Manually
