### PR TITLE
lua: download tarball from github release tag

### DIFF
--- a/interpreters/lua/.gitignore
+++ b/interpreters/lua/.gitignore
@@ -1,4 +1,4 @@
-lua-*.tar.gz
-lua-*/
+*.tar.gz
+lua/
 /luamod_list.h
 /luamod_proto.h

--- a/interpreters/lua/Make.defs
+++ b/interpreters/lua/Make.defs
@@ -24,8 +24,8 @@ CONFIGURED_APPS += $(APPDIR)/interpreters/lua
 # Enable <lua.h> and <lauxlib.h> includes.
 
 CFLAGS += ${INCDIR_PREFIX}\
-	$(APPDIR)/interpreters/lua/lua-$(CONFIG_INTERPRETER_LUA_VERSION)/src
+	$(APPDIR)/interpreters/lua/lua
 CXXFLAGS += ${INCDIR_PREFIX}\
-	$(APPDIR)/interpreters/lua/lua-$(CONFIG_INTERPRETER_LUA_VERSION)/src
+	$(APPDIR)/interpreters/lua/lua
 
 endif

--- a/interpreters/lua/Makefile
+++ b/interpreters/lua/Makefile
@@ -30,15 +30,15 @@ MODULE    = $(CONFIG_INTERPRETERS_LUA)
 # Lua library
 
 LUA_VERSION  = $(patsubst "%",%,$(strip $(CONFIG_INTERPRETER_LUA_VERSION)))
-LUA_TARBALL  = lua-$(LUA_VERSION).tar.gz
-LUA_UNPACK   = lua-$(LUA_VERSION)
-LUA_URL_BASE = http://www.lua.org/ftp
+LUA_TARBALL  = v$(LUA_VERSION).tar.gz
+LUA_UNPACK   = lua
+LUA_URL_BASE = https://github.com/lua/lua/archive/refs/tags/
 LUA_URL      = $(LUA_URL_BASE)/$(LUA_TARBALL)
-LUA_SRC      = $(LUA_UNPACK)$(DELIM)src
+LUA_SRC      = $(LUA_UNPACK)
 
 MAINSRC       = $(LUA_SRC)$(DELIM)lua.c
 CORELIBS_SRCS = $(filter-out $(LUA_SRC)$(DELIM)lauxlib.c,$(wildcard $(LUA_SRC)$(DELIM)*lib.c))
-EXCLUDE_SRCS  = $(MAINSRC) $(CORELIBS_SRCS) $(LUA_SRC)$(DELIM)luac.c $(LUA_SRC)$(DELIM)linit.c
+EXCLUDE_SRCS  = $(MAINSRC) $(CORELIBS_SRCS) $(LUA_SRC)$(DELIM)onelua.c $(LUA_SRC)$(DELIM)luac.c $(LUA_SRC)$(DELIM)linit.c
 CSRCS         = $(filter-out $(EXCLUDE_SRCS),$(wildcard $(LUA_SRC)$(DELIM)*.c))
 CSRCS        += nuttx_linit.c
 
@@ -72,6 +72,7 @@ $(LUA_TARBALL):
 	$(Q) curl -O -L $(LUA_URL)
 	$(Q) echo "Unpacking $(LUA_TARBALL) to $(LUA_UNPACK)"
 	$(Q) tar -xvzf $(LUA_TARBALL)
+	$(Q) mv lua-$(LUA_VERSION) $(LUA_UNPACK)
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(LUA_UNPACK)/.git),)


### PR DESCRIPTION
## Summary

The tarball from github has same file layout as git repo while the tarball from ftp doesn't, so change URL to github
Update Makefile to accommodate this change.

## Impact
No.

## Testing
Local test and CI pass.
