### PR TITLE
tools/mkimport: Allow additions LDELFFLAGS from exported Nuttx builds.

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -90,5 +90,5 @@ endif
 
 # ELF module definitions
 
-LDELFFLAGS = -r -e _start -Bstatic
+LDELFFLAGS += -r -e _start -Bstatic
 LDELFFLAGS += $(addprefix -T,$(call CONVERT_PATH,$(TOPDIR)/scripts/gnu-elf.ld))


### PR DESCRIPTION
## Summary

This pull request is paired with this [PR](https://github.com/apache/nuttx/pull/8870), from the Nuttx repository. It allows  LDELFFLAGS to be extended based on the target's definitions. 

## Impact

An additional definition, `LDELFFLAGS` is added to the exported `Make.defs`  in the application repository `import/scripts/` directory. These flags are picked up with the additions from the above PR and used when building the application elf targets.

`$ cat import/scripts/Make.defs`
```
LDNAME           = ld-kernel32.script
LDELFFLAGS       = (flags from board Make.def, or toolchain)
```

## Testing

I've tried this out on `rv-virt:knsh32` from #8643, the upstream `rv-virt:knsh64` as well as the vexriscv-smp port I'm working on `#8762`. However this PR may have wider implications.
