### PR TITLE
netutils/iperf: guaranteed precision before division

### DIFF
--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -272,7 +272,7 @@ static void iperf_report_task(FAR void *arg)
              ts_diff(&last, &start),
              ts_diff(&now, &start),
              now_len -last_len,
-             (double)((now_len - last_len) * 8 / 1000000) /
+             ((double)((now_len - last_len) * 8) / 1000000) /
              (double)ts_diff(&now, &last)
              );
       if (time != 0 && ts_diff(&now, &start) >= time)
@@ -287,7 +287,7 @@ static void iperf_report_task(FAR void *arg)
              ts_diff(&start, &start),
              ts_diff(&now, &start),
              now_len,
-             (double)(now_len * 8 / 1000000) /
+             ((double)(now_len * 8) / 1000000) /
              (double)ts_diff(&now, &start)
              );
     }


### PR DESCRIPTION
## Summary

netutils/iperf: guaranteed precision before division

Iperf test on photon/wlan
Before:
`   0.00-   1.08 sec      65536 Bytes    0.00 Mbits/sec`
After:
`   0.00-   1.04 sec      74970 Bytes    0.58 Mbits/sec`

## Impact

N/A

## Testing

photon/wlan