### PR TITLE
apps: fix nxstyle

### DIFF
--- a/examples/adc/adc.h
+++ b/examples/adc/adc.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/examples/adc/adc.h
+ * apps/examples/adc/adc.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -30,10 +30,13 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* CONFIG_NSH_BUILTIN_APPS - Build the ADC test as an NSH built-in function.
  *  Default: Built as a standalone program
- * CONFIG_EXAMPLES_ADC_DEVPATH - The default path to the ADC device. Default: /dev/adc0
+ * CONFIG_EXAMPLES_ADC_DEVPATH - The default path to the ADC device.
+ *   Default: /dev/adc0
  * CONFIG_EXAMPLES_ADC_NSAMPLES - This number of samples is
  *   collected and the program terminates.  Default:  Samples are collected
  *   indefinitely.

--- a/examples/charger/Makefile
+++ b/examples/charger/Makefile
@@ -1,3 +1,22 @@
+############################################################################
+# apps/examples/charger/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 
 include $(APPDIR)/Make.defs
 -include $(SDKDIR)/Make.defs

--- a/examples/fboverlay/Makefile
+++ b/examples/fboverlay/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/graphics/fboverlay/Makefile
+# apps/examples/fboverlay/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/examples/flash_test/Makefile
+++ b/examples/flash_test/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/system/flash_test/Makefile
+# apps/examples/flash_test/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary
fix error: Relative file path does not match actual file
Add missing Apache Foundation copyright header
## Impact
none
## Testing

