### PR TITLE
industry/scpi: fix compilation of SCPI library

### DIFF
--- a/industry/scpi/Make.defs
+++ b/industry/scpi/Make.defs
@@ -22,4 +22,9 @@ ifneq ($(CONFIG_SCPI_PARSER),)
 
 CONFIGURED_APPS += $(APPDIR)/industry/scpi
 
+# Allows `<scpi-parser/<>.h>` import.
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/industry/scpi/scpi-parser/libscpi/inc
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/industry/scpi/scpi-parser/libscpi/inc
+
 endif


### PR DESCRIPTION
## Summary
Fix compilation of SCPI library
Expose SCPI library API to application

## Impact
SCPI parser APIs can be used

## Testing
Code compiles locally