### PR TITLE
nshlib: Fix the ps command format

### DIFF
--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -627,7 +627,7 @@ int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
                    "%3s "
 #endif
                    "%3s %-8s %-7s %3s %-8s %-9s "
-                   "%-8s "
+                   "%-16s "
 #if CONFIG_MM_BACKTRACE >= 0 && !defined(CONFIG_NSH_DISABLE_PSHEAPUSAGE)
                    "%8s "
 #endif


### PR DESCRIPTION
## Summary

- I noticed that the ps command shows the wrong format due to recent changes on sigmask length from 32bits to 64bits
- This commit fixes this issue

```
Before:
nsh> ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           0000000000000000 001000 000544  54.4%  CPU0 IDLE
    1     1   1   0 FIFO     Kthread N-- Running            0000000000000000 001000 000664  66.4%  CPU1 IDLE
    2     2   2   0 FIFO     Kthread N-- Running            0000000000000000 001000 000664  66.4%  CPU2 IDLE
    3     3   3   0 FIFO     Kthread N-- Running            0000000000000000 001000 000664  66.4%  CPU3 IDLE
    4     4 --- 192 RR       Kthread --- Waiting  Semaphore 0000000000000000 001992 000416  20.8%  hpwork 0x10824b44
    5     5   0 100 RR       Task    --- Running            0000000000000000 002000 001272  63.6%  nsh_main

After:
nsh> ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK           STACK   USED  FILLED COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           0000000000000000 001000 000544  54.4%  CPU0 IDLE
    1     1   1   0 FIFO     Kthread N-- Running            0000000000000000 001000 000664  66.4%  CPU1 IDLE
    2     2   2   0 FIFO     Kthread N-- Running            0000000000000000 001000 000664  66.4%  CPU2 IDLE
    3     3   3   0 FIFO     Kthread N-- Running            0000000000000000 001000 000664  66.4%  CPU3 IDLE
    4     4 --- 192 RR       Kthread --- Waiting  Semaphore 0000000000000000 001992 000416  20.8%  hpwork 0x10824b44
    5     5   0 100 RR       Task    --- Running            0000000000000000 002000 001416  70.8%  nsh_main
```
## Impact

- None

## Testing

- Tested with sabre-6quad:smp on qemu-7.1
