### PR TITLE
builtin: uid and gid configuration for builtin app

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -253,10 +253,19 @@ REGLIST := $(addprefix $(BUILTIN_REGISTRY)$(DELIM),$(addsuffix .bdat,$(PROGNAME)
 APPLIST := $(PROGNAME)
 
 $(REGLIST): $(DEPCONFIG) Makefile
+ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
+	$(call REGISTER,$(firstword $(APPLIST)),$(firstword $(PRIORITY)),$(firstword $(STACKSIZE)),$(if $(BUILD_MODULE),,$(firstword $(APPLIST))_main),$(firstword $(UID)),$(firstword $(GID)),$(firstword $(MODE)))
+else
 	$(call REGISTER,$(firstword $(APPLIST)),$(firstword $(PRIORITY)),$(firstword $(STACKSIZE)),$(if $(BUILD_MODULE),,$(firstword $(APPLIST))_main))
+endif
 	$(eval APPLIST=$(filter-out $(firstword $(APPLIST)),$(APPLIST)))
 	$(if $(filter-out $(firstword $(PRIORITY)),$(PRIORITY)),$(eval PRIORITY=$(filter-out $(firstword $(PRIORITY)),$(PRIORITY))))
 	$(if $(filter-out $(firstword $(STACKSIZE)),$(STACKSIZE)),$(eval STACKSIZE=$(filter-out $(firstword $(STACKSIZE)),$(STACKSIZE))))
+ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
+	$(if $(filter-out $(firstword $(UID)),$(UID)),$(eval UID=$(filter-out $(firstword $(UID)),$(UID))))
+	$(if $(filter-out $(firstword $(GID)),$(GID)),$(eval GID=$(filter-out $(firstword $(GID)),$(GID))))
+	$(if $(filter-out $(firstword $(MODE)),$(MODE)),$(eval MODE=$(filter-out $(firstword $(MODE)),$(MODE))))
+endif
 
 register:: $(REGLIST)
 	@:

--- a/Make.defs
+++ b/Make.defs
@@ -82,12 +82,31 @@ BUILTIN_REGISTRY = $(APPDIR)$(DELIM)builtin$(DELIM)registry
 DEPCONFIG = $(TOPDIR)$(DELIM).config
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
+define REGISTER
+	$(Q) echo Register: $1
+	$(Q) echo { "$(subst ",,$(1))", $2, $3, $(patsubst ,0,$(subst ",,$(4))), $(patsubst ,0,$(5)), $(patsubst ,0,$(6)), $(patsubst ,0555,$(7))}, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo int $(subst ",,$(4))(int argc, char *argv[]); > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"
+
+	$(Q) touch $(BUILTIN_REGISTRY)$(DELIM).updated"
+endef
+else
 define REGISTER
 	$(Q) echo Register: $1
 	$(Q) echo { "$(subst ",,$(1))", $2, $3, $(subst ",,$(4)) }, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
 	$(Q) echo int $(subst ",,$(4))(int argc, char *argv[]); > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"
 
 	$(Q) touch $(BUILTIN_REGISTRY)$(DELIM).updated"
+endef
+endif
+else
+ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
+define REGISTER
+	$(Q) echo "{ \"$1\", $2, $3, $(patsubst ,0,$(4)), $(patsubst ,0,$(5)), $(patsubst ,0,$(6)), $(patsubst ,0555,$(7)) }," > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) if [ ! -z $4 ]; then \
+	        echo "int $4(int argc, char *argv[]);" > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"; \
+	     fi;
+	$(Q) touch "$(BUILTIN_REGISTRY)$(DELIM).updated"
 endef
 else
 define REGISTER
@@ -98,6 +117,7 @@ define REGISTER
 	     fi;
 	$(Q) touch "$(BUILTIN_REGISTRY)$(DELIM).updated"
 endef
+endif
 endif
 
 # Standard include path

--- a/builtin/builtin_list.c
+++ b/builtin/builtin_list.c
@@ -26,6 +26,8 @@
 
 #include <nuttx/lib/builtin.h>
 
+#include <sys/stat.h>
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -43,7 +45,11 @@
 const struct builtin_s g_builtins[] =
 {
 #  include "builtin_list.h"
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  { NULL, 0, 0, 0, 0, 0, 0 }
+#else
   { NULL, 0, 0, 0 }
+#endif
 };
 
 const int g_builtin_count = sizeof(g_builtins) / sizeof(g_builtins[0]);


### PR DESCRIPTION
## Summary
File uid and gid configuration for builtin fs, if set-user-ID bit is set in the file permissions, then the euid of process set as file uid. Use the confiuration to emulate builtin app set.

MODE must octal number and use similar with linux chmod OCTAL-MODE FILE
    UID  = 2000
    GID  = 3000
    MODE = 06555

## Impact

That pull is followed by https://github.com/apache/nuttx/pull/8924

## Testing
sim:nsh with CONFIG_SCHED_USER_IDENTITY=y
hello example emulates to set uid and file set-user-ID bit, and call geteuid and getegid API.
    UID  = 2000
    GID  = 3000
    MODE = 06555

    nsh> ls -l /bin/hello
     -r-sr-sr-x    2000    3000       0 hello
    nsh> hello
    geteuid:2000
    getegid:3000

let's ignore the below warning:
```
/home/runner/work/nuttx-apps/nuttx-apps/apps/builtin/builtin_list.c:43:1: warning: #include outside of 'Included Files' section
```
since builtin_list.c has the special inclusion requirement.