### PR TITLE
system/adb: Replace adb special reset cause with boardctl.h's value

### DIFF
--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -50,21 +50,10 @@ config ADBD_TOKEN_SIZE
 
 endif # ADBD_AUTHENTICATION
 
-if BOARDCTL_RESET
-config ADBD_RESET_RECOVERY
-	int "Reset argument for recovery"
-	default 1
-
-config ADBD_RESET_BOOTLOADER
-	int "Reset argument for bootloader"
-	default 2
-endif # BOARDCTL_RESET
-
-if !BOARDCTL_UNIQUEID
 config ADBD_DEVICE_ID
 	string "Default adb device id"
+	depends on !BOARDCTL_UNIQUEID
 	default ""
-endif # BOARDCTL_UNIQUEID
 
 config ADBD_PRODUCT_NAME
 	string "Default adb product name"

--- a/system/adb/adb_main.c
+++ b/system/adb/adb_main.c
@@ -56,15 +56,15 @@ void adb_reboot_impl(const char *target)
 #ifdef CONFIG_BOARDCTL_RESET
   if (strcmp(target, "recovery") == 0)
     {
-      boardctl(BOARDIOC_RESET, CONFIG_ADBD_RESET_RECOVERY);
+      boardctl(BOARDIOC_RESET, BOARDIOC_SOFTRESETCAUSE_ENTER_RECOVERY);
     }
   else if (strcmp(target, "bootloader") == 0)
     {
-      boardctl(BOARDIOC_RESET, CONFIG_ADBD_RESET_BOOTLOADER);
+      boardctl(BOARDIOC_RESET, BOARDIOC_SOFTRESETCAUSE_ENTER_BOOTLOADER);
     }
   else
     {
-      boardctl(BOARDIOC_RESET, 0);
+      boardctl(BOARDIOC_RESET, BOARDIOC_SOFTRESETCAUSE_USER_REBOOT);
     }
 #else
   adb_log("reboot not implemented\n");


### PR DESCRIPTION
## Summary

depends on https://github.com/apache/nuttx/pull/8964

## Impact

unify the reset cause usage

## Testing

CI