### PR TITLE
nshlib: Add boot command

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -519,6 +519,11 @@ config NSH_DISABLE_READLINK
 	default DEFAULT_SMALL
 	depends on PSEUDOFS_SOFTLINKS
 
+config NSH_DISABLE_BOOT
+	bool "Disable boot"
+	default DEFAULT_SMALL
+	depends on BOARDCTL_BOOT_IMAGE
+
 config NSH_DISABLE_REBOOT
 	bool "Disable reboot"
 	default DEFAULT_SMALL

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -1158,6 +1158,14 @@ system image.
 
   Show target of a soft link.
 
+- `boot [<image path> [<header size>]]`
+
+  Boot a new firmware image. This command depends on hardware support
+  CONFIG_BOARDCTL_BOOT_IMAGE. `<image path>` may point to a partion or file
+  which contain the firmware to boot. The optional, numeric argument
+  `<header size>` may be useful for skipping metadata information preprended
+  to the firmware image.
+
 - `reboot [<n>]`
 
   Reset and reboot the system immediately. This command depends on hardware

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1149,6 +1149,10 @@ int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
+#if defined(CONFIG_BOARDCTL_BOOT_IMAGE) && !defined(CONFIG_NSH_DISABLE_BOOT)
+  int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
+
 #if defined(CONFIG_BOARDCTL_RESET) && !defined(CONFIG_NSH_DISABLE_REBOOT)
   int cmd_reboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -129,6 +129,10 @@ static const struct cmdmap_s g_cmdmap[] =
   { "basename",  cmd_basename, 2, 3, "<path> [<suffix>]" },
 #endif
 
+#if defined(CONFIG_BOARDCTL_BOOT_IMAGE) && !defined(CONFIG_NSH_DISABLE_BOOT)
+  { "boot",     cmd_boot,     1, 3, "[<image path> [<header size>]]" },
+#endif
+
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_LOOPS)
   { "break",     cmd_break,   1, 1, NULL },
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -105,9 +105,9 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifdef CONFIG_NSH_ALIAS
-  { "alias",    cmd_alias,   1, CONFIG_NSH_MAXARGUMENTS,
+  { "alias",    cmd_alias,    1, CONFIG_NSH_MAXARGUMENTS,
     "[name[=value] ... ]" },
-  { "unalias",  cmd_unalias, 1, CONFIG_NSH_MAXARGUMENTS,
+  { "unalias",  cmd_unalias,  1, CONFIG_NSH_MAXARGUMENTS,
     "[-a] name [name ... ]" },
 #endif
 
@@ -126,7 +126,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_BASENAME
-  { "basename",  cmd_basename, 2, 3, "<path> [<suffix>]" },
+  { "basename", cmd_basename, 2, 3, "<path> [<suffix>]" },
 #endif
 
 #if defined(CONFIG_BOARDCTL_BOOT_IMAGE) && !defined(CONFIG_NSH_DISABLE_BOOT)
@@ -134,7 +134,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_LOOPS)
-  { "break",     cmd_break,   1, 1, NULL },
+  { "break",    cmd_break,    1, 1, NULL },
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_CAT
@@ -279,7 +279,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 # if defined(CONFIG_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSETUP)
-  { "losetup",   cmd_losetup, 3, 6,
+  { "losetup",  cmd_losetup,  3, 6,
     "[-d <dev-path>] | [[-o <offset>] [-r] [-s <sect-size>] "
     "<dev-path> <file-path>]" },
 # endif
@@ -287,7 +287,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 # if defined(CONFIG_SMART_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSMART)
-  { "losmart",   cmd_losmart, 2, 11,
+  { "losmart",  cmd_losmart,  2, 11,
     "[-d <dev-path>] | [[-m <minor>] [-o <offset>] [-e <erase-size>] "
     "[-s <sect-size>] [-r] <file-path>]" },
 # endif
@@ -295,7 +295,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 # if defined(CONFIG_MTD_LOOP) && !defined(CONFIG_NSH_DISABLE_LOMTD)
-  { "lomtd",   cmd_lomtd, 3, 9,
+  { "lomtd",    cmd_lomtd,    3, 9,
     "[-d <dev-path>] | [[-o <offset>] [-e <erase-size>] "
     "[-s <sect-size>] <dev-path> <file-path>]]" },
 # endif
@@ -355,10 +355,10 @@ static const struct cmdmap_s g_cmdmap[] =
     defined(CONFIG_FSUTILS_MKSMARTFS)
 # ifndef CONFIG_NSH_DISABLE_MKSMARTFS
 #  ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
-  { "mksmartfs",  cmd_mksmartfs,  2, 6,
+  { "mksmartfs", cmd_mksmartfs, 2, 6,
     "[-s <sector-size>] [-f] <path> [<num-root-directories>]" },
 #  else
-  { "mksmartfs",  cmd_mksmartfs,  2, 5, "[-s <sector-size>] [-f] <path>" },
+  { "mksmartfs", cmd_mksmartfs, 2, 5, "[-s <sector-size>] [-f] <path>" },
 #  endif
 # endif
 #endif
@@ -412,12 +412,12 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #if defined(CONFIG_PM) && !defined(CONFIG_NSH_DISABLE_PMCONFIG)
-  { "pmconfig", cmd_pmconfig,  1, 4,
+  { "pmconfig", cmd_pmconfig, 1, 4,
     "[stay|relax] [normal|idle|standby|sleep] [domain]" },
 #endif
 
 #if defined(CONFIG_BOARDCTL_POWEROFF) && !defined(CONFIG_NSH_DISABLE_POWEROFF)
-  { "poweroff", cmd_poweroff,  1, 2, NULL },
+  { "poweroff", cmd_poweroff, 1, 2, NULL },
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_PRINTF
@@ -456,7 +456,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #if defined(CONFIG_BOARDCTL_RESET_CAUSE) && !defined(CONFIG_NSH_DISABLE_RESET_CAUSE)
-  { "resetcause",   cmd_reset_cause,   1, 1, NULL },
+  { "resetcause", cmd_reset_cause, 1, 1, NULL },
 #endif
 
 #ifdef NSH_HAVE_DIROPTS
@@ -586,10 +586,10 @@ static const struct cmdmap_s g_cmdmap[] =
      defined(CONFIG_NSH_LOGIN_PASSWD) && \
     !defined(CONFIG_FSUTILS_PASSWD_READONLY)
 #  ifndef CONFIG_NSH_DISABLE_USERADD
-  { "useradd",   cmd_useradd, 3, 3, "<username> <password>" },
+  { "useradd",  cmd_useradd,  3, 3, "<username> <password>" },
 #  endif
 #  ifndef CONFIG_NSH_DISABLE_USERDEL
-  { "userdel",   cmd_userdel, 2, 2, "<username>" },
+  { "userdel",  cmd_userdel,  2, 2, "<username>" },
 #  endif
 #endif
 

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -165,7 +165,7 @@ int cmd_shutdown(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #endif
 
   /* boardctl() will not return in any case.  It if does, it means that
-   * there was a problem with the shutdown/resaet operation.
+   * there was a problem with the shutdown/reset operation.
    */
 
   nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl", NSH_ERRNO);
@@ -311,6 +311,52 @@ int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   /* boardctl() will not return in any case.  It if does, it means that
    * there was a problem with the shutdown operation.
+   */
+
+  nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl", NSH_ERRNO);
+  return ERROR;
+}
+#endif
+
+/****************************************************************************
+ * Name: cmd_boot
+ ****************************************************************************/
+
+#if defined(CONFIG_BOARDCTL_BOOT_IMAGE) && !defined(CONFIG_NSH_DISABLE_BOOT)
+int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
+{
+  struct boardioc_boot_info_s info;
+
+  memset(&info, 0, sizeof(info));
+
+  /* Invoke the BOARDIOC_BOOT_IMAGE board control to reset the board.  If
+   * the board_boot_image() function returns, then it was not possible to
+   * boot the image due to some constraints.
+   */
+
+  switch (argc)
+    {
+      default:
+        info.header_size = strtoul(argv[2], NULL, 0);
+
+        /* Go through */
+
+      case 1:
+        info.path = argv[1];
+
+        /* Go through */
+
+      case 0:
+
+        /* Nothing to do */
+
+        break;
+    }
+
+  boardctl(BOARDIOC_BOOT_IMAGE, (uintptr_t)&info);
+
+  /* boardctl() will not return in this case.  It if does, it means that
+   * there was a problem with the boot operation.
    */
 
   nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl", NSH_ERRNO);


### PR DESCRIPTION
## Summary

 `boot [<image path> [<header size>]]`

  Boot a new firmware image. This command depends on hardware support
  CONFIG_BOARDCTL_BOOT_IMAGE. `<image path>` may point to a partion or file
  which contain the firmware to boot. The optional, numeric argument
  `<header size>` may be useful for skipping metadata information preprended
  to the firmware image.

## Impact

new nsh command

## Testing

CI