### PR TITLE
fsutils: Add ROMLoader utility

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -254,6 +254,22 @@ endif
 
 depend:: .depend
 
+ifneq ($(ROMLOADER_COPY),)
+
+# The original idea was to use symbolic links to avoid file duplication.
+# However, the genromfs tool does not follow symbolic links. So, we
+# have to copy the files.
+
+ROMLOADER_DIR = $(APPDIR)$(DELIM)fsutils$(DELIM)romloader$(DELIM)rom
+romloader:: $(ROMLOADER_COPY)
+	$(Q) mkdir -p $(ROMLOADER_DIR)
+	$(Q) for file in ${ROMLOADER_COPY}; do \
+		cp -rf "$${file}" $(ROMLOADER_DIR) ; \
+	done
+else
+romloader::
+endif
+
 clean::
 	$(call CLEAN)
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),install)
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),context)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),register)))
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),depend)))
+$(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),romloader)))
 $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 
@@ -76,7 +77,7 @@ ifeq ($(CONFIG_BUILD_KERNEL),y)
 
 install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 
-$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
+$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_romloader) $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) for app in ${CONFIGURED_APPS}; do \
 		$(MAKE) -C "$${app}" archive ; \
 	done
@@ -98,10 +99,10 @@ else
 
 ifeq ($(CONFIG_BUILD_LOADABLE),)
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
+$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_romloader) $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) for %%G in ($(CONFIGURED_APPS)) do ( $(MAKE) -C %%G archive )
 else
-$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
+$(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_romloader) $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) for app in ${CONFIGURED_APPS}; do \
 		$(MAKE) -C "$${app}" archive ; \
 	done
@@ -112,7 +113,7 @@ endif
 
 else
 
-$(SYMTABSRC): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
+$(SYMTABSRC): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_romloader) $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) for app in ${CONFIGURED_APPS}; do \
 		$(MAKE) -C "$${app}" archive ; \
 	done

--- a/fsutils/romloader/.gitignore
+++ b/fsutils/romloader/.gitignore
@@ -1,0 +1,3 @@
+/romfs.img
+/rom.c
+/rom

--- a/fsutils/romloader/Kconfig
+++ b/fsutils/romloader/Kconfig
@@ -1,0 +1,71 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config FSUTILS_ROMLOADER
+	bool "Enable ROM image creator and loader (ROMLoader)"
+	default n
+	depends on (FS_ROMFS && BOARDCTL_ROMDISK) || FS_CROMFS
+	depends on !DISABLE_MOUNTPOINT
+	---help---
+		Mount a ROM file system containing the files inside the loader
+		directory (apps/fsutils/romloader/rom). This is a convenience
+		feature that allows the user and/or application files to be built into
+		a ROM file system without code duplication.
+
+if FSUTILS_ROMLOADER
+
+choice
+	prompt "ROM file system type"
+	default FSUTILS_ROMLOADER_ROMFS  if   FS_ROMFS && BOARDCTL_ROMDISK
+	default FSUTILS_ROMLOADER_CROMFS if  !FS_ROMFS && FS_CROMFS
+
+config FSUTILS_ROMLOADER_ROMFS
+	bool "ROMFS"
+	depends on FS_ROMFS && BOARDCTL_ROMDISK
+	---help---
+		Automatically generates and mounts an internal ROMFS file
+		system
+
+config FSUTILS_ROMLOADER_CROMFS
+	bool "CROMFS"
+	depends on FS_CROMFS
+	---help---
+		Automatically generates and mounts an internal CROMFS file
+		system
+
+endchoice # ROM file system type
+
+config FSUTILS_ROMLOADER_MOUNTPOINT
+	string "ROMFS mount point"
+	default "/mnt/romloader"
+	---help---
+		The path where the ROM file system will be mounted.
+
+if FSUTILS_ROMLOADER_ROMFS
+
+config FSUTILS_ROMLOADER_SECTORSIZE
+	int "ROMFS sector size"
+	default 512
+	---help---
+		The sector size of the ROMFS file system.
+
+config FSUTILS_ROMLOADER_DEVMINOR
+	int "ROMFS minor device number"
+	default 0
+	---help---
+		The minor device number of the ROMFS block. For example, the N in
+		/dev/ramN. Used for registering the RAM block driver that will hold
+		the ROMFS file system containing the storage files.
+
+config FSUTILS_ROMLOADER_DEVPATH
+	string "ROMFS device path"
+	default "/dev/ram0"
+	---help---
+		The path to the ROMFS block driver device. This must match
+		FSUTILS_ROMLOADER_DEVMINOR. Used for registering the RAM block driver
+		that will hold the ROMFS file system containing the storage files.
+
+endif # FSUTILS_ROMLOADER_ROMFS
+endif # FSUTILS_ROMLOADER

--- a/fsutils/romloader/Make.defs
+++ b/fsutils/romloader/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/fsutils/romloader/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_FSUTILS_ROMLOADER),)
+CONFIGURED_APPS += $(APPDIR)/fsutils/romloader
+endif

--- a/fsutils/romloader/Makefile
+++ b/fsutils/romloader/Makefile
@@ -1,0 +1,106 @@
+############################################################################
+# apps/fsutils/romloader/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# ROMLoader application
+
+############################################################################
+# Flags
+############################################################################
+
+ROM_DIR = $(APPDIR)$(DELIM)fsutils$(DELIM)romloader$(DELIM)rom
+IMG_SRC_FILE = rom.c
+
+ifeq ($(CONFIG_FSUTILS_ROMLOADER_ROMFS),y)
+  ROMFS_IMG = romfs.img
+else
+  NXTOOLDIR = $(TOPDIR)/tools
+  GENCROMFSSRC = gencromfs.c
+  GENCROMFSEXE = gencromfs$(HOSTEXEEXT)
+endif
+
+CSRCS = $(IMG_SRC_FILE)
+
+############################################################################
+# Targets
+############################################################################
+
+# Make sure to always rebuild the image file for the case where files are
+# manually added or removed from the ROM directory.
+
+.PHONY: $(IMG_SRC_FILE)
+
+ensure_rom_dir:
+	$(Q) mkdir -p $(ROM_DIR)
+
+ifeq ($(CONFIG_FSUTILS_ROMLOADER_ROMFS),y)
+
+# ROMFS targets
+
+checkgenromfs:
+	$(Q) genromfs -h 1>/dev/null 2>&1 || { \
+ echo "Host executable genromfs not available in PATH"; \
+ echo "You may need to download it from http://romfs.sourceforge.net/"; \
+ exit 1; \
+	}
+
+$(ROMFS_IMG): checkgenromfs ensure_rom_dir
+	$(Q) genromfs -f $@.tmp -d $(ROM_DIR) -V "ROMLOADER"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
+
+$(IMG_SRC_FILE): $(ROMFS_IMG)
+	$(Q) echo "#include <nuttx/compiler.h>" >$@ && \
+		xxd -i $(ROMFS_IMG) | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" >>$@
+
+else
+
+# CROMFS targets
+
+$(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
+	$(Q) $(MAKE) -C $(NXTOOLDIR) -f Makefile.host $(GENCROMFSEXE)
+
+$(IMG_SRC_FILE): $(NXTOOLDIR)/$(GENCROMFSEXE) ensure_rom_dir
+	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(ROM_DIR) $@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
+
+endif
+
+context:: $(IMG_SRC_FILE)
+
+distclean::
+	$(call DELFILE, $(IMG_SRC_FILE))
+	$(call DELDIR,  $(ROM_DIR))
+ifeq ($(CONFIG_FSUTILS_ROMLOADER_ROMFS),y)
+	$(call DELFILE, $(ROMFS_IMG))
+endif
+
+############################################################################
+# Applications Configuration
+############################################################################
+
+PROGNAME = romloader
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
+MODULE = $(CONFIG_FSUTILS_ROMLOADER)
+
+MAINSRC = romloader_main.c
+
+include $(APPDIR)/Application.mk

--- a/fsutils/romloader/README.md
+++ b/fsutils/romloader/README.md
@@ -1,0 +1,56 @@
+# ROMLoader
+
+ROMLoader is a utility application that creates and mounts a ROM File System based on the files and folders stored inside the ```apps/fsutils/romloader/rom``` folder. It is designed for use in situations where a read-only file system is required.
+
+The ROMLoader utility works by scanning the files and folders in the ```rom``` folder and creating a file system image based on their contents. The resulting file system image can then be mounted as a read-only file system by running ```romloader```, allowing applications to access its contents without the ability to modify them. Currently, the ROMFS and CROMFS file systems are supported by ROMLoader.
+
+Additionally, other applications can add files and folders to the ROMFS file system by adding the file/folder path to the "ROMLOADER_COPY" variable inside its Makefile. This allows for easy customization and expansion of the ROMFS file system.
+
+**WARNING**: The ```apps/fsutils/romloader/rom``` folder is automatically cleaned when using ```make distclean```. This means that any files added to this folder will be deleted when cleaning the configuration.
+
+## Configuration Options
+
+The ROMLoader utility can be configured using the following options in the Kconfig:
+
+* ```CONFIG_FSUTILS_ROMLOADER```: Enables the ROMLoader utility;
+* ```CONFIG_FSUTILS_ROMLOADER_ROMFS```: Uses the ROMFS file system;
+* ```CONFIG_FSUTILS_ROMLOADER_CROMFS```: Uses the CROMFS file system;
+* ```CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT```: Sets the mount point for the file system.
+
+For the ROMFS file system, the following options are also available:
+
+* ```CONFIG_FSUTILS_ROMLOADER_SECTORSIZE```: Sets the sector size of the ROMFS file system;
+* ```CONFIG_FSUTILS_ROMLOADER_DEVMINOR```: Sets the minor device number of the ROMFS block;
+* ```CONFIG_FSUTILS_ROMLOADER_DEVPATH```: The path to the ROMFS block driver device.
+
+## Examples
+
+### Using ROMLoader with other applications
+
+In this example, we will add the file ```file_a.txt``` inside a ```folder_a``` from the ```app_a``` application to the ROM.
+To add the file, add the following line to the "Makefile" inside the ```app_a``` folder:
+
+```ROMLOADER_COPY += folder_a/file_a.txt```
+
+Note that if this file is generated during compilation, an explicit rule with the file as target must also be added to the "Makefile" to ensure that it is generated before the ROM is created. For example:
+
+```folder_a/file_a.txt: generate_file_a```
+
+### Using ROMLoader with user files
+
+In this example, we will manually add the file ```file_b``` to the ROM image.
+Just copy the desired file to the ```apps/fsutils/romloader/rom``` folder. It will be automatically added to the file system.
+
+### Mounting the file system
+
+To mount the file system, run the ```romloader``` application inside NSH:
+
+```
+nsh> romloader
+Registering romdisk at /dev/ram0
+Mounting ROMFS filesystem at target=/mnt/romloader with source=/dev/ram0
+nsh> ls mnt/romloader
+/mnt/romloader:
+ file_a
+ file_b
+```

--- a/fsutils/romloader/romloader_main.c
+++ b/fsutils/romloader/romloader_main.c
@@ -1,0 +1,138 @@
+/****************************************************************************
+ * apps/fsutils/romloader/romloader_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/mount.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#ifdef CONFIG_FSUTILS_ROMLOADER_ROMFS
+#  include <sys/boardctl.h>
+#  include <nuttx/drivers/ramdisk.h>
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_FSUTILS_ROMLOADER_ROMFS
+#  define NSECTORS(b)  (((b) + CONFIG_FSUTILS_ROMLOADER_SECTORSIZE - 1) / \
+                        CONFIG_FSUTILS_ROMLOADER_SECTORSIZE)
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Symbols from Auto-Generated Code
+ ****************************************************************************/
+
+#ifdef CONFIG_FSUTILS_ROMLOADER_ROMFS
+extern const unsigned char romfs_img[];
+extern const unsigned int romfs_img_len;
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * romloader_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int ret;
+#ifdef CONFIG_FSUTILS_ROMLOADER_ROMFS
+  struct boardioc_romdisk_s desc;
+
+  /* Create a ROM disk for the ROMFS filesystem */
+
+  printf("Registering romdisk at /dev/ram%d\n",
+         CONFIG_FSUTILS_ROMLOADER_DEVMINOR);
+
+  desc.minor    = CONFIG_FSUTILS_ROMLOADER_DEVMINOR;   /* Minor device number of the ROM disk. */
+  desc.nsectors = NSECTORS(romfs_img_len);             /* The number of sectors in the ROM disk */
+  desc.sectsize = CONFIG_FSUTILS_ROMLOADER_SECTORSIZE; /* The size of one sector in bytes */
+  desc.image    = (FAR uint8_t *)romfs_img;            /* File system image */
+
+  ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
+  if (ret < 0)
+    {
+      dprintf(STDERR_FILENO, "ERROR: romdisk_register failed: %s\n",
+              strerror(errno));
+      return 1;
+    }
+
+  /* Mount the ROMFS file system */
+
+  printf("Mounting ROMFS filesystem at target=%s with source=%s\n",
+         CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT,
+         CONFIG_FSUTILS_ROMLOADER_DEVPATH);
+
+  ret = mount(CONFIG_FSUTILS_ROMLOADER_DEVPATH,
+              CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT,
+              "romfs",
+              MS_RDONLY,
+              NULL);
+
+  if (ret < 0)
+    {
+      dprintf(STDERR_FILENO,
+              "ERROR: mount(%s,%s,romfs) failed: %s\n",
+              CONFIG_FSUTILS_ROMLOADER_DEVPATH,
+              CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT,
+              strerror(errno));
+
+      return 1;
+    }
+#else
+  /* Mount the CROMFS file system */
+
+  printf("Mounting CROMFS filesystem at target=%s\n",
+         CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT);
+
+  ret = mount(NULL,
+              CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT,
+              "cromfs",
+              MS_RDONLY,
+              NULL);
+
+  if (ret < 0)
+    {
+      dprintf(STDERR_FILENO,
+              "ERROR: mount(%s,cromfs) failed: %s\n",
+              CONFIG_FSUTILS_ROMLOADER_MOUNTPOINT,
+              strerror(errno));
+
+      return 1;
+    }
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Currently, most applications that need to load files duplicate code to generate and mount an ROMFS file system.
This PR aims to provide applications and users an easy way to include files in a ROMFS/CROMFS image by providing a ROMLoader application that creates an image based on what is included in its ```rom``` folder.
It also provides other applications the ```ROMLOADER_COPY``` variable to automatically add files to the image.

Note that this is the best compromise between intrusiveness and easiness of use I've found. Any suggestions on how to improve it are greatly appreciated. The first commit I submitted was less intrusive but had problems when trying to add files that are downloaded/generated during the compilation process.

## Impact

Add an easy way to include files into an ROM file system to avoid code duplication.

## Testing

Tested using a modified version of the `bastest` and `bas` applications and a WIP port of the game ZORK.
