### PR TITLE
nsh/nsh_parse: Fix handling of back-quotes

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -1769,7 +1769,13 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
 
               /* Is it a back-quote ? These are not removed here */
 
-              if (*pend != '`')
+              if (*pend == '`')
+                {
+                  /* Yes, keep the quotes in place */
+
+                  pend = qend;
+                }
+              else
                 {
                   /* No, get rid of the single / double quotes here */
 


### PR DESCRIPTION
## Summary
The logic that handles back-quotes was faulty, i.e. example command
set FOO `ls -l` would be split into two tokens as follows:
- set FOO `ls
- -l`

This results in nsh: `: no matching ` error, this fixes that issue.
## Impact
Fix something I broke when shell aliases were introduced.
nsh> set FOO `ls -la`
nsh: `: no matching `

## Testing
icicle:nsh
