### PR TITLE
system/usbmsc: set stack size to DEFAULT_TASK_STACKSIZE

### DIFF
--- a/system/usbmsc/Kconfig
+++ b/system/usbmsc/Kconfig
@@ -156,7 +156,7 @@ endif # SYSTEM_USBMSC_TRACE
 
 config SYSTEM_USBMSC_CMD_STACKSIZE
 	int "Stacksize of msconn and msdis commands"
-	default 768
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		Size of the stack used by the small 'msconn' and 'msdis' command
 		applications.  Warning, just because the applications are small,


### PR DESCRIPTION
## Summary
system/usbmsc: set stack size to DEFAULT_TASK_STACKSIZE
768 for stack is too small to work

Related PR on the NuttX side https://github.com/apache/nuttx/pull/8962
## Impact

## Testing
CI