### PR TITLE
nshlib: Add switchboot command

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -519,6 +519,11 @@ config NSH_DISABLE_READLINK
 	default DEFAULT_SMALL
 	depends on PSEUDOFS_SOFTLINKS
 
+config NSH_DISABLE_SWITCHBOOT
+	bool "Switch boot partition"
+	default DEFAULT_SMALL
+	depends on BOARDCTL_SWITCH_BOOT
+
 config NSH_DISABLE_BOOT
 	bool "Disable boot"
 	default DEFAULT_SMALL

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -1158,6 +1158,12 @@ system image.
 
   Show target of a soft link.
 
+- `switchboot <image path>
+
+  Switch to the updated or specified boot system. This command depends on
+  hardware support CONFIG_BOARDCTL_SWITCH_BOOT. `<image path>` point to a
+  partion or file which contain the firmware to boot.
+
 - `boot [<image path> [<header size>]]`
 
   Boot a new firmware image. This command depends on hardware support

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1149,6 +1149,10 @@ int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
+#if defined(CONFIG_BOARDCTL_SWITCH_BOOT) && !defined(CONFIG_NSH_DISABLE_SWITCHBOOT)
+int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
+
 #if defined(CONFIG_BOARDCTL_BOOT_IMAGE) && !defined(CONFIG_NSH_DISABLE_BOOT)
   int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -529,6 +529,10 @@ static const struct cmdmap_s g_cmdmap[] =
   { "source",   cmd_source,   2, 2, "<script-path>" },
 #endif
 
+#if defined(CONFIG_BOARDCTL_SWITCH_BOOT) && !defined(CONFIG_NSH_DISABLE_SWITCHBOOT)
+  { "swtichboot", cmd_swtichboot, 2, 2, "<image path>" },
+#endif
+
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_TEST)
   { "test",     cmd_test,     3, CONFIG_NSH_MAXARGUMENTS, "<expression>" },
 #endif

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -319,6 +319,24 @@ int cmd_poweroff(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #endif
 
 /****************************************************************************
+ * Name: cmd_switchboot
+ ****************************************************************************/
+
+#if defined(CONFIG_BOARDCTL_SWITCH_BOOT) && !defined(CONFIG_NSH_DISABLE_SWITCHBOOT)
+int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
+{
+  if (argc != 2)
+    {
+      nsh_output(vtbl, g_fmtarginvalid, argv[0]);
+      return ERROR;
+    }
+
+  boardctl(BOARDIOC_SWITCH_BOOT, (uintptr_t)argv[1]);
+  return 0;
+}
+#endif
+
+/****************************************************************************
  * Name: cmd_boot
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

switchboot <image path>

Switch to the updated or specified boot system. This command depends on hardware support CONFIG_BOARDCTL_SWITCH_BOOT. `<image path>` point to a partion or file which contain the firmware to boot.

## Impact

New nsh command

## Testing

CI