### PR TITLE
 ostest: Fixed use of uninitialized variable.

### DIFF
--- a/testing/ostest/cancel.c
+++ b/testing/ostest/cancel.c
@@ -236,6 +236,7 @@ static FAR void *sig_waiter(FAR void *parameter)
 
   printf("sig_waiter: Waiting to receive signal %d ...\n", SIG_WAITCANCEL);
 
+  sigemptyset(&set);
   ret = sigwaitinfo(&set, &info);
 
   pthread_testcancel();


### PR DESCRIPTION
## Summary

Fixes an uninitialized variable in ostest (and stops the corresponding compiler warning).

## Impact

Bug fix.

## Testing

Build test.
