### PR TITLE
apps/examples/pipe: check POSIX-compliant behavior of NuttX's FIFOs

### DIFF
--- a/examples/pipe/redirect_test.c
+++ b/examples/pipe/redirect_test.c
@@ -24,11 +24,11 @@
 
 #include <nuttx/config.h>
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sched.h>
-#include <semaphore.h>
 #include <errno.h>
 
 #include "pipe.h"
@@ -40,12 +40,6 @@
 #define READ_SIZE 37
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-static sem_t g_rddone;
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -53,53 +47,30 @@ static sem_t g_rddone;
  * Name: redirect_reader
  ****************************************************************************/
 
-static int redirect_reader(int argc, char *argv[])
+static void *redirect_reader(pthread_addr_t pvarg)
 {
   char buffer[READ_SIZE];
+  int *fd = (int *)pvarg;
   int fdin;
-  int fdout;
   int ret;
   int nbytes = 0;
 
-  printf("redirect_reader: started with fdin=%s\n", argv[1]);
+  fprintf(stderr, "redirect_reader: started with fdin=%d\n", fd[0]);
 
-  /* Convert the fdin to binary */
-
-  fdin  = atoi(argv[1]);
-  fdout = atoi(argv[2]);
-
-  /* Close fdout -- we don't need it */
-
-  ret = close(fdout);
-  if (ret != 0)
-    {
-      fprintf(stderr, "redirect_reader: failed to close fdout=%d\n",
-              fdout);
-      return 1;
-    }
+  fdin  = fd[0];
 
   /* Re-direct the fdin to stdin */
 
   ret = dup2(fdin, 0);
-  if (ret != 0)
+  if (ret < 0)
     {
       fprintf(stderr, "redirect_reader: dup2 failed: %d\n", errno);
       close(fdin);
-      return 2;
-    }
-
-  /* Close the original file descriptor */
-
-  ret = close(fdin);
-  if (ret != 0)
-    {
-      fprintf(stderr, "redirect_reader: failed to close fdin=%d\n", fdin);
-      return 3;
+      return (void *)(uintptr_t)1;
     }
 
   /* Then read from stdin until we hit the end of file */
 
-  fflush(stdout);
   for (; ; )
     {
       /* Read from stdin */
@@ -107,9 +78,8 @@ static int redirect_reader(int argc, char *argv[])
       ret = read(0, buffer, READ_SIZE);
       if (ret < 0)
         {
-          fprintf(stderr, "redirect_reader: read failed, errno=%d\n",
-                  errno);
-          return 4;
+          fprintf(stderr, "redirect_reader: read failed, errno=%d\n", errno);
+          return (void *)(uintptr_t)2;
         }
       else if (ret == 0)
         {
@@ -120,93 +90,85 @@ static int redirect_reader(int argc, char *argv[])
 
       /* Echo to stdout */
 
-      ret = write(1, buffer, ret);
+      ret = write(2, buffer, ret);
       if (ret < 0)
         {
-          fprintf(stderr, "redirect_reader: read failed, errno=%d\n",
+          fprintf(stderr, "redirect_reader: write failed, errno=%d\n",
                   errno);
-          return 5;
+          return (void *)(uintptr_t)3;
         }
     }
 
-  printf("redirect_reader: %d bytes read\n", nbytes);
+  fprintf(stderr, "redirect_reader: %d bytes read\n", nbytes);
   ret = close(0);
   if (ret != 0)
     {
       fprintf(stderr, "redirect_reader: failed to close fd=0\n");
-      return 6;
+      return (void *)(uintptr_t)4;
     }
 
-  sem_post(&g_rddone);
-  printf("redirect_reader: Returning success\n");
-  return 0;
+  fprintf(stderr, "redirect_reader: Returning success\n");
+  return NULL;
 }
 
 /****************************************************************************
  * Name: redirect_writer
  ****************************************************************************/
 
-static int redirect_writer(int argc, char *argv[])
+static void *redirect_writer(pthread_addr_t pvarg)
 {
-  int fdin;
+  int *fd = (int *)pvarg;
   int fdout;
   int nbytes = 0;
   int ret;
 
-  fprintf(stderr, "redirect_writer: started with fdout=%s\n", argv[2]);
+  fprintf(stderr, "redirect_writer: started with fdout=%d\n", fd[1]);
 
-  /* Convert the fdout to binary */
-
-  fdin  = atoi(argv[1]);
-  fdout = atoi(argv[2]);
-
-  /* Close fdin -- we don't need it */
-
-  ret = close(fdin);
-  if (ret != 0)
-    {
-      fprintf(stderr, "redirect_reader: failed to close fdin=%d\n", fdin);
-      return 1;
-    }
+  fdout = fd[1];
 
   /* Re-direct the fdout to stdout */
 
   ret = dup2(fdout, 1);
-  if (ret != 0)
+  if (ret < 0)
     {
-      fprintf(stderr, "redirect_writer: dup2 failed: %d\n", errno);
-      return 2;
-    }
-
-  /* Close the original file descriptor */
-
-  ret = close(fdout);
-  if (ret != 0)
-    {
-      fprintf(stderr, "redirect_reader: failed to close fdout=%d\n",
-              fdout);
-      return 3;
+      fprintf(stderr, "redirect_writer: dup2 failed: %d\n", ret);
+      return (void *)(uintptr_t)1;
     }
 
   /* Then write a bunch of stuff to stdout */
 
-  fflush(stderr);
-  nbytes += printf("\nFour score and seven years ago our fathers brought forth on this continent a new nation,\n");
-  nbytes += printf("conceived in Liberty, and dedicated to the proposition that all men are created equal.\n");
-  nbytes += printf("\nNow we are engaged in a great civil war, testing whether that nation, or any nation, so\n");
-  nbytes += printf("conceived and so dedicated, can long endure. We are met on a great battle-field of that war.\n");
-  nbytes += printf("We have come to dedicate a portion of that field, as a final resting place for those who here\n");
-  nbytes += printf("gave their lives that that nation might live. It is altogether fitting and proper that we\n");
+  fflush(stdout);
+  nbytes += printf("\nFour score and seven years ago our fathers brought"
+                   "forth on this continent a new nation,\n");
+  nbytes += printf("conceived in Liberty, and dedicated to the proposition"
+                   "that all men are created equal.\n");
+  nbytes += printf("\nNow we are engaged in a great civil war, testing"
+                   "whether that nation, or any nation, so\n");
+  nbytes += printf("conceived and so dedicated, can long endure. We are met"
+                   "on a great battle-field of that war.\n");
+  nbytes += printf("We have come to dedicate a portion of that field, as a"
+                   "final resting place for those who here\n");
+  nbytes += printf("gave their lives that that nation might live. It is"
+                   "altogether fitting and proper that we\n");
   nbytes += printf("should do this.\n");
-  nbytes += printf("\nBut, in a larger sense, we can not dedicate - we can not consecrate - we can not hallow - this ground.\n");
-  nbytes += printf("The brave men, living and dead, who struggled here, have consecrated it, far above our poor power\n");
-  nbytes += printf("to add or detract. The world will little note, nor long remember what we say here, but it can\n");
-  nbytes += printf("never forget what they did here. It is for us the living, rather, to be dedicated here to the\n");
-  nbytes += printf("unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to\n");
-  nbytes += printf("be here dedicated to the great task remaining before us - that from these honored dead we take\n");
-  nbytes += printf("increased devotion to that cause for which they gave the last full measure of devotion - that we\n");
-  nbytes += printf("here highly resolve that these dead shall not have died in vain - that this nation, under God,\n");
-  nbytes += printf("shall have a new birth of freedom - and that government of the people, by the people, for the\n");
+  nbytes += printf("\nBut, in a larger sense, we can not dedicate - we can"
+                   "not consecrate - we can not hallow - this ground.\n");
+  nbytes += printf("The brave men, living and dead, who struggled here, have"
+                   "consecrated it, far above our poor power\n");
+  nbytes += printf("to add or detract. The world will little note, nor long"
+                   "remember what we say here, but it can\n");
+  nbytes += printf("never forget what they did here. It is for us the"
+                   "living, rather, to be dedicated here to the\n");
+  nbytes += printf("unfinished work which they who fought here have thus far"
+                   "so nobly advanced. It is rather for us to\n");
+  nbytes += printf("be here dedicated to the great task remaining before us"
+                   "- that from these honored dead we take\n");
+  nbytes += printf("increased devotion to that cause for which they gave the"
+                   "last full measure of devotion - that we\n");
+  nbytes += printf("here highly resolve that these dead shall not have died"
+                   "in vain - that this nation, under God,\n");
+  nbytes += printf("shall have a new birth of freedom - and that government"
+                   "of the people, by the people, for the\n");
   nbytes += printf("people, shall not perish from the earth.\n\n");
   fflush(stdout);
 
@@ -216,11 +178,18 @@ static int redirect_writer(int argc, char *argv[])
   if (ret != 0)
     {
       fprintf(stderr, "redirect_writer: failed to close fd=1\n");
-      return 4;
+      return (void *)(uintptr_t)2;
+    }
+
+  ret = close(fdout);
+  if (ret != 0)
+    {
+      fprintf(stderr, "redirect_writer: failed to close fdout\n");
+      return (void *)(uintptr_t)4;
     }
 
   fprintf(stderr, "redirect_writer: Returning success\n");
-  return 0;
+  return NULL;
 }
 
 /****************************************************************************
@@ -233,15 +202,11 @@ static int redirect_writer(int argc, char *argv[])
 
 int redirection_test(void)
 {
-  char *argv[3];
-  char buffer1[8];
-  char buffer2[8];
-  int readerid;
-  int writerid;
+  pthread_t readerid;
+  pthread_t writerid;
+  void *value;
   int fd[2];
   int ret;
-
-  sem_init(&g_rddone, 0, 0);
 
   /* Create the pipe */
 
@@ -250,42 +215,20 @@ int redirection_test(void)
     {
       fprintf(stderr, "redirection_test: pipe failed with errno=%d\n",
               errno);
-      return 5;
-    }
-
-  sprintf(buffer1, "%d", fd[0]);
-  argv[0] = buffer1;
-  sprintf(buffer2, "%d", fd[1]);
-  argv[1] = buffer2;
-  argv[2] = NULL;
-
-  /* Start redirect_reader thread */
-
-  printf("redirection_test: Starting redirect_reader task with fd=%d\n",
-         fd[0]);
-  readerid = task_create("redirect_reader",
-                         50, CONFIG_EXAMPLES_PIPE_STACKSIZE,
-                         redirect_reader, argv);
-  if (readerid < 0)
-    {
-      fprintf(stderr, "redirection_test: "
-              "Failed to create redirect_writer task: %d\n", errno);
       return 1;
     }
 
   /* Start redirect_writer task */
 
-  printf("redirection_test: Starting redirect_writer task with fd=%d\n",
-         fd[1]);
-  writerid = task_create("redirect_writer",
-                         50, CONFIG_EXAMPLES_PIPE_STACKSIZE,
-                         redirect_writer, argv);
-  if (writerid < 0)
+  fprintf(stderr,
+          "redirection_test: Starting redirect_writer task with fd=%d\n",
+          fd[1]);
+  ret = pthread_create(&writerid, NULL, redirect_writer, fd);
+  if (ret < 0)
     {
       fprintf(stderr, "redirection_test: "
               "Failed to create redirect_writer task: %d\n", errno);
-
-      ret = task_delete(readerid);
+      ret = pthread_cancel(writerid);
       if (ret != 0)
         {
           fprintf(stderr, "redirection_test: "
@@ -295,6 +238,39 @@ int redirection_test(void)
       return 2;
     }
 
+  /* Start redirect_reader thread */
+
+  fprintf(stderr,
+          "redirection_test: Starting redirect_reader task with fd=%d\n",
+          fd[0]);
+  ret = pthread_create(&readerid, NULL, redirect_reader, fd);
+
+  if (ret < 0)
+    {
+      fprintf(stderr, "redirection_test: "
+              "Failed to create redirect_writer task: %d\n", ret);
+      return 3;
+    }
+
+  /* Wait for redirect_reader thread to complete */
+
+  fprintf(stderr, "redirection_test: Waiting for null_reader thread\n");
+  ret = pthread_join(readerid, &value);
+  if (ret != 0)
+    {
+      fprintf(stderr, \
+        "interlock_test: pthread_join failed, error=%d\n", ret);
+      ret = 4;
+    }
+  else
+    {
+      printf("interlock_test: reader returned %p\n", value);
+      if (value != NULL)
+        {
+          ret = 5;
+        }
+    }
+
   /* We should be able to close the pipe file descriptors now. */
 
   if (close(fd[0]) != 0)
@@ -302,23 +278,11 @@ int redirection_test(void)
       fprintf(stderr, "pipe_main: close failed: %d\n", errno);
     }
 
-  if (close(fd[1]) != 0)
-    {
-      fprintf(stderr, "pipe_main: close failed: %d\n", errno);
-    }
-
-  if (ret != 0)
-    {
-      fprintf(stderr, "pipe_main: PIPE test FAILED (%d)\n", ret);
-      return 6;
-    }
-
   /* Wait for redirect_writer thread to complete */
 
-  printf("redirection_test: Waiting...\n");
+  fprintf(stderr, "redirection_test: Waiting...\n");
   fflush(stdout);
-  sem_wait(&g_rddone);
 
-  printf("redirection_test: returning %d\n", ret);
+  fprintf(stderr, "redirection_test: returning %d\n", ret);
   return ret;
 }

--- a/examples/pipe/transfer_test.c
+++ b/examples/pipe/transfer_test.c
@@ -77,8 +77,8 @@ static void *transfer_reader(pthread_addr_t pvarg)
       if (ret < 0)
         {
           fprintf(stderr, \
-          "transfer_reader: read failed, errno=%d\n", \
-          errno);
+                  "transfer_reader: read failed, errno=%d\n",
+                  errno);
 
           return (void *)(uintptr_t)1;
         }
@@ -87,8 +87,8 @@ static void *transfer_reader(pthread_addr_t pvarg)
           if (nbytes < NREAD_BYTES)
             {
               fprintf(stderr, \
-              "transfer_reader: Too few bytes read -- aborting: %d\n", \
-              nbytes);
+                      "transfer_reader: Too few bytes read. Aborting: %d\n",
+                      nbytes);
 
               return (void *)(uintptr_t)2;
             }
@@ -105,8 +105,8 @@ static void *transfer_reader(pthread_addr_t pvarg)
           if (buffer[ndx] != value)
             {
               fprintf(stderr, \
-              "transfer_reader: Byte %d, expected %d, found %d\n",
-                    nbytes + ndx, value, buffer[ndx]);
+                      "transfer_reader: Byte %d, expected %d, found %d\n",
+                      nbytes + ndx, value, buffer[ndx]);
 
               return (void *)(uintptr_t)3;
             }
@@ -118,8 +118,8 @@ static void *transfer_reader(pthread_addr_t pvarg)
       if (nbytes > NREAD_BYTES)
         {
           fprintf(stderr, \
-          "transfer_reader: Too many bytes read -- aborting: %d\n", \
-          nbytes);
+                  "transfer_reader: Too many bytes read. Aborting: %d\n",
+                  nbytes);
 
           return (void *)(uintptr_t)4;
         }
@@ -153,13 +153,13 @@ static void *transfer_writer(pthread_addr_t pvarg)
       if (ret < 0)
         {
           fprintf(stderr, \
-          "transfer_writer: write failed, errno=%d\n", errno);
+                  "transfer_writer: write failed, errno=%d\n", errno);
           return (void *)(uintptr_t)1;
         }
       else if (ret != WRITE_SIZE)
         {
           fprintf(stderr, \
-          "transfer_writer: Unexpected write size=%d\n", ret);
+                  "transfer_writer: Unexpected write size=%d\n", ret);
           return (void *)(uintptr_t)2;
         }
     }
@@ -184,17 +184,18 @@ int transfer_test(int fdin, int fdout)
   int tmp;
   int ret;
 
+  printf("transfer_test: fdin=%d fdout=%d\n", fdin, fdout);
+
   /* Start transfer_reader thread */
 
-  printf("transfer_test: \
-        Starting transfer_reader thread\n");
+  printf("transfer_test: Starting transfer_reader thread\n");
   ret = pthread_create(&readerid, NULL, \
         transfer_reader, (void *)(intptr_t)fdin);
   if (ret != 0)
     {
         fprintf(stderr, \
-        "transfer_test: Failed to create transfer_reader thread, \
-        error=%d\n", ret);
+                "transfer_test: Failed to create transfer_reader thread,"
+                "error=%d\n", ret);
       return 1;
     }
 
@@ -206,15 +207,15 @@ int transfer_test(int fdin, int fdout)
   if (ret != 0)
     {
       fprintf(stderr, \
-        "transfer_test: Failed to create transfer_writer thread, \
-        error=%d\n", ret);
+              "transfer_test: Failed to create transfer_writer thread,"
+              "error=%d\n", ret);
       pthread_detach(readerid);
       ret = pthread_cancel(readerid);
       if (ret != 0)
         {
           fprintf(stderr, \
-            "transfer_test: Failed to cancel transfer_reader thread, \
-            error=%d\n", ret);
+                  "transfer_test: Failed to cancel transfer_reader thread,"
+                  "error=%d\n", ret);
         }
 
       return 2;
@@ -256,4 +257,3 @@ int transfer_test(int fdin, int fdout)
   printf("transfer_test: returning %d\n", ret);
   return ret;
 }
-


### PR DESCRIPTION
## Summary

Adjust the test considering the [POSIX-compliant behavior of NuttX's FIFO](https://github.com/apache/nuttx/pull/8985) (`mkfifo`), which should block `open` for read-only and write-only when there are no writers or readers, respectively. This test's result is expected to be the same as any other POSIX-compliant system.

This commit also:

 * Fix redirect test;
 * Use pthread instead `task_create` to be able to run this test on POSIX-compliant systems;
 * General fixes regarding formatting and error messages;

## Impact

Test the POSIX-compliant implementation of NuttX's pipes.

## Testing

Testing with `sim:citest` and on Linux.