### PR TITLE
system/ramspeed:Fix the problem that irq_disable is changed due to missing break

### DIFF
--- a/system/ramspeed/ramspeed_main.c
+++ b/system/ramspeed/ramspeed_main.c
@@ -143,6 +143,7 @@ static void parse_commandline(int argc, FAR char **argv,
                 printf(RAMSPEED_PREFIX "<size> must >= 32");
                 exit(EXIT_FAILURE);
               }
+
             break;
           case 'v':
             OPTARG_TO_VALUE(info->value, uint8_t, 16);
@@ -155,6 +156,7 @@ static void parse_commandline(int argc, FAR char **argv,
                 exit(EXIT_FAILURE);
               }
 
+            break;
           case 'i':
             info->irq_disable = true;
             break;


### PR DESCRIPTION
## Summary
Fix the problem that "when repeat_num!=0, there is no break, so irq_disable will be configured to true by default".

## Impact

## Testing

