### PR TITLE
testing/ostest: make sure that signets and pthread_rwlock tests are executed properly 

### DIFF
--- a/testing/ostest/pthread_rwlock.c
+++ b/testing/ostest/pthread_rwlock.c
@@ -327,6 +327,8 @@ static FAR void *timeout_thread2(FAR void *data)
   struct timespec time;
   int status;
 
+  pthread_yield();
+
   status = clock_gettime(CLOCK_REALTIME, &time);
   time.tv_sec += 2;
 

--- a/testing/ostest/signest.c
+++ b/testing/ostest/signest.c
@@ -232,7 +232,7 @@ void signest_test(void)
 
   g_nest_level = 0;
 
-  ret = sched_getparam (0, &param);
+  ret = sched_getparam(0, &param);
   if (ret < 0)
     {
       printf("signest_test: ERROR sched_getparam() failed\n");
@@ -244,8 +244,8 @@ void signest_test(void)
 
   prio = param.sched_priority + 1;
   printf("signest_test: Starting signal waiter task at priority %d\n", prio);
-  waiterpid = task_create("waiter", param.sched_priority,
-                           STACKSIZE, waiter_main, NULL);
+  waiterpid = task_create("waiter", prio, STACKSIZE,
+                          waiter_main, NULL);
   if (waiterpid == ERROR)
     {
       printf("signest_test: ERROR failed to start waiter_main\n");
@@ -259,8 +259,8 @@ void signest_test(void)
 
   prio++;
   printf("signest_test: Starting interfering task at priority %d\n", prio);
-  interferepid = task_create("interfere", param.sched_priority,
-                           STACKSIZE, interfere_main, NULL);
+  interferepid = task_create("interfere", prio, STACKSIZE,
+                             interfere_main, NULL);
   if (interferepid == ERROR)
     {
       printf("signest_test: ERROR failed to start interfere_main\n");


### PR DESCRIPTION
## Summary
Make sure that signets and pthread_rwlock tests are executed properly.
The issues has been found during working on https://github.com/apache/nuttx/pull/7464

## Impact
`ostest` is even more reliable

## Testing
Pass `sim:ostest`
