### PR TITLE
github/linters/setup.cfg: ignore E203 for flake8

### DIFF
--- a/.github/linters/setup.cfg
+++ b/.github/linters/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W503,W605
+ignore = W503,W605,E203
 max-complexity = 27
 max-line-length = 125
 show-source = True


### PR DESCRIPTION
## Summary
- github/linters/setup.cfg: ignore E203 for flake8 to fix compatibility issues with black
For more details, see https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8

## Impact

## Testing
CI
