### PR TITLE
netutils/iperf: Support local/RPMsg socket test

### DIFF
--- a/netutils/iperf/iperf.h
+++ b/netutils/iperf/iperf.h
@@ -44,10 +44,11 @@ extern "C"
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPERF_FLAG_CLIENT (1)
+#define IPERF_FLAG_CLIENT (1 << 0)
 #define IPERF_FLAG_SERVER (1 << 1)
-#define IPERF_FLAG_TCP (1 << 2)
-#define IPERF_FLAG_UDP (1 << 3)
+#define IPERF_FLAG_TCP    (1 << 2)
+#define IPERF_FLAG_UDP    (1 << 3)
+#define IPERF_FLAG_LOCAL  (1 << 4)
 
 /****************************************************************************
  * Public Types
@@ -62,6 +63,7 @@ struct iperf_cfg_t
   uint16_t sport;
   uint32_t interval;
   uint32_t time;
+  FAR const char *path; /* local path or rpmsg name */
 };
 
 /****************************************************************************

--- a/netutils/iperf/iperf.h
+++ b/netutils/iperf/iperf.h
@@ -49,6 +49,7 @@ extern "C"
 #define IPERF_FLAG_TCP    (1 << 2)
 #define IPERF_FLAG_UDP    (1 << 3)
 #define IPERF_FLAG_LOCAL  (1 << 4)
+#define IPERF_FLAG_RPMSG  (1 << 5)
 
 /****************************************************************************
  * Public Types
@@ -63,6 +64,7 @@ struct iperf_cfg_t
   uint16_t sport;
   uint32_t interval;
   uint32_t time;
+  FAR const char *host; /* host name (dip) or rpmsg cpu */
   FAR const char *path; /* local path or rpmsg name */
 };
 

--- a/netutils/iperf/iperf_main.c
+++ b/netutils/iperf/iperf_main.c
@@ -56,6 +56,7 @@ struct wifi_iperf_t
   FAR struct arg_str *ip;
   FAR struct arg_lit *server;
   FAR struct arg_lit *udp;
+  FAR struct arg_str *local;
   FAR struct arg_int *port;
   FAR struct arg_int *interval;
   FAR struct arg_int *time;
@@ -79,12 +80,45 @@ static void iperf_showusage(FAR const char *progname,
                             FAR struct wifi_iperf_t *args, int exitcode)
 {
   printf("USAGE: %s [-sua] [-c <ip>] [-p <port>] [-i <interval>] "
-         "[-t <time>]\n", progname);
+         "[-t <time>] [--local <path>]\n", progname);
   printf("iperf command:\n");
   arg_print_glossary(stdout, (FAR void **)args, NULL);
 
   arg_freetable((FAR void **)args, sizeof(*args) / sizeof(FAR void *));
   exit(exitcode);
+}
+
+/****************************************************************************
+ * Name: iperf_printcfg
+ *
+ * Description:
+ *   Print config line before start
+ *
+ ****************************************************************************/
+
+static void iperf_printcfg(FAR struct iperf_cfg_t *cfg)
+{
+  printf("\n mode=%s%s-%s ",
+         cfg->flag & IPERF_FLAG_LOCAL ? "local-":"",
+         cfg->flag & IPERF_FLAG_TCP ? "tcp":"udp",
+         cfg->flag & IPERF_FLAG_SERVER ? "server":"client");
+
+  if (cfg->flag & IPERF_FLAG_LOCAL)
+    {
+      printf("path=%s, ", cfg->path);
+    }
+  else
+    {
+      printf("sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
+             "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d, ",
+             cfg->sip & 0xff, (cfg->sip >> 8) & 0xff,
+             (cfg->sip >> 16) & 0xff, (cfg->sip >> 24) & 0xff, cfg->sport,
+             cfg->dip & 0xff, (cfg->dip >> 8) & 0xff,
+             (cfg->dip >> 16) & 0xff, (cfg->dip >> 24) & 0xff, cfg->dport);
+    }
+
+  printf("interval=%" PRId32 ", time=%" PRId32 "\n",
+         cfg->interval, cfg->time);
 }
 
 /****************************************************************************
@@ -106,6 +140,7 @@ int main(int argc, FAR char *argv[])
                            "run in client mode, connecting to <host>");
   iperf_args.server = arg_lit0("s", "server", "run in server mode");
   iperf_args.udp = arg_lit0("u", "udp", "use UDP rather than TCP");
+  iperf_args.local = arg_str0(NULL, "local", "<path>", "use local socket");
   iperf_args.port = arg_int0("p", "port", "<port>",
                              "server port to listen on/connect to");
   iperf_args.interval = arg_int0("i", "interval", "<interval>",
@@ -114,6 +149,10 @@ int main(int argc, FAR char *argv[])
                         "time in seconds to transmit for (default 10 secs)");
   iperf_args.abort = arg_lit0("a", "abort", "abort running iperf");
   iperf_args.end = arg_end(1);
+
+  /* Value of local is needed for server, optional for client. */
+
+  iperf_args.local->hdr.flag |= ARG_HASOPTVALUE;
 
   nerrors = arg_parse(argc, argv, (FAR void**) &iperf_args);
   if (nerrors != 0)
@@ -146,17 +185,40 @@ int main(int argc, FAR char *argv[])
       cfg.flag |= IPERF_FLAG_CLIENT;
     }
 
-  addr.s_addr = 0;
-  netlib_get_ipv4addr(DEVNAME, &addr);
-  if (addr.s_addr == 0)
+  if (iperf_args.local->count > 0)
     {
-      printf("ERROR: access IP is 0x00\n");
-      return -1;
+      cfg.flag |= IPERF_FLAG_LOCAL;
+      if (strlen(iperf_args.local->sval[0]) > 0)
+        {
+          /* iperf -s --local <path> or iperf -c <whatever> --local <path> */
+
+          cfg.path = iperf_args.local->sval[0];
+        }
+      else if (iperf_args.ip->count > 0)
+        {
+          /* iperf -c <path> --local */
+
+          cfg.path = iperf_args.ip->sval[0];
+        }
+      else
+        {
+          printf("ERROR: should specific local socket path\n");
+          iperf_showusage(argv[0], &iperf_args, 0);
+        }
     }
+  else
+    {
+      netlib_get_ipv4addr(DEVNAME, &addr);
+      if (addr.s_addr == 0)
+        {
+          printf("ERROR: access IP is 0x00\n");
+          goto out;
+        }
 
-  printf("       IP: %s\n", inet_ntoa_r(addr, inetaddr, sizeof(inetaddr)));
+      printf("     IP: %s\n", inet_ntoa_r(addr, inetaddr, sizeof(inetaddr)));
 
-  cfg.sip = addr.s_addr;
+      cfg.sip = addr.s_addr;
+    }
 
   if (iperf_args.udp->count == 0)
     {
@@ -221,21 +283,12 @@ int main(int argc, FAR char *argv[])
         }
     }
 
+  iperf_printcfg(&cfg);
+  iperf_start(&cfg);
+
+out:
   arg_freetable((FAR void **)&iperf_args,
                 sizeof(iperf_args) / sizeof(FAR void *));
-
-  printf("\n mode=%s-%s "
-         "sip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d,"
-         "dip=%" PRId32 ".%" PRId32 ".%" PRId32 ".%" PRId32 ":%d, "
-         "interval=%" PRId32 ", time=%" PRId32 "\n",
-         cfg.flag & IPERF_FLAG_TCP ?"tcp":"udp",
-         cfg.flag & IPERF_FLAG_SERVER ?"server":"client",
-         cfg.sip & 0xff, (cfg.sip >> 8) & 0xff, (cfg.sip >> 16) & 0xff,
-         (cfg.sip >> 24) & 0xff, cfg.sport,
-         cfg.dip & 0xff, (cfg.dip >> 8) & 0xff, (cfg.dip >> 16) & 0xff,
-         (cfg.dip >> 24) & 0xff, cfg.dport,
-         cfg.interval, cfg.time);
-  iperf_start(&cfg);
 
   return 0;
 }

--- a/netutils/iperf/iperf_main.c
+++ b/netutils/iperf/iperf_main.c
@@ -75,22 +75,15 @@ struct wifi_iperf_t
  *
  ****************************************************************************/
 
-static void iperf_showusage(FAR const char *progname, int exitcode)
+static void iperf_showusage(FAR const char *progname,
+                            FAR struct wifi_iperf_t *args, int exitcode)
 {
-  printf("USAGE: %s [-sua] [-c <ip>] [-p <port>]\
-         [-i <interval>] [-t <time>]\n", progname);
+  printf("USAGE: %s [-sua] [-c <ip>] [-p <port>] [-i <interval>] "
+         "[-t <time>]\n", progname);
   printf("iperf command:\n");
-  printf("  -c, --client=<ip>  run in client mode,\
-         connecting to <host>\n");
-  printf("  -s, --server  run in server mode\n");
-  printf("  -u, --udp  use UDP rather than TCP\n");
-  printf("  -p, --port=<port>  server port to listen on/connect to\n");
-  printf("  -i, --interval=<interval>\
-         seconds between periodic bandwidth reports\n");
-  printf("  -t, --time=<time>\
-         time in seconds to transmit for (default 10 secs)\n");
-  printf("  -a, --abort  abort running iperf\n");
-  printf("\n");
+  arg_print_glossary(stdout, (FAR void **)args, NULL);
+
+  arg_freetable((FAR void **)args, sizeof(*args) / sizeof(FAR void *));
   exit(exitcode);
 }
 
@@ -126,21 +119,21 @@ int main(int argc, FAR char *argv[])
   if (nerrors != 0)
     {
       arg_print_errors(stderr, iperf_args.end, argv[0]);
-      iperf_showusage(argv[0], 0);
+      iperf_showusage(argv[0], &iperf_args, 0);
     }
 
   if (iperf_args.abort->count != 0)
     {
       iperf_stop();
       printf("ERROR: abort->count: %d\n", iperf_args.abort->count);
-      iperf_showusage(argv[0], 0);
+      iperf_showusage(argv[0], &iperf_args, 0);
     }
 
   if (((iperf_args.ip->count == 0) && (iperf_args.server->count == 0)) ||
          ((iperf_args.ip->count != 0) && (iperf_args.server->count != 0)))
     {
       printf("ERROR: should specific client/server mode\n");
-      iperf_showusage(argv[0], 0);
+      iperf_showusage(argv[0], &iperf_args, 0);
     }
 
   if (iperf_args.ip->count == 0)


### PR DESCRIPTION
## Summary
Patches included:
- netutils/iperf: Use argtable's builtin glossary to print usage
- netutils/iperf: Split out sockaddr from general logic 
- netutils/iperf: Support local socket test 
- netutils/iperf: Support RPMsg socket test 

Usage:
```
# local socket
iperf -s --local <path>
iperf -c <path> --local || iperf -c <whatever> --local <path>

# rpmsg socket
iperf -s --rpmsg <name>
iperf -c <cpu> --rpmsg <name>
```
Note:
- Can combine with other options, e.g. `-u --local` will result in local UDP (DGRAM).
- RPMsg with SOCK_DGRAM (`-u`) doesn't have server mode (bind) yet, iperf may not work in this case before rpsock is enhanced.
- Need https://github.com/apache/nuttx/pull/9042 for RPMsg test.

## Impact
Improve `iperf` functionality.

## Testing
manually
