### PR TITLE
apps/system: Call arg_freetable before iptables/tcpdump exit

### DIFF
--- a/system/iptables/iptables.c
+++ b/system/iptables/iptables.c
@@ -407,6 +407,7 @@ int main(int argc, FAR char *argv[])
 {
   struct iptables_args_s args;
   int nerrors;
+  int ret = 0;
 
   args.table        = arg_str1("t", "table", "table", "table to manipulate");
 
@@ -440,20 +441,20 @@ int main(int argc, FAR char *argv[])
     {
       arg_print_errors(stderr, args.end, argv[0]);
       iptables_showusage(argv[0], (FAR void**)&args);
-      return 0;
     }
-
-  if (strcmp(args.table->sval[0], TABLE_NAME_NAT) == 0)
+  else if (strcmp(args.table->sval[0], TABLE_NAME_NAT) == 0)
     {
-      int ret = iptables_nat(&args);
+      ret = iptables_nat(&args);
       if (ret < 0)
         {
           printf("iptables got error on NAT: %d!\n", ret);
         }
-
-      return ret;
+    }
+  else
+    {
+      printf("Unknown table: %s\n", args.table->sval[0]);
     }
 
-  printf("Unknown table: %s\n", args.table->sval[0]);
-  return 0;
+  arg_freetable((FAR void **)&args, sizeof(args) / sizeof(FAR void *));
+  return ret;
 }

--- a/system/tcpdump/tcpdump.c
+++ b/system/tcpdump/tcpdump.c
@@ -273,28 +273,28 @@ int main(int argc, FAR char *argv[])
       arg_print_errors(stdout, args.end, argv[0]);
       printf("Usage:\n");
       arg_print_glossary(stdout, (FAR void**)&args, "  %-30s %s\n");
-      return 0;
+      goto out;
     }
 
   ifindex = if_nametoindex(args.interface->sval[0]);
   if (ifindex == 0)
     {
       printf("Failed to get index of device %s\n", args.interface->sval[0]);
-      return 0;
+      goto out;
     }
 
   cfgs.fd = open(args.file->sval[0], O_WRONLY | O_CREAT | O_TRUNC, 0644);
   if (cfgs.fd < 0)
     {
       perror("ERROR: open() failed");
-      return 0;
+      goto out;
     }
 
   cfgs.sd = socket_open(ifindex);
   if (cfgs.sd < 0)
     {
       close(cfgs.fd);
-      return 0;
+      goto out;
     }
 
   if (args.snaplen->count > 0)
@@ -310,5 +310,8 @@ int main(int argc, FAR char *argv[])
 
   close(cfgs.sd);
   close(cfgs.fd);
+
+out:
+  arg_freetable((FAR void **)&args, sizeof(args) / sizeof(FAR void *));
   return 0;
 }


### PR DESCRIPTION
## Summary
Call arg_freetable before iptables/tcpdump exit.
Previously forget to free argtable before exit.

## Impact
Avoid memleak.

## Testing
manually
