### PR TITLE
ostest:  fix smp ostest fail

### DIFF
--- a/testing/ostest/cond.c
+++ b/testing/ostest/cond.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <semaphore.h>
 
 #include "ostest.h"
 
@@ -59,6 +60,7 @@ static int signaler_nloops = 0;
 static int signaler_already = 0;
 static int signaler_state = 0;
 static int signaler_nerrors = 0;
+static sem_t sem_thread_started;
 
 /****************************************************************************
  * Private Functions
@@ -78,6 +80,7 @@ static void *thread_waiter(void *parameter)
       status       = pthread_mutex_lock(&mutex);
       waiter_state = RUNNING;
 
+      sem_post(&sem_thread_started);
       if (status != 0)
         {
           printf("waiter_thread: "
@@ -219,7 +222,10 @@ static void *thread_signaler(void *parameter)
        * To avoid this situaltion, we add the following usleep()
        */
 
-      usleep(10 * 1000);
+      while (data_available == 1)
+        {
+          usleep(10 * 1000);
+        }
 #endif
 
       signaler_nloops++;
@@ -247,6 +253,8 @@ void cond_test(void)
   int prio_max;
   int prio_mid;
   int status;
+
+  sem_init(&sem_thread_started, 0, 0);
 
   /* Initialize the mutex */
 
@@ -302,6 +310,8 @@ void cond_test(void)
       printf("cond_test: pthread_create failed, status=%d\n", status);
     }
 
+  sem_wait(&sem_thread_started);
+
   printf("cond_test: Starting signaler\n");
   status = pthread_attr_init(&attr);
   if (status != 0)
@@ -338,6 +348,7 @@ void cond_test(void)
   printf("cond_test: signaler terminated, now cancel the waiter\n");
   pthread_detach(waiter);
   pthread_cancel(waiter);
+  sem_destroy(&sem_thread_started);
 
   printf("cond_test: \tWaiter\tSignaler\n");
   printf("cond_test: Loops\t%d\t%d\n", waiter_nloops, signaler_nloops);

--- a/testing/ostest/pthread_rwlock.c
+++ b/testing/ostest/pthread_rwlock.c
@@ -43,6 +43,7 @@ struct race_cond_s
  ****************************************************************************/
 
 static int g_race_cond_thread_pos;
+static sem_t g_sem_thread_started;
 
 /****************************************************************************
  * Private Functions
@@ -308,6 +309,7 @@ static FAR void *timeout_thread1(FAR void *data)
       ASSERT(false);
     }
 
+  sem_post(&g_sem_thread_started);
   sem_wait(rc->sem1);
 
   status = pthread_rwlock_unlock(rc->rw_lock);
@@ -408,6 +410,9 @@ static void test_timeout(void)
   rc.rw_lock = &rw_lock;
 
   status = pthread_create(&thread1, NULL, timeout_thread1, &rc);
+
+  status = sem_wait(&g_sem_thread_started);
+
   status = pthread_create(&thread2, NULL, timeout_thread2, &rc);
 
   pthread_join(thread1, NULL);
@@ -424,6 +429,8 @@ void pthread_rwlock_test(void)
   int status;
 
   printf("pthread_rwlock: Initializing rwlock\n");
+
+  sem_init(&g_sem_thread_started, 0, 0);
 
   status = pthread_rwlock_init(&rw_lock, NULL);
   if (status != 0)
@@ -489,4 +496,6 @@ void pthread_rwlock_test(void)
   test_two_threads();
 
   test_timeout();
+
+  sem_destroy(&g_sem_thread_started);
 }

--- a/testing/ostest/robust.c
+++ b/testing/ostest/robust.c
@@ -202,6 +202,14 @@ void robust_test(void)
       nerrors++;
     }
 
+  /* Make sure waiter exit completely */
+
+  do
+    {
+      sleep(1);
+    }
+  while (kill(g_robust_mutex.pid, 0) == 0 || errno != ESRCH);
+
   /* Make the mutex consistent and try again.  It should succeed this time. */
 
   printf("robust_test: Make the mutex consistent again.\n");

--- a/testing/ostest/sem.c
+++ b/testing/ostest/sem.c
@@ -240,6 +240,15 @@ void sem_test(void)
       ASSERT(false);
     }
 
+  /* Make sure waiter_thread1 and waiter_thread2 in sem_wait */
+
+  do
+    {
+      sem_getvalue(&sem, &status);
+      usleep(10 * 1000L);
+    }
+  while (status != -2);
+
   printf("sem_test: Starting poster thread 3\n");
   status = pthread_attr_init(&attr);
   if (status != 0)

--- a/testing/ostest/wqueue.c
+++ b/testing/ostest/wqueue.c
@@ -119,7 +119,12 @@ static FAR void *verifier(FAR void *arg)
 
   /* Wait for count workers to run. */
 
-  usleep(SLEEP_TIME);
+  do
+    {
+      usleep(SLEEP_TIME);
+      sem_getvalue(&call_sem, &call_count);
+    }
+  while (call_count != VERIFY_COUNT);
 
   sem_getvalue(&call_sem, &call_count);
   printf("wqueue_test: call = %d, expect = %d\n", call_count, VERIFY_COUNT);


### PR DESCRIPTION
## Summary
 we need improve thread waiting strategy, if we don't do this ostest may fail, especially in smp

## Impact
none

## Testing
ostest
