### PR TITLE
system/critmon: fix warning

### DIFF
--- a/system/critmon/critmon.c
+++ b/system/critmon/critmon.c
@@ -248,12 +248,14 @@ static int critmon_process_directory(FAR struct dirent *entryp)
       else
         {
           maxrun = "None";
+          runtime = "None";
         }
     }
   else
     {
       maxcrit = "None";
       maxrun  = "None";
+      runtime = "None";
     }
 
   /* Finally, output the stack info that we gleaned from the procfs */


### PR DESCRIPTION
## Summary
fix warning ：
critmon.c:269:3: warning: 'runtime' may be used uninitialized in this function [-Wmaybe-uninitialized]
  269 |   printf("%11s %11s %11s %-16s %-5s %s\n",
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  270 |          maxpreemp, maxcrit, maxrun, runtime, entryp->d_name, name);

## Impact

## Testing

