### PR TITLE
Add TinyCBOR library and test example

### DIFF
--- a/examples/cbortest/Kconfig
+++ b/examples/cbortest/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_TINYCBOR_TEST
+	tristate "TinyCBOR Test Example"
+	default n
+	depends on FSUTILS_TINYCBOR_LIB
+	---help---
+		Enable the TinyCBOR test example
+
+if EXAMPLES_TINYCBOR_TEST
+
+config EXAMPLES_TINYCBOR_TEST_PROGNAME
+	string "Program name"
+	default "cbor"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_TINYCBOR_TEST_PRIORITY
+	int "TINYCBOR_TEST task priority"
+	default 100
+
+config EXAMPLES_TINYCBOR_TEST_STACKSIZE
+	int "TINYCBOR_TEST stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/cbortest/Make.defs
+++ b/examples/cbortest/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/cbortest/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_TINYCBOR_TEST),)
+CONFIGURED_APPS += $(APPDIR)/examples/cbortest
+endif

--- a/examples/cbortest/Makefile
+++ b/examples/cbortest/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/cbortest/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# TINYCBOR_TEST built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_TINYCBOR_TEST_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_TINYCBOR_TEST_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_TINYCBOR_TEST_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_TINYCBOR_TEST)
+
+# TINYCBOR_TEST Example
+
+MAINSRC = cbortest_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/cbortest/cbortest_main.c
+++ b/examples/cbortest/cbortest_main.c
@@ -1,0 +1,111 @@
+/****************************************************************************
+ * apps/examples/cbortest/cbortest_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <wchar.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#include "tinycbor/cbor.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MINMEA_MAX_LENGTH    256
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * cbortest_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  CborError res;
+  CborEncoder encoder;
+  CborEncoder map_encoder;
+  uint8_t output[50];
+  size_t output_len;
+  int i;
+
+  printf("TinyCBOR test: Encoding { \"t\": 1234 }\n");
+
+  /*  Init our CBOR Encoder */
+
+  cbor_encoder_init(&encoder, output, sizeof(output), 0);
+
+  /* Create a Map Encoder that maps keys to values, 1 = Key-Value Pairs */
+
+  res = cbor_encoder_create_map(&encoder, &map_encoder, 1);
+
+  /* Check for any error */
+
+  assert(res == CborNoError);
+
+  /*  First Key-Value Pair: Map the Key */
+
+  res = cbor_encode_text_stringz(&map_encoder, "t");
+
+  /* Check for any error */
+
+  assert(res == CborNoError);
+
+  /*  First Key-Value Pair: Map the Value */
+
+  res = cbor_encode_int(&map_encoder, 1234);
+
+  /* Check for any error */
+
+  assert(res == CborNoError);
+
+  /*  Close the Map Encoder */
+
+  res = cbor_encoder_close_container(&encoder, &map_encoder);
+
+  /* Check for any error */
+
+  assert(res == CborNoError);
+
+  /* How many bytes were encoded */
+
+  output_len = cbor_encoder_get_buffer_size(&encoder, output);
+  printf("CBOR Output: %d bytes\n", output_len);
+
+  /*  Dump the encoded CBOR output (6 bytes): */
+
+  printf("Expected sequence:  0xa1 0x61 0x74 0x19 0x04 0xd2\n");
+
+  for (i = 0; i < output_len; i++)
+    {
+      printf("  0x%02x\n", output[i]);
+    }
+
+  return 0;
+}

--- a/fsutils/libtinycbor/.gitignore
+++ b/fsutils/libtinycbor/.gitignore
@@ -1,0 +1,2 @@
+/minmea
+/*.zip

--- a/fsutils/libtinycbor/.gitignore
+++ b/fsutils/libtinycbor/.gitignore
@@ -1,2 +1,2 @@
-/minmea
+/tinycbor
 /*.zip

--- a/fsutils/libtinycbor/Kconfig
+++ b/fsutils/libtinycbor/Kconfig
@@ -1,0 +1,17 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config FSUTILS_TINYCBOR_LIB
+	bool "TinyCBOR Library (RFC 8949)"
+	default n
+	depends on ALLOW_MIT_COMPONENTS
+	---help---
+		Enable support for the TinyCBOR library. This is an
+		implementation of RFC-8949 (Concise Binary Object
+		Representation).
+		More info: https://lupyuen.github.io/articles/cbor2
+
+if FSUTILS_TINYCBOR_LIB
+endif

--- a/fsutils/libtinycbor/Make.defs
+++ b/fsutils/libtinycbor/Make.defs
@@ -1,0 +1,24 @@
+############################################################################
+# apps/fsutils/libtinycbor/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_FSUTILS_TINYCBOR_LIB),)
+CONFIGURED_APPS += $(APPDIR)/fsutils/libtinycbor
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/fsutils/libtinycbor
+endif

--- a/fsutils/libtinycbor/Makefile
+++ b/fsutils/libtinycbor/Makefile
@@ -1,0 +1,64 @@
+############################################################################
+# apps/fsutils/libtinycbor/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+TINYCBOR_URL ?= "https://github.com/intel/tinycbor/archive"
+TINYCBOR_VERSION ?= 3cba6b11aaa0f6f674cd56ebaa573c4b65f71ee7
+
+TINYCBOR_UNPACKNAME = tinycbor
+
+$(TINYCBOR_UNPACKNAME):
+	@echo "Downloading: $(TINYCBOR_UNPACKNAME)"
+	$(Q) curl -O -L $(TINYCBOR_URL)/$(TINYCBOR_VERSION).zip
+	$(Q) mkdir $(TINYCBOR_UNPACKNAME)
+	$(Q) unzip -o -j $(TINYCBOR_VERSION).zip -d $(TINYCBOR_UNPACKNAME)
+	$(Q) patch -Np1 < fix_open_memstream.patch
+	$(call DELFILE, $(TINYCBOR_VERSION).zip)
+
+# Files
+
+CSRCS += tinycbor/cborencoder.c
+CSRCS += tinycbor/cborencoder_close_container_checked.c
+CSRCS += tinycbor/cborencoder_float.c
+CSRCS += tinycbor/cborerrorstrings.c
+CSRCS += tinycbor/cborparser.c
+CSRCS += tinycbor/cborparser_dup_string.c
+CSRCS += tinycbor/cborparser_float.c
+CSRCS += tinycbor/cborpretty.c
+CSRCS += tinycbor/cborpretty_stdio.c
+CSRCS += tinycbor/cbortojson.c
+CSRCS += tinycbor/cborvalidation.c
+CSRCS += tinycbor/open_memstream.c
+
+CFLAGS += -std=c99
+
+clean::
+	$(call DELFILE, $(OBJS))
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(TINYCBOR_UNPACKNAME)/.git),)
+context:: $(TINYCBOR_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(TINYCBOR_UNPACKNAME))
+endif
+
+include $(APPDIR)/Application.mk

--- a/fsutils/libtinycbor/fix_open_memstream.patch
+++ b/fsutils/libtinycbor/fix_open_memstream.patch
@@ -1,0 +1,31 @@
+From a66a373a9417d3f481e9346286d93e33fac8e616 Mon Sep 17 00:00:00 2001
+From: Lee Lup Yuen <luppy@appkaki.com>
+Date: Wed, 5 Jan 2022 08:32:38 +0800
+Subject: [PATCH] Fix open_memstream.c compilation
+
+diff --git a/tinycbor/open_memstream.c b/tinycbor/open_memstream.c
+index 3365378..37a0d08 100644
+--- a/tinycbor/open_memstream.c
++++ b/tinycbor/open_memstream.c
+@@ -32,7 +32,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#if defined(__unix__) || defined(__APPLE__)
++#if defined(__unix__) || defined(__APPLE__) || defined(__NuttX__)
+ #  include <unistd.h>
+ #endif
+ #ifdef __APPLE__
+@@ -41,6 +41,9 @@ typedef int LenType;
+ #elif __linux__
+ typedef ssize_t RetType;
+ typedef size_t LenType;
++#elif __NuttX__
++typedef ssize_t RetType;
++typedef size_t LenType;
+ #else
+ #  error "Cannot implement open_memstream!"
+ #endif
+-- 
+2.34.1
+


### PR DESCRIPTION
## Summary
Add TinyCBOR library (initially integrated by Lup Yuen: https://lupyuen.github.io/articles/cbor2 )
## Impact
Users will be able to use CBOR library on NuttX
## Testing
ESP32-DevkitC.

Please ignore code style issue caused by TinyCBOR CamelCase
