### PR TITLE
nshlib/netcmds:support to set MTU

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -367,6 +367,8 @@ int netlib_set_ipv4dnsaddr(FAR const struct in_addr *inaddr);
 int netlib_set_ipv6dnsaddr(FAR const struct in6_addr *inaddr);
 #endif
 
+int netlib_set_mtu(FAR const char *ifname, int mtu);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -103,6 +103,8 @@ ifeq ($(CONFIG_NET_ETHERNET),y)
 CSRCS += netlib_setmacaddr.c netlib_getmacaddr.c
 endif
 
+CSRCS += netlib_setmtu.c
+
 ifeq ($(CONFIG_WIRELESS_IEEE802154),y)
 CSRCS += netlib_seteaddr.c netlib_getpanid.c netlib_saddrconv.c netlib_eaddrconv.c
 endif

--- a/netutils/netlib/netlib_setmtu.c
+++ b/netutils/netlib/netlib_setmtu.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_setmtu.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#include <netinet/in.h>
+#include <net/if.h>
+
+#include "netutils/netlib.h"
+
+#ifdef CONFIG_NET
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_set_mtu
+ *
+ * Description:
+ *   Set MTU of the NuttX driver state structure
+ *
+ * Parameters:
+ *   ifname   The name of the interface to use
+ *   mtu    Maximum Transmission Unit，MTU
+ *
+ * Return:
+ *   0 on success; -1 on failure (errno may not be set)
+ *
+ ****************************************************************************/
+
+int netlib_set_mtu(FAR const char *ifname, int mtu)
+{
+  int ret = ERROR;
+
+  if (ifname != NULL && mtu != 0)
+    {
+      /* Get a socket (only so that we get access to the INET subsystem) */
+
+      int sockfd = socket(NET_SOCK_FAMILY, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+      if (sockfd >= 0)
+        {
+          struct ifreq req;
+
+          /* Put the driver name into the request */
+
+          strlcpy(req.ifr_name, ifname, IFNAMSIZ);
+
+          /* Put the new MTU into the request */
+
+          req.ifr_mtu = mtu;
+
+          /* Perform the ioctl to set the MTU */
+
+          ret = ioctl(sockfd, SIOCSIFMTU, (unsigned long)&req);
+          close(sockfd);
+        }
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_NET */

--- a/nshlib/README.md
+++ b/nshlib/README.md
@@ -670,7 +670,7 @@ system image.
 
   Dump data in hexadecimal format from a file or character device.
 
-- `ifconfig [nic_name [address_family] [<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] [dns <dns-address>] [hw <hw-mac>]`
+- `ifconfig [nic_name [address_family] [mtu <len>] | [[<ip-address>|dhcp]] [dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] [dns <dns-address>] [hw <hw-mac>]]`
 
   Show the current configuration of the network, for example:
 

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -255,7 +255,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #ifdef CONFIG_NET
 # ifndef CONFIG_NSH_DISABLE_IFCONFIG
   { "ifconfig", cmd_ifconfig, 1, 12,
-    "[interface [address_family] [<ip-address>|dhcp]] "
+    "[interface [address_family] [<ip-address>|dhcp]] | [mtu <len>]"
     "[dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] "
     "[dns <dns-address>] [hw <hw-mac>]" },
 # endif

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -580,6 +580,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   FAR void *handle;
 #endif
   int ret;
+  int mtu = 0;
 
   /* With one or no arguments, ifconfig simply shows the status of the
    * network device:
@@ -720,6 +721,22 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
                   continue;
                 }
+              else if (!strcmp(tmp, "mtu"))
+                {
+                  if (argc - 1 >= i + 1)
+                    {
+                      mtu = atoi(argv[i + 1]);
+                      i++;
+                      if (mtu < 1280)
+                        {
+                          mtu = 1280;
+                        }
+                    }
+                  else
+                    {
+                      badarg = true;
+                    }
+                }
               else if (hostip == NULL && i <= 4)
                 {
                   /* Let first non-option be host ip, to support inet/inet6
@@ -757,6 +774,12 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       nsh_sethwaddr(ifname, &macaddr);
     }
 #endif
+
+  if (mtu != 0)
+    {
+      netlib_set_mtu(ifname, mtu);
+      return OK;
+    }
 
   /* Set IP address */
 


### PR DESCRIPTION
## Summary
support to set MTU
## Impact
N/A
## Testing
Usage:ifconfig interfacename mtu ***
example:
ap> ifconfig eth0 mtu 1300
ap> ifconfig
eth0	Link encap:Ethernet HWaddr 42:de:09:1c:71:1e at RUNNING mtu 1300
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fe80::40de:9ff:fe1c:711e/64
	inet6 DRaddr: ::/64
