### PR TITLE
 wireless/wapi: support WPA3 on `wapi psk` command

### DIFF
--- a/include/wireless/wapi.h
+++ b/include/wireless/wapi.h
@@ -265,6 +265,14 @@ enum wpa_alg_e
   WPA_ALG_BIP_CMAC_256
 };
 
+enum wpa_ver_e
+{
+  WPA_VER_NONE = 0,
+  WPA_VER_1,
+  WPA_VER_2,
+  WPA_VER_3
+};
+
 /* This structure provides the wireless configuration to
  * wpa_driver_wext_associate().
  */
@@ -323,6 +331,10 @@ EXTERN FAR const char *g_wapi_essid_flags[];
 /* Passphrase algorithm flag names. */
 
 EXTERN FAR const char *g_wapi_alg_flags[];
+
+/* Passphrase WPA Version flag names. */
+
+EXTERN FAR const char *g_wapi_wpa_ver_flags[];
 
 /* Supported operation mode names. */
 

--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -545,6 +545,7 @@ static int wapi_essid_cmd(int sock, int argc, FAR char **argv)
 static int wapi_psk_cmd(int sock, int argc, FAR char **argv)
 {
   enum wpa_alg_e alg_flag;
+  enum wpa_ver_e ver_flag;
   uint8_t auth_wpa;
   int passlen;
   int cipher;
@@ -561,16 +562,38 @@ static int wapi_psk_cmd(int sock, int argc, FAR char **argv)
 
   /* Convert input strings to values */
 
-  alg_flag = (enum wpa_alg_e)wapi_str2ndx(argv[2], g_wapi_alg_flags);
-
   if (argc > 3)
     {
-      auth_wpa = atoi(argv[3]);
+      ver_flag = (enum wpa_ver_e)wapi_str2ndx(argv[3], g_wapi_wpa_ver_flags);
     }
   else
     {
-      auth_wpa = IW_AUTH_WPA_VERSION_WPA2;
+      ver_flag = WPA_VER_2;
     }
+
+  switch (ver_flag)
+    {
+      case WPA_VER_NONE:
+        auth_wpa = IW_AUTH_WPA_VERSION_DISABLED;
+        break;
+
+      case WPA_VER_1:
+        auth_wpa = IW_AUTH_WPA_VERSION_WPA;
+        break;
+
+      case WPA_VER_2:
+        auth_wpa = IW_AUTH_WPA_VERSION_WPA2;
+        break;
+
+      case WPA_VER_3:
+        auth_wpa = IW_AUTH_WPA_VERSION_WPA3;
+        break;
+
+      default:
+        return -EINVAL;
+    }
+
+  alg_flag = (enum wpa_alg_e)wapi_str2ndx(argv[2], g_wapi_alg_flags);
 
   switch (alg_flag)
     {
@@ -1081,7 +1104,7 @@ static void wapi_showusage(FAR const char *progname, int exitcode)
   fprintf(stderr, "\t%s essid        <ifname> <essid>      <index/flag>\n",
                    progname);
   fprintf(stderr, "\t%s psk          <ifname> <passphrase> <index/flag> "
-                  "<wpa>\n", progname);
+                  "[wpa]\n", progname);
   fprintf(stderr, "\t%s disconnect   <ifname>\n", progname);
   fprintf(stderr, "\t%s mode         <ifname>              <index/mode>\n",
                    progname);
@@ -1117,6 +1140,12 @@ static void wapi_showusage(FAR const char *progname, int exitcode)
   for (i = 0; g_wapi_alg_flags[i]; i++)
     {
       fprintf(stderr, "\t[%d] %s\n", i, g_wapi_alg_flags[i]);
+    }
+
+  fprintf(stderr, "\nPassphrase WPA version:\n");
+  for (i = 0; g_wapi_wpa_ver_flags[i]; i++)
+    {
+      fprintf(stderr, "\t[%d] %s\n", i, g_wapi_wpa_ver_flags[i]);
     }
 
   fprintf(stderr, "\nOperating Modes:\n");

--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -591,7 +591,7 @@ static int wapi_psk_cmd(int sock, int argc, FAR char **argv)
         break;
 
       default:
-        return -1;
+        return -EINVAL;
     }
 
   ret = wpa_driver_wext_set_auth_param(sock, argv[0],

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -83,6 +83,7 @@ FAR const char *g_wapi_essid_flags[] =
 {
   "WAPI_ESSID_OFF",
   "WAPI_ESSID_ON",
+  "WAPI_ESSID_DELAY_ON",
   NULL
 };
 

--- a/wireless/wapi/src/wireless.c
+++ b/wireless/wapi/src/wireless.c
@@ -132,6 +132,17 @@ FAR const char *g_wapi_alg_flags[] =
   NULL
 };
 
+/* Passphrase WPA Version */
+
+FAR const char *g_wapi_wpa_ver_flags[] =
+{
+  "WPA_VER_NONE",
+  "WPA_VER_1",
+  "WPA_VER_2",
+  "WPA_VER_3",
+  NULL
+};
+
 /* PTA PRIORITY */
 
 FAR const char *g_wapi_pta_prio_flags[] =


### PR DESCRIPTION
## Summary

Similarly to the `alg_flag` of the `wapi_psk_cmd` (which can be set by text), the new `ver_flag` is able to select the WPA version which will be sent to the Wi-Fi driver through the `IW_AUTH_WPA_VERSION` command. A new bit field (`IW_AUTH_WPA_VERSION_WPA3`) was created to indicate WPA3 is set.
It's up to the arch's Wi-Fi driver to implement handling of this new bit field and config the underlying driver to handle WPA3 on AP and/or STA mode. This implementation doesn't interfere with commonly used commands: 
`wapi psk wlan0 mypasswd 3` still selects CCMP algorithm and WPA2 and is equivalent to `wapi psk wlan0 mypasswd 3 WPA_VER_2` from now on.

One can use `wapi psk wlan0 mypasswd 3 WPA_VER_3` to set WPA3.

Please consider that `wapi` documentation and necessary flags were submitted in NuttX's OS repository: https://github.com/apache/nuttx/pull/9139

## Impact

This enables users to select WPA3-SAE networks, even for AP or STA modes. Please note that - considering Espressif's SoCs - STA mode sets a security threshold, i.e., it was able to connect to a WPA3-SAE network prior to this change because it connects to an equally or more secure network than the set threshold. Considering this patch, the device is now able to ignore WPA2 APs when WPA3 is set.

## Testing

Internal CI testing and ESP32-S3-DevKitC-1 v1.6 connecting to a WPA3-SAE AP.