### PR TITLE
examples: Enable cxxinfo output if CONFIG_DEBUG_FEATURES is defined

### DIFF
--- a/examples/etl/etl_main.cxx
+++ b/examples/etl/etl_main.cxx
@@ -38,8 +38,8 @@
 // Debug ********************************************************************
 // Non-standard debug that may be enabled just for testing the constructors
 
-#ifndef CONFIG_DEBUG_FEATURES
-#  undef CONFIG_DEBUG_CXX
+#ifdef CONFIG_DEBUG_FEATURES
+#  define CONFIG_DEBUG_CXX
 #endif
 
 #ifdef CONFIG_DEBUG_CXX

--- a/examples/helloxx/helloxx_main.cxx
+++ b/examples/helloxx/helloxx_main.cxx
@@ -35,8 +35,8 @@
 // Debug ********************************************************************
 // Non-standard debug that may be enabled just for testing the constructors
 
-#ifndef CONFIG_DEBUG_FEATURES
-#  undef CONFIG_DEBUG_CXX
+#ifdef CONFIG_DEBUG_FEATURES
+#  define CONFIG_DEBUG_CXX
 #endif
 
 #ifdef CONFIG_DEBUG_CXX


### PR DESCRIPTION
## Summary

fix the wrong logic

## Impact

Minor

## Testing

CI