### PR TITLE
spitool: add support for 32-bit SPI BUS width

### DIFF
--- a/system/spi/spi_common.c
+++ b/system/spi/spi_common.c
@@ -192,7 +192,7 @@ int spitool_common_args(FAR struct spitool_s *spitool, FAR char **arg)
 
       case 'w':
         ret = arg_decimal(arg, &value);
-        if (value != 8 && value != 16)
+        if (value != 8 && value != 16 && value != 32)
           {
             goto out_of_range;
           }

--- a/system/spi/spi_exch.c
+++ b/system/spi/spi_exch.c
@@ -124,9 +124,13 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
         {
           spitool_printf(spitool, "%02X ", txdata[d]);
         }
-      else
+      else if (spitool->width <= 16)
         {
           spitool_printf(spitool, "%04X ", ((uint16_t *)txdata)[d]);
+        }
+      else
+        {
+          spitool_printf(spitool, "%08" PRIX32 " ", ((uint32_t *)txdata)[d]);
         }
     }
 
@@ -175,9 +179,13 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
         {
           spitool_printf(spitool, "%02X ", rxdata[d]);
         }
-      else
+      else if (spitool->width <= 16)
         {
           spitool_printf(spitool, "%04X ", ((uint16_t *)rxdata)[d]);
+        }
+      else
+        {
+          spitool_printf(spitool, "%08" PRIX32 " ", ((uint32_t *)rxdata)[d]);
         }
     }
 


### PR DESCRIPTION
## Summary
Extend SPI tool with support for 32-bit data width

## Impact
Currently SPI tool only supports 8 and 16-bit width.

## Testing
Tested on SPI driver with loopback enabled, successfully sent and received single and multiple words at 8, 16 and 32 bit widths.
