### PR TITLE
Added example for Bosch BMP280 pressure sensor

### DIFF
--- a/examples/bmp280/Kconfig
+++ b/examples/bmp280/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_BMP280
+	tristate "BMP280 Barometer sensor example"
+	default n
+	depends on SENSORS_BMP280
+	---help---
+		Enable the BMP280 example
+
+if EXAMPLES_BMP280
+
+config EXAMPLES_BMP280_PROGNAME
+	string "Program name"
+	default "bmp280"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_BMP280_PRIORITY
+	int "BMP280 task priority"
+	default 100
+
+config EXAMPLES_BMP280_STACKSIZE
+	int "BMP280 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/bmp280/Make.defs
+++ b/examples/bmp280/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/bmp280/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_BMP280),)
+CONFIGURED_APPS += $(APPDIR)/examples/bmp280
+endif

--- a/examples/bmp280/Makefile
+++ b/examples/bmp280/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/bmp280/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# BMP280 Barometer sensor example built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_BMP280_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_BMP280_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_BMP280_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_BMP280)
+
+# BMP280 Barometer sensor example
+
+MAINSRC = bmp280_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/bmp280/bmp280_main.c
+++ b/examples/bmp280/bmp280_main.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * apps/examples/bmp280/bmp280_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <nuttx/sensors/sensor.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * bmp280_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int fd;
+  int ret;
+  struct sensor_baro sensor_data;
+
+  fd = open("/dev/uorb/sensor_baro0", O_RDONLY | O_NONBLOCK);
+  if (fd < 0)
+    {
+      printf("Failed to open BMP280 sensor");
+      return EXIT_FAILURE;
+    }
+
+  ret = read(fd, &sensor_data, sizeof(sensor_data));
+  if (ret != sizeof(sensor_data))
+    {
+      perror("Could not read");
+      return EXIT_FAILURE;
+    }
+
+  printf("Absolute pressure [hPa] = %f\n", sensor_data.pressure);
+  printf("Temperature [C] = %f\n", sensor_data.temperature);
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
Added BMP280 example to apps.
Currently, there is a BMP180/280 example which reads from _/dev/press0_. It is not compatible with BMP280 since the driver binds to _/dev/uorb/sensor_baro0_.

## Impact
New example add to apps/example.

## Testing
Tested on the BMP280 I2C sensor using a Tiva TM4C board. No issues noticed.
