### PR TITLE
ostest: rwlock need to be destroy

### DIFF
--- a/testing/ostest/pthread_rwlock_cancel.c
+++ b/testing/ostest/pthread_rwlock_cancel.c
@@ -257,6 +257,9 @@ static void test_timeout(void)
     }
 #endif /* CONFIG_CANCELLATION_POINTS */
 #endif /* CONFIG_PTHREAD_CLEANUP */
+
+    pthread_rwlock_destroy(&write_lock);
+    pthread_rwlock_destroy(&read_lock);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
rwlock need to be destroy

## Impact
none

## Testing
ostest
