### PR TITLE
Fix MQTTC to wait for connection (MQTT ACK)

### DIFF
--- a/examples/mqttc/mqttc_pub.c
+++ b/examples/mqttc/mqttc_pub.c
@@ -212,6 +212,7 @@ static int initserver(FAR const struct mqttc_cfg_s *cfg)
 int main(int argc, FAR char *argv[])
 {
   int sockfd;
+  int timeout = 100;
   enum MQTTErrors mqtterr;
   pthread_t thrdid;
   int n = 1;
@@ -278,10 +279,22 @@ int main(int argc, FAR char *argv[])
       goto err_with_socket;
     }
 
+  /* Wait for MQTT ACK or time-out */
+
+  while (!mqtt_cfg.client.event_connect && --timeout > 0)
+    {
+     usleep(10000);
+    }
+
+  if (timeout == 0)
+    {
+      goto err_with_thrd;
+    }
+
   while (n--)
     {
       mqtterr = mqtt_publish(&mqtt_cfg.client, mqtt_cfg.topic,
-                             mqtt_cfg.msg, strlen(mqtt_cfg.msg) + 1,
+                             mqtt_cfg.msg, strlen(mqtt_cfg.msg),
                              mqtt_cfg.qos);
       if (mqtterr != MQTT_OK)
         {

--- a/netutils/mqttc/0001_add_connection_status.patch
+++ b/netutils/mqttc/0001_add_connection_status.patch
@@ -1,0 +1,66 @@
+diff -Naur MQTT-C_orig/include/mqtt.h MQTT-C/include/mqtt.h
+--- MQTT-C_orig/include/mqtt.h	2021-03-29 14:53:52.000000000 -0300
++++ MQTT-C/include/mqtt.h	2023-05-13 09:52:45.704346335 -0300
+@@ -1233,6 +1233,9 @@
+ 
+     /** @brief The sending message queue. */
+     struct mqtt_message_queue mq;
++
++    /** @brief Flag is set on connection event */
++    bool event_connect;
+ };
+ 
+ /**
+diff -Naur MQTT-C_orig/src/mqtt.c MQTT-C/src/mqtt.c
+--- MQTT-C_orig/src/mqtt.c	2021-03-29 14:53:52.000000000 -0300
++++ MQTT-C/src/mqtt.c	2023-05-13 10:00:36.725165859 -0300
+@@ -118,6 +118,10 @@
+ 
+     client->socketfd = sockfd;
+ 
++    /* Indicate we are not connected yet */
++
++    client->event_connect = false;
++
+     mqtt_mq_init(&client->mq, sendbuf, sendbufsz);
+ 
+     client->recv_buffer.mem_start = recvbuf;
+@@ -151,6 +155,10 @@
+ 
+     client->socketfd = (mqtt_pal_socket_handle) -1;
+ 
++    /* Indicate we are not connected yet */
++
++    client->event_connect = false;
++
+     mqtt_mq_init(&client->mq, NULL, 0);
+ 
+     client->recv_buffer.mem_start = NULL;
+@@ -179,6 +187,10 @@
+     client->error = MQTT_ERROR_CONNECT_NOT_CALLED;
+     client->socketfd = socketfd;
+ 
++    /* Indicate we are not connected yet */
++
++    client->event_connect = false;
++
+     mqtt_mq_init(&client->mq, sendbuf, sendbufsz);
+ 
+     client->recv_buffer.mem_start = recvbuf;
+@@ -592,6 +604,7 @@
+         case MQTT_CONTROL_PUBCOMP:
+         case MQTT_CONTROL_DISCONNECT:
+             msg->state = MQTT_QUEUED_COMPLETE;
++            client->event_connect = false;
+             break;
+         case MQTT_CONTROL_PUBLISH:
+             inspected = ( MQTT_PUBLISH_QOS_MASK & (msg->start[0]) ) >> 1; /* qos */
+@@ -732,6 +745,8 @@
+                         mqtt_recv_ret = MQTT_ERROR_CONNECTION_REFUSED;
+                     }
+                     break;
++                } else {
++                    client->event_connect = true;
+                 }
+                 break;
+             case MQTT_CONTROL_PUBLISH:

--- a/netutils/mqttc/Makefile
+++ b/netutils/mqttc/Makefile
@@ -37,6 +37,8 @@ $(MQTTC_TARBALL):
 $(MQTTC_UNPACK): $(MQTTC_TARBALL)
 	$(Q) tar zxf $(MQTTC_TARBALL)
 	$(Q) mv MQTT-C-$(MQTTC_VERSION) $(MQTTC_UNPACK)
+	$(Q) echo "Patching $(MQTTC_UNPACK)"
+	$(Q) cat 0001_add_connection_status.patch | patch -s -N -d $(MQTTC_UNPACK) -p1
 	$(Q) touch $(MQTTC_UNPACK)
 
 # Download and unpack tarball if no git repo found


### PR DESCRIPTION
## Summary
Fix MQTTC to wait for connection (MQTT ACK) and avoid passing '\0' in the payload
## Impact
Users will get MQTTC example working with other MQTT Brokers like TagoIO
## Testing
ESP32-Devkitc sending data to TagoIO
