### PR TITLE
telnetd/Kconfig: cosmetic change

### DIFF
--- a/system/telnetd/Kconfig
+++ b/system/telnetd/Kconfig
@@ -10,10 +10,11 @@ config SYSTEM_TELNETD
 	---help---
 		Enable the Telnet daemon application
 
+if SYSTEM_TELNETD
+
 config SYSTEM_TELNETD_PROGNAME
 	string "Telnetd program name"
 	default "telnetd"
-	depends on SYSTEM_TELNETD
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.
@@ -21,12 +22,10 @@ config SYSTEM_TELNETD_PROGNAME
 config SYSTEM_TELNETD_PRIORITY
 	int "Telnetd task priority"
 	default 100
-	depends on SYSTEM_TELNETD
 
 config SYSTEM_TELNETD_STACKSIZE
 	int "Telnetd task stack size"
 	default DEFAULT_TASK_STACKSIZE
-	depends on SYSTEM_TELNETD
 
 config SYSTEM_TELNETD_PORT
 	int "Telnetd port number"
@@ -38,9 +37,9 @@ config SYSTEM_TELNETD_PORT
 config SYSTEM_TELNETD_SESSION_PRIORITY
 	int "Telnetd session task priority"
 	default 100
-	depends on SYSTEM_TELNETD
 
 config SYSTEM_TELNETD_SESSION_STACKSIZE
 	int "Telnetd session task stack size"
 	default 3072
-	depends on SYSTEM_TELNETD
+
+endif # SYSTEM_TELNETD


### PR DESCRIPTION
## Summary
telnetd/Kconfig: cosmetic change

## Impact
With this change `# CONFIG_SYSTEM_TELNETD_PORT is not set` will not be present in the generated `.config` file if telnetd is disabled.

## Testing
CI