### PR TITLE
examples/foc: various improvements

### DIFF
--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
   if (ret < 0)
     {
       PRINTF("ERROR: validate args failed\n");
-      goto errout_no_mutex;
+      goto errout_no_threads;
     }
 
 #ifndef CONFIG_NSH_ARCHINIT
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
   if (ret < 0)
     {
       PRINTF("ERROR: failed to initialize threads %d\n", ret);
-      goto errout_no_mutex;
+      goto errout_no_intf;
     }
 
   /* Initialize control interface */
@@ -450,6 +450,16 @@ int main(int argc, char *argv[])
 
 errout:
 
+  /* De-initialize control interface */
+
+  ret = foc_intf_deinit();
+  if (ret < 0)
+    {
+      PRINTF("ERROR: foc_inf_deinit failed %d\n", ret);
+    }
+
+errout_no_intf:
+
   /* Stop FOC control threads */
 
   for (i = 0; i < CONFIG_MOTOR_FOC_INST; i += 1)
@@ -491,17 +501,11 @@ errout:
         }
     }
 
-  /* De-initialize control interface */
+  /* De-initialize control threads */
 
-  ret = foc_intf_deinit();
-  if (ret < 0)
-    {
-      PRINTF("ERROR: foc_inf_deinit failed %d\n", ret);
-      goto errout;
-    }
-
-errout_no_mutex:
   foc_threads_deinit();
+
+errout_no_threads:
 
   PRINTF("foc_main exit\n");
   return 0;

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -1046,6 +1046,39 @@ int foc_motor_deinit(FAR struct foc_motor_b16_s *motor)
 
   DEBUGASSERT(motor);
 
+  #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
+  /* Deinitialzie open-loop handler */
+
+  ret = foc_angle_deinit_b16(&motor->openloop);
+  if (ret < 0)
+    {
+      PRINTFV("ERROR: foc_angle_deinit_b16 failed %d!\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_QENCO
+  /* Deinitialzie qenco handler */
+
+  ret = foc_angle_deinit_b16(&motor->qenco);
+  if (ret < 0)
+    {
+      PRINTFV("ERROR: foc_angle_deinit_b16 failed %d!\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_HALL
+  /* Deinitialzie hall handler */
+
+  ret = foc_angle_deinit_b16(&motor->hall);
+  if (ret < 0)
+    {
+      PRINTFV("ERROR: foc_angle_deinit_b16 failed %d!\n", ret);
+      goto errout;
+    }
+#endif
+
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
   /* Deinitialize motor alignment routine */
 
@@ -1058,7 +1091,7 @@ int foc_motor_deinit(FAR struct foc_motor_b16_s *motor)
 #endif
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
-  /* Deinitialize motor identment routine */
+  /* Deinitialize motor identification routine */
 
   ret = foc_routine_deinit_b16(&motor->ident);
   if (ret < 0)

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -531,6 +531,7 @@ static int foc_motor_setpoint(FAR struct foc_motor_f32_s *motor, uint32_t sp)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
       case FOC_MMODE_IDENT_ONLY:
 #endif
+      case FOC_MMODE_IDLE:
         {
           /* Do nothing */
 
@@ -1005,6 +1006,11 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
     }
   else
 #endif
+  if (motor->envp->cfg->mmode == FOC_MMODE_IDLE)
+    {
+      motor->ctrl_state = FOC_CTRL_STATE_IDLE;
+    }
+  else
     {
       motor->ctrl_state = FOC_CTRL_STATE_INIT;
     }

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -1033,6 +1033,39 @@ int foc_motor_deinit(FAR struct foc_motor_f32_s *motor)
 
   DEBUGASSERT(motor);
 
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
+  /* Deinitialzie open-loop handler */
+
+  ret = foc_angle_deinit_f32(&motor->openloop);
+  if (ret < 0)
+    {
+      PRINTFV("ERROR: foc_angle_deinit_f32 failed %d!\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_QENCO
+  /* Deinitialzie qenco handler */
+
+  ret = foc_angle_deinit_f32(&motor->qenco);
+  if (ret < 0)
+    {
+      PRINTFV("ERROR: foc_angle_deinit_f32 failed %d!\n", ret);
+      goto errout;
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_HALL
+  /* Deinitialzie hall handler */
+
+  ret = foc_angle_deinit_f32(&motor->hall);
+  if (ret < 0)
+    {
+      PRINTFV("ERROR: foc_angle_deinit_f32 failed %d!\n", ret);
+      goto errout;
+    }
+#endif
+
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
   /* Deinitialize motor alignment routine */
 
@@ -1045,7 +1078,7 @@ int foc_motor_deinit(FAR struct foc_motor_f32_s *motor)
 #endif
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
-  /* Deinitialize motor identment routine */
+  /* Deinitialize motor identification routine */
 
   ret = foc_routine_deinit_f32(&motor->ident);
   if (ret < 0)

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -113,6 +113,7 @@ static void foc_help(void)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
   PRINTF("       5 - ident only\n");
 #endif
+  PRINTF("       6 - IDLE state\n");
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
   PRINTF("  [-r] torque [x1000]\n");
@@ -343,23 +344,23 @@ int validate_args(FAR struct args_s *args)
 
   /* Example control mode */
 
-  if (
+  if (args->cfg.mmode != FOC_MMODE_IDLE &&
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-    args->cfg.mmode != FOC_MMODE_TORQ &&
+      args->cfg.mmode != FOC_MMODE_TORQ &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
-    args->cfg.mmode != FOC_MMODE_VEL &&
+      args->cfg.mmode != FOC_MMODE_VEL &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
-    args->cfg.mmode != FOC_MMODE_POS &&
+      args->cfg.mmode != FOC_MMODE_POS &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_ALIGN
-    args->cfg.mmode != FOC_MMODE_ALIGN_ONLY &&
+      args->cfg.mmode != FOC_MMODE_ALIGN_ONLY &&
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
-    args->cfg.mmode != FOC_MMODE_IDENT_ONLY &&
+      args->cfg.mmode != FOC_MMODE_IDENT_ONLY &&
 #endif
-    1)
+      1)
     {
       PRINTF("Invalid ctrl mode value %d s\n", args->cfg.mmode);
       goto errout;

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 
+#include <stdint.h>
 #include <pthread.h>
 #include <mqueue.h>
 
@@ -124,6 +125,7 @@ struct foc_ctrl_env_s
 int foc_threads_init(void);
 void foc_threads_deinit(void);
 bool foc_threads_terminated(void);
+uint32_t foc_threads_get(void);
 int foc_ctrlthr_init(FAR struct foc_ctrl_env_s *foc, int i, FAR mqd_t *mqd,
                      FAR pthread_t *thread);
 

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -79,6 +79,7 @@ enum foc_motor_mode_e
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
   FOC_MMODE_IDENT_ONLY = 5,  /* Motor identification only */
 #endif
+  FOC_MMODE_IDLE       = 6,  /* IDLE state */
 };
 
 /* Controller state */


### PR DESCRIPTION
## Summary

- examples/foc: add controller IDLE mode - useful for testing purposes
- examples/foc/foc_main.c: fix de-initialization sequence
- examples/foc: send messages only to active control threads
- examples/foc: add missing deinit calls

## Impact

## Testing
CI
