### PR TITLE
logging/nxscope: various improvements

### DIFF
--- a/include/logging/nxscope/nxscope.h
+++ b/include/logging/nxscope/nxscope.h
@@ -360,6 +360,7 @@ struct nxscope_s
   FAR uint8_t                 *streambuf;
   size_t                       streambuf_len;
   size_t                       stream_i;
+  bool                         stream_retry;
 
 #ifdef CONFIG_LOGGING_NXSCOPE_CRICHANNELS
   /* Critical buffer data */

--- a/logging/nxscope/Kconfig
+++ b/logging/nxscope/Kconfig
@@ -52,4 +52,12 @@ config LOGGING_NXSCOPE_CRICHANNELS
 	---help---
 		Enable the support for non-buffered critical channels
 
+config LOGGING_NXSCOPE_DISABLE_PUTLOCK
+	bool "NxScope disable lock in channels put interfaces"
+	default n
+	---help---
+		This option disables lock in channels put interfaces.
+		In that case, the user is responsible for ensuring
+		thread-safe operations with nxscope_lock/nxscope_unlock functions.
+
 endif # LOGGING_NXSCOPE

--- a/logging/nxscope/nxscope.c
+++ b/logging/nxscope/nxscope.c
@@ -809,7 +809,7 @@ int nxscope_init(FAR struct nxscope_s *s, FAR struct nxscope_cfg_s *cfg)
   DEBUGASSERT(cfg->rxbuf_len > 0);
   s->rxbuf_len = cfg->rxbuf_len;
 
-  s->rxbuf = zalloc(s->chinfo_size);
+  s->rxbuf = zalloc(s->rxbuf_len);
   if (s->rxbuf == NULL)
     {
       ret = -errno;

--- a/logging/nxscope/nxscope_chan.c
+++ b/logging/nxscope/nxscope_chan.c
@@ -457,7 +457,9 @@ static int nxscope_put_common_m(FAR struct nxscope_s *s, uint8_t type,
 
   DEBUGASSERT(s);
 
+#ifndef CONFIG_LOGGING_NXSCOPE_DISABLE_PUTLOCK
   nxscope_lock(s);
+#endif
 
   /* Validate data */
 
@@ -506,7 +508,9 @@ static int nxscope_put_common_m(FAR struct nxscope_s *s, uint8_t type,
 #endif
 
 errout:
+#ifndef CONFIG_LOGGING_NXSCOPE_DISABLE_PUTLOCK
   nxscope_unlock(s);
+#endif
 
   return ret;
 }

--- a/logging/nxscope/nxscope_internals.c
+++ b/logging/nxscope/nxscope_internals.c
@@ -61,12 +61,15 @@ int nxscope_stream_send(FAR struct nxscope_s *s, FAR uint8_t *buff,
 
   /* Finalize stream frame */
 
-  ret = PROTO_FRAME_FINAL(s, s->proto_stream,
-                          NXSCOPE_HDRID_STREAM, buff, buff_i);
-  if (ret < 0)
+  if (!s->stream_retry)
     {
-      _err("ERROR: PROTO_FRAME_FINAL failed %d\n", ret);
-      goto errout;
+      ret = PROTO_FRAME_FINAL(s, s->proto_stream,
+                              NXSCOPE_HDRID_STREAM, buff, buff_i);
+      if (ret < 0)
+        {
+          _err("ERROR: PROTO_FRAME_FINAL failed %d\n", ret);
+          goto errout;
+        }
     }
 
   /* Send stream data */
@@ -75,6 +78,11 @@ int nxscope_stream_send(FAR struct nxscope_s *s, FAR uint8_t *buff,
   if (ret < 0)
     {
       _err("ERROR: INTF_SEND failed %d\n", ret);
+      s->stream_retry = true;
+    }
+  else
+    {
+      s->stream_retry = false;
     }
 
 errout:


### PR DESCRIPTION
## Summary

- logging/nxscope: fix invalid zalloc size for rxbuf
- logging/nxscope: add an option to disable lock in channels put interfaces
    
    With this option enabled the user can speed up adding a large amount of data to the stream buffer
    by minimizing the usage of the nxscope lock interface:
    
      nxscope_lock(&nxs->nxs);
      nxscope_put_vfloat(&nxs, 0, data0, 1);
      nxscope_put_vfloat(&nxs, 1, data1, 1);
      nxscope_put_vfloat(&nxs, 2, data2, 1);
      nxscope_put_vfloat(&nxs, 3, data3, 1);
      nxscope_unlock(&nxs->nxs);

-  logging/nxscope: do not complete the stream frame if the previous send failed.    
    In this case, the buffer already contains a frame ready to be send

## Impact

## Testing
examples/foc with enabled nxscope logging (not yet upstream)
