### PR TITLE
nshlib: Add support for disabling echoback

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -70,6 +70,12 @@ config NSH_PROMPT_STRING
 	---help---
 		Provide the shell prompt string, default is "nsh> ".
 
+config NSH_DISABLE_ECHOBACK
+	bool "Disable echoback"
+	default n
+	---help---
+		If this option is selected, the NSH disables echoback.
+
 choice
 	prompt "Command Line Editor"
 	default NSH_READLINE if DEFAULT_SMALL

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <termios.h>
 
 #ifdef CONFIG_NSH_CLE
 #  include "system/cle.h"
@@ -168,6 +169,21 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 #endif
         }
     }
+
+#ifdef CONFIG_NSH_DISABLE_ECHOBACK
+  /* Disable echoback */
+
+  if (isatty(INFD(pstate)))
+    {
+      struct termios cfg;
+
+      if (tcgetattr(INFD(pstate), &cfg) == 0)
+        {
+          cfg.c_lflag &= ~ECHO;
+          tcsetattr(INFD(pstate), TCSANOW, &cfg);
+        }
+    }
+#endif
 
   /* Then enter the command line parsing loop */
 


### PR DESCRIPTION
## Summary

If ```CONFIG_NSH_DISABLE_ECHOBACK``` is selected, the NSH disables echoback prompt.
I needed this changes to use ```nsh``` like a AT-command based modem.