### PR TITLE
nshlib: fix memory leak found out by -fanalyzer 

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -391,7 +391,7 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   ret = dd_infopen(infile, &dd);
   if (ret < 0)
     {
-      goto errout_with_paths;
+      goto errout_with_alloc;
     }
 
   /* Open the output file */
@@ -475,6 +475,8 @@ errout_with_outf:
 
 errout_with_inf:
   close(dd.infd);
+
+errout_with_alloc:
   free(dd.buffer);
 
 errout_with_paths:


### PR DESCRIPTION
## Summary

nshlib: fix memory leak found out by -fanalyzer 

```bash
nsh_ddcmd.c: In function ‘cmd_dd’:
nsh_ddcmd.c:492:1: warning: leak of ‘dd.buffer’ [CWE-401] [-Wanalyzer-malloc-leak]
  492 | }
      | ^
  ‘cmd_dd’: events 1-14
    |
    |  294 | int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
    |      |     ^~~~~~
    |      |     |
    |      |     (1) entry to ‘cmd_dd’
    |......
    |  334 |   for (i = 1; i < argc; i++)
    |      |               ~~~~~~~~
    |      |                 |
    |      |                 (2) following ‘true’ branch (when ‘i < argc’)...
    |  335 |     {
    |  336 |       if (strncmp(argv[i], "if=", 3) == 0)
    |      |          ~            ~
    |      |          |            |
    |      |          |            (3) ...to here
    |      |          (4) following ‘true’ branch...
    |  337 |         {
    |  338 |           if (infile != NULL)
    |      |              ~
    |      |              |
    |      |              (5) ...to here
    |      |              (6) following ‘false’ branch (when ‘infile’ is NULL)...
    |......
    |  343 |           infile = nsh_getfullpath(vtbl, &argv[i][3]);
    |      |                                           ~~~~~~~
    |      |                                               |
    |      |                                               (7) ...to here
    |......
    |  373 |   if (infile == NULL || outfile == NULL)
    |      |      ~
    |      |      |
    |      |      (8) following ‘false’ branch...
    |......
    |  382 |   dd.buffer = malloc(dd.sectsize);
    |      |               ~~~~~~~~~~~~~~~~~~~
    |      |               |        |
    |      |               |        (9) ...to here
    |      |               (10) allocated here
    |  383 |   if (!dd.buffer)
    |      |      ~
    |      |      |
    |      |      (11) assuming ‘dd.buffer’ is non-NULL
    |      |      (12) following ‘false’ branch...
    |......
    |  391 |   ret = dd_infopen(infile, &dd);
    |      |         ~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (13) ...to here
    |      |         (14) calling ‘dd_infopen’ from ‘cmd_dd’
    |
    +--> ‘dd_infopen’: events 15-17
           |
           |  158 | static inline int dd_infopen(FAR const char *name, FAR struct dd_s *dd)
           |      |                   ^~~~~~~~~~
           |      |                   |
           |      |                   (15) entry to ‘dd_infopen’
           |......
           |  161 |   if (dd->infd < 0)
           |      |      ~             
           |      |      |
           |      |      (16) following ‘true’ branch...
           |  162 |     {
           |  163 |       FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
           |      |                              ~~~~
           |      |                              |
           |      |                              (17) ...to here
           |
    <------+
    |
  ‘cmd_dd’: events 18-25
    |
    |  391 |   ret = dd_infopen(infile, &dd);
    |      |         ^~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (18) returning to ‘cmd_dd’ from ‘dd_infopen’
    |  392 |   if (ret < 0)
    |      |      ~   
    |      |      |
    |      |      (19) following ‘true’ branch (when ‘ret < 0’)...
    |  393 |     {
    |  394 |       goto errout_with_paths;
    |      |       ~~~~
    |      |       |
    |      |       (20) ...to here
    |......
    |  481 |   if (infile)
    |      |      ~   
    |      |      |
    |      |      (21) following ‘true’ branch (when ‘infile’ is non-NULL)...
    |  482 |     {
    |  483 |       nsh_freefullpath(infile);
    |      |       ~~~~~~~~~~~~~~~~~~~~~~~~
    |      |       |
    |      |       (22) ...to here
    |......
    |  486 |   if (outfile)
    |      |      ~   
    |      |      |
    |      |      (23) following ‘false’ branch (when ‘outfile’ is NULL)...
    |......
    |  491 |   return ret;
    |      |          ~~~
    |      |          |
    |      |          (24) ...to here
    |  492 | }
    |      | ~        
    |      | |
    |      | (25) ‘dd.buffer’ leaks here; was allocated at (10)
    |

```

## Impact

N/A

## Testing

