### PR TITLE
CI: set-output command is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
             esac
           fi
 
-          echo ::set-output name=os_ref::$OS_REF
-          echo ::set-output name=apps_ref::$APPS_REF
+          echo "name=$OS_REF" >> $GITHUB_OUTPUT
+          echo "app_ref=$APPS_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout nuttx repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
CI currently runs with the warning:

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The is the apps version of https://github.com/apache/nuttx/pull/9289

## Testing
Passing CI should be sufficient to verify we are still pulling the correct source references for the two repos.
