### PR TITLE
tools: Disable wasm build if toolchain not found

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -268,4 +268,8 @@ distclean:: clean
 
 WASM_BUILD ?= n
 
-include $(APPDIR)/tools/Wasm.mk
+ifeq ($(WASM_BUILD),y)
+	ifneq ($(CONFIG_INTERPRETERS_WAMR)$(CONFIG_INTERPRETERS_WASM)$(CONFIG_INTERPRETERS_TOYWASM),)
+		include $(APPDIR)/tools/Wasm.mk
+	endif
+endif


### PR DESCRIPTION
## Summary
tools: Disable wasm build if toolchain not found

Fix #1751 
## Impact
wasm build only
## Testing
CI and local machine