### PR TITLE
support memdump can dump by seq number

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -224,7 +224,8 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifdef CONFIG_DEBUG_MM
 # ifndef CONFIG_NSH_DISABLE_MEMDUMP
-  { "memdump",  cmd_memdump,  1, 3, "[pid/used/free/on/off]" },
+  { "memdump",  cmd_memdump,  1, 4, "[pid/used/free/on/off]"
+                                    " <minseq> <maxseq>"},
 # endif
 #endif
 

--- a/nshlib/nsh_mmcmds.c
+++ b/nshlib/nsh_mmcmds.c
@@ -56,11 +56,20 @@ int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
 int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  FAR const char *arg = "used";
+  char arg[CONFIG_NSH_LINELEN] = "";
+  int i;
 
-  if (argc > 1)
+  if (argc == 1)
     {
-      arg = argv[1];
+      strlcpy(arg, "used", CONFIG_NSH_LINELEN);
+    }
+  else
+    {
+      for (i = 1; i < argc; i++)
+        {
+          strlcat(arg, argv[i], CONFIG_NSH_LINELEN);
+          strlcat(arg, " ", CONFIG_NSH_LINELEN);
+        }
     }
 
   return nsh_writefile(vtbl, argv[0], arg, strlen(arg),


### PR DESCRIPTION
## Summary
support memdump can dump by seq number
## Impact
memdump
## Testing
nsh with mm_backtrace = 8
