### PR TITLE
netlib: set addr.sin_zero to 0 in netlib_set_ipv4dnsaddr

### DIFF
--- a/netutils/netlib/netlib_setipv4dnsaddr.c
+++ b/netutils/netlib/netlib_setipv4dnsaddr.c
@@ -68,6 +68,7 @@ int netlib_set_ipv4dnsaddr(FAR const struct in_addr *inaddr)
       addr.sin_family = AF_INET;
       addr.sin_port   = 0;
       memcpy(&addr.sin_addr, inaddr, sizeof(struct in_addr));
+      bzero(&addr.sin_zero, sizeof(addr.sin_zero));
 
       ret = dns_add_nameserver((FAR const struct sockaddr *)&addr,
                                sizeof(struct sockaddr_in));


### PR DESCRIPTION
## Summary
In `dns_add_nameserver`, the `dns_check_nameserver` is comparing addresses with `addrlen = sizeof(struct sockaddr_in)` for IPv4 addresses, so the trailing `sin_zero` field should be `0`, otherwise it may fail to figure out same nameserver address.

## Impact

## Testing

