### PR TITLE
ostest/cond_test: cond and mutex need to be destroyed

### DIFF
--- a/testing/ostest/cond.c
+++ b/testing/ostest/cond.c
@@ -348,6 +348,8 @@ void cond_test(void)
   printf("cond_test: signaler terminated, now cancel the waiter\n");
   pthread_detach(waiter);
   pthread_cancel(waiter);
+  pthread_cond_destroy(&cond);
+  pthread_mutex_destroy(&mutex);
   sem_destroy(&sem_thread_started);
 
   printf("cond_test: \tWaiter\tSignaler\n");


### PR DESCRIPTION
## Summary
cond and mutex need to be destroyed
## Impact
none
## Testing
ostest
