### PR TITLE
system/coredump: add coredump tool to capture system status

### DIFF
--- a/system/coredump/Kconfig
+++ b/system/coredump/Kconfig
@@ -1,0 +1,25 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig SYSTEM_COREDUMP
+	tristate "Coredump tool capture system status"
+	default n
+	depends on ELF_COREDUMP
+
+if SYSTEM_COREDUMP
+
+config SYSTEM_COREDUMP_STACKSIZE
+	int "coredump stack size"
+	default DEFAULT_TASK_STACKSIZE
+	---help---
+		This is the stack size that will be used when starting the coredump.
+
+config SYSTEM_COREDUMP_PRIORITY
+	int "coredump priority"
+	default 100
+	---help---
+		This is the task priority that will be used when starting the coredump.
+
+endif # SYSTEM_COREDUMP

--- a/system/coredump/Make.defs
+++ b/system/coredump/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/coredump/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_COREDUMP),)
+CONFIGURED_APPS += $(APPDIR)/system/coredump
+endif

--- a/system/coredump/Makefile
+++ b/system/coredump/Makefile
@@ -1,0 +1,30 @@
+############################################################################
+# apps/system/coredump/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+MAINSRC = coredump.c
+
+PROGNAME = coredump
+PRIORITY = $(CONFIG_SYSTEM_COREDUMP_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_COREDUMP_STACKSIZE)
+MODULE = $(CONFIG_SYSTEM_COREDUMP)
+
+include $(APPDIR)/Application.mk

--- a/system/coredump/coredump.c
+++ b/system/coredump/coredump.c
@@ -1,0 +1,149 @@
+/****************************************************************************
+ * apps/system/coredump/coredump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/streams.h>
+#include <nuttx/binfmt/binfmt.h>
+
+#include <sys/types.h>
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <syslog.h>
+
+#include <execinfo.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * coredump_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  FAR struct lib_stdoutstream_s *outstream;
+  FAR struct lib_hexdumpstream_s *hstream;
+  FAR struct lib_lzfoutstream_s *lstream;
+  char *name = NULL;
+  FAR void *stream;
+  int logmask;
+  int pid = 0;
+  FILE *file;
+
+  if (argc >= 2)
+    {
+      pid = atoi(argv[1]);
+      if (pid == 0)
+        {
+          name = argv[1];
+        }
+
+      if (argc >= 3)
+        {
+          if (name == NULL)
+            {
+              name = argv[2];
+            }
+          else
+            {
+              pid = atoi(argv[2]);
+            }
+        }
+    }
+
+  if (pid == 0)
+    {
+      pid = INVALID_PROCESS_ID;
+    }
+
+  if (name != NULL)
+    {
+      file = fopen(name, "w");
+      if (file == NULL)
+        {
+          return 1;
+        }
+    }
+  else
+    {
+      file = stdout;
+    }
+
+  hstream = malloc(sizeof(*hstream) + sizeof(*lstream) + sizeof(*outstream));
+  if (hstream == NULL)
+    {
+      if (name != NULL)
+        {
+          fclose(file);
+        }
+
+      return 1;
+    }
+
+  lstream = (FAR void *)(hstream + 1);
+  outstream = (FAR void *)(lstream + 1);
+
+  logmask = setlogmask(LOG_ALERT);
+
+  printf("Start coredump:\n");
+
+  /* Initialize hex output stream */
+
+  lib_stdoutstream(outstream, file);
+  lib_hexdumpstream(hstream, (FAR void *)outstream);
+
+  stream = hstream;
+
+#ifdef CONFIG_BOARD_COREDUMP_COMPRESSION
+
+  /* Initialize LZF compression stream */
+
+  lib_lzfoutstream(lstream, stream);
+  stream = lstream;
+
+#endif
+
+  /* Do core dump */
+
+  core_dump(NULL, stream, pid);
+
+#ifdef CONFIG_BOARD_COREDUMP_COMPRESSION
+  printf("Finish coredump (Compression Enabled).\n");
+#else
+  printf("Finish coredump.\n");
+#endif
+
+  setlogmask(logmask);
+
+  free(hstream);
+
+  if (name != NULL)
+    {
+      fclose(file);
+    }
+
+  return 0;
+}


### PR DESCRIPTION

![Screenshot from 2023-05-24 14-38-21](https://github.com/apache/nuttx-apps/assets/758493/700171ae-f853-4040-8440-b462db20a67a)

## Summary

sabre-6quad/coredump: add coredump config to enable ci check
tools/coredump: add coredump python parser
sched/misc: add coredump support on assert
elf/coredump: add support of dump task stack without memory segments
stream/hexdump: add hexdump stream to dump binary to syslog

1. Build config coredump:
    
```
      $ ./tools/configure.sh ./boards/arm/imx6/sabre-6quad/configs/coredump
      $ make
```
    
2. Run qemu and get the coredump snapshot:
    
```bash
      $ qemu-system-arm -semihosting -M sabrelite -m 1024 -smp 4 -nographic -kernel ./nuttx -s
      ABCDGHIJKNOPQ
    
      NuttShell (NSH) NuttX-10.4.0
      nsh> coredump
      [CPU0] [ 6] Start coredump:
      [CPU0] [ 6] 5A5601013D03FF077F454C4601010100C0000304002800C00D003420036000070400053400200008200A4000000420030034C024200001D8092004E00200601A
      [CPU0] [ 6] 060C0000E85D831040030018200E400300072003403C601F06100000F8518310400340574003E0041F00142003025683106003A000E0081F005A201B4003A000
      [CPU0] [ 6] E0071F03987F831040030060200E4003E0041F209003288A8310400300B820104003E0041F061C0000D09283104003609C2003C01F00202006007C2003000320
      [CPU0] [ 6] 0308435055302049444C45200BE02700E0333BE01B0040A70094200340CFE0576BE0070040730006200340000424A782101420030474A482102020074137400B
      [CPU0] [ 6] 0030200B4027422309F51880108E8A80107F0161AA600040BFE102670031E01FBF4053E00300E0233BE02B0040A7E10267E02C6B403BE05700436B019319A167
      [CPU0] [ 6] 200F20005A560100A703FF010000200000202003007C20030003200308435055322049444C45200BE0170000022003E00300E0233BE02B0040A7009420030001
      [CPU0] [ 6] 2003E02F6BE007B3E04C00025683102005E0080040BFE102670033E01FBF402FE00300E0233BE02B0040A7E10267E02C6BE007B3E04C00005AE1196706687077
      [CPU0] [ 6] 6F726B00E01CBF00042003E00300A03BE0500040A7C167A06BE01CA7E00300E007B3E0170042FF05BC748310785C213B00005A560100F303FF0A000074A48210
      [CPU0] [ 6] 38748310242007010100E00D0008987F8310998C8010A4200303FF000020201260004008007C200300032003076E73685F6D61696E200AE0180000052003E003
      [CPU0] [ 6] 00E0233BE02B0040A70094200340DFE02F6BE007B3E0170000022003078480831088998310200A0200F08E2007200FC1674003400004CC8A8310042007006420
      [CPU0] [ 6] 030028200BE1176707636F726564756D70200AE0180000062003E00300E0233BE02B0040A7C167E02F6BE007B3E017000BDC458310E0988310780A0000415B03
      [CPU0] [ 6] 6C9A8310416B408B4133408F01788F217BA000405F00B0202F02EB21816003035F0000602012E0EB000100005A5601002103FF0E000000005E831000A27C3F00
      [CPU0] [ 6] 005080200DE0FF00E0FF00E0FF00E0CA000100005A5601001203FF010000E0FF00E0FF00E0FF00E0DA000100005A5601005403FF01000020000838748310D037
      [CPU0] [ 6] 8310DF200B0487328010C8200B400F400720120000400B00AB2017005F200B04432B80101520030002200B0101012004E00600028137806033E0FF00E0FF00E0
      [CPU0] [ 6] FF00E083000100005A560100F203FF010000600007808310BC8F8310DF200A088732801084FFFFFFA0200F0006200F04848A83105F200704E92D8110F1200340
      [CPU0] [ 6] 1303108C8310202200FF200A0900988E8310FD248010F7A01B061BD3801054AC826033C0004023403304CDD2801001200FE00300030FA2801020061200C15080
      [CPU0] [ 6] 103081821089678010A18E8310B35CE0092B400F0333EC8010404F4003200EE0640040C34003407B0D08F781107F7B801071F28010A99480C340000291938060
      [CPU0] [ 6] 2340AB4003400B05A1928010F883E005AF01F99080DF40174003009DA00F00642003400F0071A00F013F692063200B018D37E00163E0FF00E0FF00E02E000100
      [CPU0] [ 6] 005A5601003A03FF010000600003589083102006E0080001F092801707636F726564756D70200A600003EFBEADDEE0FF03E0FF03E0FF03E01B032342E07A0001
      [CPU0] [ 6] 00005A560101C003FF010000E095000BF08E83100927801054AC8210400B201201005F2003400BE00717E0CB0040DBE007E7E00FFF40170055200F0043201720
      [CPU0] [ 6] 0A6023401F4017400006111D8010207183600F047D40831018200B4023E003470794818210D91A8010E0174701E43FE00173403306F49A8310DF4C8160170448
      [CPU0] [ 6] 99831041201704CE1F841002200704CD3F81100C2007049D34811040201B200A05002EF781106C200B008D200B001D201F05893E81107978806F000A200300D8
      [CPU0] [ 6] 204F01D57B800F00882027400300F1E0020F009F202B40434027C06B122F798010789B8310F803000008040000C89683600F04277A80108C200700BC2037202A
      [CPU0] [ 6] 01008F202B20060200D092200F000820082003006C20470730A7821000FCFFFF201160000533208110D0072008201F410340230020202301B12220BB200B2019
      [CPU0] [ 6] 010006200301992420DF0323000001200B01001C805740034037400340420000208F60000504000534002040166000046BE88110F0213F200A000040AB00FF20
      [CPU0] [ 6] 0000E120E7400B020B188160174000400F201A00FF402B048517811065200340FB201260B000FD203303F7528110408300A9A00700E84083E00200033F698010
      [CPU0] [ 6] 401B018D37814720005A5601000800090100006000010000
      [CPU0] [ 6] Finish coredump (Compression Enabled).
```
    
3. Copy the hex body and save to file:
    
```bash
      $ cat elf.dump
      [CPU0] [ 6] 5A5601013D03FF077F454C4601010100C0000304002800C00D003420036000070400053400200008200A4000000420030034C024200001D8092004E00200601A
      ...
      [CPU0] [ 6] 401B018D37814720005A5601000800090100006000010000
```

4. Run tools/coredump.py to convert hex dump to elf coredump:
    
```bash
      $ ./tools/coredump.py elf.dump
      Chunk #1 is compressed, 317 bytes (original size: 1023 bytes)
      ...
      Chunk #10 is compressed, 8 bytes (original size: 9 bytes)
    
      $ ls elf.core
      elf.core
```
    
5. Pass core(elf.core) and bin elf(nuttx) to gdb:
**!!(Toolchain(arm-none-eabi-gdb) version must be newer than 11.3) !!**
    
```bash
      $ arm-none-eabi-gdb -c elf.core nuttx
      GNU gdb (Arm GNU Toolchain 11.3.Rel1) 12.1.90.20220802-git
      ...
      Reading symbols from nuttx...
    
      [New process 6]
      [New process 1]
      [New process 2]
      [New process 3]
      [New process 4]
      [New process 5]
      [New process 6]
      Core was generated by `'.
      #0  0x10808a8e in up_idle () at chip/imx_idle.c:61
      61    }
      [Current thread is 1 (process 6)]
      (gdb)
      (gdb) info thread
        Id   Target Id         Frame
      * 1    process 6         0x10808a8e in up_idle () at chip/imx_idle.c:61
        2    process 1         0x10808a8e in up_idle () at chip/imx_idle.c:61
        3    process 2         0x00000000 in ?? ()
        4    process 3         0x00000000 in ?? ()
        5    process 4         up_switch_context (tcb=0x1082a474 <g_idletcb>, rtcb=rtcb@entry=0x10837438) at common/arm_switchcontext.c:95
        6    process 5         up_switch_context (tcb=0x10838ef0, rtcb=rtcb@entry=0x10838000) at common/arm_switchcontext.c:95
        7    process 6         elf_emit_tcb_note (cinfo=0x10839a6c, tcb=0x10838ef0) at libelf/libelf_coredump.c:272
      (gdb) thread 6
      [Switching to thread 6 (process 5)]
      #0  up_switch_context (tcb=0x10838ef0, rtcb=rtcb@entry=0x10838000) at common/arm_switchcontext.c:95
      95          arm_switchcontext(&rtcb->xcp.regs, tcb->xcp.regs);
      (gdb) bt
      #0  up_switch_context (tcb=0x10838ef0, rtcb=rtcb@entry=0x10838000) at common/arm_switchcontext.c:95
      #1  0x10803286 in nxsem_wait (sem=0x10838fbc) at semaphore/sem_wait.c:176
      #2  0x10812de8 in nxsched_waitpid (pid=pid@entry=6, stat_loc=stat_loc@entry=0x10838a84, options=options@entry=4) at sched/sched_waitpid.c:169
      #3  0x10812df6 in waitpid (pid=pid@entry=6, stat_loc=stat_loc@entry=0x10838a84, options=options@entry=4) at sched/sched_waitpid.c:639
      #4  0x1080d31a in nsh_builtin (vtbl=vtbl@entry=0x10838c10, cmd=0x10838e98 <error: Cannot access memory at address 0x10838e98>, argv=argv@entry=0x10838adc, redirfile=redirfile@entry=0x0, oflags=oflags@entry=0) at nsh_builtin.c:162
      #5  0x1080a20e in nsh_execute (oflags=0, redirfile=0x0, argv=0x10838adc, argc=1, vtbl=0x10838c10) at nsh_parse.c:641
      #6  nsh_parse_command (vtbl=vtbl@entry=0x10838c10, cmdline=<optimized out>) at nsh_parse.c:2742
      #7  0x1080a510 in nsh_parse (vtbl=vtbl@entry=0x10838c10, cmdline=cmdline@entry=0x10838e98 <error: Cannot access memory at address 0x10838e98>) at nsh_parse.c:2826
      #8  0x10809390 in nsh_session (pstate=0x10838c10, login=login@entry=1, argc=argc@entry=1, argv=argv@entry=0x108383f8) at nsh_session.c:245
      #9  0x108090f8 in nsh_consolemain (argc=argc@entry=1, argv=argv@entry=0x108383f8) at nsh_consolemain.c:71
      #10 0x1080909c in nsh_main (argc=1, argv=0x108383f8) at nsh_main.c:74
      #11 0x1080693e in nxtask_startup (entrypt=0x10809071 <nsh_main>, argc=1, argv=0x108383f8) at sched/task_startup.c:70
      #12 0x1080378c in nxtask_start () at task/task_start.c:134
      #13 0x00000000 in ?? ()
      Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

## Impact

N/A, new feature

## Testing

sabre-6quad/coredump