### PR TITLE
system/nxdiag: Fix issues introduced by #1776

### DIFF
--- a/system/nxdiag/nxdiag.c
+++ b/system/nxdiag/nxdiag.c
@@ -29,7 +29,6 @@
 #include <unistd.h>
 
 #include <nuttx/config.h>
-#include <nuttx/info.h>
 #include <nuttx/version.h>
 
 #include "sysinfo.h"
@@ -260,7 +259,7 @@ int main(int argc, char *argv[])
       printf("\tBuild: %s\n", CONFIG_VERSION_BUILD);
 #endif
       printf("\tArch: %s\n", CONFIG_ARCH);
-      printf("\tConfig: %s\n\n", CONFIG_BASE_DEFCONFIG);
+      printf("\tDefconfig: %s\n\n", CONFIG_BASE_DEFCONFIG);
     }
 
 #ifdef CONFIG_SYSTEM_NXDIAG_COMP_FLAGS

--- a/tools/host_sysinfo.py
+++ b/tools/host_sysinfo.py
@@ -28,6 +28,14 @@ class validate_flags_arg(argparse.Action):
 # Common functions #
 
 
+def eprint(*args, **kwargs):
+    """
+    Prints the arguments passed to stderr.
+    """
+
+    print(*args, file=sys.stderr, **kwargs)
+
+
 def get_installed_packages():
     """
     Gets the list of packages installed on the host system. This function works on
@@ -112,7 +120,7 @@ def get_installed_packages():
                         )
                         packages.append(f"{name} ({version})")
         except subprocess.CalledProcessError:
-            pass
+            eprint("Error: Failed to get installed packages.")
 
     elif platform.system() == "Darwin":
         try:
@@ -130,7 +138,7 @@ def get_installed_packages():
                         version = "Unknown"
                     packages.append(f"{package} ({version})")
         except subprocess.CalledProcessError:
-            pass
+            eprint("Error: Failed to get installed packages.")
 
     packages.sort()
     return packages


### PR DESCRIPTION
## Summary

Requires apache/nuttx#9400.

Fix compilation issues introduced in #1776 by removing the non-existent info.h.

## Impact

Fix compilation error when enabling the Nxdiag application.

## Testing

Tested using ESP32-DevKitC