### PR TITLE
tools/Wasm.mk: Generate object file name with full path

### DIFF
--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -93,27 +93,27 @@ PRIORITY            ?= SCHED_PRIORITY_DEFAULT
 # XIP: Execution In Place
 # JIT: Just In Time
 
-WAMR_MODE       ?= INT
+WAMR_MODE ?= INT
 
 # Targets follow
 
 .PRECIOUS: $(WBIN)
 
 WSRCS := $(MAINSRC) $(CSRCS)
-WOBJS := $(WSRCS:%.c=%.wo)
+WOBJS := $(WSRCS:=$(SUFFIX).wo)
 
 all:: $(WBIN)
 
-$(WOBJS): %.wo : %.c
+$(WOBJS): %.c$(SUFFIX).wo : %.c
 	$(Q) $(WCC) $(WCFLAGS) -c $^ -o $@
 
 $(WBIN): $(WOBJS)
 	$(shell mkdir -p $(APPDIR)/wasm)
-	$(Q) $(WAR) $@ $(filter-out $(MAINSRC:%.c=%.wo),$^)
+	$(Q) $(WAR) $@ $(filter-out $(MAINSRC:=$(SUFFIX).wo),$^)
 	$(foreach main,$(MAINSRC), \
 	  $(eval mainindex=$(strip $(call GETINDEX,$(main),$(MAINSRC)))) \
-	  $(eval dstname=$(shell echo $(main:%.c=%.wo) | sed -e 's/\//_/g')) \
-	  $(shell cp -rf $(strip $(main:%.c=%.wo)) \
+	$(eval dstname=$(shell echo $(main:=$(SUFFIX).wo) | sed -e 's/\//_/g')) \
+	  $(shell cp -rf $(strip $(main:=$(SUFFIX).wo)) \
 	    $(strip $(APPDIR)/wasm/$(word $(mainindex),$(PROGNAME))#$(WASM_INITIAL_MEMORY)#$(STACKSIZE)#$(PRIORITY)#$(WAMR_MODE)#$(dstname)) \
 	   ) \
 	 )


### PR DESCRIPTION
## Summary

For example, before this patch, object file is like:
```
apps/examples/hello/hello_main.wo
```
With this patch, it will be:
```
apps/examples/hello/hello_main.c.home.huang.Work.nx.apps.examples.hello.wo
'''
Follow the native build:
'''
apps/examples/hello/hello_main.c.home.huang.Work.nx.apps.examples.hello.o
```
## Impact
Minor
## Testing
CI and local machine
