### PR TITLE
Make: Generate builtin_list with a macro guard

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -84,15 +84,19 @@ DEPCONFIG = $(TOPDIR)$(DELIM).config
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define REGISTER
 	$(Q) echo Register: $1
-	$(Q) echo { "$(subst ",,$(1))", $2, $3, $(subst ",,$(4)) }, > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
-	$(Q) echo int $(subst ",,$(4))(int argc, char *argv[]); > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"
+	$(Q) echo "#ifndef CONFIG_$(call UPPER_CASE,$(1))_WASM_BUILD_ONLY" > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo { "$(subst ",,$(1))", $2, $3, $(subst ",,$(4)) }, >> "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo "#endif" >> "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo int $(subst ",,$(4))(int argc, char *argv[]); >> "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"
 
 	$(Q) touch $(BUILTIN_REGISTRY)$(DELIM).updated"
 endef
 else
 define REGISTER
 	$(Q) echo "Register: $1"
-	$(Q) echo "{ \"$1\", $2, $3, $4 }," > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo "#ifndef CONFIG_$(call UPPER_CASE,$(1))_WASM_BUILD_ONLY" > "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo "{ \"$1\", $2, $3, $4 }," >> "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
+	$(Q) echo "#endif" >> "$(BUILTIN_REGISTRY)$(DELIM)$1.bdat"
 	$(Q) if [ ! -z $4 ]; then \
 	        echo "int $4(int argc, char *argv[]);" > "$(BUILTIN_REGISTRY)$(DELIM)$1.pdat"; \
 	     fi;

--- a/examples/mcuboot/swap_test/Makefile
+++ b/examples/mcuboot/swap_test/Makefile
@@ -22,7 +22,7 @@ include $(APPDIR)/Make.defs
 
 MAINSRC   += confirm_main.c set_img_main.c version_main.c
 
-PROGNAME  += mcuboot_confirm mcuboot_set_img mcuboot_version
+PROGNAME  += mcuboot_confirm_swap mcuboot_set_img mcuboot_version
 PRIORITY  += SCHED_PRIORITY_DEFAULT
 STACKSIZE += $(CONFIG_DEFAULT_TASK_STACKSIZE)
 


### PR DESCRIPTION
## Summary

If we add `WASM_BUILD = y` to a makefile of some apps, the app will be compiled as a builtin nsh command and a wasm module, by add a guard to builtin_list, we can control wether to build the app as a nsh command.

For example, without this patch we will get `hello.bdat`:
```
{ "hello", 100, 2048, hello_main },
```
With this patch, we will get a macro guarded version of it:
```
#ifndef CONFIG_HELLO_WASM_BUILD_ONLY
{ "hello", 100, 2048, hello_main },
#endif
```

If we don't want to build the app into nsh, just add a new option XXX_WASM_BUILD_ONLY to Kconfig of this app and enable it.

Depends on: https://github.com/apache/nuttx/pull/9462
## Impact
New feature
## Testing
CI and local machine
