### PR TITLE
wireless/bluetooth/btsak: fix help messages

### DIFF
--- a/wireless/bluetooth/btsak/README.md
+++ b/wireless/bluetooth/btsak/README.md
@@ -54,7 +54,7 @@ Description:  Enable security (encryption) for a connection:
               This command may return error if required level of security
               is not possible to achieve due to local or remote device
               limitation (eg input output capabilities).
-Usage:        bt <ifname> security [-h] <addr> public|private <level>
+Usage:        bt <ifname> security [-h] <addr> public|random <level>
 Where:        <addr>  - The 6-byte address of the connected peer
               <level> - Security level, on of:
 
@@ -76,7 +76,7 @@ Where:        See "GATT Commands" below
 ```
 Command:      exchange-mtu
 Description:  Set MTU to out maximum and negotiate MTU with peer
-Usage:        bt <ifname> gatt exchange-mtu [-h] <addr> public|private
+Usage:        bt <ifname> gatt exchange-mtu [-h] <addr> public|random
 ```
 
 ```
@@ -88,19 +88,19 @@ Usage:        bt <ifname> gatt mget [-h]
 ```
 Command:      discover
 Description:  Initiate discovery
-Usage:        bt <ifname> gatt discover [-h] <addr> public|private <uuid16> [<start> [<end>]]
+Usage:        bt <ifname> gatt discover [-h] <addr> public|random <uuid16> [<start> [<end>]]
 ```
 
 ```
 Command:      characteristic
 Description:  Initiate characteristics discovery
-Usage:        bt <ifname> gatt characteristic [-h] <addr> public|private [<start> [<end>]]
+Usage:        bt <ifname> gatt characteristic [-h] <addr> public|random [<start> [<end>]]
 ```
 
 ```
 Command:      descriptor
 Description:  Initiate characteristics discovery
-Usage:        bt <ifname> gatt descriptor [-h] <addr> public|private [<start> [<end>]]
+Usage:        bt <ifname> gatt descriptor [-h] <addr> public|random [<start> [<end>]]
 ```
 
 ```
@@ -112,13 +112,13 @@ Usage:        bt <ifname> gatt dget [-h]
 ```
 Command:      read
 Description:  Initiate a GATT read operation.
-Usage:        bt <ifname> gatt read [-h] <addr> public|private <handle> [<offset>]
+Usage:        bt <ifname> gatt read [-h] <addr> public|random <handle> [<offset>]
 ```
 
 ```
 Command:      read-multiple
 Description:  Initiate a GATT read-multiple operation.
-Usage:        bt <ifname> gatt read-multiple [-h] <addr> public|private <handle> [<handle> [<handle>]..]
+Usage:        bt <ifname> gatt read-multiple [-h] <addr> public|random <handle> [<handle> [<handle>]..]
 ```
 
 ```
@@ -130,7 +130,7 @@ Usage:        bt <ifname> gatt rget [-h]
 ```
 Command:      write
 Description:  Initiate a GATT write operation.
-Usage:        bt <ifname> gatt write [-h] <addr> public|private <handle> <byte> [<byte> [<byte>]..]
+Usage:        bt <ifname> gatt write [-h] <addr> public|random <handle> <byte> [<byte> [<byte>]..]
 ```
 
 ```

--- a/wireless/bluetooth/btsak/btsak.h
+++ b/wireless/bluetooth/btsak/btsak.h
@@ -178,7 +178,7 @@ int btsak_str2addr(FAR const char *str, FAR uint8_t *addr);
  *
  * Description:
  *   Convert a string to an address type.  String options are "public" or
- *   "private".
+ *   "random".
  *
  ****************************************************************************/
 

--- a/wireless/bluetooth/btsak/btsak_gatt.c
+++ b/wireless/bluetooth/btsak/btsak_gatt.c
@@ -51,7 +51,7 @@
  * Name: btsak_cmd_discover_common
  *
  * Description:
- *   gatt [-h] <discover-cmd> [-h] <addr> public|private [<uuid16>]
+ *   gatt [-h] <discover-cmd> [-h] <addr> public|random [<uuid16>]
  *
  ****************************************************************************/
 
@@ -238,7 +238,7 @@ static void btsak_cmd_connect_common(FAR struct btsak_s *btsak, int argc,
  ****************************************************************************/
 
 static void btsak_cmd_read_common(FAR struct btsak_s *btsak, int argc,
-                                     FAR char *argv[], bool multiple)
+                                  FAR char *argv[], bool multiple)
 {
   int i;
   int j;
@@ -332,7 +332,7 @@ static void btsak_cmd_read_common(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_gatt_exchange_mtu
  *
  * Description:
- *   gatt [-h] exchange_mtu [-h] <addr> public|private command
+ *   gatt [-h] exchange_mtu [-h] <addr> public|random command
  *
  ****************************************************************************/
 
@@ -398,7 +398,7 @@ void btsak_cmd_gatt_exchange_mtu(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_discover
  *
  * Description:
- *   gatt [-h] discover [-h] <addr> public|private <uuid16> command
+ *   gatt [-h] discover [-h] <addr> public|random <uuid16> command
  *
  ****************************************************************************/
 
@@ -412,7 +412,7 @@ void btsak_cmd_discover(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_gatt_discover_characteristic
  *
  * Description:
- *   gatt [-h] characteristic [-h] <addr> public|private command
+ *   gatt [-h] characteristic [-h] <addr> public|random command
  *
  ****************************************************************************/
 
@@ -426,7 +426,7 @@ void btsak_cmd_gatt_discover_characteristic(FAR struct btsak_s *btsak,
  * Name: btsak_cmd_gatt_discover_descriptor
  *
  * Description:
- *   gatt [-h] descriptor [-h] <addr> public|private command
+ *   gatt [-h] descriptor [-h] <addr> public|random command
  *
  ****************************************************************************/
 
@@ -440,7 +440,7 @@ void btsak_cmd_gatt_discover_descriptor(FAR struct btsak_s *btsak,
  * Name: btsak_cmd_gatt_read
  *
  * Description:
- *   gatt [-h] read [-h] <addr> public|private <handle> [<offset>] command
+ *   gatt [-h] read [-h] <addr> public|random <handle> [<offset>] command
  *
  ****************************************************************************/
 
@@ -459,7 +459,7 @@ void btsak_cmd_gatt_read(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_gatt_read_multiple
  *
  * Description:
- *   gatt [-h] read-multiple [-h] <addr> public|private <handle>
+ *   gatt [-h] read-multiple [-h] <addr> public|random <handle>
  *        [<handle> [<handle>]..]
  *
  ****************************************************************************/
@@ -488,7 +488,7 @@ void btsak_cmd_gatt_read_multiple(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_gatt_write
  *
  * Description:
- *   gatt [-h] write [-h] [-h] <addr> public|private <handle> <byte>
+ *   gatt [-h] write [-h] [-h] <addr> public|random <handle> <byte>
  *        [<byte> [<byte>]..]
  *
  ****************************************************************************/
@@ -571,12 +571,12 @@ void btsak_cmd_gatt_write(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_gatt_connect
  *
  * Description:
- *   gatt [-h] connect [-h] <addr> public|private
+ *   gatt [-h] connect [-h] <addr> public|random
  *
  ****************************************************************************/
 
 void btsak_cmd_connect(FAR struct btsak_s *btsak, int argc,
-                         FAR char *argv[])
+                       FAR char *argv[])
 {
   btsak_cmd_connect_common(btsak, argc, argv, SIOCBTCONNECT);
 }
@@ -585,12 +585,12 @@ void btsak_cmd_connect(FAR struct btsak_s *btsak, int argc,
  * Name: btsak_cmd_gatt_connect
  *
  * Description:
- *   gatt [-h] disconnect [-h] <addr> public|private
+ *   gatt [-h] disconnect [-h] <addr> public|random
  *
  ****************************************************************************/
 
 void btsak_cmd_disconnect(FAR struct btsak_s *btsak, int argc,
-                         FAR char *argv[])
+                          FAR char *argv[])
 {
   btsak_cmd_connect_common(btsak, argc, argv, SIOCBTDISCONNECT);
 }

--- a/wireless/bluetooth/btsak/btsak_main.c
+++ b/wireless/bluetooth/btsak/btsak_main.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <errno.h>
+#include <sys/param.h>
 
 #include <nuttx/wireless/bluetooth/bt_core.h>
 #include <nuttx/net/bluetooth.h>
@@ -68,89 +69,93 @@ static const struct btsak_command_s g_btsak_commands[] =
 {
   {
     "help",
-    (CODE void *)btsak_cmd_help,
+    btsak_cmd_help,
     NULL
   },
-  {"info",
-    (CODE void *)btsak_cmd_info,
+  {
+    "info",
+    btsak_cmd_info,
     "[-h]"
   },
-  {"features",
-    (CODE void *)btsak_cmd_features,
+  {
+    "features",
+    btsak_cmd_features,
     "[-h] [le]"
   },
-  {"scan",
-    (CODE void *)btsak_cmd_scan,
+  {
+    "scan",
+    btsak_cmd_scan,
     "[-h] <start [-d]|get|stop>"
   },
   {
     "advertise",
-    (CODE void *)btsak_cmd_advertise,
+    btsak_cmd_advertise,
     "[-h] <start|stop>"
   },
   {
     "security",
-    (CODE void *)btsak_cmd_security,
-    "[-h] <addr> public|private <level>"
+    btsak_cmd_security,
+    "[-h] <addr> public|random <level>"
   },
   {
     "gatt",
-    (CODE void *)btsak_cmd_gatt,
+    btsak_cmd_gatt,
     "[-h] <cmd> [option [option [option...]]]"
   }
 };
 
-#define NCOMMANDS (sizeof(g_btsak_commands) / sizeof(struct btsak_command_s))
+#define NCOMMANDS nitems(g_btsak_commands)
 
 static const struct btsak_command_s g_btsak_gatt_commands[] =
 {
-  {"exchange-mtu",
-    (CODE void *)btsak_cmd_gatt_exchange_mtu,
-    "[-h] <addr> public|private"
+  {
+    "exchange-mtu",
+    btsak_cmd_gatt_exchange_mtu,
+    "[-h] <addr> public|random"
   },
   {
     "connect",
-    (CODE void *)btsak_cmd_connect,
-    "[-h] <addr> public|private"
+    btsak_cmd_connect,
+    "[-h] <addr> public|random"
   },
   {
     "disconnect",
-    (CODE void *)btsak_cmd_disconnect,
-    "[-h] <addr> public|private"
+    btsak_cmd_disconnect,
+    "[-h] <addr> public|random"
   },
   {
     "discover",
-    (CODE void *)btsak_cmd_discover,
-    "[-h] <addr> public|private <uuid16> [<start> [<end>]]"
+    btsak_cmd_discover,
+    "[-h] <addr> public|random <uuid16> [<start> [<end>]]"
   },
   {
     "characteristic",
-    (CODE void *)btsak_cmd_gatt_discover_characteristic,
-    "[-h] <addr> public|private [<start> [<end>]]"
+    btsak_cmd_gatt_discover_characteristic,
+    "[-h] <addr> public|random [<start> [<end>]]"
   },
   {
     "descriptor",
-    (CODE void *)btsak_cmd_gatt_discover_descriptor,
-    "[-h] <addr> public|private [<start> [<end>]]"
+    btsak_cmd_gatt_discover_descriptor,
+    "[-h] <addr> public|random [<start> [<end>]]"
   },
   {
     "read",
-    (CODE void *)btsak_cmd_gatt_read,
-    "[-h] <addr> public|private <handle> [<offset>]"
+    btsak_cmd_gatt_read,
+    "[-h] <addr> public|random <handle> [<offset>]"
   },
   {
     "read-multiple",
-    (CODE void *)btsak_cmd_gatt_read_multiple,
-    "[-h] <addr> public|private <handle> [<handle> [<handle>]..]"
+    btsak_cmd_gatt_read_multiple,
+    "[-h] <addr> public|random <handle> [<handle> [<handle>]..]"
   },
   {
     "write",
-    (CODE void *)btsak_cmd_gatt_write,
-    "[-h] <addr> public|private <handle> <byte> [<byte> [<byte>]..]"
+    btsak_cmd_gatt_write,
+    "[-h] <addr> public|random <handle> <byte> [<byte> [<byte>]..]"
   }
 };
 
-#define GATT_NCOMMANDS (sizeof(g_btsak_gatt_commands) / sizeof(struct btsak_command_s))
+#define GATT_NCOMMANDS nitems(g_btsak_gatt_commands)
 
 static const bt_addr_t g_default_epaddr =
 {
@@ -539,7 +544,7 @@ int btsak_str2addr(FAR const char *str, FAR uint8_t *addr)
  *
  * Description:
  *   Convert a string to an address type.  String options are "public" or
- *   "private".
+ *   "random".
  *
  ****************************************************************************/
 

--- a/wireless/bluetooth/btsak/btsak_scan.c
+++ b/wireless/bluetooth/btsak/btsak_scan.c
@@ -169,7 +169,7 @@ static void btsak_cmd_scanget(FAR struct btsak_s *btsak, FAR char *cmd,
           for (i = 0; i < btreq.btr_nrsp; i++)
             {
               rsp = &result[i];
-              printf("%2d.\taddr:           "
+              printf("%2d.\taddr:            "
                      "%02x:%02x:%02x:%02x:%02x:%02x type: %d\n",
                      i + 1,
                      rsp->sr_addr.val[5], rsp->sr_addr.val[4],

--- a/wireless/bluetooth/btsak/btsak_security.c
+++ b/wireless/bluetooth/btsak/btsak_security.c
@@ -83,7 +83,7 @@ static void btsak_security_showusage(FAR const char *progname,
   fprintf(stderr,
           "\toutput capabilities).\n\n");
   fprintf(stderr, "Usage:\n\n");
-  fprintf(stderr, "\t%s <ifname> %s [-h] <addr> public|private <level>\n",
+  fprintf(stderr, "\t%s <ifname> %s [-h] <addr> public|random <level>\n",
           progname, cmd);
   fprintf(stderr,
           "\nWhere:\n\n");


### PR DESCRIPTION
## Summary
Currently the help messages use "private" string while code expects "random".
Remove not needed `(CODE void *)` cast.
Use 'nitems' macro to calculate number of elements in array Align output in `btsak_cmd_scanget` command.
Fix style issues

## Impact
Should be none

## Testing
Pass CI
Tested with `btsak` application on ESP32