### PR TITLE
netutils/dhcpc: Set BOOTP BROADCAST flag when IPFORWARD is enabled

### DIFF
--- a/netutils/dhcpc/Kconfig
+++ b/netutils/dhcpc/Kconfig
@@ -32,10 +32,15 @@ config NETUTILS_DHCPC_RETRIES
 
 config NETUTILS_DHCPC_BOOTP_FLAGS
 	hex "Flags of Bootstrap"
-	default 0x0000
+	default 0x0000 if !NET_IPFORWARD
+	default 0x8000 if NET_IPFORWARD
 	---help---
 		This setting to set the BOOTP broadcast flags.
 		Reference RFC1542: Clarifications and Extensions for the
 		Bootstrap Protocol.
+
+		Note: We're not always able to receive unicast traffic before
+		being fully configured, e.g. with forward enabled. Then we need
+		to enable the broadcast flag under these situations.
 
 endif

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -267,8 +267,12 @@ static int dhcpc_sendmsg(FAR struct dhcpc_state_s *pdhcpc,
       /* Broadcast DISCOVER message to all servers */
 
       case DHCPDISCOVER:
-        /* REVISIT: We don't need the broadcast flag since we can receive
-         * unicast traffic before being fully configured.
+        /* Socket binded to INADDR_ANY is not intended to receive unicast
+         * traffic before being fully configured, at least dhclient
+         * configured with socket-only won't do so on Linux and BSDs.
+         * We can sometimes receive unicast traffic before being fully
+         * configured, it's good, but not always, so we need to set the
+         * broadcast flag under some situations.
          */
 
         /* Broadcast bit. */
@@ -283,9 +287,6 @@ static int dhcpc_sendmsg(FAR struct dhcpc_state_s *pdhcpc,
       /* Send REQUEST message to the server that sent the *first* OFFER */
 
       case DHCPREQUEST:
-        /* REVISIT: We don't need the broadcast flag since we can receive
-         * unicast traffic before being fully configured.
-         */
 
         /* Broadcast bit. */
 


### PR DESCRIPTION
## Summary
Socket binded to `INADDR_ANY` is not intended to receive unicast traffic before being fully configured, at least dhclient configured with socket-only won't do so on Linux and BSDs (https://github.com/isc-projects/dhcp/blob/v4_4_3/common/socket.c#L1201).

We can sometimes receive unicast traffic before being fully configured, it's good, but not always, so we need to set the broadcast flag under some situations.

## Impact

## Testing
dhcpc with `CONFIG_NET_IPFORWARD=y`
