### PR TITLE
testing/ostest: adjust PTHREAD_CLEANUP_STACKSIZE with nuttx project

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -70,7 +70,7 @@ ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += specific.c
 endif
 
-ifeq ($(CONFIG_PTHREAD_CLEANUP),y)
+ifneq ($(CONFIG_PTHREAD_CLEANUP_STACKSIZE),0)
 CSRCS += pthread_cleanup.c
 endif
 

--- a/testing/ostest/cancel.c
+++ b/testing/ostest/cancel.c
@@ -49,7 +49,7 @@ static sem_t sem_thread_started;
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
 static void sem_cleaner(FAR void *arg)
 {
   printf("sem_cleaner #%u\n", (unsigned int)((uintptr_t)arg));
@@ -60,7 +60,7 @@ static FAR void *sem_waiter(FAR void *parameter)
 {
   int status;
 
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
   int i;
 
   /* Register some clean-up handlers */
@@ -161,7 +161,7 @@ static FAR void *sem_waiter(FAR void *parameter)
 }
 
 #if !defined(CONFIG_DISABLE_MQUEUE) && defined(CONFIG_CANCELLATION_POINTS)
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
 static void mqueue_cleaner(FAR void *arg)
 {
   FAR mqd_t *mqcancel = (FAR mqd_t *)arg;
@@ -182,7 +182,7 @@ static FAR void *mqueue_waiter(FAR void *parameter)
   char msgbuffer[CONFIG_MQ_MAXMSGSIZE];
   size_t nbytes;
 
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
   /* Register clean-up handler */
 
   pthread_cleanup_push(mqueue_cleaner, (FAR void *)&mqcancel);
@@ -249,7 +249,7 @@ static FAR void *asynch_waiter(FAR void *parameter)
 {
   int status;
 
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
   int i;
 
   /* Register some clean-up handlers */

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -451,7 +451,7 @@ static int user_main(int argc, char *argv[])
       pthread_rwlock_cancel_test();
       check_test_memory_usage();
 
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
       /* Verify pthread cancellation cleanup handlers */
 
       printf("\nuser_main: pthread_cleanup test\n");

--- a/testing/ostest/pthread_rwlock_cancel.c
+++ b/testing/ostest/pthread_rwlock_cancel.c
@@ -204,7 +204,7 @@ static void test_timeout(void)
    * usable state after deferred cancellation.
    */
 
-#ifdef CONFIG_PTHREAD_CLEANUP
+#if defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0
 #ifdef CONFIG_CANCELLATION_POINTS
   status = pthread_rwlock_trywrlock(&write_lock);
   if (status != EBUSY)
@@ -256,7 +256,7 @@ static void test_timeout(void)
       ASSERT(false);
     }
 #endif /* CONFIG_CANCELLATION_POINTS */
-#endif /* CONFIG_PTHREAD_CLEANUP */
+#endif /* defined(CONFIG_PTHREAD_CLEANUP_STACKSIZE) && CONFIG_PTHREAD_CLEANUP_STACKSIZE > 0 */
 
     pthread_rwlock_destroy(&write_lock);
     pthread_rwlock_destroy(&read_lock);


### PR DESCRIPTION
## Summary

testing/ostest: adjust PTHREAD_CLEANUP_STACKSIZE with nuttx project

in project nuttx "remove PTHREAD_CLEANUP, and use PTHREAD_CLEANUP_STACKSIZE to enable or disable interfaces pthread_cleanup_push() and pthread_cleanup_pop()", apps project also needes adjust code.

## Impact

Kconfig

## Testing

CI, need merge with https://github.com/apache/nuttx/pull/9527