### PR TITLE
netutils/iperf: Fix possible precision loss

### DIFF
--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -323,8 +323,8 @@ static void iperf_report_task(FAR void *arg)
              ts_diff(&last, &start),
              ts_diff(&now, &start),
              now_len -last_len,
-             ((double)((now_len - last_len) * 8) / 1000000) /
-             (double)ts_diff(&now, &last)
+             (((now_len - last_len) * 8) / 1000000.0) /
+             ts_diff(&now, &last)
              );
       if (time != 0 && ts_diff(&now, &start) >= time)
         {
@@ -338,8 +338,8 @@ static void iperf_report_task(FAR void *arg)
              ts_diff(&start, &start),
              ts_diff(&now, &start),
              now_len,
-             ((double)(now_len * 8) / 1000000) /
-             (double)ts_diff(&now, &start)
+             ((now_len * 8) / 1000000.0) /
+             ts_diff(&now, &start)
              );
     }
 


### PR DESCRIPTION
## Summary
Fix the floating point precision issue when calculating data in the iperf cycle, to prevent abnormal bandwidth display caused by this.

## Impact
None

## Testing
bl616evb:wifi

