### PR TITLE
Remove the unnecessary cast from pid_t to int

### DIFF
--- a/examples/watcher/watcher_main.c
+++ b/examples/watcher/watcher_main.c
@@ -206,9 +206,9 @@ static int watcher_daemon(int argc, FAR char *argv[])
       goto errout;
     }
 
-  fprintf(fp, "%d %d %d %d %d\n", (int)watcher_pid,
-          (int)CONFIG_EXAMPLES_WATCHER_SIGNAL, (int)SUBSCRIBE_CMD,
-          (int)FEED_CMD, (int)UNSUBSCRIBE_CMD);
+  fprintf(fp, "%d %d %d %d %d\n", watcher_pid,
+          CONFIG_EXAMPLES_WATCHER_SIGNAL, SUBSCRIBE_CMD,
+          FEED_CMD, UNSUBSCRIBE_CMD);
   fclose(fp);
 
   /* Suspends the calling thread until delivery of a non-blocked signal. */

--- a/testing/ostest/waitpid.c
+++ b/testing/ostest/waitpid.c
@@ -120,7 +120,7 @@ static void waitpid_last(void)
   printf("waitpid_last: Waiting for PID=%d with waitpid()\n",
          g_waitpids[NCHILDREN - 1]);
 
-  ret = (int)waitpid(g_waitpids[NCHILDREN - 1], &stat_loc, 0);
+  ret = waitpid(g_waitpids[NCHILDREN - 1], &stat_loc, 0);
   if (ret < 0)
     {
       int errcode = errno;


### PR DESCRIPTION
## Summary

from the comment: https://github.com/apache/nuttx/pull/9564#discussion_r1233425912

## Impact

minor

## Testing

ci