### PR TITLE
nimble: various improvements for nimble intergartion

### DIFF
--- a/examples/nimble/Kconfig
+++ b/examples/nimble/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_NIMBLE
+	tristate "NimBLE example"
+	default n
+	---help---
+		Enable the nimble example
+
+if EXAMPLES_NIMBLE
+
+config EXAMPLES_NIMBLE_PROGNAME
+	string "Program name"
+	default "nimble"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_NIMBLE_PRIORITY
+	int "NimBLE task priority"
+	default 100
+
+config EXAMPLES_NIMBLE_STACKSIZE
+	int "NimBLE stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif # EXAMPLES_NIMBLE
+

--- a/examples/nimble/Make.defs
+++ b/examples/nimble/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/nimble/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_NIMBLE),)
+CONFIGURED_APPS += $(APPDIR)/examples/nimble
+endif

--- a/examples/nimble/Makefile
+++ b/examples/nimble/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/examples/nimble/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# NimBLE built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_NIMBLE_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_NIMBLE_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_NIMBLE_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_NIMBLE)
+
+# NimBLE Example
+
+MAINSRC = nimble_main.c
+
+include $(APPDIR)/wireless/bluetooth/nimble/Makefile.nimble
+
+include $(APPDIR)/Application.mk

--- a/examples/nimble/nimble_main.c
+++ b/examples/nimble/nimble_main.c
@@ -1,0 +1,322 @@
+/****************************************************************************
+ * apps/examples/nimble/nimble_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/boardctl.h>
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "netutils/netinit.h"
+
+#include "nimble/nimble_npl.h"
+#include "nimble/nimble_port.h"
+
+#include "host/ble_hs.h"
+#include "host/util/util.h"
+
+#include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
+#include "services/ans/ble_svc_ans.h"
+#include "services/ias/ble_svc_ias.h"
+#include "services/lls/ble_svc_lls.h"
+#include "services/tps/ble_svc_tps.h"
+#include "services/gap/ble_svc_gap.h"
+#include "services/bas/ble_svc_bas.h"
+#include "services/dis/ble_svc_dis.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Not used now */
+
+#define TASK_DEFAULT_PRIORITY       0
+#define TASK_DEFAULT_STACK          NULL
+#define TASK_DEFAULT_STACK_SIZE     0
+
+/****************************************************************************
+ * External Functions Prototypes
+ ****************************************************************************/
+
+void ble_hci_sock_ack_handler(void *param);
+void ble_hci_sock_init(void);
+void ble_hci_sock_set_device(int dev);
+
+/****************************************************************************
+ * Private Functions Prototypes
+ ****************************************************************************/
+
+static void put_ad(uint8_t ad_type, uint8_t ad_len, FAR const void *ad,
+                   FAR uint8_t *buf, FAR uint8_t *len);
+static void update_ad(void);
+static void start_advertise(void);
+static int gap_event_cb(FAR struct ble_gap_event *event, FAR void *arg);
+static void app_ble_sync_cb(void);
+static void nimble_host_task(FAR void *param);
+static FAR void *ble_hci_sock_task(FAR void *param);
+static FAR void *ble_host_task(FAR void *param);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const char *g_gap_name = "NuttX NimBLE";
+static uint8_t g_own_addr_type;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: put_ad
+ ****************************************************************************/
+
+static void put_ad(uint8_t ad_type, uint8_t ad_len, FAR const void *ad,
+                   FAR uint8_t *buf, FAR uint8_t *len)
+{
+  buf[(*len)++] = ad_len + 1;
+  buf[(*len)++] = ad_type;
+
+  memcpy(&buf[*len], ad, ad_len);
+
+  *len += ad_len;
+}
+
+/****************************************************************************
+ * Name: update_ad
+ ****************************************************************************/
+
+static void update_ad(void)
+{
+  uint8_t ad_flags = BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP;
+  uint8_t ad_len   = 0;
+  uint8_t ad[BLE_HS_ADV_MAX_SZ];
+
+  put_ad(BLE_HS_ADV_TYPE_FLAGS, 1, &ad_flags, ad, &ad_len);
+  put_ad(BLE_HS_ADV_TYPE_COMP_NAME, sizeof(g_gap_name), g_gap_name,
+         ad, &ad_len);
+
+  ble_gap_adv_set_data(ad, ad_len);
+}
+
+/****************************************************************************
+ * Name: start_advertise
+ ****************************************************************************/
+
+static void start_advertise(void)
+{
+  struct ble_gap_adv_params advp;
+  int                       rc;
+
+  printf("advertise\n");
+
+  update_ad();
+
+  memset(&advp, 0, sizeof advp);
+  advp.conn_mode = BLE_GAP_CONN_MODE_UND;
+  advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
+  rc = ble_gap_adv_start(g_own_addr_type, NULL, BLE_HS_FOREVER,
+                         &advp, gap_event_cb, NULL);
+  assert(rc == 0);
+}
+
+/****************************************************************************
+ * Name: gap_event_cb
+ ****************************************************************************/
+
+static int gap_event_cb(FAR struct ble_gap_event *event, FAR void *arg)
+{
+  switch (event->type)
+    {
+      case BLE_GAP_EVENT_CONNECT:
+        {
+          if (event->connect.status)
+            {
+              start_advertise();
+            }
+          break;
+        }
+
+      case BLE_GAP_EVENT_DISCONNECT:
+        {
+          start_advertise();
+          break;
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: app_ble_sync_cb
+ ****************************************************************************/
+
+static void app_ble_sync_cb(void)
+{
+  ble_addr_t addr;
+  int        rc;
+
+  /* Generate new non-resolvable private address */
+
+  rc = ble_hs_id_gen_rnd(1, &addr);
+  assert(rc == 0);
+
+  /* Set generated address */
+
+  rc = ble_hs_id_set_rnd(addr.val);
+  assert(rc == 0);
+
+  rc = ble_hs_util_ensure_addr(0);
+  assert(rc == 0);
+
+  rc = ble_hs_id_infer_auto(0, &g_own_addr_type);
+  assert(rc == 0);
+
+  start_advertise();
+}
+
+/****************************************************************************
+ * Name: nimble_host_task
+ ****************************************************************************/
+
+static void nimble_host_task(FAR void *param)
+{
+  ble_hs_cfg.sync_cb = app_ble_sync_cb;
+  ble_svc_gap_device_name_set(g_gap_name);
+  nimble_port_run();
+}
+
+/****************************************************************************
+ * Name: ble_hci_sock_task
+ ****************************************************************************/
+
+static FAR void *ble_hci_sock_task(FAR void *param)
+{
+  ble_hci_sock_ack_handler(param);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: ble_host_task
+ ****************************************************************************/
+
+static FAR void *ble_host_task(FAR void *param)
+{
+  nimble_host_task(param);
+  return NULL;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nimble_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct ble_npl_task s_task_host;
+  struct ble_npl_task s_task_hci;
+  uint8_t             batt_level = 0;
+  int                 ret        = 0;
+
+  /* allow to specify custom hci */
+
+  if (argc > 1)
+    {
+      ble_hci_sock_set_device(atoi(argv[1]));
+    }
+
+#ifndef CONFIG_NSH_ARCHINIT
+  /* Perform architecture-specific initialization */
+
+  boardctl(BOARDIOC_INIT, 0);
+#endif
+
+#ifndef CONFIG_NSH_NETINIT
+  /* Bring up the network */
+
+  netinit_bringup();
+#endif
+
+  nimble_port_init();
+  ble_hci_sock_init();
+
+  /* Initialize services */
+
+  ble_svc_gap_init();
+  ble_svc_gatt_init();
+  ble_svc_ans_init();
+  ble_svc_ias_init();
+  ble_svc_lls_init();
+  ble_svc_tps_init();
+  ble_svc_bas_init();
+  ble_svc_dis_init();
+
+  /* Create task which handles HCI socket */
+
+  ret = ble_npl_task_init(&s_task_hci, "hci_sock", ble_hci_sock_task,
+                          NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
+                          TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
+  if (ret != 0)
+    {
+      printf("ERROR: starting hci task: %i\n", ret);
+    }
+
+  /* Create task which handles default event queue for host stack. */
+
+  ret = ble_npl_task_init(&s_task_host, "ble_host", ble_host_task,
+                          NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
+                          TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
+  if (ret != 0)
+    {
+      printf("ERROR: starting ble task: %i\n", ret);
+    }
+
+  while (true)
+    {
+      /* Simulate battery */
+
+      batt_level += 1;
+      if (batt_level > 100)
+        {
+          batt_level = 0;
+        }
+
+      ble_svc_bas_battery_level_set(batt_level);
+
+      sleep(1);
+    }
+
+  return 0;
+}

--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -7,13 +7,23 @@ config NIMBLE
 		host-layer stack.
 
 if NIMBLE
-config NIMBLE_STACKSIZE
-	int "nimble stack size"
-	default DEFAULT_TASK_STACKSIZE
 
 config NIMBLE_REF
 	string "Version"
 	default "bc7828341226d860429c63994065f8f1b8b8d7b0"
 	---help---
 		Git ref name to use when downloading from nimBLE repo
-endif
+
+config NIMBLE_PORTING_EXAMPLE
+	bool "Apache nimBLE NuttX porting example"
+	default y
+
+if NIMBLE_PORTING_EXAMPLE
+
+config NIMBLE_PORTING_EXAMPLE_STACKSIZE
+	int "Apache NimBLE NuttX porting example stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif # NIMBLE_PORTING_EXAMPLE
+
+endif # NIMBLE

--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -1,9 +1,9 @@
 config NIMBLE
-	bool "Apache nimBLE (BLE host-layer)"
+	bool "Apache NimBLE (BLE host-layer)"
 	default n
 	depends on !WIRELESS_BLUETOOTH_HOST
 	---help---
-		Enable Apache nimBLE Bluetooth Low Energy
+		Enable Apache NimBLE Bluetooth Low Energy
 		host-layer stack.
 
 if NIMBLE
@@ -12,10 +12,208 @@ config NIMBLE_REF
 	string "Version"
 	default "bc7828341226d860429c63994065f8f1b8b8d7b0"
 	---help---
-		Git ref name to use when downloading from nimBLE repo
+		Git ref name to use when downloading from NimBLE repo
+
+if DEBUG_FEATURES
+
+config NIMBLE_DEBUG_ERROR
+	bool "Apache NimBLE error output"
+	default n
+	depends on DEBUG_ERROR
+
+config NIMBLE_DEBUG_WARN
+	bool "Apache NimBLE warnings output"
+	default n
+	depends on DEBUG_ERROR
+
+config NIMBLE_DEBUG_INFO
+	bool "Apache NimBLE informational debug output"
+	default n
+	depends on DEBUG_INFO
+
+endif # DEBUG_FEATURES
+
+config NIMBLE_TINYCRYPT
+	bool "Apache NimBLE tinycrypt support"
+	default y
+
+config NIMBLE_MESH
+	bool "Apache NimBLE mesh support"
+	default n
+	depends on EXPERIMENTAL
+
+menu "NimBLE role configuration"
+
+config NIMBLE_ROLE_BROADCASTER
+	bool "NimBLE broadcaster role"
+	default n
+
+config NIMBLE_ROLE_CENTRAL
+	bool "NimBLE central role"
+	default n
+
+config NIMBLE_ROLE_OBSERVER
+	bool "NimBLE observer role"
+	default n
+
+config NIMBLE_ROLE_PERIPHERAL
+	bool "NimBLE peripheral role"
+	default n
+
+endmenu # "NimBLE role configuration"
+
+choice
+	prompt "NimBLE BLE version"
+	default NIMBLE_BLE_VERSION_50
+
+config NIMBLE_BLE_VERSION_50
+	bool "NimBLE BLE version 5.0"
+
+config NIMBLE_BLE_VERSION_51
+	bool "NimBLE BLE version 5.1"
+
+config NIMBLE_BLE_VERSION_52
+	bool "NimBLE BLE version 5.2"
+
+config NIMBLE_BLE_VERSION_53
+	bool "NimBLE BLE version 5.3"
+
+endchoice # "NimBLE BLE version"
+
+config NIMBLE_BLE_VERSION
+	int
+	default 50 if NIMBLE_BLE_VERSION_50
+	default 51 if NIMBLE_BLE_VERSION_51
+	default 52 if NIMBLE_BLE_VERSION_52
+	default 53 if NIMBLE_BLE_VERSION_53
+
+menu "NimBLE BLE features"
+
+config NIMBLE_BLE_SUBRATING
+	bool "NimBLE connection subrating support"
+	default n
+
+config NIMBLE_BLE_EXT_ADV
+	bool "NimBLE extended advertising support"
+	default n
+
+config NIMBLE_BLE_EXT_ADV_MAX_SIZE
+	int "NimBLE extended advertising maximum size"
+	depends on NIMBLE_BLE_EXT_ADV
+	range 31 1650
+	default 31
+
+config NIMBLE_BLE_MAX_CONN
+	int "NimBLE maximum number of connections"
+	default 1
+
+config NIMBLE_BLE_MAX_PERIODIC_SYNCS
+	int "NimBLE maximum number of period syncs"
+	default 1
+
+config NIMBLE_BLE_MULTI_ADV_INSTANCES
+	int "NimBLE number of multi-advertising instances"
+	default 0
+	---help---
+	  The total number of advertising instances is this number plus 1
+
+config NIMBLE_BLE_PERIODIC_ADV
+	bool "NimBLE periodic advertising support"
+	default n
+
+config NIMBLE_BLE_PERIODIC_ADV_SYNC_TRANSFER
+	int "NimBLE periodic advertising sync transfer support"
+	depends on NIMBLE_BLE_PERIODIC_ADV && NIMBLE_BLE_VERSION > 50
+	default 0
+
+config NIMBLE_BLE_POWER_CONTROL
+	bool "NimBLE BLE LE power control support"
+	depends on NIMBLE_BLE_VERSION > 51
+	default n
+
+config NIMBLE_BLE_WHITELIST
+	bool "NimBLE BLE whitelist support"
+	default n
+
+endmenu # "NimBLE BLE features"
+
+menu "NimBLE BLE Host configuration"
+
+config NIMBLE_HS_FLOW_CTRL
+	bool "NimBLE Host flow control enable"
+	default n
+
+endmenu # "NimBLE BLE Host configuration"
+
+config NIMBLE_BLE_ATT_PREFFERED_MTU
+	int "NimBLE preferred MTU size"
+	default 256
+
+config NIMBLE_L2CAP_COC_MAX_NUM
+	int "NimBLE maximum number of connection oriented channels"
+	range 0 9
+	default 0
+	---help---
+	  When set to 0, BLE COC is disabled
+
+menu "NimBLE BLE privacy and security settings"
+
+config NIMBLE_BLE_RPA_TIMEOUT
+	int "NimBLE BLE RPA timeout"
+	default 300
+	---help---
+	  The rate that new random addresses should be generated (seconds)
+
+config NIMBLE_BLE_SM_BONDING
+	bool "NimBLE BLE bonding enable"
+	default y
+	---help---
+	  Enables bonding (persistence and restoration of secure links)
+
+config NIMBLE_BLE_SM_LEGACY
+	bool "NimBLE security manager legacy pairing"
+	default y
+
+config NIMBLE_BLE_SM_SC
+	bool "NimBLE security manager secure connections"
+	default y
+
+if NIMBLE_BLE_SM_SC
+
+config NIMBLE_BLE_SM_SC_DEBUG
+	bool "NimBLE secure connections debug mode"
+	default n
+
+config NIMBLE_BLE_SM_SC_ONLY
+	bool "NimBLE secure connections pairing only"
+	default n
+
+endif # NIMBLE_BLE_SM_SC
+
+endmenu # "NimBLE BLE security manager settings"
+
+menu "NimBLE memory configuration"
+
+config NIMBLE_MSYS_1_BLOCK_COUNT
+	int "NimBLE MSYS_1 block count"
+	default 12
+
+config NIMBLE_MSYS_1_BLOCK_SIZE
+	int "NimBLE MSYS_1 block size"
+	default 292
+
+config NIMBLE_MSYS_2_BLOCK_COUNT
+	int "NimBLE MSYS_2 block count"
+	default 0
+
+config NIMBLE_MSYS_2_BLOCK_SIZE
+	int "NimBLE MSYS_2 block size"
+	default 0
+
+endmenu # "NimBLE memory configuration"
 
 config NIMBLE_PORTING_EXAMPLE
-	bool "Apache nimBLE NuttX porting example"
+	bool "Apache NimBLE NuttX porting example"
 	default y
 
 if NIMBLE_PORTING_EXAMPLE

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -20,17 +20,23 @@
 
 include $(APPDIR)/Make.defs
 
-PRIORITY  = 255
-STACKSIZE = $(CONFIG_NIMBLE_STACKSIZE)
-
 NIMBLE_UNPACKDIR = mynewt-nimble
 NIMBLE_ROOT = $(APPDIR)/wireless/bluetooth/nimble/$(NIMBLE_UNPACKDIR)
-
--include $(NIMBLE_ROOT)/porting/examples/nuttx/Make.defs
-
 CONFIG_NIMBLE_REF := $(patsubst "%",%,$(strip $(CONFIG_NIMBLE_REF)))
 NIMBLE_TAR := $(CONFIG_NIMBLE_REF).tar.gz
 NIMBLE_URL := https://github.com/apache/mynewt-nimble/archive/$(NIMBLE_TAR)
+
+ifneq ($(CONFIG_NIMBLE_PORTING_EXAMPLE),)
+# Nimble porting example built-in application
+
+-include $(NIMBLE_ROOT)/porting/examples/nuttx/Make.defs
+PRIORITY  = 255
+STACKSIZE = $(CONFIG_NIMBLE_PORTING_EXAMPLE_STACKSIZE)
+
+# nimBLE assumes this flag since it expects undefined macros to be zero value
+
+CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
+endif
 
 $(NIMBLE_TAR):
 	$(Q) curl -L $(NIMBLE_URL) -o $(NIMBLE_TAR)
@@ -48,9 +54,5 @@ distclean::
 	$(call DELFILE,$(NIMBLE_TAR))
 	$(call DELDIR,$(NIMBLE_UNPACKDIR))
 endif
-
-# nimBLE assumes this flag since it expects undefined macros to be zero value
-
-CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
 
 include $(APPDIR)/Application.mk

--- a/wireless/bluetooth/nimble/Makefile
+++ b/wireless/bluetooth/nimble/Makefile
@@ -27,13 +27,13 @@ NIMBLE_TAR := $(CONFIG_NIMBLE_REF).tar.gz
 NIMBLE_URL := https://github.com/apache/mynewt-nimble/archive/$(NIMBLE_TAR)
 
 ifneq ($(CONFIG_NIMBLE_PORTING_EXAMPLE),)
-# Nimble porting example built-in application
+# NimBLE porting example built-in application
 
 -include $(NIMBLE_ROOT)/porting/examples/nuttx/Make.defs
 PRIORITY  = 255
 STACKSIZE = $(CONFIG_NIMBLE_PORTING_EXAMPLE_STACKSIZE)
 
-# nimBLE assumes this flag since it expects undefined macros to be zero value
+# NimBLE assumes this flag since it expects undefined macros to be zero value
 
 CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
 endif

--- a/wireless/bluetooth/nimble/Makefile.nimble
+++ b/wireless/bluetooth/nimble/Makefile.nimble
@@ -1,0 +1,69 @@
+############################################################################
+# apps/wireless/bluetooth/nimble/Makefile.nimble
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+NIMBLE_ROOT = $(APPDIR)/wireless/bluetooth/nimble/mynewt-nimble
+
+# Configure NimBLE variables
+
+ifneq ($(CONFIG_NIMBLE_TINYCRYPT),)
+NIMBLE_CFG_TINYCRYPT = 1
+endif
+
+ifneq ($(CONFIG_NIMBLE_MESH),)
+NIMBLE_CFG_MESH = 1
+endif
+
+# Skip files that don't build for this port
+
+NIMBLE_IGNORE += $(NIMBLE_ROOT)/porting/nimble/src/hal_timer.c
+NIMBLE_IGNORE += $(NIMBLE_ROOT)/porting/nimble/src/os_cputime.c
+NIMBLE_IGNORE += $(NIMBLE_ROOT)/porting/nimble/src/os_cputime_pwr2.c
+
+# include NimBLE porting defs
+
+include $(NIMBLE_ROOT)/porting/nimble/Makefile.defs
+
+CSRCS += $(NIMBLE_SRC)
+
+# Source files for NPL OSAL
+
+CSRCS += $(wildcard $(NIMBLE_ROOT)/porting/npl/nuttx/src/*.c)
+CSRCS += $(wildcard $(NIMBLE_ROOT)/nimble/transport/socket/src/*.c)
+CSRCS += $(TINYCRYPT_SRC)
+
+# Add NPL and all NimBLE directories to include paths
+
+NIMBLE_ALL_INC =  $(APPDIR)/wireless/bluetooth/nimble/include
+NIMBLE_ALL_INC += $(NIMBLE_ROOT)/porting/npl/nuttx/include
+NIMBLE_ALL_INC += $(NIMBLE_ROOT)/nimble/transport/socket/include
+NIMBLE_ALL_INC += $(NIMBLE_ROOT)/nimble/include
+NIMBLE_ALL_INC += $(NIMBLE_INCLUDE)
+NIMBLE_ALL_INC += $(TINYCRYPT_INCLUDE)
+
+CFLAGS += $(addprefix ${INCDIR_PREFIX}, $(NIMBLE_ALL_INC))
+CXXFLAGS += $(addprefix ${INCDIR_PREFIX}, $(NIMBLE_ALL_INC))
+
+# NimBLE assumes this flag since it expects undefined macros to be zero value
+
+CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
+
+# disable printf format checks
+
+CFLAGS += -Wno-format

--- a/wireless/bluetooth/nimble/include/logcfg/logcfg.h
+++ b/wireless/bluetooth/nimble/include/logcfg/logcfg.h
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * apps/wireless/bluetooth/nimble/include/logcfg/logcfg.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_WIRELESS_BLUETOOTH_NIMBLE_INCLUDE_LOGCFG_LOGCFG_H
+#define __APPS_WIRELESS_BLUETOOTH_NIMBLE_INCLUDE_LOGCFG_LOGCFG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_NIMBLE_DEBUG_ERROR
+#  define nimble_err  _err
+#else
+#  define nimble_err  _none
+#endif
+
+#ifdef CONFIG_NIMBLE_DEBUG_WARN
+#  define nimble_warn _warn
+#else
+#  define nimble_warn _none
+#endif
+
+#ifdef CONFIG_NIMBLE_DEBUG_INFO
+#  define nimble_info _info
+#else
+#  define nimble_info _none
+#endif
+
+#define BLE_HS_LOG_DEBUG(msg, ...)    nimble_info(msg, ##__VA_ARGS__)
+#define BLE_HS_LOG_INFO(msg, ...)     nimble_info(msg, ##__VA_ARGS__)
+#define BLE_HS_LOG_WARN(msg, ...)     nimble_warn(msg, ##__VA_ARGS__)
+#define BLE_HS_LOG_ERROR(msg, ...)    nimble_err(msg, ##__VA_ARGS__)
+#define BLE_HS_LOG_CRITICAL(msg, ...) nimble_err(msg, ##__VA_ARGS__)
+#define BLE_HS_LOG_DISABLED(msg, ...) nimble_err(msg, ##__VA_ARGS__)
+
+#define DFLT_LOG_DEBUG(msg, ...)      nimble_info(msg, ##__VA_ARGS__)
+#define DFLT_LOG_INFO(msg, ...)       nimble_info(msg, ##__VA_ARGS__)
+#define DFLT_LOG_WARN(msg, ...)       nimble_warn(msg, ##__VA_ARGS__)
+#define DFLT_LOG_ERROR(msg, ...)      nimble_err(msg, ##__VA_ARGS__)
+#define DFLT_LOG_CRITICAL(msg, ...)   nimble_err(msg, ##__VA_ARGS__)
+#define DFLT_LOG_DISABLED(msg, ...)   nimble_err(msg, ##__VA_ARGS__)
+
+#endif  /* __APPS_WIRELESS_BLUETOOTH_NIMBLE_INCLUDE_LOGCFG_LOGCFG_H */

--- a/wireless/bluetooth/nimble/include/syscfg/syscfg.h
+++ b/wireless/bluetooth/nimble/include/syscfg/syscfg.h
@@ -1,0 +1,306 @@
+/****************************************************************************
+ * apps/wireless/bluetooth/nimble/include/syscfg/syscfg.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_WIRELESS_BLUETOOTH_NIMBLE_INCLUDE_SYSCFG_SYSCFG_H
+#define __APPS_WIRELESS_BLUETOOTH_NIMBLE_INCLUDE_SYSCFG_SYSCFG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Macros used by NimBLE ****************************************************/
+
+#define MYNEWT_VAL(_name)               MYNEWT_VAL_ ## _name
+#define MYNEWT_VAL_CHOICE(_name, _val)  MYNEWT_VAL_ ## _name ## __ ## _val
+
+/* NimBLE NuttX specific configuration **************************************/
+
+#define MYNEWT_VAL_BLE_SOCK_USE_NUTTX        (1)
+#define MYNEWT_VAL_NEWT_FEATURE_LOGCFG       (1)
+
+/* NimBLE user specific configuration ***************************************/
+
+#define MYNEWT_VAL_MSYS_1_BLOCK_COUNT        (CONFIG_NIMBLE_MSYS_1_BLOCK_COUNT)
+#define MYNEWT_VAL_MSYS_1_BLOCK_SIZE         (CONFIG_NIMBLE_MSYS_1_BLOCK_SIZE)
+#define MYNEWT_VAL_MSYS_2_BLOCK_COUNT        (CONFIG_NIMBLE_MSYS_2_BLOCK_COUNT)
+#define MYNEWT_VAL_MSYS_2_BLOCK_SIZE         (CONFIG_NIMBLE_MSYS_2_BLOCK_SIZE)
+
+/* MSYS sanity check not supported */
+
+#define MYNEWT_VAL_MSYS_1_SANITY_MIN_COUNT   (0)
+#define MYNEWT_VAL_MSYS_2_SANITY_MIN_COUNT   (0)
+
+/* Transport configuration */
+
+#define MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_HS_COUNT     (10)
+#define MYNEWT_VAL_BLE_TRANSPORT_ACL_FROM_LL_COUNT     (0)
+#define MYNEWT_VAL_BLE_TRANSPORT_ACL_SIZE              (251)
+#define MYNEWT_VAL_BLE_TRANSPORT_EVT_COUNT             (4)
+#define MYNEWT_VAL_BLE_TRANSPORT_EVT_DISCARDABLE_COUNT (16)
+#define MYNEWT_VAL_BLE_TRANSPORT_EVT_SIZE              (70)
+
+/* L2CAP configuration */
+
+#define MYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM        (CONFIG_NIMBLE_L2CAP_COC_MAX_NUM)
+#define MYNEWT_VAL_BLE_L2CAP_COC_MPS            (MYNEWT_VAL_MSYS_1_BLOCK_SIZE-8)
+#define MYNEWT_VAL_BLE_L2CAP_COC_SDU_BUFF_COUNT (1)
+#define MYNEWT_VAL_BLE_L2CAP_ENHANCED_COC       (0)
+#define MYNEWT_VAL_BLE_L2CAP_JOIN_RX_FRAGS      (1)
+#define MYNEWT_VAL_BLE_L2CAP_MAX_CHANS          (3*MYNEWT_VAL_BLE_MAX_CONNECTIONS)
+#define MYNEWT_VAL_BLE_L2CAP_RX_FRAG_TIMEOUT    (30000)
+#define MYNEWT_VAL_BLE_L2CAP_SIG_MAX_PROCS      (1)
+
+/* Host configuration */
+
+#define MYNEWT_VAL_BLE_HOST                     (1)
+#define MYNEWT_VAL_BLE_HS_AUTO_START            (1)
+#define MYNEWT_VAL_BLE_HS_DEBUG                 (0)
+
+#ifdef CONFIG_NIMBLE_HS_FLOW_CTRL
+#  define MYNEWT_VAL_BLE_HS_FLOW_CTRL                  (1)
+#  define MYNEWT_VAL_BLE_HS_FLOW_CTRL_ITVL             (1000)
+#  define MYNEWT_VAL_BLE_HS_FLOW_CTRL_THRESH           (2)
+#  define MYNEWT_VAL_BLE_HS_FLOW_CTRL_TX_ON_DISCONNECT (0)
+#else
+#  define MYNEWT_VAL_BLE_HS_FLOW_CTRL                  (0)
+#endif
+
+#define MYNEWT_VAL_BLE_HS_PHONY_HCI_ACKS               (0)
+#define MYNEWT_VAL_BLE_HS_REQUIRE_OS                   (1)
+#define MYNEWT_VAL_BLE_HS_STOP_ON_SHUTDOWN             (1)
+#define MYNEWT_VAL_BLE_HS_STOP_ON_SHUTDOWN_TIMEOUT     (2000)
+
+/* BLE role configuration */
+
+#ifdef CONFIG_NIMBLE_ROLE_BROADCASTER
+#  define MYNEWT_VAL_BLE_ROLE_BROADCASTER    (1)
+#else
+#  define MYNEWT_VAL_BLE_ROLE_BROADCASTER    (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_ROLE_CENTRAL
+#  define MYNEWT_VAL_BLE_ROLE_CENTRAL        (1)
+#else
+#  define MYNEWT_VAL_BLE_ROLE_CENTRAL        (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_ROLE_OBSERVER
+#  define MYNEWT_VAL_BLE_ROLE_OBSERVER       (1)
+#else
+#  define MYNEWT_VAL_BLE_ROLE_OBSERVER       (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_ROLE_PERIPHERAL
+#  define MYNEWT_VAL_BLE_ROLE_PERIPHERAL     (1)
+#else
+#  define MYNEWT_VAL_BLE_ROLE_PERIPHERAL     (0)
+#endif
+
+/* BLE features */
+
+#ifdef CONFIG_NIMBLE_MESH
+#  define MYNEWT_VAL_BLE_MESH                       (1)
+#else
+#  define MYNEWT_VAL_BLE_MESH                       (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_CONN_SUBRATING
+#  define MYNEWT_VAL_BLE_CONN_SUBRATING             (1)
+#else
+#  define MYNEWT_VAL_BLE_CONN_SUBRATING             (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_EXT_ADV
+#  define MYNEWT_VAL_BLE_EXT_ADV                           (1)
+#  define MYNEWT_VAL_BLE_EXT_ADV_MAX_SIZE           (CONFIG_NIMBLE_BLE_EXT_ADV_MAX_SIZE)
+#else
+#  define MYNEWT_VAL_BLE_EXT_ADV                    (0)
+#endif
+
+#define MYNEWT_VAL_BLE_MAX_CONNECTIONS              (CONFIG_NIMBLE_BLE_MAX_CONN)
+#define MYNEWT_VAL_BLE_MAX_PERIODIC_SYNCS           (CONFIG_NIMBLE_BLE_MAX_PERIODIC_SYNCS)
+#define MYNEWT_VAL_BLE_MULTI_ADV_INSTANCES          (CONFIG_NIMBLE_BLE_MULTI_ADV_INSTANCES)
+
+#ifdef CONFIG_NIMBLE_BLE_PERIODIC_ADV
+#  define MYNEWT_VAL_BLE_PERIODIC_ADV               (1)
+#else
+#  define MYNEWT_VAL_BLE_PERIODIC_ADV               (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_PERIODIC_ADV_SYNC_TRANSFER
+#  define MYNEWT_VAL_BLE_PERIODIC_ADV_SYNC_TRANSFER (1)
+#else
+#  define MYNEWT_VAL_BLE_PERIODIC_ADV_SYNC_TRANSFER (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_POWER_CONTROL
+#  define MYNEWT_VAL_BLE_POWER_CONTROL              (1)
+#else
+#  define MYNEWT_VAL_BLE_POWER_CONTROL              (0)
+#endif
+
+#define MYNEWT_VAL_BLE_VERSION                      (CONFIG_NIMBLE_BLE_VERSION)
+
+#ifdef CONFIG_NIMBLE_BLE_WHITELIST
+#  define MYNEWT_VAL_BLE_WHITELIST                  (1)
+#else
+#  define MYNEWT_VAL_BLE_WHITELIST                  (0)
+#endif
+
+/* ATT configuration */
+
+#define MYNEWT_VAL_BLE_ATT_PREFERRED_MTU        (CONFIG_NIMBLE_BLE_ATT_PREFFERED_MTU)
+#define MYNEWT_VAL_BLE_ATT_SVR_FIND_INFO        (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_FIND_TYPE        (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_INDICATE         (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_MAX_PREP_ENTRIES (64)
+#define MYNEWT_VAL_BLE_ATT_SVR_NOTIFY           (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_QUEUED_WRITE     (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_QUEUED_WRITE_TMO (30000)
+#define MYNEWT_VAL_BLE_ATT_SVR_READ             (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_READ_BLOB        (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_READ_GROUP_TYPE  (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_READ_MULT        (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_READ_TYPE        (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_SIGNED_WRITE     (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_WRITE            (1)
+#define MYNEWT_VAL_BLE_ATT_SVR_WRITE_NO_RSP     (1)
+
+/* GAP configuration */
+
+#define MYNEWT_VAL_BLE_GAP_MAX_PENDING_CONN_PARAM_UPDATE (1)
+
+/* GATT configuration */
+
+#define MYNEWT_VAL_BLE_GATT_DISC_ALL_CHRS   (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_DISC_ALL_DSCS   (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_DISC_ALL_SVCS   (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_DISC_CHR_UUID   (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_DISC_SVC_UUID   (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_FIND_INC_SVCS   (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_INDICATE        (1)
+#define MYNEWT_VAL_BLE_GATT_MAX_PROCS       (4)
+#define MYNEWT_VAL_BLE_GATT_NOTIFY          (1)
+#define MYNEWT_VAL_BLE_GATT_READ            (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_READ_LONG       (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_READ_MAX_ATTRS  (8)
+#define MYNEWT_VAL_BLE_GATT_READ_MULT       (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_READ_UUID       (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_RESUME_RATE     (1000)
+#define MYNEWT_VAL_BLE_GATT_SIGNED_WRITE    (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_WRITE           (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_WRITE_LONG      (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_WRITE_MAX_ATTRS (4)
+#define MYNEWT_VAL_BLE_GATT_WRITE_NO_RSP    (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+#define MYNEWT_VAL_BLE_GATT_WRITE_RELIABLE  (MYNEWT_VAL_BLE_ROLE_CENTRAL)
+
+/* Security configuration */
+
+#define MYNEWT_VAL_BLE_RPA_TIMEOUT          (CONFIG_NIMBLE_BLE_RPA_TIMEOUT)
+
+#ifdef CONFIG_NIMBLE_BLE_SM_BONDING
+#  define MYNEWT_VAL_BLE_SM_BONDING         (1)
+#else
+#  define MYNEWT_VAL_BLE_SM_BONDING         (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_SM_LEGACY
+#  define MYNEWT_VAL_BLE_SM_LEGACY          (1)
+#else
+#  define MYNEWT_VAL_BLE_SM_LEGACY          (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_SM_SC
+#  define MYNEWT_VAL_BLE_SM_SC              (1)
+#else
+#  define MYNEWT_VAL_BLE_SM_SC                             (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_SM_SC_DEBUG
+#  define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS   (1)
+#else
+#  define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS   (0)
+#endif
+
+#ifdef CONFIG_NIMBLE_BLE_SM_SC_ONLY
+#  define MYNEWT_VAL_BLE_SM_SC_ONLY         (1)
+#else
+#  define MYNEWT_VAL_BLE_SM_SC_ONLY         (0)
+#endif
+
+#define MYNEWT_VAL_BLE_SM_IO_CAP            (BLE_HS_IO_NO_INPUT_OUTPUT)
+#define MYNEWT_VAL_BLE_SM_KEYPRESS          (0)
+#define MYNEWT_VAL_BLE_SM_LVL               (0)
+#define MYNEWT_VAL_BLE_SM_MAX_PROCS         (1)
+#define MYNEWT_VAL_BLE_SM_MITM              (0)
+#define MYNEWT_VAL_BLE_SM_OOB_DATA_FLAG     (0)
+#define MYNEWT_VAL_BLE_SM_OUR_KEY_DIST      (0)
+#define MYNEWT_VAL_BLE_SM_THEIR_KEY_DIST    (0)
+#define MYNEWT_VAL_BLE_STORE_MAX_BONDS      (3)
+#define MYNEWT_VAL_BLE_STORE_MAX_CCCDS      (8)
+
+/* ANS service */
+
+#define MYNEWT_VAL_BLE_SVC_ANS_NEW_ALERT_CAT (0)
+#define MYNEWT_VAL_BLE_SVC_ANS_UNR_ALERT_CAT (0)
+
+/* BAS service */
+
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE (1)
+#define MYNEWT_VAL_BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM     (0)
+
+/* DIS service */
+
+#define MYNEWT_VAL_BLE_SVC_DIS_DEFAULT_READ_PERM           (-1)
+#define MYNEWT_VAL_BLE_SVC_DIS_FIRMWARE_REVISION_DEFAULT   (NULL)
+#define MYNEWT_VAL_BLE_SVC_DIS_FIRMWARE_REVISION_READ_PERM (-1)
+#define MYNEWT_VAL_BLE_SVC_DIS_HARDWARE_REVISION_DEFAULT   (NULL)
+#define MYNEWT_VAL_BLE_SVC_DIS_HARDWARE_REVISION_READ_PERM (-1)
+#define MYNEWT_VAL_BLE_SVC_DIS_MANUFACTURER_NAME_DEFAULT   (NULL)
+#define MYNEWT_VAL_BLE_SVC_DIS_MANUFACTURER_NAME_READ_PERM (-1)
+#define MYNEWT_VAL_BLE_SVC_DIS_MODEL_NUMBER_DEFAULT        "Apache NuttX NimBLE"
+#define MYNEWT_VAL_BLE_SVC_DIS_MODEL_NUMBER_READ_PERM      (0)
+#define MYNEWT_VAL_BLE_SVC_DIS_SERIAL_NUMBER_DEFAULT       (NULL)
+#define MYNEWT_VAL_BLE_SVC_DIS_SERIAL_NUMBER_READ_PERM     (-1)
+#define MYNEWT_VAL_BLE_SVC_DIS_SOFTWARE_REVISION_DEFAULT   (NULL)
+#define MYNEWT_VAL_BLE_SVC_DIS_SOFTWARE_REVISION_READ_PERM (-1)
+#define MYNEWT_VAL_BLE_SVC_DIS_SYSTEM_ID_DEFAULT           (NULL)
+#define MYNEWT_VAL_BLE_SVC_DIS_SYSTEM_ID_READ_PERM         (-1)
+
+/* GAP service */
+
+#define MYNEWT_VAL_BLE_SVC_GAP_APPEARANCE                  (0)
+#define MYNEWT_VAL_BLE_SVC_GAP_APPEARANCE_WRITE_PERM       (-1)
+#define MYNEWT_VAL_BLE_SVC_GAP_CENTRAL_ADDRESS_RESOLUTION  (-1)
+#define MYNEWT_VAL_BLE_SVC_GAP_DEVICE_NAME                 "nimble"
+#define MYNEWT_VAL_BLE_SVC_GAP_DEVICE_NAME_MAX_LENGTH      (31)
+#define MYNEWT_VAL_BLE_SVC_GAP_DEVICE_NAME_WRITE_PERM      (-1)
+#define MYNEWT_VAL_BLE_SVC_GAP_PPCP_MAX_CONN_INTERVAL      (0)
+#define MYNEWT_VAL_BLE_SVC_GAP_PPCP_MIN_CONN_INTERVAL      (0)
+#define MYNEWT_VAL_BLE_SVC_GAP_PPCP_SLAVE_LATENCY          (0)
+#define MYNEWT_VAL_BLE_SVC_GAP_PPCP_SUPERVISION_TMO        (0)
+
+#endif  /* __APPS_WIRELESS_BLUETOOTH_NIMBLE_INCLUDE_SYSCFG_SYSCFG_H */


### PR DESCRIPTION
## Summary

- nimble: make nimble porting example optional
  Enabled by default for the moment to avoid CI errors
- nimble: improve integration with NuttX
    1. add Makefile.nimble that helps integrate NimBLE with custom applications
      To enable NimBLE for an custom application, user needs to include Makefile.nimble in the app's Makefile:
        include $(APPDIR)/wireless/bluetooth/nimble/Makefile.nimble
    
    2. add NuttX specific syscfg.h
      - file based on nimble/porting/examples/nuttx/include/syscfg/syscfg.h
      - all unnecessary definitions was removed
      - definitions are configurable from Kconfig
    
    3. add NuttX specific logcfg.h
      - bind NimBLE logging with debug.h macros

- examples: add NimBLE example, based on nimble/porting/examples/nuttx
  It's better to keep this example as part of nuttx-apps instead of relying on an external project

## Impact

## Testing
nrf52832-dk/sdc_nimble
