### PR TITLE
bluetooth/btsak: add dependency on WIRELESS_BLUETOOTH_HOST=y

### DIFF
--- a/wireless/bluetooth/btsak/Kconfig
+++ b/wireless/bluetooth/btsak/Kconfig
@@ -6,6 +6,7 @@
 config BTSAK
 	tristate "Bluetooth Swiss Army Knife"
 	default n
+	depends on WIRELESS_BLUETOOTH_HOST
 	---help---
 		Enable the Bluetooth Swiss Army Knife
 


### PR DESCRIPTION
## Summary
bluetooth/btsak: add dependency on WIRELESS_BLUETOOTH_HOST=y

## Impact

## Testing
CI
