### PR TITLE
system/ramspeed: Allow read and write buffers to be allocated from the heap.

### DIFF
--- a/system/ramspeed/ramspeed_main.c
+++ b/system/ramspeed/ramspeed_main.c
@@ -92,10 +92,11 @@ struct ramspeed_s
 
 static void show_usage(FAR const char *progname, int exitcode)
 {
-  printf("\nUsage: %s -r <hex-address> -w <hex-address> -s <decimal-size>"
+  printf("\nUsage: %s -a -r <hex-address> -w <hex-address> -s <decimal-size>"
          " -v <hex-value>[0x00] -n <decimal-repeat number>[100] -i\n",
          progname);
   printf("\nWhere:\n");
+  printf("  -a allocate RW buffers on heap. Overwrites -r and -w option.\n");
   printf("  -r <hex-address> read address.\n");
   printf("  -w <hex-address> write address.\n");
   printf("  -s <decimal-size> number of memory locations (in bytes).\n");
@@ -116,20 +117,24 @@ static void parse_commandline(int argc, FAR char **argv,
                               FAR struct ramspeed_s *info)
 {
   int ch;
+  bool allocate_rw_address = false;
 
   memset(info, 0, sizeof(struct ramspeed_s));
   info->repeat_num = 100;
 
-  if (argc < 7)
+  if (argc < 4)
     {
       printf(RAMSPEED_PREFIX "Missing required arguments\n");
       show_usage(argv[0], EXIT_FAILURE);
     }
 
-  while ((ch = getopt(argc, argv, "r:w:s:v:n:i")) != ERROR)
+  while ((ch = getopt(argc, argv, "r:w:s:v:n:i:a")) != ERROR)
     {
       switch (ch)
         {
+          case 'a':
+            allocate_rw_address = true;
+            break;
           case 'r':
             OPTARG_TO_VALUE(info->src, const void *, 16);
             break;
@@ -165,6 +170,12 @@ static void parse_commandline(int argc, FAR char **argv,
             show_usage(argv[0], EXIT_FAILURE);
             break;
         }
+    }
+
+  if (allocate_rw_address)
+    {
+      info->dest = malloc(info->size);
+      info->src = malloc(info->size);
     }
 
   if (info->dest == NULL || info->src == NULL || info->size == 0)


### PR DESCRIPTION
## Summary

Allocates the read and write buffers used from ramspeed on the heap.

This change makes it much easier to use the ramspeed test in BUILD_KERNEL, as one does not need to know which virtual address is safe to use.

## Impact

Using ramspeed in conjunction with BUILD_KERNEL is easier.

## Testing

arty_a7:knsh with `CONFIG_SYSTEM_RAMSPEED=m`

```
nsh> ramspeed -a -s 4096
______memcpy performance______
______Perform 32 Bytes access ______
RAM Speed: Time-consuming is too short, please increase the <repeat number>
RAM Speed: Time-consuming is too short, please increase the <repeat number>
______Perform 64 Bytes access ______
RAM Speed: Time-consuming is too short, please increase the <repeat number>
... more results follow.
```
