### PR TITLE
mk: Attempt to silence "Nothing to be done for xx" messages.

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -106,6 +106,7 @@ VPATH += :.
 # Targets follow
 
 all:: $(OBJS)
+	@:
 .PHONY: clean depend distclean
 .PRECIOUS: $(BIN)
 
@@ -198,6 +199,7 @@ endif
 	$(eval PROGOBJ=$(filter-out $(firstword $(PROGOBJ)),$(PROGOBJ)))
 
 install:: $(PROGLIST)
+	@:
 
 else
 
@@ -226,10 +228,12 @@ $(MAINZIGOBJ): %$(ZIGEXT)$(SUFFIX)$(OBJEXT): %$(ZIGEXT)
 		$(call ELFCOMPILEZIG, $<, $@), $(call COMPILEZIG, $<, $@))
 
 install::
+	@:
 
 endif # BUILD_MODULE
 
 context::
+	@:
 
 ifneq ($(PROGNAME),)
 
@@ -243,8 +247,10 @@ $(REGLIST): $(DEPCONFIG) Makefile
 	$(if $(filter-out $(firstword $(STACKSIZE)),$(STACKSIZE)),$(eval STACKSIZE=$(filter-out $(firstword $(STACKSIZE)),$(STACKSIZE))))
 
 register:: $(REGLIST)
+	@:
 else
 register::
+	@:
 endif
 
 .depend: Makefile $(wildcard $(foreach SRC, $(SRCS), $(addsuffix /$(SRC), $(subst :, ,$(VPATH))))) $(DEPCONFIG)
@@ -254,6 +260,7 @@ endif
 	$(Q) touch $@
 
 depend:: .depend
+	@:
 
 clean::
 	$(call CLEAN)

--- a/Directory.mk
+++ b/Directory.mk
@@ -51,6 +51,7 @@ endif
 	$(Q) touch .kconfig
 
 clean: $(foreach SDIR, $(CLEANSUBDIRS), $(SDIR)_clean)
+	@:
 
 distclean: $(foreach SDIR, $(CLEANSUBDIRS), $(SDIR)_distclean)
 ifneq ($(MENUDESC),)


### PR DESCRIPTION
## Summary

When rebuilding, it's not really useful to see reams of "Nothing to be done for" for every application being built. This change attempts to silence these messages.

## Impact

Stops make spitting out "nothing to be done.." messages for each target of every application. These can be distracting, when a large number of applications are enabled.

## Testing

With 5 registered applications.

Before the change:

```
$ make import --no-print-directory -j16
cc  -O2 -Wall -Wstrict-prototypes -Wshadow -DHAVE_STRTOK_C=1 nuttx/apps/import/tools/incdir.c -o "nuttx/apps/import/tools/incdir"
make[3]: Nothing to be done for 'context'.
make[3]: Nothing to be done for 'context'.
make[3]: Nothing to be done for 'context'.
LN: platform/board to /path/to/xx
make[3]: Nothing to be done for 'context'.
make[3]: Nothing to be done for 'context'.
make[3]: Nothing to be done for 'context'.
make[3]: Nothing to be done for 'context'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[3]: Nothing to be done for 'register'.
make[1]: Nothing to be done for 'register'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'depend'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[2]: Nothing to be done for 'all'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
make[3]: Nothing to be done for 'install'.
```

After the change:
```
$ make import --no-print-directory -j16
cc  -O2 -Wall -Wstrict-prototypes -Wshadow -DHAVE_STRTOK_C=1 nuttx/apps/import/tools/incdir.c -o "nuttx/apps/import/tools/incdir"
LN: platform/board to /path/to/xx
make[1]: Nothing to be done for 'register'.
```

There's still one additional 'Nothing to be done for..' sneaking in there which I can't seem to silence. But the output is still now much cleaner (IMO).