### PR TITLE
nshlib/dd: Increase the integer width for sector size in dd.

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -76,8 +76,8 @@ struct dd_s
   uint32_t     skip;       /* The number of sectors skipped on input */
   bool         eof;        /* true: The end of the input or output file has been hit */
   bool         verify;     /* true: Verify infile and outfile correctness */
-  uint16_t     sectsize;   /* Size of one sector */
-  uint16_t     nbytes;     /* Number of valid bytes in the buffer */
+  size_t       sectsize;   /* Size of one sector */
+  size_t       nbytes;     /* Number of valid bytes in the buffer */
   FAR uint8_t *buffer;     /* Buffer of data to write to the output file */
 };
 
@@ -92,7 +92,7 @@ struct dd_s
 static int dd_write(FAR struct dd_s *dd)
 {
   FAR uint8_t *buffer = dd->buffer;
-  uint16_t written ;
+  size_t written;
   ssize_t nbytes;
 
   /* Is the out buffer full (or is this the last one)? */


### PR DESCRIPTION
## Summary

Increases the maximum sector size, and number of bytes that can be transferred with DD.

On some systems, using sector sizes larger than 65536 is needed for profiling performance or testing.

## Impact

Can now use DD with sector size > 65536.

## Testing

arty_a7:knsh.

Example usage also in [#9080](https://github.com/apache/nuttx/issues/9080) (from Nuttx)

