### PR TITLE
Change the way of definition of SUFFIX

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -61,7 +61,7 @@ ifeq ($(BUILD_MODULE),y)
   LDLIBS += $(COMPILER_RT_LIB)
 endif
 
-SUFFIX = $(subst $(DELIM),.,$(CWD))
+SUFFIX ?= $(subst $(DELIM),.,$(CWD))
 
 PROGNAME := $(subst ",,$(PROGNAME))
 


### PR DESCRIPTION
## Summary
When archiving, if the number of files is large, the full path in SUFFIX may exceed the command line limit for Cygwin and other
programs. To avoid this, the SUFFIX can be changed in the Makefile in each application or library.

## Impact
No impact since existing Makefiles do not have SUFFIX overrides.

## Testing
Build check
