### PR TITLE
system/nxdiag: Add Espressif's HAL version

### DIFF
--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -20,7 +20,8 @@
 
 include $(APPDIR)/Make.defs
 
-NXTOOLSDIR = $(APPDIR)/tools
+NXTOOLSDIR = $(APPDIR)$(DELIM)tools
+NXDIAGDIR = $(APPDIR)$(DELIM)system$(DELIM)nxdiag
 
 # Sysinfo application info
 
@@ -58,12 +59,29 @@ endif
 
 # Vendor-specific checks
 
+# Espressif
+
 ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF),y)
-ifdef ESPTOOL_BINDIR
-NXDIAG_FLAGS += --espressif "$(ESPTOOL_BINDIR)"
-else
-NXDIAG_FLAGS += --espressif "$(TOPDIR)"
+
+ARCH_ESP_HALDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)chip$(DELIM)esp-hal-3rdparty
+
+# If the esp-hal-3rdparty directory is not in the arch directory, then it can be
+# cloned to the nxdiag directory for debugging purposes.
+HALDIR := $(shell if [ -d $(ARCH_ESP_HALDIR)$(DELIM).git ]; then echo "$(ARCH_ESP_HALDIR)"; else echo "$(NXDIAGDIR)$(DELIM)esp-hal-3rdparty"; fi)
+
+INFO_DEPS += espressif_prepare
+
+espressif_prepare:
+ifeq ($(HALDIR),$(ARCH_ESP_HALDIR))
+	(cd ${HALDIR} && git fetch -q --depth=10000 && git fetch -q --tags)
 endif
+
+ifdef ESPTOOL_BINDIR
+NXDIAG_FLAGS += --espressif "$(ESPTOOL_BINDIR)" "$(HALDIR)"
+else
+NXDIAG_FLAGS += --espressif "$(TOPDIR)" "$(HALDIR)"
+endif
+
 endif
 
 # Common build
@@ -77,8 +95,12 @@ checkpython3:
 		exit 1; \
 	fi
 
-sysinfo.h : checkpython3
-	@python3 $(NXTOOLSDIR)$(DELIM)host_sysinfo.py $(NXDIAG_FLAGS) > sysinfo.h || (echo "host_sysinfo.py failed $$?"; exit 1)
+sysinfo.h : checkpython3 $(INFO_DEPS)
+	@python3 $(NXTOOLSDIR)$(DELIM)host_sysinfo.py $(NXDIAG_FLAGS) > sysinfo.h
+	if ([ $$? -ne 0 ]); then \
+		echo "ERROR: Failed to generate sysinfo.h"; \
+		exit 1; \
+	fi
 
 context:: sysinfo.h
 

--- a/system/nxdiag/nxdiag.c
+++ b/system/nxdiag/nxdiag.c
@@ -344,6 +344,7 @@ int main(int argc, char *argv[])
       printf("Toolchain version:\n");
       print_array(ESPRESSIF_TOOLCHAIN, ESPRESSIF_TOOLCHAIN_ARRAY_SIZE);
       printf("Esptool version: %s\n\n", ESPRESSIF_ESPTOOL);
+      printf("HAL version: %s\n\n", ESPRESSIF_HAL);
 #endif
     }
 


### PR DESCRIPTION
## Summary

Adds the currently used ESP HAL version to NXdiag's output.
Also refactor some portions of the code.

## Impact

New information for NXdiag.

## Testing

Tested on ESP32-C3-DevKitC