### PR TITLE
import/mk: Update ELF flags to represent build configuration type.

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -90,5 +90,8 @@ endif
 
 # ELF module definitions
 
-LDELFFLAGS += -r -e _start -Bstatic
+ifeq ($(CONFIG_BINFMT_ELF_RELOCATABLE),y)
+  LDELFFLAGS += -r
+endif
+LDELFFLAGS += -e _start -Bstatic
 LDELFFLAGS += $(addprefix -T,$(call CONVERT_PATH,$(TOPDIR)/scripts/gnu-elf.ld))


### PR DESCRIPTION
## Summary
Allows board configuration to select the output ELF format for applications built using the `make import` target.

This PR should be paired with [#9635](https://github.com/apache/nuttx/pull/9635), from the NuttX main repository.

## Impact

The format of application ELFs built through `make import` can be set by board configuration.

## Testing

Copied from [#9635](https://github.com/apache/nuttx/pull/9635):

```
# Using a board configuration which has `CONFIG_BINFMT_ELF_EXECUTABLE=y`
$ cd nuttx
$ ./tools/configure.sh arty_a7:knsh
$ make
$ make export
$ cd ../apps
$ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
$ make import
$ riscv64-unknown-elf-readelf -a bin/init | grep Type:
  Type:                              EXEC (Executable file)

# Using a board configuration which does not define `CONFIG_BINFMT_ELF_EXECUTABLE`
$ cd nuttx
$ ./tools/configure.sh rv-virt:knsh32:knsh
$ make
$ make export
$ cd ../apps
$ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
$ make import
$ riscv64-unknown-elf-readelf -a bin/init | grep Type:
  Type:                              REL (Relocatable file)
```