### PR TITLE
Add small test of pthread_exit()/pthread_self() on main thread.

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -66,6 +66,10 @@ CSRCS += cancel.c cond.c mutex.c timedmutex.c sem.c semtimed.c barrier.c
 CSRCS += timedwait.c
 CSRCS += pthread_rwlock.c pthread_rwlock_cancel.c
 
+ifeq ($(CONFIG_SCHED_WAITPID),y)
+CSRCS += pthread_exit.c
+endif
+
 ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += specific.c
 endif

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -230,6 +230,12 @@ void pthread_rwlock_test(void);
 
 void pthread_rwlock_cancel_test(void);
 
+/* pthread_exit.c ***********************************************************/
+
+#ifdef CONFIG_SCHED_WAITPID
+void pthread_exit_test(void);
+#endif
+
 /* pthread_cleanup.c ********************************************************/
 
 void pthread_cleanup_test(void);

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -441,6 +441,14 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
+#ifdef CONFIG_SCHED_WAITPID
+      /* Verify pthread_exit() and pthread_self() */
+
+      printf("\nuser_main: pthread_exit() test\n");
+      pthread_exit_test();
+      check_test_memory_usage();
+#endif
+
       /* Verify pthreads rwlock interfaces */
 
       printf("\nuser_main: pthread_rwlock test\n");

--- a/testing/ostest/pthread_exit.c
+++ b/testing/ostest/pthread_exit.c
@@ -1,0 +1,114 @@
+/****************************************************************************
+ * apps/testing/ostest/pthread_exit.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/wait.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "ostest.h"
+
+#ifdef CONFIG_SCHED_WAITPID
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define PRIORITY  100
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void *pthread_exit_thread(FAR void *parameter)
+{
+  unsigned me = (unsigned)pthread_self();
+
+  printf("pthread_exit_thread %u: Sleeping for 10 second\n", me);
+  sleep(5);
+  printf("pthread_exit_thread %u: Still running...\n", me);
+  sleep(5);
+  printf("pthread_exit_thread %u: Exiting\n", me);
+  return NULL;
+}
+
+static int pthread_exit_main(int argc, char **argv)
+{
+  pthread_t child;
+#ifdef SDCC
+  pthread_attr_t attr;
+#endif
+  unsigned me = (unsigned)pthread_self();
+  int ret;
+
+  printf("pthread_exit_main %u: Starting pthread_exit_thread\n", me);
+#ifdef SDCC
+  pthread_attr_init(&attr);
+  ret = pthread_create(&child, &attr, pthread_exit_thread, NULL);
+#else
+  ret = pthread_create(&child, NULL, pthread_exit_thread, NULL);
+#endif
+  if (ret != 0)
+    {
+      printf("Thread creation failed, return code %d", ret);
+    }
+
+  printf("pthread_exit_main %u: Sleeping for 5 seconds\n", me);
+  fflush(stdout);
+  sleep(5);
+
+  printf("pthread_exit_main %u: Calling pthread_exit()\n", me);
+  pthread_exit(NULL);
+
+  printf("pthread_exit_main %u: ERROR:  Still running\n", me);
+  exit(0);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void pthread_exit_test(void)
+{
+  int statloc;
+  int ret;
+
+  ret = task_create("pthread_exit", PRIORITY, STACKSIZE, pthread_exit_main,
+                    NULL);
+  if (ret < 0)
+    {
+      printf("pthread_exit_test:  ERROR task_create Failed\n");
+    }
+  else
+    {
+      printf("pthread_exit_test: Started pthread_exit_main at PID=%d\n",
+             ret);
+      waitpid((pid_t)ret, &statloc, 0);
+    }
+}
+
+#endif /* CONFIG_SCHED_WAITPID */


### PR DESCRIPTION
## Summary

Add a minimal test to assure that pthread_self() and pthread_exit() work correctly when called from the main thread.

## Impact

None expected.  Worst case would be an OS test failure

## Testing

sim/ostest

Test result:

1. Test has to run in a separate task because it will exit.

   pthread_exit_test:  Starting pthread_exit_main at PID=183

2. Test logic a) starts the pthread_exit_thread, b) waits 5 seconds and then c) calls pthread_exit()

    a) pthread_exit_main 183: Starting pthread_exit_thread
    b) pthread_exit_main 183: Sleeping for 5 seconds

3. Process does not terminate (correct) and pthread_exit_thread is started
4. The pthread_exit_thread d) sleeps for 5 seconds, then e) 5 more seconds, then f)  implicitly calls pthread_exit()

    d) pthread_exit_thread 189: Sleeping for 10 second
    c) pthread_exit_main 183: Calling pthread_exit()
    e) pthread_exit_thread 189: Still running...
    f) pthread_exit_thread 189: Exiting

5. Now the process terminates and the OS test continues
