### PR TITLE
tools/mkimport: Add system map to mkimport script.

### DIFF
--- a/tools/mkimport.sh
+++ b/tools/mkimport.sh
@@ -162,7 +162,7 @@ cp -rf ${REGISTERSDIR} ${BUILTINDIR}/. || \
 
 # Move the .config file in place in the import directory
 
-SFILES=".config"
+SFILES=".config System.map"
 for file in ${SFILES}; do
 	if [ -f "${EXPORTDIR}/${file}" ]; then
 		cp -a ${EXPORTDIR}/${file} ${IMPORTDIR}/${file} || \


### PR DESCRIPTION
## Summary

The `make export` target from the Nuttx repository correctly packs the System.map file. This change ensure that ./tools/mkimport.sh extracts this file correctly into the `import`correctly.

## Impact

The `System.map` file is now available in the import directory for applications to build against.

## Testing

```
$ cd nuttx
$ ./tools/configure.sh rv-virt:knsh32:knsh
$ make
$ make export
$ cd ../apps
$ ./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz
$ ls import
include  libs  Make.defs  Makefile  scripts  startup  System.map  tools
```
Notice the addition of the `System.map` file.
