### PR TITLE
rexec: warn users about cleartext password transmission

### DIFF
--- a/netutils/rexec/Kconfig
+++ b/netutils/rexec/Kconfig
@@ -8,6 +8,7 @@ config NETUTILS_REXEC
 	default n
 	---help---
 		Enable support for the remote execution client.
+		Warning: rexec transmits passwords in cleartext, unencrypted.
 
 if NETUTILS_REXEC
 

--- a/netutils/rexecd/Kconfig
+++ b/netutils/rexecd/Kconfig
@@ -8,6 +8,7 @@ config NETUTILS_REXECD
 	default n
 	---help---
 		Enable support for the Remote Execution server.
+		Warning: rexec transmits passwords in cleartext, unencrypted.
 
 if NETUTILS_REXECD
 


### PR DESCRIPTION
Close apache/nuttx#9642.

## Summary
Warn users about cleartext password transmission of rexec.

## Impact

## Testing

