### PR TITLE
libuv: fix compile warning

### DIFF
--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -102,9 +102,12 @@ ifneq ($(CONFIG_LIBC_DLFCN),)
 CSRCS += dl.c
 endif
 
-ifneq ($(CONFIG_NET),)
+ifneq ($(CONFIG_LIBC_NETDB),)
 CSRCS += getaddrinfo.c
 CSRCS += getnameinfo.c
+endif
+
+ifneq ($(CONFIG_NET),)
 CSRCS += inet.c
 endif
 


### PR DESCRIPTION
CC:  pthread/pthread_mutexinconsistent.c libuv/src/unix/getaddrinfo.c:103:9: warning: implicit declaration of function ‘getaddrinfo’; did you mean ‘uv_getaddrinfo’? [-Wimplicit-function-declaration]
  103 |   err = getaddrinfo(req->hostname, req->service, req->hints, &req->addrinfo);
      |         ^~~~~~~~~~~
      |         uv_getaddrinfo
libuv/src/unix/getaddrinfo.c: In function ‘uv_freeaddrinfo’:
libuv/src/unix/getaddrinfo.c:222:5: warning: implicit declaration of function ‘freeaddrinfo’; did you mean ‘uv_freeaddrinfo’? [-Wimplicit-function-declaration]
  222 |     freeaddrinfo(ai);
      |     ^~~~~~~~~~~~
      |     uv_freeaddrinfo
CC:  misc/lib_crc16ccitt.c libuv/src/unix/getnameinfo.c: In function ‘uv__getnameinfo_work’:
libuv/src/unix/getnameinfo.c:45:9: warning: implicit declaration of function ‘getnameinfo’; did you mean ‘uv_getnameinfo’? [-Wimplicit-function-declaration]
   45 |   err = getnameinfo((struct sockaddr*) &req->storage,
      |         ^~~~~~~~~~~
      |         uv_getnameinfo


## Summary
CONFIG_LIBC_NETDB may be disabled and getaddrinfo/getnameinfo are not valid while libuv is compiling.  
That is to fix the wrong dependency.

## Impact
None
## Testing
sim:usbdev
