### PR TITLE
nshlib: add `-h` option for ls command

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -323,7 +323,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_LS
-  CMD_MAP("ls",       cmd_ls,       1, 5, "[-lRs] <dir-path>"),
+  CMD_MAP("ls",       cmd_ls,       1, 5, "[-lRsh] <dir-path>"),
 #endif
 
 #if defined(CONFIG_MODULE) && !defined(CONFIG_NSH_DISABLE_MODCMDS)

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -83,6 +83,11 @@
 #define LSFLAGS_SIZE          1
 #define LSFLAGS_LONG          2
 #define LSFLAGS_RECURSIVE     4
+#define LSFLAGS_HUMANREADBLE  16
+
+#define KB                   (1UL << 10)
+#define MB                   (1UL << 20)
+#define GB                   (1UL << 30)
 
 /****************************************************************************
  * Private Functions
@@ -251,7 +256,25 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
 
       if ((lsflags & LSFLAGS_SIZE) != 0)
         {
-          nsh_output(vtbl, "%8" PRIdOFF, buf.st_size);
+          if (lsflags & LSFLAGS_HUMANREADBLE && buf.st_size >= KB)
+            {
+              if (buf.st_size >= GB)
+                {
+                  nsh_output(vtbl, "%7.1fG", (float)buf.st_size / GB);
+                }
+              else if (buf.st_size >= MB)
+                {
+                  nsh_output(vtbl, "%7.1fM", (float)buf.st_size / MB);
+                }
+              else
+                {
+                  nsh_output(vtbl, "%7.1fK", (float)buf.st_size / KB);
+                }
+            }
+          else
+            {
+              nsh_output(vtbl, "%8" PRIdOFF, buf.st_size);
+            }
         }
     }
 
@@ -1255,7 +1278,7 @@ int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   /* Get the ls options */
 
   int option;
-  while ((option = getopt(argc, argv, "lRs")) != ERROR)
+  while ((option = getopt(argc, argv, "lRsh")) != ERROR)
     {
       switch (option)
         {
@@ -1269,6 +1292,10 @@ int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
           case 's':
             lsflags |= LSFLAGS_SIZE;
+            break;
+
+          case 'h':
+            lsflags |= LSFLAGS_HUMANREADBLE;
             break;
 
           case '?':


### PR DESCRIPTION
## Summary
Added `-h` options support for `ls` nsh command

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
N/A

## Testing
config: ./tools/configure.sh sim:nsh
CONFIG_LIBC_FLOATINGPOINT=y
```
nsh> ls -l /dev
/dev:
 crw-rw-rw-       0 console
 crw-rw-rw-       0 gpio0
 crw-rw-rw-       0 gpio1
 crw-rw-rw-       0 gpio2
 crw-rw-rw-       0 gpio3
 crw-rw-rw-       0 loop
 crw-rw-rw-       0 null
 crw-rw-rw-       0 oneshot
 brw-rw-rw- 1048576 ram0
 brw-rw-rw-    1024 ram1
 brw-rw-rw-  524288 ram2
 crw-rw-rw-       0 zero
nsh> ls /lh /dev
nsh: ls: too many arguments
nsh> ls -lh /dev
/dev:
 crw-rw-rw-       0 console
 crw-rw-rw-       0 gpio0
 crw-rw-rw-       0 gpio1
 crw-rw-rw-       0 gpio2
 crw-rw-rw-       0 gpio3
 crw-rw-rw-       0 loop
 crw-rw-rw-       0 null
 crw-rw-rw-       0 oneshot
 brw-rw-rw-    1.0M ram0
 brw-rw-rw-    1.0K ram1
 brw-rw-rw-  512.0K ram2
 crw-rw-rw-       0 zero
```

config: ./tools/configure.sh ../vendor/sim/boards/miwear/configs/miwear -j16
```
nsh> ls -l /resource/misc/media
/resource/misc/media:
 -rwxrwxr-x  384044 AlexaTimer.wav
 -rwxrwxr-x   57001 AlexaReminder.mp3
 -rwxrwxr-x  384132 AlexaAlarm.wav
 -rw-rw-r--   20733 Clank.mp3
 -rw-rw-r--   45183 NotificationXylophone.mp3
 -rw-rw-r--   27420 Robot.mp3
 -rw-rw-r--   21986 FadeIn.mp3
 -rw-rw-r--   42049 Flute.mp3
 -rw-rw-r--  362748 Latona-15s.mp3
 drwxrwxr-x    4096 .
 -rw-rw-r--   47198 alarm_volume_adjust.mp3
 -rw-rw-r--   95338 Expect.mp3
 drwxrwxr-x    4096 ..
 -rw-rw-r--  409435 Sunrise.mp3
 -rw-rw-r--   55841 Fresh.mp3
 -rw-rw-r--   36685 Bells-1s.mp3
 -rw-rw-r--    4432 camera_click.mp3
 -rw-rw-r--  469621 MiRemix.mp3
nsh>
nsh> ls -lh /resource/misc/media
/resource/misc/media:
 -rwxrwxr-x  375.0K AlexaTimer.wav
 -rwxrwxr-x   55.7K AlexaReminder.mp3
 -rwxrwxr-x  375.1K AlexaAlarm.wav
 -rw-rw-r--   20.2K Clank.mp3
 -rw-rw-r--   44.1K NotificationXylophone.mp3
 -rw-rw-r--   26.8K Robot.mp3
 -rw-rw-r--   21.5K FadeIn.mp3
 -rw-rw-r--   41.1K Flute.mp3
 -rw-rw-r--  354.2K Latona-15s.mp3
 drwxrwxr-x    4.0K .
 -rw-rw-r--   46.1K alarm_volume_adjust.mp3
 -rw-rw-r--   93.1K Expect.mp3
 drwxrwxr-x    4.0K ..
 -rw-rw-r--  399.8K Sunrise.mp3
 -rw-rw-r--   54.5K Fresh.mp3
 -rw-rw-r--   35.8K Bells-1s.mp3
 -rw-rw-r--    4.3K camera_click.mp3
 -rw-rw-r--  458.6K MiRemix.mp3
```

