### PR TITLE
gdbstub:Support a general gdbstub, support serial port and network link

### DIFF
--- a/system/gdbstub/Kconfig
+++ b/system/gdbstub/Kconfig
@@ -1,0 +1,25 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_GDBSTUB
+	tristate "GDBSTUB"
+	---help---
+		Enable support for gdbstub.
+
+if SYSTEM_GDBSTUB
+
+config SYSTEM_GDBSTUB_STACKSIZE
+	int "gdbstub stack size"
+	default DEFAULT_TASK_STACKSIZE
+	---help---
+		The size of stack allocated for the gdbstub task.
+
+config SYSTEM_GDBSTUB_PRIORITY
+	int "gdbstub priority"
+	default 100
+	---help---
+		The priority of the gdbstub task.
+
+endif

--- a/system/gdbstub/Make.defs
+++ b/system/gdbstub/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/gdbstub/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_GDBSTUB),)
+CONFIGURED_APPS += $(APPDIR)/system/gdbstub
+endif

--- a/system/gdbstub/Makefile
+++ b/system/gdbstub/Makefile
@@ -1,0 +1,30 @@
+############################################################################
+# apps/system/gdbstub/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME = gdbstub
+PRIORITY = $(CONFIG_SYSTEM_GDBSTUB_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_GDBSTUB_STACKSIZE)
+MODULE = $(CONFIG_SYSTEM_GDBSTUB)
+
+MAINSRC = gdbstub.c
+
+include $(APPDIR)/Application.mk

--- a/system/gdbstub/gdbstub.c
+++ b/system/gdbstub/gdbstub.c
@@ -1,0 +1,250 @@
+/****************************************************************************
+ * apps/system/gdbstub/gdbstub.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <fcntl.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include <nuttx/gdbstub.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int gdb_monitor(FAR struct gdb_state_s *state, FAR const char *cmd)
+{
+#ifdef CONFIG_SYSTEM_POPEN
+  FAR FILE *file;
+
+  file = popen(cmd, "r");
+  if (file != NULL)
+    {
+      char buf[128];
+
+      while (1)
+        {
+          size_t len = fread(buf, 1, sizeof(buf) - 1, file);
+          if (len == 0 && (feof(file) || ferror(file)))
+            {
+              break;
+            }
+
+          buf[len] = '\0';
+          gdb_console_message(state, buf);
+        }
+
+      pclose(file);
+      return 0;
+    }
+  else
+    {
+      return -errno;
+    }
+#else
+  return -EPROTONOSUPPORT;
+#endif
+}
+
+static ssize_t gdb_send(FAR void *priv, FAR void *buf,
+                        size_t len)
+{
+  int fd = *(FAR int *)priv;
+  size_t i = 0;
+
+  while (i < len)
+    {
+      ssize_t ret = write(fd, (FAR char *)buf + i, len - i);
+      if (ret < 0)
+        {
+          return -errno;
+        }
+
+      i += ret;
+    }
+
+  return len;
+}
+
+static ssize_t gdb_recv(FAR void *priv, FAR void *buf,
+                        size_t len)
+{
+  int fd = *(FAR int *)priv;
+  size_t i = 0;
+
+  while (i < len)
+    {
+      ssize_t ret = read(fd, (FAR char *)buf + i, len - i);
+      if (ret < 0)
+        {
+          return -errno;
+        }
+
+      i += ret;
+    }
+
+  return len;
+}
+
+static void usage(FAR const char *progname)
+{
+  fprintf(stderr, "USAGE: %s [tty Options | Net Options] \n", progname);
+  fprintf(stderr, "tty Options:\n");
+  fprintf(stderr, "   -d [tty device path]  etc:/dev/ttyS0\n");
+  fprintf(stderr, "Net Options:\n");
+  fprintf(stderr, "   -p [Port]  etc:1234\n");
+  fprintf(stderr, "   -h: show help message and exit\n");
+  fprintf(stderr, "Choose one of the two modes of tty and net\n");
+
+  exit(EXIT_FAILURE);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+#ifdef CONFIG_NET
+  FAR char *port = NULL;
+  int sock = 0;
+#endif
+  FAR struct gdb_state_s *state;
+  FAR char *dev = NULL;
+  int ret;
+  int fd;
+
+#ifdef CONFIG_NET
+  while ((ret = getopt_long(argc, argv, "d:p:h", NULL, NULL)) != ERROR)
+#else
+  while ((ret = getopt_long(argc, argv, "d:h", NULL, NULL)) != ERROR)
+#endif
+    {
+      switch (ret)
+      {
+        case 'd':
+          dev = optarg;
+          break;
+#ifdef CONFIG_NET
+        case 'p':
+          port = optarg;
+          break;
+#endif
+        case 'h':
+        case '?':
+        default:
+          usage(argv[0]);
+          break;
+      }
+    }
+
+#ifdef CONFIG_NET
+  if (port)
+    {
+      struct sockaddr_in addr;
+
+      if (((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0))
+        {
+          fprintf(stderr, "ERROR: Failed to open socket: %d\n", errno);
+          return -errno;
+        }
+
+      memset(&addr, 0, sizeof(addr));
+      addr.sin_family = AF_INET;
+      addr.sin_addr.s_addr = htonl(INADDR_ANY);
+      addr.sin_port = htons(atoi(port));
+      if ((bind(sock, (FAR struct sockaddr *)&addr, sizeof(addr)) < 0))
+        {
+          fprintf(stderr, "ERROR: Failed to bind socket: %d\n", errno);
+          return -errno;
+        }
+
+      if (listen(sock, 1) < 0)
+        {
+          fprintf(stderr, "ERROR: Failed to listen socket: %d\n", errno);
+          return -errno;
+        }
+
+reconnect:
+      if (((fd = accept(sock, NULL, NULL)) < 0))
+        {
+          fprintf(stderr, "ERROR: Failed to accept socket: %d\n", errno);
+          return -errno;
+        }
+    }
+  else
+#endif
+  if (dev)
+    {
+      fd = open(dev, O_RDWR);
+      if (fd < 0)
+        {
+          fprintf(stderr, "ERROR: Failed to open %s: %d\n", dev, errno);
+          return -errno;
+        }
+    }
+  else
+    {
+      usage(argv[0]);
+    }
+
+  state = gdb_state_init(gdb_send, gdb_recv, gdb_monitor, &fd);
+  if (state == NULL)
+    {
+      ret = -ENOMEM;
+      goto errout;
+    }
+
+  do
+    {
+      ret = gdb_process(state);
+      if (ret == -ECONNRESET)
+        {
+#ifdef CONFIG_NET
+          if (port)
+            {
+              close(fd);
+              goto reconnect;
+            }
+
+#endif
+          continue;
+        }
+    }
+  while (ret >= 0);
+
+  gdb_state_uninit(state);
+
+errout:
+  close(fd);
+#ifdef CONFIG_NET
+  if (port && sock)
+    {
+      close(sock);
+    }
+#endif
+
+  return ret;
+}


### PR DESCRIPTION
Partially implement the gdb rsp protocol,
you can debug the nuttx kernel through the serial port or the network

## Summary
support gdbstub app
## Impact
debug
## Testing
stm32f429i-disco:gdbstub

run `gdbstub -d /dev/ttyS1 &` on nsh
then use gdb to connet board

```
# ajh @ 12700 in ~/work/vela_all/nuttx on git:5734e6a882 x [14:49:47]
$ arm-none-eabi-gdb nuttx -ex "set target-charset ASCII" -ex "set print pretty on" -ex "set remotelogfile gdb.log"  -ex "set serial baud 115200" -ex "target remote /dev/ttyUSB1"
GNU gdb (Arm GNU Toolchain 12.2.Rel1 (Build arm-12.24)) 12.1.90.20221210-git
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-pc-linux-gnu --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://bugs.linaro.org/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from nuttx...
Remote debugging using /dev/ttyUSB1
warning: multi-threaded target stopped without sending a thread-id, using first non-exited thread
up_idle () at chip/stm32_idle.c:152
152     {
(gdb) bt
#0  up_idle () at chip/stm32_idle.c:152
#1  0x080029d0 in nx_start () at init/nx_start.c:698
#2  0x08000204 in __start () at chip/stm32_start.c:198
(gdb) info threads
  Id   Target Id                                                                       Frame
* 1    Remote target                                                                   up_idle ()
    at chip/stm32_idle.c:152
  2    Thread 1 (Name: nsh_main, State: Waiting,Semaphore, Priority: 100, Stack: 2000) sys_call2 (nbr=2,
    parm1=268436488, parm2=268449988) at /home/ajh/work/vela_all/nuttx/include/arch/syscall.h:187
  3    Thread 2 (Name: gdbstub, State: Running, Priority: 100, Stack: 8128)            exception_common ()
    at armv7-m/arm_exception.S:144
(gdb) thread 2
[Switching to thread 2 (Thread 1)]
#0  sys_call2 (nbr=2, parm1=268436488, parm2=268449988)
    at /home/ajh/work/vela_all/nuttx/include/arch/syscall.h:187
187       return reg0;
(gdb) bt
#0  sys_call2 (nbr=2, parm1=268436488, parm2=268449988)
    at /home/ajh/work/vela_all/nuttx/include/arch/syscall.h:187
#1  0x0800c34c in up_switch_context (tcb=0x100013e0, rtcb=0x10000388) at common/arm_switchcontext.c:95
#2  0x08005c50 in nxsem_wait (sem=0x2000001c <g_usart1priv+28>) at semaphore/sem_wait.c:176
#3  0x0800811a in uart_read (filep=0x10000808, buffer=0x10000fbb "\b\f\020", buflen=1) at serial/serial.c:1051
#4  0x080153b8 in file_read (filep=0x10000808, buf=0x10000fbb, nbytes=1) at vfs/fs_read.c:92
#5  0x080153f4 in nx_read (fd=0, buf=0x10000fbb, nbytes=1) at vfs/fs_read.c:140
#6  0x08015414 in read (fd=0, buf=0x10000fbb, nbytes=1) at vfs/fs_read.c:170
#7  0x0800cb0c in readline_getc (vtbl=0x1000100c) at readline_fd.c:72
#8  0x0800cc4c in readline_common (vtbl=0x1000100c, buf=0x10001370 "gdbstub", buflen=64) at readline_common.c:513
#9  0x0800cbfc in readline_fd (buf=0x10001370 "gdbstub", buflen=64, infd=0, outfd=1) at readline_fd.c:222
#10 0x0800ca7e in nsh_session (pstate=0x100010e8, login=1, argc=1, argv=0x100008d0) at nsh_session.c:212
#11 0x0800c6ae in nsh_consolemain (argc=1, argv=0x100008d0) at nsh_consolemain.c:71
#12 0x0800c664 in nsh_main (argc=1, argv=0x100008d0) at nsh_main.c:73
#13 0x080091c8 in nxtask_startup (entrypt=0x800c629 <nsh_main>, argc=1, argv=0x100008d0)
    at sched/task_startup.c:70
#14 0x08004900 in nxtask_start () at task/task_start.c:134
#15 0x00000000 in ?? ()

```
