### PR TITLE
boot: add support for a minimal NuttX-based bootloader

### DIFF
--- a/boot/miniboot/Kconfig
+++ b/boot/miniboot/Kconfig
@@ -1,0 +1,23 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig BOOT_MINIBOOT
+	bool "Minimal bootloader"
+	default n
+	select BOARDCTL_BOOT_IMAGE
+	---help---
+		Enable support for the minimal NuttX based bootloader.
+
+config MINIBOOT_SLOT_PATH
+	string "Application firmware image slot path"
+	default "/dev/ota0"
+	---help---
+		The path to the application firmware image slot character
+		device driver.
+		Default: /dev/ota0
+
+config MINIBOOT_HEADER_SIZE
+	hex "Application firmware image header size"
+	default 0x200

--- a/boot/miniboot/Make.defs
+++ b/boot/miniboot/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/boot/miniboot/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_BOOT_MINIBOOT),)
+CONFIGURED_APPS += $(APPDIR)/boot/miniboot
+endif

--- a/boot/miniboot/Makefile
+++ b/boot/miniboot/Makefile
@@ -1,0 +1,29 @@
+############################################################################
+# apps/boot/miniboot/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = miniboot
+PRIORITY  = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
+
+MAINSRC = miniboot_main.c
+
+include $(APPDIR)/Application.mk

--- a/boot/miniboot/miniboot_main.c
+++ b/boot/miniboot/miniboot_main.c
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * apps/boot/miniboot/miniboot_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <syslog.h>
+
+#include <sys/boardctl.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: miniboot_main
+ *
+ * Description:
+ *   Minimal bootlaoder entry point.
+ *
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct boardioc_boot_info_s info;
+
+  syslog(LOG_INFO, "*** miniboot ***\n");
+
+  /* Perform architecture-specific initialization (if configured) */
+
+  boardctl(BOARDIOC_INIT, 0);
+
+#ifdef CONFIG_BOARDCTL_FINALINIT
+  /* Perform architecture-specific final-initialization (if configured) */
+
+  boardctl(BOARDIOC_FINALINIT, 0);
+#endif
+
+  /* Call board specific image boot */
+
+  info.path        = CONFIG_MINIBOOT_SLOT_PATH;
+  info.header_size = CONFIG_MINIBOOT_HEADER_SIZE;
+
+  return boardctl(BOARDIOC_BOOT_IMAGE, (uintptr_t)&info);
+}


### PR DESCRIPTION
## Summary
- boot: add support for a minimal NuttX-based bootloader
    This can be useful for development purposes when you don't need any complex bootloader yet,
    but just want to jump to the app image.
    
    Can be helpful when we need to switch from secure environment to non-secure environment.

## Impact

## Testing
nrf9160: boot from secure bootlaoder to non-secure app
