### PR TITLE
Remove the const cast from the initialization of boardioc_symtab_s::symtab

### DIFF
--- a/examples/module/module_main.c
+++ b/examples/module/module_main.c
@@ -153,7 +153,7 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_BUILD_FLAT
   /* Set the OS symbol table indirectly through the boardctl() */
 
-  symdesc.symtab   = (FAR struct symtab_s *)g_mod_exports;
+  symdesc.symtab   = g_mod_exports;
   symdesc.nsymbols = g_mod_nexports;
   ret = boardctl(BOARDIOC_OS_SYMTAB, (uintptr_t)&symdesc);
   if (ret < 0)

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -262,7 +262,7 @@ int main(int argc, FAR char *argv[])
 
   /* Make sure that we are using our symbol tablee */
 
-  symdesc.symtab   = (FAR struct symtab_s *)g_spawn_exports; /* Discard 'const' */
+  symdesc.symtab   = g_spawn_exports;
   symdesc.nsymbols = g_spawn_nexports;
   boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
 

--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -165,7 +165,7 @@
  */
 
 FAR const struct symtab_s *g_thttpdsymtab;
-int                         g_thttpdnsymbols;
+int                        g_thttpdnsymbols;
 #endif
 
 /****************************************************************************

--- a/netutils/thttpd/thttpd.c
+++ b/netutils/thttpd/thttpd.c
@@ -57,7 +57,6 @@
 #include <arpa/inet.h>
 
 #include <nuttx/compiler.h>
-#include <nuttx/symtab.h>
 #include "netutils/thttpd.h"
 
 #include "config.h"

--- a/netutils/thttpd/thttpd_cgi.c
+++ b/netutils/thttpd/thttpd_cgi.c
@@ -55,7 +55,6 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/symtab.h>
 #include <nuttx/binfmt/binfmt.h>
 #include "netutils/thttpd.h"
 

--- a/nshlib/nsh_init.c
+++ b/nshlib/nsh_init.c
@@ -135,7 +135,7 @@ void nsh_initialize(void)
 #if defined(CONFIG_NSH_SYMTAB)
   /* Make sure that we are using our symbol table */
 
-  symdesc.symtab   = (FAR struct symtab_s *)CONFIG_NSH_SYMTAB_ARRAYNAME; /* Discard 'const' */
+  symdesc.symtab   = CONFIG_NSH_SYMTAB_ARRAYNAME;
   symdesc.nsymbols = CONFIG_NSH_SYMTAB_COUNTNAME;
 
   boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);


### PR DESCRIPTION
## Summary

follow up the change in nuttx side: https://github.com/apache/nuttx/pull/9671

## Impact

minor

## Testing

ci
