### PR TITLE
nshlib: Add fdinfo to get information about the process associated fd

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -365,6 +365,11 @@ config NSH_DISABLE_EXPORT
 	bool "Disable export"
 	default DEFAULT_SMALL
 
+config NSH_DISABLE_FDINFO
+	bool "Disable fdinfo"
+	default DEFAULT_SMALL
+	depends on FS_PROCFS
+
 config NSH_DISABLE_FREE
 	bool "Disable free"
 	default DEFAULT_SMALL

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -951,6 +951,9 @@ void nsh_usbtrace(void);
 #ifndef CONFIG_NSH_DISABLE_PS
   int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_FDINFO)
+  int cmd_fdinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
 #ifndef CONFIG_NSH_DISABLE_XD
   int cmd_xd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -571,9 +571,9 @@
 #  undef NSH_HAVE_READFILE
 #endif
 
-/* nsh_foreach_direntry used by the ls and ps commands */
+/* nsh_foreach_direntry used by the ls and ps and fdinfo commands */
 
-#if defined(CONFIG_NSH_DISABLE_LS) && defined(CONFIG_NSH_DISABLE_PS)
+#if defined(CONFIG_NSH_DISABLE_LS) && defined(CONFIG_NSH_DISABLE_PS) && defined(CONFIG_NSH_DISABLE_FDINFO)
 #  undef NSH_HAVE_FOREACH_DIRENTRY
 #endif
 

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -234,6 +234,12 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("false",    cmd_false,    1, 1, NULL),
 #endif
 
+#ifdef CONFIG_FS_PROCFS
+#  ifndef CONFIG_NSH_DISABLE_FDINFO
+  CMD_MAP("fdinfo",   cmd_fdinfo,   1, 2, "[pid]"),
+#  endif
+#endif
+
 #ifndef CONFIG_NSH_DISABLE_FREE
   CMD_MAP("free",     cmd_free,     1, 1, NULL),
 #endif

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -42,6 +42,8 @@
 #include <errno.h>
 #include <debug.h>
 
+#include "nsh.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT)
 #  include <sys/mount.h>
 #  include <sys/boardctl.h>


### PR DESCRIPTION
## Summary
In this modification, we can use fdinfo to get all the fd information, or specify the PID (e.g. fdinfo 11) to get the fd information of the target process
## Impact

## Testing

