### PR TITLE
tools: Don't register app into nsh if WASM_BUILD_ONLY == y

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -93,6 +93,20 @@ ifneq ($(BUILD_MODULE),y)
   OBJS += $(MAINCOBJ) $(MAINCXXOBJ) $(MAINRUSTOBJ) $(MAINZIGOBJ)
 endif
 
+# Condition flags
+
+DO_REGISTRATION = y
+
+ifeq ($(PROGNAME),)
+  DO_REGISTRATION = n
+endif
+
+ifeq ($(WASM_BUILD),y)
+ifeq ($(WASM_BUILD_ONLY),y)
+  DO_REGISTRATION = n
+endif
+endif
+
 # Compile flags, notice the default flags only suitable for flat build
 
 ZIGELFFLAGS ?= $(ZIGFLAGS)
@@ -235,7 +249,7 @@ endif # BUILD_MODULE
 context::
 	@:
 
-ifneq ($(PROGNAME),)
+ifeq ($(DO_REGISTRATION),y)
 
 REGLIST := $(addprefix $(BUILTIN_REGISTRY)$(DELIM),$(addsuffix .bdat,$(PROGNAME)))
 APPLIST := $(PROGNAME)


### PR DESCRIPTION
## Summary
Provide a method to build wasm app only, by define a variable WASM_BUILD_ONLY 

## Impact

Build system

## Testing

CI and local machine
