### PR TITLE
examples/pwm: Fix duty cycle overflow

### DIFF
--- a/examples/pwm/pwm_main.c
+++ b/examples/pwm/pwm_main.c
@@ -523,7 +523,8 @@ int main(int argc, FAR char *argv[])
   for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       info.channels[i].channel = g_pwmstate.channels[i];
-      info.channels[i].duty = b16divi(uitoub16(g_pwmstate.duties[i]), 100);
+      info.channels[i].duty = g_pwmstate.duties[i] ? \
+        b16divi(uitoub16(g_pwmstate.duties[i]) - 1, 100) : 0;
       printf(" channel: %d duty: %08" PRIx32,
         info.channels[i].channel, info.channels[i].duty);
     }
@@ -531,7 +532,8 @@ int main(int argc, FAR char *argv[])
   printf("\n");
 
 #else
-  info.duty  = b16divi(uitoub16(g_pwmstate.duty), 100);
+  info.duty = g_pwmstate.duty ? \
+    b16divi(uitoub16(g_pwmstate.duty) - 1, 100) : 0;
 #  ifdef CONFIG_PWM_PULSECOUNT
   info.count = g_pwmstate.count;
 


### PR DESCRIPTION
## Summary

This commit fixes the overflow that happens when setting the duty cycle to 100% in the PWM example.
It now correctly passes to the lower level the value `0xffff` rather than `0x0000` when setting the duty cycle to 100 and makes sure that no underflow happens when setting the duty cycle to 0.

## Impact

Correct handling of the duty cycle range in the PWM example.

## Testing

`esp32c3-devkit:pwm`