### PR TITLE
testing/ostest: fix Compiler Warning (level 1) C4716: 'function' must return a value

### DIFF
--- a/testing/ostest/pthread_exit.c
+++ b/testing/ostest/pthread_exit.c
@@ -86,6 +86,8 @@ static int pthread_exit_main(int argc, char **argv)
 
   printf("pthread_exit_main %u: ERROR:  Still running\n", me);
   exit(0);
+
+  return 0;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

testing/ostest: fix Compiler Warning (level 1) C4716: 'function' must return a value

https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4716?view=msvc-170
Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check