### PR TITLE
ostest: Skip test_dev_null when CONFIG_DEV_NULL isn't enabled

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -22,12 +22,15 @@ if(CONFIG_TESTING_OSTEST)
 
   set(SRCS
       getopt.c
-      dev_null.c
       restart.c
       sigprocmask.c
       sighand.c
       signest.c
       sighelper.c)
+
+  if(CONFIG_DEV_NULL)
+    list(APPEND SRCS dev_null.c)
+  endif()
 
   if(CONFIG_SIG_SIGSTOP_ACTION)
     if(CONFIG_SIG_SIGKILL_ACTION)

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -29,9 +29,13 @@ MODULE = $(CONFIG_TESTING_OSTEST)
 
 # NuttX OS Test
 
-CSRCS   = getopt.c dev_null.c restart.c sigprocmask.c sighand.c signest.c
+CSRCS   = getopt.c restart.c sigprocmask.c sighand.c signest.c
 CSRCS  += sighelper.c
 MAINSRC = ostest_main.c
+
+ifeq ($(CONFIG_DEV_NULL),y)
+CSRCS += dev_null.c
+endif
 
 ifeq ($(CONFIG_SIG_SIGSTOP_ACTION),y)
 ifeq ($(CONFIG_SIG_SIGKILL_ACTION),y)

--- a/testing/ostest/dev_null.c
+++ b/testing/ostest/dev_null.c
@@ -41,7 +41,7 @@ static FAR char buffer[1024];
  * Public Functions
  ****************************************************************************/
 
-int dev_null(void)
+int dev_null_test(void)
 {
   int nbytes;
   int fd;

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -99,7 +99,9 @@ int setvbuf_test(void);
 
 /* dev_null.c ***************************************************************/
 
-int dev_null(void);
+#ifdef CONFIG_DEV_NULL
+int dev_null_test(void);
+#endif
 
 /* fpu.c ********************************************************************/
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -325,9 +325,11 @@ static int user_main(int argc, char *argv[])
 
       /* Checkout /dev/null */
 
+#ifdef CONFIG_DEV_NULL
       printf("\nuser_main: /dev/null test\n");
-      dev_null();
+      dev_null_test();
       check_test_memory_usage();
+#endif
 
 #ifdef CONFIG_TESTING_OSTEST_AIO
       /* Check asynchronous I/O */


### PR DESCRIPTION
## Summary

report here: https://github.com/apache/nuttx/pull/9837#issuecomment-1637282337

## Impact

ostest

## Testing

ci