### PR TITLE
ostest/rmutex: mutex need to be destroyed

### DIFF
--- a/testing/ostest/rmutex.c
+++ b/testing/ostest/rmutex.c
@@ -207,4 +207,5 @@ void recursive_mutex_test(void)
     }
 
   printf("recursive_mutex_test: Complete\n");
+  pthread_mutex_destroy(&mut);
 }


### PR DESCRIPTION
## Summary
ostest/rmutex: mutex need to be destroyed

## Impact
none

## Testing
none
