### PR TITLE
examples: Change unionfs_mount to mount

### DIFF
--- a/examples/thttpd/thttpd_main.c
+++ b/examples/thttpd/thttpd_main.c
@@ -47,10 +47,6 @@
 #  include <sys/boardctl.h>
 #endif
 
-#ifdef CONFIG_THTTPD_BINFS
-#  include <nuttx/fs/unionfs.h>
-#endif
-
 #ifdef CONFIG_NET_SLIP
 #  include <nuttx/net/net.h>
 #endif
@@ -138,7 +134,7 @@
 
 #ifdef CONFIG_THTTPD_BINFS
 #  define ROMFS_MOUNTPT      "/mnt/tmp1"
-#  define ROMFS_PREFIX       NULL
+#  define ROMFS_PREFIX       ""
 #  define BINFS_MOUNTPT      "/mnt/tmp2"
 #  define BINFS_PREFIX       "cgi-bin"
 #  define UNIONFS_MOUNTPT    CONFIG_THTTPD_PATH
@@ -294,8 +290,9 @@ int main(int argc, FAR char *argv[])
 
   printf("Creating UNIONFS filesystem at %s\n", UNIONFS_MOUNTPT);
 
-  ret = unionfs_mount(ROMFS_MOUNTPT, ROMFS_PREFIX, BINFS_MOUNTPT,
-                      BINFS_PREFIX, UNIONFS_MOUNTPT);
+  ret = mount(NULL, UNIONFS_MOUNTPT, "unionfs", 0,
+              "fspath1=" ROMFS_MOUNTPT ",prefix1=" ROMFS_PREFIX
+              ",fspath2=" BINFS_MOUNTPT ",prefix2=" BINFS_PREFIX);
   if (ret < 0)
     {
       printf("ERROR: Failed to create the union file system at %s: %d\n",

--- a/examples/unionfs/unionfs_main.c
+++ b/examples/unionfs/unionfs_main.c
@@ -39,7 +39,6 @@
 #include <errno.h>
 
 #include <nuttx/drivers/ramdisk.h>
-#include <nuttx/fs/unionfs.h>
 
 #include "romfs_atestdir.h"
 #include "romfs_btestdir.h"
@@ -75,15 +74,15 @@
 #endif
 
 #ifndef CONFIG_EXAMPLES_UNIONFS_MOUNTPT
-#  define "/mnt/unionfs"
+#  define CONFIG_EXAMPLES_UNIONFS_MOUNTPT "/mnt/unionfs"
 #endif
 
 #ifndef CONFIG_EXAMPLES_UNIONFS_TMPA
-#  define "/mnt/a"
+#  define CONFIG_EXAMPLES_UNIONFS_TMPA "/mnt/a"
 #endif
 
 #ifndef CONFIG_EXAMPLES_UNIONFS_TMPB
-#  define "/mnt/b"
+#  define CONFIG_EXAMPLES_UNIONFS_TMPB "/mnt/b"
 #endif
 
 #define NSECTORS(b)        (((b)+CONFIG_EXAMPLES_UNIONFS_SECTORSIZE-1)/CONFIG_EXAMPLES_UNIONFS_SECTORSIZE)
@@ -175,9 +174,9 @@ int main(int argc, FAR char *argv[])
 
   /* Now create and mount the union file system */
 
-  ret = unionfs_mount(CONFIG_EXAMPLES_UNIONFS_TMPA, NULL,
-                      CONFIG_EXAMPLES_UNIONFS_TMPB, "offset",
-                      CONFIG_EXAMPLES_UNIONFS_MOUNTPT);
+  ret = mount(NULL, CONFIG_EXAMPLES_UNIONFS_MOUNTPT, "unionfs", 0,
+              "fspath1=" CONFIG_EXAMPLES_UNIONFS_TMPA
+              ",fspath2=" CONFIG_EXAMPLES_UNIONFS_TMPB ",prefix2=offset");
   if (ret < 0)
     {
       printf("ERROR: Failed to create the union file system: %d\n", ret);


### PR DESCRIPTION
## Summary

since unionfs_mount isn't exported through syscall

## Impact

code refactor

## Testing

sim:unionfs