### PR TITLE
cmake:migrate apps CMakeLists for [audioutils benchmarks]

### DIFF
--- a/audioutils/fmsynth/CMakeLists.txt
+++ b/audioutils/fmsynth/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/audioutils/CMakeLists.txt
+# apps/audioutils/fmsynth/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,6 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
-
-nuttx_generate_kconfig(MENUDESC "Audio Utility libraries")
+if(CONFIG_AUDIOUTILS_MMLPARSER_LIB)
+  target_sources(apps PRIVATE fmsynth.c fmsynth_eg.c fmsynth_op.c)
+endif()

--- a/audioutils/mml_parser/CMakeLists.txt
+++ b/audioutils/mml_parser/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/audioutils/CMakeLists.txt
+# apps/audioutils/mml_parser/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,7 +17,6 @@
 # the License.
 #
 # ##############################################################################
-
-nuttx_add_subdirectory()
-
-nuttx_generate_kconfig(MENUDESC "Audio Utility libraries")
+if(CONFIG_AUDIOUTILS_MMLPARSER_LIB)
+  target_sources(apps PRIVATE mml_parser.c)
+endif()

--- a/audioutils/nxaudio/CMakeLists.txt
+++ b/audioutils/nxaudio/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/audioutils/CMakeLists.txt
+# apps/audioutils/nxaudio/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,6 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
-
-nuttx_generate_kconfig(MENUDESC "Audio Utility libraries")
+if(CONFIG_AUDIOUTILS_NXAUDIO_LIB)
+  target_sources(apps PRIVATE nxaudio.c)
+endif()

--- a/benchmarks/coremark/CMakeLists.txt
+++ b/benchmarks/coremark/CMakeLists.txt
@@ -1,0 +1,101 @@
+# ##############################################################################
+# apps/benchmarks/coremark/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BENCHMARK_COREMARK)
+
+  # ############################################################################
+  # Config and Fetch Coremark application
+  # ############################################################################
+
+  set(COREMARKAPP_DIR ${CMAKE_CURRENT_LIST_DIR}/coremark)
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/coremark)
+    FetchContent_Declare(coremark
+                         URL https://github.com/eembc/coremark/archive/main.zip)
+    FetchContent_MakeAvailable(coremark)
+    set(COREMARKAPP_DIR ${coremark_SOURCE_DIR})
+  endif()
+
+  if(CONFIG_COREMARK_MULTITHREAD_OVERRIDE)
+    set(COREMARK_NTHREADS ${CONFIG_COREMARK_MULTITHREAD_COUNT})
+  endif()
+
+  if(CONFIG_SMP_NCPUS)
+    set(COREMARK_NTHREADS ${CONFIG_SMP_NCPUS})
+  else()
+    set(COREMARK_NTHREADS 1)
+  endif()
+
+  if(CONFIG_COREMARK_PRINT_ARGS)
+    set(COREMARK_PRINT_ARGS 1)
+  else()
+    set(COREMARK_PRINT_ARGS 0)
+  endif()
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+
+  get_target_property(FLAGS_STR_LIST nuttx COMPILE_OPTIONS)
+  list(JOIN FLAGS_STR_LIST " " FLAGS_STR)
+  set(CFLAGS
+      -Wno-undef -DUSE_PTHREAD -DPERFORMANCE_RUN=1
+      -DMULTITHREAD=${COREMARK_NTHREADS} -DFLAGS_STR="${FLAGS_STR}"
+      -DMEM_LOCATION="Stack")
+
+  if(CONFIG_COREMARK_ITERATIONS_OVERRIDE)
+    list(APPEND CFLAGS -DITERATIONS=${CONFIG_COREMARK_ITERATIONS_COUNT})
+  endif()
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  set(CSRCS
+      ${COREMARKAPP_DIR}/core_main.c ${COREMARKAPP_DIR}/core_list_join.c
+      ${COREMARKAPP_DIR}/core_matrix.c ${COREMARKAPP_DIR}/core_state.c
+      ${COREMARKAPP_DIR}/core_util.c ${COREMARKAPP_DIR}/posix/core_portme.c)
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${COREMARKAPP_DIR} ${COREMARKAPP_DIR}/posix)
+
+  # ############################################################################
+  # Applications Configuration
+  # ############################################################################
+
+  nuttx_add_application(
+    NAME
+    coremark
+    PRIORITY
+    ${CONFIG_COREMARK_PRIORITY}
+    STACKSIZE
+    ${CONFIG_COREMARK_STACKSIZE}
+    MODULE
+    ${CONFIG_BENCHMARK_COREMARK}
+    COMPILE_FLAGS
+    ${CFLAGS}
+    SRCS
+    ${CSRCS}
+    INCLUDE_DIRECTORIES
+    ${INCDIR})
+
+endif()


### PR DESCRIPTION
## Summary
  cmake: add support for audioutils and coremark.

## Impact

## Testing
coremark has passed verification with stm32/nucleo-g431rb
