### PR TITLE
add support for tinydtls and wakaama

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1807,3 +1807,18 @@ apps/testing/crypto/hmac.c
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+apps/crypto/tinydtls
+======================
+ /*******************************************************************************
+  * Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016 Olaf Bergmann (TZI) and others.
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+  * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  * and the Eclipse Distribution License is available at
+  * http://www.eclipse.org/org/documents/edl-v10.php.
+  * Contributors:
+  *    Olaf Bergmann  - initial API and implementation
+  *    Hauke Mehrtens - memory optimization, ECC integration
+  *******************************************************************************/

--- a/LICENSE
+++ b/LICENSE
@@ -1822,3 +1822,35 @@ apps/crypto/tinydtls
   *    Olaf Bergmann  - initial API and implementation
   *    Hauke Mehrtens - memory optimization, ECC integration
   *******************************************************************************/
+
+apps/netutils/wakaama
+=====================
+ *Eclipse Distribution License - v 1.0*
+
+ Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   * Neither the name of the Eclipse Foundation, Inc. nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crypto/tinydtls/.gitignore
+++ b/crypto/tinydtls/.gitignore
@@ -1,0 +1,2 @@
+/tinydtls
+/*.tar.gz

--- a/crypto/tinydtls/CMakeLists.txt
+++ b/crypto/tinydtls/CMakeLists.txt
@@ -1,0 +1,92 @@
+# ##############################################################################
+# apps/crypto/tinydtls/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_CRYPTO_TINYDTLS)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/tinydtls)
+    FetchContent_Declare(
+      tinydtls
+      DOWNLOAD_NAME "${CONFIG_TINYDTLS_VERSION}.tar.gz"
+      DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
+      URL "https://github.com/eclipse/tinydtls/archive/${CONFIG_TINYDTLS_VERSION}.tar.gz"
+          SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/tinydtls
+          BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/crypto/tinydtls/tinydtls
+          CONFIGURE_COMMAND
+          ""
+          BUILD_COMMAND
+          ""
+          INSTALL_COMMAND
+          ""
+          TEST_COMMAND
+          ""
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(tinydtls)
+
+    if(NOT tinydtls_POPULATED)
+      FetchContent_Populate(tinydtls)
+    endif()
+  endif()
+
+  add_subdirectory(tinydtls)
+
+  target_compile_definitions(
+    tinydtls
+    PRIVATE HAVE_ARPA_INET_H
+            HAVE_ASSERT_H
+            HAVE_FCNTL_H
+            HAVE_GETRANDOM
+            HAVE_INTTYPES_H
+            HAVE_MEMSET
+            HAVE_NETDB_H
+            HAVE_NETINET_IN_H
+            HAVE_RANDOM
+            HAVE_SELECT
+            HAVE_SOCKET
+            HAVE_STDDEF_H
+            HAVE_STDINT_H
+            HAVE_STDLIB_H
+            HAVE_STRDUP
+            HAVE_STRERROR
+            HAVE_STRINGS_H
+            HAVE_STRING_H
+            HAVE_STRNLEN
+            HAVE_SYS_SOCKET_H
+            HAVE_SYS_STAT_H
+            HAVE_SYS_TIME_H
+            HAVE_SYS_TYPES_H
+            HAVE_TIME_H
+            HAVE_UNISTD_H
+            HAVE_VPRINTF
+            HAVE_SNPRINTF)
+
+  target_compile_options(tinydtls PRIVATE -Wno-unused -Wno-inline)
+
+  # TODO: this should be function in nuttx/cmake/nuttx_add_library.cmake
+  set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES tinydtls)
+  nuttx_add_library_internal(tinydtls)
+
+  # allow #include "tinydtls/xxx.h"
+  target_include_directories(tinydtls PUBLIC .)
+
+endif()

--- a/crypto/tinydtls/Kconfig
+++ b/crypto/tinydtls/Kconfig
@@ -1,0 +1,19 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config CRYPTO_TINYDTLS
+	bool "Eclipse Tinydtls"
+	default n
+	depends on ALLOW_ECLIPSE_COMPONENTS
+	---help---
+		Enable Eclipse tinydtls - a minimal library for DTLS.
+
+if CRYPTO_TINYDTLS
+
+config TINYDTLS_VERSION
+	string "Tinydtls version"
+	default "ba830a390642d057fcf21bbb6bd57546d12e584c"
+
+endif # CRYPTO_TINYDTLS

--- a/netutils/wakaama/.gitignore
+++ b/netutils/wakaama/.gitignore
@@ -1,0 +1,2 @@
+/wakaama
+/*.tar.gz

--- a/netutils/wakaama/CMakeLists.txt
+++ b/netutils/wakaama/CMakeLists.txt
@@ -1,0 +1,98 @@
+# ##############################################################################
+# apps/netutils/wakaama/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_WAKAAMA)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/wakaama)
+    FetchContent_Declare(
+      wakaama
+      DOWNLOAD_NAME "${CONFIG_WAKAAMA_VERSION}.tar.gz"
+      DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
+      URL "https://github.com/eclipse/wakaama/archive/${CONFIG_WAKAAMA_VERSION}.tar.gz"
+          SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/wakaama
+          BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/netutils/wakaama/wakaama
+          CONFIGURE_COMMAND
+          ""
+          BUILD_COMMAND
+          ""
+          INSTALL_COMMAND
+          ""
+          TEST_COMMAND
+          ""
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(wakaama)
+
+    if(NOT wakaama_POPULATED)
+      FetchContent_Populate(wakaama)
+    endif()
+  endif()
+
+  include(wakaama/wakaama.cmake)
+
+  set(WAKAAMA_OPTIONS -Wno-format -Wno-type-limits -Wno-cast-align
+                      -Wno-unused-but-set-variable)
+  set(WAKAAMA_DEFINITIONS)
+
+  if(CONFIG_ENDIAN_BIG)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_BIG_ENDIAN)
+  else()
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_LITTLE_ENDIAN)
+  endif()
+
+  if(CONFIG_WAKAAMA_CLIENT_MODE)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_CLIENT_MODE)
+  endif()
+
+  if(CONFIG_WAKAAMA_SERVER_MODE)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_SERVER_MODE)
+  endif()
+
+  if(CONFIG_WAKAAMA_BOOTSTRAP)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_BOOTSTRAP)
+  endif()
+
+  if(CONFIG_WAKAAMA_BOOTSTRAP_SERVER_MODE)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_BOOTSTRAP_SERVER_MODE)
+  endif()
+
+  if(CONFIG_WAKAAMA_JSON)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_SUPPORT_JSON)
+  endif()
+
+  if(CONFIG_WAKAAMA_SENML_JSON)
+    list(APPEND WAKAAMA_DEFINITIONS LWM2M_SUPPORT_SENML_JSON)
+  endif()
+
+  list(APPEND WAKAAMA_DEFINITIONS
+       LWM2M_COAP_DEFAULT_BLOCK_SIZE=${CONFIG_WAKAAMA_COAP_DEFAULT_BLOCK_SIZE})
+
+  nuttx_add_library(wakaama)
+  target_include_directories(wakaama PUBLIC wakaama/include)
+  target_compile_options(wakaama PUBLIC ${WAKAAMA_OPTIONS})
+  target_compile_definitions(wakaama PUBLIC ${WAKAAMA_DEFINITIONS})
+  target_sources_wakaama(wakaama)
+
+  include(examples.cmake)
+
+endif()

--- a/netutils/wakaama/Kconfig
+++ b/netutils/wakaama/Kconfig
@@ -1,0 +1,83 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NETUTILS_WAKAAMA
+	bool "Eclipse Wakaama"
+	default n
+	depends on ALLOW_ECLIPSE_COMPONENTS
+	---help---
+		Enable Eclipse Wakaama (formerly liblwm2m) - an implementation
+		of LWM2M protocol.
+
+if NETUTILS_WAKAAMA
+
+config WAKAAMA_VERSION
+	string "Wakaama version"
+	default "514659414c792f8c252782af63551b6d09704a7b"
+
+config WAKAAMA_COAP_DEFAULT_BLOCK_SIZE
+	int "Wakaama LWM2M COAP default block size"
+	default 1024
+
+config WAKAAMA_CLIENT_MODE
+	bool "Wakaama client mode"
+	default n
+
+config WAKAAMA_SERVER_MODE
+	bool "Wakaama server mode"
+	default n
+
+config WAKAAMA_BOOTSTRAP
+	bool "Wakaama bootstrap"
+	default n
+
+config WAKAAMA_OLD_CONTENT_FORMAT_SUPPORT
+	bool "Wakaama old content format support"
+	default n
+
+config WAKAAMA_TLV
+	bool "Wakaama TLV support"
+	default n
+
+config WAKAAMA_JSON
+	bool "Wakaama JSON support"
+	default n
+
+config WAKAAMA_SENML_JSON
+	bool "Wakaama SenML JSON support"
+	default n
+
+menuconfig WAKAAMA_EXAMPLES
+	bool "Wakaama examples"
+
+if WAKAAMA_EXAMPLES
+
+if WAKAAMA_CLIENT_MODE
+
+choice
+	prompt "Wakaama clinet example"
+	default WAKAAMA_EXAMPLE_CLIENT_LIGHT
+
+config WAKAAMA_EXAMPLE_CLIENT_LIGHT
+	bool "Wakaama light client example"
+
+config WAKAAMA_EXAMPLE_CLIENT
+	bool "Wakaama client example"
+
+config WAKAAMA_EXAMPLE_CLIENT_DTLS
+	bool "Wakaama client DTLS example"
+	depends on CRYPTO_TINYDTLS
+
+endchoice # "Wakaama clinet example"
+
+config WAKAAMA_EXAMPLE_CLIENT_STACKSIZE
+	int "Wakaama client example stack size"
+	default 8192
+
+endif # WAKAAMA_CLIENT_MODE
+
+endif # WAKAAMA_EXAMPLES
+
+endif # NETUTILS_WAKAAMA

--- a/netutils/wakaama/examples.cmake
+++ b/netutils/wakaama/examples.cmake
@@ -1,0 +1,96 @@
+# ##############################################################################
+# apps/netutils/wakaama/examples.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(CLIENT_DIR wakaama/examples/client)
+set(CLIENT_LIGHT_DIR wakaama/examples/lightclient)
+set(SHARED_DIR wakaama/examples/shared)
+
+set(CLIENT_SOURCES
+    ${CLIENT_DIR}/lwm2mclient.c
+    ${CLIENT_DIR}/lwm2mclient.h
+    ${CLIENT_DIR}/object_access_control.c
+    ${CLIENT_DIR}/object_connectivity_moni.c
+    ${CLIENT_DIR}/object_connectivity_stat.c
+    ${CLIENT_DIR}/object_device.c
+    ${CLIENT_DIR}/object_firmware.c
+    ${CLIENT_DIR}/object_location.c
+    ${CLIENT_DIR}/object_security.c
+    ${CLIENT_DIR}/object_server.c
+    ${CLIENT_DIR}/object_test.c
+    ${CLIENT_DIR}/system_api.c
+    ${SHARED_DIR}/commandline.c
+    ${SHARED_DIR}/platform.c)
+
+set(CLIENT_LIGHT_SOURCES
+    ${CLIENT_LIGHT_DIR}/lightclient.c
+    ${CLIENT_LIGHT_DIR}/object_device.c
+    ${CLIENT_LIGHT_DIR}/object_security.c
+    ${CLIENT_LIGHT_DIR}/object_server.c
+    ${CLIENT_LIGHT_DIR}/object_test.c
+    ${SHARED_DIR}/commandline.c
+    ${SHARED_DIR}/platform.c)
+
+if(CONFIG_WAKAAMA_EXAMPLE_CLIENT)
+  nuttx_add_application(
+    NAME
+    lwm2mclient
+    SRCS
+    ${CLIENT_SOURCES}
+    ${SHARED_DIR}/connection.c
+    STACKSIZE
+    ${CONFIG_WAKAAMA_EXAMPLE_CLIENT_STACKSIZE}
+    INCLUDE_DIRECTORIES
+    ${SHARED_DIR}
+    DEPENDS
+    wakaama)
+endif()
+
+if(CONFIG_WAKAAMA_EXAMPLE_CLIENT_DTLS)
+  nuttx_add_application(
+    NAME
+    lwm2mclient_dtls
+    SRCS
+    ${CLIENT_SOURCES}
+    ${SHARED_DIR}/dtlsconnection.c
+    STACKSIZE
+    ${CONFIG_WAKAAMA_EXAMPLE_CLIENT_STACKSIZE}
+    INCLUDE_DIRECTORIES
+    ${SHARED_DIR}
+    DEFINITIONS
+    WITH_TINYDTLS
+    DEPENDS
+    wakaama
+    tinydtls)
+endif()
+
+if(CONFIG_WAKAAMA_EXAMPLE_CLIENT_LIGHT)
+  nuttx_add_application(
+    NAME
+    lwm2mclient_light
+    SRCS
+    ${CLIENT_LIGHT_SOURCES}
+    ${SHARED_DIR}/connection.c
+    STACKSIZE
+    ${CONFIG_WAKAAMA_EXAMPLE_CLIENT_STACKSIZE}
+    INCLUDE_DIRECTORIES
+    ${SHARED_DIR}
+    DEPENDS
+    wakaama)
+endif()


### PR DESCRIPTION
## Summary

- crypto: add Eclipse tinydtls support
- netutils: add Eclipse Wakaama support

only CMake build supported

## Impact

## Testing
sim and nrf9160-dk

