### PR TITLE
nshlib: refine dd verify printing format

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -230,38 +231,11 @@ static int dd_verify(FAR const char *infile, FAR const char *outfile,
 
       if (memcmp(dd->buffer, buffer, dd->nbytes) != 0)
         {
-          int i;
-
-          nsh_output(dd->vtbl, "infile sector %d", sector);
-          for (i = 0; i < dd->nbytes; i++)
-            {
-              if (i % 16 == 0)
-                {
-                  nsh_output(dd->vtbl, "\n");
-                }
-
-              nsh_output(dd->vtbl, "%02x", dd->buffer[i]);
-              if (i + 1 % 2 == 0)
-                {
-                  nsh_output(dd->vtbl, " ");
-                }
-            }
-
-          nsh_output(dd->vtbl, "\noutfile sector %d", sector);
-          for (i = 0; i < dd->nbytes; i++)
-            {
-              if (i % 16 == 0)
-                {
-                  nsh_output(dd->vtbl, "\n");
-                }
-
-              nsh_output(dd->vtbl, "%02x", dd->buffer[i]);
-              if (i + 1 % 2 == 0)
-                {
-                  nsh_output(dd->vtbl, " ");
-                }
-            }
-
+          char msg[32];
+          snprintf(msg, sizeof(msg), "infile sector %d", sector);
+          nsh_dumpbuffer(dd->vtbl, msg, dd->buffer, dd->nbytes);
+          snprintf(msg, sizeof(msg), "\noutfile sector %d", sector);
+          nsh_dumpbuffer(dd->vtbl, msg, buffer, dd->nbytes);
           nsh_output(dd->vtbl, "\n");
           ret = ERROR;
           break;


### PR DESCRIPTION
before:
infile sector 0
```
7f454c46010101000000000000000000
02002800010000007d13001834000000
8cbd2a00000400053400200004002800
```
now:
infile sector 0:
```
0000: 7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00 .ELF............ 
0010: 02 00 28 00 01 00 00 00 7d 13 00 18 34 00 00 00 ..(.....}...4... 
0020: 8c bd 2a 00 00 04 00 05 34 00 20 00 04 00 28 00 ..*.....4. ...(.
```
