### PR TITLE
adb: add adb log level

### DIFF
--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -21,7 +21,7 @@
 include $(APPDIR)/Make.defs
 
 ADBD_URL ?= "https://github.com/spiriou/microADB/archive"
-ADBD_VERSION ?= 305007e0e574e7cc2b8d706b0f5d8cc76675fc51
+ADBD_VERSION ?= 494ef47c614722bb521db09fa7fa9286ab54db84
 
 ADB_DIR := $(APPDIR)/system/adb
 ADB_UNPACKNAME := microADB

--- a/system/adb/adb_banner.c
+++ b/system/adb/adb_banner.c
@@ -50,7 +50,7 @@ int adb_fill_connect_data(char *buf, size_t bufsize)
     {
       /* Failed to get board id */
 
-      adb_log("failed to get board id\n");
+      adb_err("failed to get board id\n");
       len = snprintf(buf, remaining, "device::");
     }
   else

--- a/system/adb/adb_main.c
+++ b/system/adb/adb_main.c
@@ -40,7 +40,8 @@
  * Public Functions
  ****************************************************************************/
 
-void adb_log_impl(FAR const char *func, int line, FAR const char *fmt, ...)
+void adb_log_impl(int priority, FAR const char *func, int line,
+                  FAR const char *fmt, ...)
 {
   struct va_format vaf;
   va_list ap;
@@ -48,7 +49,24 @@ void adb_log_impl(FAR const char *func, int line, FAR const char *fmt, ...)
   va_start(ap, fmt);
   vaf.fmt = fmt;
   vaf.va  = &ap;
-  syslog(LOG_ERR, "%s (%d): %pV", func, line, &vaf);
+
+  switch (priority)
+    {
+      case ADB_INFO:
+        priority = LOG_INFO;
+        break;
+      case ADB_ERR:
+        priority = LOG_ERR;
+        break;
+      case ADB_WARN:
+        priority = LOG_WARNING;
+        break;
+      default:
+        priority = LOG_INFO;
+        break;
+    }
+
+  syslog(priority, "%s (%d): %pV", func, line, &vaf);
   va_end(ap);
 }
 

--- a/system/adb/logcat_service.c
+++ b/system/adb/logcat_service.c
@@ -126,7 +126,7 @@ static void logcat_on_data_available(uv_poll_t * handle,
 
   if (status)
     {
-      adb_log("status error %d\n", status);
+      adb_err("status error %d\n", status);
 
       /* Fatal error, stop service */
 
@@ -139,7 +139,7 @@ static void logcat_on_data_available(uv_poll_t * handle,
   ret = read(fd, ap->p.data, CONFIG_ADBD_PAYLOAD_SIZE);
   if (ret < 0)
     {
-      adb_log("frame read failed %d %d\n", ret, errno);
+      adb_err("frame read failed %d %d\n", ret, errno);
       if (errno == EAGAIN)
         {
           /* TODO this should never happen */
@@ -198,7 +198,7 @@ adb_service_t * logcat_service(adb_client_t *client, const char *params)
 
   if (ret < 0)
     {
-      adb_log("failed to open %s (%d)\n", CONFIG_SYSLOG_DEVPATH, errno);
+      adb_err("failed to open %s (%d)\n", CONFIG_SYSLOG_DEVPATH, errno);
       free(service);
       return NULL;
     }


### PR DESCRIPTION
## Summary

Add adb log level prevent mistakenly printing INFO messages.
depends on https://github.com/spiriou/microADB/pull/35

## Impact

adb

## Testing

bes board