### PR TITLE
ntpclient: change sendto/recv timeout to Kconfig

### DIFF
--- a/netutils/ntpclient/Kconfig
+++ b/netutils/ntpclient/Kconfig
@@ -66,6 +66,10 @@ config NETUTILS_NTPCLIENT_SIGWAKEUP
 	int "NTP client wakeup signal number"
 	default 18
 
+config NETUTILS_NTPCLIENT_TIMEOUT_MS
+	int "NTP client timeout of send and recv"
+	default 5000
+
 config NETUTILS_NTPCLIENT_WITH_AUTH
 	bool "NTP client with authentication"
 	default n

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -875,8 +875,8 @@ static int ntpc_create_dgram_socket(int domain)
 
   /* Setup a send timeout on the socket */
 
-  tv.tv_sec  = 5;
-  tv.tv_usec = 0;
+  tv.tv_sec  = CONFIG_NETUTILS_NTPCLIENT_TIMEOUT_MS / 1000;
+  tv.tv_usec = CONFIG_NETUTILS_NTPCLIENT_TIMEOUT_MS % 1000;
 
   ret = setsockopt(sd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(struct timeval));
   if (ret < 0)
@@ -887,9 +887,6 @@ static int ntpc_create_dgram_socket(int domain)
     }
 
   /* Setup a receive timeout on the socket */
-
-  tv.tv_sec  = 5;
-  tv.tv_usec = 0;
 
   ret = setsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(struct timeval));
   if (ret < 0)


### PR DESCRIPTION
## Summary
Change the timeout period of ntpclient to configurable to reduce the impact The NTP packet is lost during the first TLS connection after the board is started.

## Impact

## Testing
sim:local
