### PR TITLE
usrsocktest: correct the parameter when pthread_kill is called

### DIFF
--- a/examples/usrsocktest/usrsocktest_wake_with_signal.c
+++ b/examples/usrsocktest/usrsocktest_wake_with_signal.c
@@ -562,7 +562,7 @@ static void do_wake_test(enum e_test_type type, int flags)
 
       for (tidx = 0; tidx < nthreads; tidx++)
         {
-          pthread_kill(tid[tidx], 1);
+          pthread_kill(tid[tidx], SIGUSR1);
 
           /* Wait threads to complete work. */
 


### PR DESCRIPTION
## Summary
When the value of the signal is modified, the function will be faulty
## Impact

## Testing
sim:local