### PR TITLE
fix memory leak in aesctr test case

### DIFF
--- a/testing/crypto/aesctr.c
+++ b/testing/crypto/aesctr.c
@@ -338,6 +338,7 @@ done:
       free(data[i]);
     }
 
+  free(p);
   return (fail);
 }
 


### PR DESCRIPTION
There is unreleased memory in the aesctr test case
Signed-off-by: makejian <makejian@xiaomi.com>