### PR TITLE
cmake:move the fetch libs  under their secondary directory

### DIFF
--- a/benchmarks/coremark/CMakeLists.txt
+++ b/benchmarks/coremark/CMakeLists.txt
@@ -26,10 +26,20 @@ if(CONFIG_BENCHMARK_COREMARK)
 
   set(COREMARKAPP_DIR ${CMAKE_CURRENT_LIST_DIR}/coremark)
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/coremark)
-    FetchContent_Declare(coremark
-                         URL https://github.com/eembc/coremark/archive/main.zip)
-    FetchContent_MakeAvailable(coremark)
-    set(COREMARKAPP_DIR ${coremark_SOURCE_DIR})
+    FetchContent_Declare(
+      coremark_fetch
+      URL https://github.com/eembc/coremark/archive/main.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/coremark BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/benchmarks/coremark/coremark
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(coremark_fetch)
+    if(NOT coremark_fetch_POPULATED)
+      FetchContent_Populate(coremark_fetch)
+    endif()
+
+    set(COREMARKAPP_DIR ${coremark_fetch_SOURCE_DIR})
   endif()
 
   if(CONFIG_COREMARK_MULTITHREAD_OVERRIDE)

--- a/crypto/libtomcrypt/CMakeLists.txt
+++ b/crypto/libtomcrypt/CMakeLists.txt
@@ -39,7 +39,7 @@ if(CONFIG_CRYPTO_LIBTOMCRYPT)
 
     FetchContent_GetProperties(libtomcrypt_fetch)
 
-    if(NOT libtomcrypt_POPULATED)
+    if(NOT libtomcrypt_fetch_POPULATED)
       FetchContent_Populate(libtomcrypt_fetch)
     endif()
 

--- a/math/libtommath/CMakeLists.txt
+++ b/math/libtommath/CMakeLists.txt
@@ -29,10 +29,19 @@ if(CONFIG_MATH_LIBTOMMATH)
 
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libtommath)
     FetchContent_Declare(
-      libtommath URL ${CONFIG_LIBTOMMATH_URL}/v${CONFIG_LIBTOMMATH_VERSION}.zip)
-    FetchContent_MakeAvailable(libtommath)
+      libtommath_fetch
+      URL ${CONFIG_LIBTOMMATH_URL}/v${CONFIG_LIBTOMMATH_VERSION}.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/libtommath BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/math/libtommath/libtommath
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
 
-    set(LIBTOMMATH_DIR ${libtommath_SOURCE_DIR})
+    FetchContent_GetProperties(libtommath_fetch)
+    if(NOT libtommath_fetch_POPULATED)
+      FetchContent_Populate(libtommath_fetch)
+    endif()
+
+    set(LIBTOMMATH_DIR ${libtommath_fetch_SOURCE_DIR})
   endif()
 
   # ############################################################################


### PR DESCRIPTION
## Summary
when fetch a lib during cmake configure phase,it will download into `/cmake-build-dir/_dep/lib_src/` directory.
every time the build directory is deleted,the download will be repeated. this patch fixes these problem.
## Impact

## Testing
sim cmake build 
