### PR TITLE
ostest/mutex: mut need to be destroyed

### DIFF
--- a/testing/ostest/mutex.c
+++ b/testing/ostest/mutex.c
@@ -156,6 +156,8 @@ void mutex_test(void)
   pthread_join(thread2, NULL);
 #endif
 
+  pthread_mutex_destroy(&mut);
+
   printf("\t\tThread1\tThread2\n");
   printf("\tLoops\t%lu\t%lu\n", nloops[0], nloops[1]);
   printf("\tErrors\t%lu\t%lu\n", nerrors[0], nerrors[1]);


### PR DESCRIPTION
## Summary
mut need to be destroyed
## Impact
none
## Testing
none
