### PR TITLE
coredump/priority: Increase the default priority of coredump to 254

### DIFF
--- a/system/coredump/Kconfig
+++ b/system/coredump/Kconfig
@@ -18,7 +18,7 @@ config SYSTEM_COREDUMP_STACKSIZE
 
 config SYSTEM_COREDUMP_PRIORITY
 	int "coredump priority"
-	default 100
+	default 254
 	---help---
 		This is the task priority that will be used when starting the coredump.
 


### PR DESCRIPTION
## Summary

coredump/priority: Increase the default priority of coredump to 254

Increase coredump priority to avoid unnecessary task switch during dump

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

coredump