### PR TITLE
examples/mtdpart:fix compiling warning in printf.

### DIFF
--- a/examples/mtdpart/mtdpart_main.c
+++ b/examples/mtdpart/mtdpart_main.c
@@ -221,7 +221,7 @@ int main(int argc, FAR char *argv[])
   partsize    = nblocks * geo.blocksize;
 
   printf("  No. partitions: %u\n", CONFIG_EXAMPLES_MTDPART_NPARTITIONS);
-  printf("  Partition size: %ju Blocks (%lu bytes)\n", (uintmax_t)nblocks,
+  printf("  Partition size: %ju Blocks (%zu bytes)\n", (uintmax_t)nblocks,
          partsize);
 
   /* Now create MTD FLASH partitions */


### PR DESCRIPTION
## Summary
fix a compiling warning.
## Impact
printf compiling warning only.
## Testing
Compiled Okay.
