### PR TITLE
sensor: add force sensor

### DIFF
--- a/system/uorb/sensor/force.c
+++ b/system/uorb/sensor/force.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/force.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/force.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static void print_sensor_force_message(FAR const struct orb_metadata *meta,
+                                       FAR const void *buffer)
+{
+  FAR const struct sensor_force *message = buffer;
+  const orb_abstime now = orb_absolute_time();
+
+  uorbinfo_raw("%s:\ttimestamp: %" PRIu64 " (%" PRIu64 " us ago) "
+               "value: %.2f event: %" PRIi32 "",
+               meta->o_name, message->timestamp, now - message->timestamp,
+               message->force, message->event);
+}
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_force, struct sensor_force, print_sensor_force_message);

--- a/system/uorb/sensor/force.h
+++ b/system/uorb/sensor/force.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/force.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_FORCE_H
+#define __APPS_SYSTEM_UORB_SENSOR_FORCE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_force);
+
+#endif

--- a/system/uorb/sensor/topics.c
+++ b/system/uorb/sensor/topics.c
@@ -36,6 +36,7 @@
 #include <sensor/co2.h>
 #include <sensor/dust.h>
 #include <sensor/ecg.h>
+#include <sensor/force.h>
 #include <sensor/gps.h>
 #include <sensor/gyro.h>
 #include <sensor/gesture.h>
@@ -77,6 +78,7 @@ static FAR const struct orb_metadata *g_sensor_list[] =
   ORB_ID(sensor_co2),
   ORB_ID(sensor_dust),
   ORB_ID(sensor_ecg),
+  ORB_ID(sensor_force),
   ORB_ID(sensor_gps),
   ORB_ID(sensor_gps_satellite),
   ORB_ID(sensor_gyro),

--- a/testing/sensortest/sensortest.c
+++ b/testing/sensortest/sensortest.c
@@ -67,6 +67,7 @@ static void print_valf(FAR const char *buffer, FAR const char *name);
 static void print_valb(FAR const char *buffer, FAR const char *name);
 static void print_vali2(FAR const char *buffer, FAR const char *name);
 static void print_ecg(FAR const char *buffer, FAR const char *name);
+static void print_force(FAR const char *buffer, FAR const char *name);
 static void print_ppgd(FAR const char *buffer, FAR const char *name);
 static void print_ppgq(FAR const char *buffer, FAR const char *name);
 static void print_cap(FAR const char *buffer, FAR const char *name);
@@ -88,6 +89,7 @@ static const struct sensor_info g_sensor_info[] =
   {print_valf,  sizeof(struct sensor_co2),   "co2"},
   {print_valf,  sizeof(struct sensor_dust),  "dust"},
   {print_ecg,   sizeof(struct sensor_ecg),   "ecg"},
+  {print_force, sizeof(struct sensor_force), "force"},
   {print_gps,   sizeof(struct sensor_gps),   "gps"},
   {print_gps_satellite,
         sizeof(struct sensor_gps_satellite), "gps_satellite"},
@@ -169,6 +171,14 @@ static void print_ecg(const char *buffer, const char *name)
   struct sensor_ecg *event = (struct sensor_ecg *)buffer;
   printf("%s: timestamp:%" PRIu64 " ecg:%.4f status:%" PRIu32,
          name, event->timestamp, event->ecg, event->status);
+}
+
+static void print_force(const char *buffer, const char *name)
+{
+  FAR struct sensor_force *event = (FAR struct sensor_force *)buffer;
+
+  printf("%s: timestamp:%" PRIu64 " value:%.2f event:%" PRIi32 "\n",
+         name, event->timestamp, event->force, event->event);
 }
 
 static void print_ppgd(const char *buffer, const char *name)


### PR DESCRIPTION
## Summary

A sensor of this type measures the force on it, and additionally compares the force with one or more specified thresholds. The sensor can output the force value directly. Moreover, it's usually applied as a press key. In that case, when it detects a force greater than some given threshold, a corresponding event is reported.

## Impact

## Testing

