### PR TITLE
audio:Resolve compilation errors in nxplayer/nxrecorder/nxlooper on ARM64

### DIFF
--- a/include/system/nxlooper.h
+++ b/include/system/nxlooper.h
@@ -51,7 +51,7 @@ struct nxlooper_s
   char            playdev[CONFIG_NAME_MAX];    /* Preferred loopback device */
   int             crefs;                       /* Number of references */
   pthread_mutex_t mutex;                       /* Thread sync mutex */
-  char            mqname[16];                  /* Name of play message queue */
+  char            mqname[32];                  /* Name of play message queue */
   mqd_t           mq;                          /* Message queue for the
                                                 * loopthread */
   pthread_t       loop_id;                     /* Thread ID of the loopthread */

--- a/include/system/nxplayer.h
+++ b/include/system/nxplayer.h
@@ -53,7 +53,7 @@ struct nxplayer_s
   int             state;                       /* Current player state */
   int             dev_fd;                      /* File descriptor of active device */
   mqd_t           mq;                          /* Message queue for the playthread */
-  char            mqname[16];                  /* Name of our message queue */
+  char            mqname[32];                  /* Name of our message queue */
   pthread_t       play_id;                     /* Thread ID of the playthread */
   int             crefs;                       /* Number of references to the player */
   pthread_mutex_t mutex;                       /* Thread sync mutex */

--- a/include/system/nxrecorder.h
+++ b/include/system/nxrecorder.h
@@ -45,7 +45,7 @@ struct nxrecorder_s
   int             state;                   /* Current recorder state */
   int             dev_fd;                  /* File descriptor of active device */
   mqd_t           mq;                      /* Message queue for the recordthread */
-  char            mqname[16];              /* Name of our message queue */
+  char            mqname[32];              /* Name of our message queue */
   pthread_t       record_id;               /* Thread ID of the recordthread */
   int             crefs;                   /* Number of references to the recorder */
   pthread_mutex_t mutex;                   /* Thread sync mutex */


### PR DESCRIPTION
## Summary

resolve compilation errors: '%0lx' directive output may be truncated writing between 1 and 16 bytes into a region of size 11 [-Werror=format-truncation=]

## Impact

## Testing

ci