### PR TITLE
cmake:migrate apps CMakeLists for canutils

### DIFF
--- a/canutils/candump/CMakeLists.txt
+++ b/canutils/candump/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/canutils/CMakeLists.txt
+# apps/canutils/candump/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,20 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
+if(CONFIG_CANUTILS_CANDUMP)
 
-nuttx_generate_kconfig(MENUDESC "CAN Utilities")
+  set(LIBCANUTILS_DIR ${NUTTX_APPS_DIR}/canutils/libcanutils)
+
+  nuttx_add_application(
+    NAME
+    candump
+    STACKSIZE
+    ${CONFIG_CANUTILS_CANDUMP_STACKSIZE}
+    MODULE
+    ${CONFIG_CANUTILS_CANDUMP}
+    SRCS
+    candump.c
+    INCLUDE_DIRECTORIES
+    ${LIBCANUTILS_DIR})
+
+endif()

--- a/canutils/canlib/CMakeLists.txt
+++ b/canutils/canlib/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/canutils/CMakeLists.txt
+# apps/canutils/canlib/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,7 +17,10 @@
 # the License.
 #
 # ##############################################################################
+if(CONFIG_CANUTILS_CANLIB)
 
-nuttx_add_subdirectory()
+  target_sources(
+    apps PRIVATE canlib_getbaud.c canlib_setbaud.c canlib_getloopback.c
+                 canlib_setloopback.c canlib_getsilent.c canlib_setsilent.c)
 
-nuttx_generate_kconfig(MENUDESC "CAN Utilities")
+endif()

--- a/canutils/cansend/CMakeLists.txt
+++ b/canutils/cansend/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/canutils/CMakeLists.txt
+# apps/canutils/cansend/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,20 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
+if(CONFIG_CANUTILS_CANSEND)
 
-nuttx_generate_kconfig(MENUDESC "CAN Utilities")
+  set(LIBCANUTILS_DIR ${NUTTX_APPS_DIR}/canutils/libcanutils)
+
+  nuttx_add_application(
+    NAME
+    cansend
+    STACKSIZE
+    ${CONFIG_CANUTILS_CANSEND_STACKSIZE}
+    MODULE
+    ${CONFIG_CANUTILS_CANSEND}
+    SRCS
+    cansend.c
+    INCLUDE_DIRECTORIES
+    ${LIBCANUTILS_DIR})
+
+endif()

--- a/canutils/libcanutils/CMakeLists.txt
+++ b/canutils/libcanutils/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/canutils/CMakeLists.txt
+# apps/canutils/libcanutils/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,8 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
+if(CONFIG_CANUTILS_LIBCANUTILS)
 
-nuttx_generate_kconfig(MENUDESC "CAN Utilities")
+  target_sources(apps PRIVATE lib.c)
+
+endif()

--- a/canutils/libobd2/CMakeLists.txt
+++ b/canutils/libobd2/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/canutils/CMakeLists.txt
+# apps/canutils/libobd2/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,9 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
+if(CONFIG_CANUTILS_LIBOBD2)
 
-nuttx_generate_kconfig(MENUDESC "CAN Utilities")
+  target_sources(apps PRIVATE obd2.c obd_sendrequest.c obd_waitresponse.c
+                              obd_decodepid.c)
+
+endif()

--- a/canutils/slcan/CMakeLists.txt
+++ b/canutils/slcan/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/canutils/CMakeLists.txt
+# apps/canutils/slcan/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,16 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
+if(CONFIG_CANUTILS_SLCAN)
 
-nuttx_generate_kconfig(MENUDESC "CAN Utilities")
+  nuttx_add_application(
+    NAME
+    slcan
+    STACKSIZE
+    ${CONFIG_CANUTILS_SLCAN_STACKSIZE}
+    MODULE
+    ${CONFIG_CANUTILS_SLCAN}
+    SRCS
+    slcan.c)
+
+endif()


### PR DESCRIPTION
## Summary

- candump
- canlib
- cansend
- libcanutils
- libobd2
- slcan

## Impact

## Testing
sim build enable related configuration
