### PR TITLE
Uorb: fix format and g_sensor_list error in sensor gps and its topics

### DIFF
--- a/system/uorb/sensor/gps.c
+++ b/system/uorb/sensor/gps.c
@@ -64,7 +64,7 @@ print_sensor_gps_satellite_message(FAR const struct orb_metadata *meta,
   for (i = 0; i < message->count; i++)
     {
       uorbinfo_raw("%s:\tnumber:%d svid: %" PRIu32
-                   "elevation: %" PRIu32 "azimuth: %" PRIu32
+                   " elevation: %" PRIu32 " azimuth: %" PRIu32
                    " snr: %" PRIu32 "",
                    meta->o_name, i, message->info[i].svid,
                    message->info[i].elevation, message->info[i].azimuth,

--- a/system/uorb/sensor/topics.c
+++ b/system/uorb/sensor/topics.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <ctype.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -127,14 +128,12 @@ FAR const struct orb_metadata *orb_get_meta(FAR const char *name)
 
   for (i = 0; g_sensor_list[i]; i++)
     {
-      if (!strncmp(g_sensor_list[i]->o_name, name,
-          strlen(g_sensor_list[i]->o_name)))
+      size_t len = strlen(g_sensor_list[i]->o_name);
+      if ((!strncmp(g_sensor_list[i]->o_name, name, len))
+          && (name[len] == '\0' || isdigit(name[len])))
         {
-          if (idx == -1 || strlen(g_sensor_list[idx]->o_name) <
-                           strlen(g_sensor_list[i]->o_name))
-            {
-              idx = i;
-            }
+          idx = i;
+          break;
         }
     }
 


### PR DESCRIPTION
## Summary

fix uorb of g_sensor_list error.

1. uorb/sensor/gps: fix uorinfo_raw print error
2. uorb/topics: update delicated match of listener topics

## Change 1
### Impact
only output of sensor_gps_satellite formated.

## Change 2
### Impact
when user input "sensor_gps_sat" which does not exist in g_sensor_list, sensor_gps will not give as output.

## Testing

Pass Vela CI.
