### PR TITLE
testing/drivertest: Fix typo error in drivertest_uart.c

### DIFF
--- a/testing/drivertest/drivertest_uart.c
+++ b/testing/drivertest/drivertest_uart.c
@@ -216,7 +216,7 @@ static void write_default(FAR void **state)
 static void read_default(FAR void **state)
 {
   FAR struct test_state_s *test_state = (FAR struct test_state_s *)*state;
-  sigset_t buffer_size = sizeof(DEFAULT_CONTENT);
+  size_t buffer_size = sizeof(DEFAULT_CONTENT);
   int cnt = 0;
   FAR char *buffer = test_state->buffer;
   assert_true(buffer != NULL);


### PR DESCRIPTION
## Summary

Made by:
```
commit 5659906fdfdac0a363aecb329c39c936324dcc55
Author: Gregory Nutt <gnutt@nuttx.org>
Date:   Fri Mar 24 12:02:04 2023 -0600

    Changes to apps needed by nutts PR 8885

    needby:965551

    ostest contains some logic that depends on internal implementation of signal sets and ostest must be updated to match those changes.

    There is no particular impact from this PR.  This PR is the result of impact from nuttx 8885.

    Tested with nuttx 8885

    Change-Id: I2550888ee29aadcfcf8a98bfe5690920ee2b17d1
```

## Impact

## Testing

internal ci