### PR TITLE
nxcamera: Solve compilation errors caused by type mismatch

### DIFF
--- a/system/nxcamera/nxcamera.c
+++ b/system/nxcamera/nxcamera.c
@@ -82,7 +82,7 @@ static int show_image(FAR struct nxcamera_s *pcam, FAR v4l2_buffer_t *buf)
                        0,
                        pcam->fmt.fmt.pix.pixelformat);
 #else
-  uint32_t *pbuf = pcam->bufs[buf->index];
+  FAR uint32_t *pbuf = (FAR uint32_t *)pcam->bufs[buf->index];
   vinfo("show image from %p: %" PRIx32 " %" PRIx32, pbuf, pbuf[0], pbuf[1]);
   return 0;
 #endif


### PR DESCRIPTION
## Summary

```
CC:  nxcamera.c nxcamera.c: In function 'show_image': nxcamera.c:85:20: error: initialization of 'uint32_t *' {aka 'unsigned int *'} from incompatible pointer type 'uint8_t *' {aka 'unsigned char *'} [-Werror=incompatible-pointer-types]
   85 |   uint32_t *pbuf = pcam->bufs[buf->index];
      |                    ^~~~
cc1: all warnings being treated as errors
```

## Impact

## Testing

please ignore:
```
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/system/nxcamera/nxcamera.c:72:13: error: Mixed case identifier found
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/system/nxcamera/nxcamera.c:89:17: error: Mixed case identifier found
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/system/nxcamera/nxcamera.c:115:16: error: Mixed case identifier found
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/system/nxcamera/nxcamera.c:138:16: error: Mixed case identifier found
```