### PR TITLE
fstest:fix typo

### DIFF
--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -375,7 +375,7 @@ static int fstest_gc(FAR struct fstest_ctx_s *ctx, size_t nbytes)
 }
 #else
 #  define fstest_gc_withfd(f,n) (-ENOSYS)
-#  define fstest_gc(n)          (-ENOSYS)
+#  define fstest_gc(ctx,n)      (-ENOSYS)
 #endif
 
 /****************************************************************************
@@ -1165,7 +1165,7 @@ int main(int argc, FAR char *argv[])
 
       /* Perform garbage collection, integrity checks */
 
-      ret = fstest_gc(buf.f_bfree);
+      ret = fstest_gc(ctx, buf.f_bfree);
       UNUSED(ret);
 
       /* Show memory usage */


### PR DESCRIPTION
## Summary

fstest_main.c:340:47: note: expected ‘struct fstest_ctx_s *’ but argument is of type ‘fsblkcnt_t’ {aka ‘long long unsigned int’}
  340 | static int fstest_gc(FAR struct fstest_ctx_s *ctx, size_t nbytes)
      |                          ~~~~~~~~~~~~~~~~~~~~~^~~
fstest_main.c:1168:13: error: too few arguments to function ‘fstest_gc’
 1168 |       ret = fstest_gc(buf.f_bfree);
      |             ^~~~~~~~~
fstest_main.c:340:12: note: declared here
  340 | static int fstest_gc(FAR struct fstest_ctx_s *ctx, size_t nbytes)
      |            ^~~

## Impact

fstest

## Testing

