### PR TITLE
nxrecorder: mode is required when oflags include O_CREAT or O_WRONLY

### DIFF
--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -1034,7 +1034,8 @@ int nxrecorder_recordinternal(FAR struct nxrecorder_s *precorder,
 
   /* Test that the specified file exists */
 
-  if ((precorder->fd = open(pfilename, O_WRONLY | O_CREAT | O_TRUNC)) == -1)
+  if ((precorder->fd = open(pfilename, O_WRONLY | O_CREAT | O_TRUNC,
+                            0666)) == -1)
     {
       /* File not found.  Test if its in the mediadir */
 


### PR DESCRIPTION
Refer -- fs_open.c:
/* If the file is opened for creation, then get the mode bits */

  if ((oflags & (O_WRONLY | O_CREAT)) != 0)
    {
      mode = va_arg(ap, mode_t);
    }

## Summary

## Impact

## Testing

