### PR TITLE
cmake:migrate lely-canopen,libdronecan,libopencyhal for cmake build

### DIFF
--- a/canutils/lely-canopen/CMakeLists.txt
+++ b/canutils/lely-canopen/CMakeLists.txt
@@ -1,0 +1,235 @@
+# ##############################################################################
+# apps/canutils/lely-canopen/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_CANUTILS_LELYCANOPEN)
+
+  # ############################################################################
+  # Config and Fetch lelycanopen lib
+  # ############################################################################
+
+  set(LELYCANOPEN_DIR ${CMAKE_CURRENT_LIST_DIR}/lely-canopen)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/lely-canopen)
+    FetchContent_Declare(
+      lelycanopen_fetch
+      URL ${CONFIG_CANUTILS_LELYCANOPEN_URL}/lely-core-${CONFIG_CANUTILS_LELYCANOPEN_VERSION}.tar.gz
+          SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/lely-canopen
+          BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/canutils/lely-canopen/lely-canopen
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(lelycanopen_fetch)
+
+    if(NOT lelycanopen_fetch_POPULATED)
+      FetchContent_Populate(lelycanopen_fetch)
+    endif()
+
+    set(LELYCANOPEN_DIR ${lelycanopen_fetch_SOURCE_DIR})
+
+    if(NOT EXISTS ${LELYCANOPEN_DIR}/.lelycanopen_patch)
+      add_custom_command(
+        OUTPUT ${LELYCANOPEN_DIR}/.lelycanopen_patch
+        COMMAND touch ${LELYCANOPEN_DIR}/.lelycanopen_patch
+        COMMAND
+          patch -p1 -d ${LELYCANOPEN_DIR} <
+          ${CMAKE_CURRENT_LIST_DIR}/0001-NuttX-port.patch > /dev/null || (exit 0
+                                                                         ))
+      add_custom_target(lelycanopen_patch
+                        DEPENDS ${LELYCANOPEN_DIR}/.lelycanopen_patch)
+    endif()
+  endif()
+
+  nuttx_add_library(lelycanopen STATIC)
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+
+  set(CFLAGS -Wno-shadow -Wno-undef -DHAVE_CONFIG_H=1)
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  set(CSRCS)
+
+  # CAN network object
+  list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/can/buf.c
+       ${LELYCANOPEN_DIR}/src/can/msg.c ${LELYCANOPEN_DIR}/src/can/vci.c
+       ${LELYCANOPEN_DIR}/src/can/net.c)
+  # CANopen library
+  list(
+    APPEND
+    CSRCS
+    ${LELYCANOPEN_DIR}/src/co/crc.c
+    ${LELYCANOPEN_DIR}/src/co/dev.c
+    ${LELYCANOPEN_DIR}/src/co/nmt.c
+    ${LELYCANOPEN_DIR}/src/co/nmt_hb.c
+    ${LELYCANOPEN_DIR}/src/co/nmt_srv.c
+    ${LELYCANOPEN_DIR}/src/co/obj.c
+    ${LELYCANOPEN_DIR}/src/co/pdo.c
+    ${LELYCANOPEN_DIR}/src/co/sdo.c
+    ${LELYCANOPEN_DIR}/src/co/ssdo.c
+    ${LELYCANOPEN_DIR}/src/co/type.c
+    ${LELYCANOPEN_DIR}/src/co/val.c)
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_TIME)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/time.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_CSDO)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/csdo.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_DCF)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/dcf.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_EMCY)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/emcy.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_GW)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/gw.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_GW_TXT)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/gw_txt.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_LSS)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/lss.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_NMTBOOT)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/nmt_boot.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_NMTCFG)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/nmt_cfg.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_RPDO)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/rpdo.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_SDEV)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/sdev.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_SYNC)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/sync.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_TPDO)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/tpdo.c)
+  endif()
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_WTM)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/co/wtm.c)
+  endif()
+
+  # utils
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_DIAG)
+    list(APPEND CSRCS ${LELYCANOPEN_DIR}/src/util/diag.c)
+  endif()
+
+  list(
+    APPEND
+    CSRCS
+    ${LELYCANOPEN_DIR}/src/util/bits.c
+    ${LELYCANOPEN_DIR}/src/util/bitset.c
+    ${LELYCANOPEN_DIR}/src/util/cmp.c
+    ${LELYCANOPEN_DIR}/src/util/config.c
+    ${LELYCANOPEN_DIR}/src/util/config_ini.c
+    ${LELYCANOPEN_DIR}/src/util/dllist.c
+    ${LELYCANOPEN_DIR}/src/util/endian.c
+    ${LELYCANOPEN_DIR}/src/util/errnum.c
+    ${LELYCANOPEN_DIR}/src/util/frbuf.c
+    ${LELYCANOPEN_DIR}/src/util/fwbuf.c
+    ${LELYCANOPEN_DIR}/src/util/lex.c
+    ${LELYCANOPEN_DIR}/src/util/membuf.c
+    ${LELYCANOPEN_DIR}/src/util/pheap.c
+    ${LELYCANOPEN_DIR}/src/util/print.c
+    ${LELYCANOPEN_DIR}/src/util/rbtree.c
+    ${LELYCANOPEN_DIR}/src/util/stop.c
+    ${LELYCANOPEN_DIR}/src/util/time.c
+    ${LELYCANOPEN_DIR}/src/util/ustring.c)
+
+  # Lely IO lib
+  if(CONFIG_CANUTILS_LELYCANOPEN_IOLIB)
+    list(
+      APPEND
+      CSRCS
+      ${LELYCANOPEN_DIR}/src/io/handle.c
+      ${LELYCANOPEN_DIR}/src/io/io.c
+      ${LELYCANOPEN_DIR}/src/io/pipe.c
+      ${LELYCANOPEN_DIR}/src/io/poll.c
+      ${LELYCANOPEN_DIR}/src/io2/posix/poll.c
+      ${LELYCANOPEN_DIR}/src/io2/ctx.c
+      ${LELYCANOPEN_DIR}/src/io/can.c
+      ${LELYCANOPEN_DIR}/src/can/socket.c)
+  endif()
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${LELYCANOPEN_DIR}/include ${NUTTX_APPS_DIR}/include/canutils/lely)
+
+  # ############################################################################
+  # Applications Configuration
+  # ############################################################################
+
+  if(CONFIG_CANUTILS_LELYCANOPEN_TOOLS_COCTL)
+    nuttx_add_application(
+      NAME
+      coctl
+      PRIORITY
+      ${CONFIG_CANUTILS_LELYCANOPEN_TOOLS_COCTL_PRIORITY}
+      STACKSIZE
+      ${CONFIG_CANUTILS_LELYCANOPEN_TOOLS_COCTL_STACKSIZE}
+      COMPILE_FLAGS
+      ${CFLAGS}
+      SRCS
+      ${LELYCANOPEN_DIR}/tools/coctl.c
+      MODULE
+      ${CONFIG_CANUTILS_LELYCANOPEN}
+      INCLUDE_DIRECTORIES
+      ${INCDIR}
+      DEPENDS
+      lelycanopen)
+  endif()
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  target_compile_options(lelycanopen PRIVATE ${CFLAGS})
+  target_sources(lelycanopen PRIVATE ${CSRCS})
+  target_include_directories(lelycanopen PRIVATE ${INCDIR})
+  if(TARGET lelycanopen_patch)
+    add_dependencies(lelycanopen lelycanopen_patch)
+  endif()
+
+endif()

--- a/canutils/libdronecan/CMakeLists.txt
+++ b/canutils/libdronecan/CMakeLists.txt
@@ -1,0 +1,95 @@
+# ##############################################################################
+# apps/canutils/libdronecan/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_CANUTILS_LIBDRONECAN)
+
+  # ############################################################################
+  # Config and Fetch libdronecan lib
+  # ############################################################################
+
+  set(LIBDRONECAN_DIR ${CMAKE_CURRENT_LIST_DIR}/libcanard)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcanard)
+    FetchContent_Declare(
+      libdronecan_fetch
+      URL ${CONFIG_LIBDRONECAN_URL}/${CONFIG_LIBDRONECAN_VERSION}.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/libcanard BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/canutils/libdronecan/libcanard
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(libdronecan_fetch)
+
+    if(NOT libdronecan_fetch_POPULATED)
+      FetchContent_Populate(libdronecan_fetch)
+    endif()
+
+    set(LIBDRONECAN_DIR ${libdronecan_fetch_SOURCE_DIR})
+  endif()
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+
+  set(CFLAGS -std=c99 -DCANARD_ASSERT=DEBUGASSERT)
+
+  # Conflict with Cyphal's libcanard
+  if(CONFIG_CANUTILS_LIBOPENCYPHAL)
+    list(APPEND CFLAGS -DcanardInit=dronecanardInit)
+  endif()
+
+  if(CONFIG_LIBDRONECAN_CANFD)
+    list(APPEND CFLAGS -DCANARD_ENABLE_CANFD=1)
+  endif()
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  set(CSRCS ${LIBDRONECAN_DIR}/canard.c)
+
+  if(CONFIG_NET_CAN)
+    list(APPEND CSRCS ${LIBDRONECAN_DIR}/drivers/socketcan/socketcan.c)
+  else()
+    list(APPEND CSRCS ${LIBDRONECAN_DIR}/drivers/nuttx/canard_nuttx.c)
+  endif()
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${NUTTX_APPS_DIR}/canutils/libdronecan/libcanard)
+
+  if(CONFIG_NET_CAN)
+    list(APPEND INCDIR
+         ${NUTTX_APPS_DIR}/canutils/libdronecan/libcanard/drivers/socketcan)
+  endif()
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  nuttx_add_user_library(libdronecan)
+
+  target_sources(libdronecan PRIVATE ${CSRCS})
+  target_compile_options(libdronecan PRIVATE ${CFLAGS})
+  target_include_directories(libdronecan PRIVATE ${INCDIR})
+
+endif()

--- a/canutils/libopencyphal/CMakeLists.txt
+++ b/canutils/libopencyphal/CMakeLists.txt
@@ -1,0 +1,75 @@
+# ##############################################################################
+# apps/canutils/libopencyphal/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_CANUTILS_LIBOPENCYPHAL)
+
+  # ############################################################################
+  # Config and Fetch libopencyphal o1heap lib
+  # ############################################################################
+
+  set(LIBOPENCYPHAL_DIR ${CMAKE_CURRENT_LIST_DIR}/libcanard)
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libcanard)
+    FetchContent_Declare(
+      libcanard_fetch
+      URL ${CONFIG_LIBOPENCYPHAL_URL}/${CONFIG_LIBOPENCYPHAL_VERSION}.zip
+          SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/libcanard BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/canutils/libopencyphal/libcanard
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+    FetchContent_GetProperties(libcanard_fetch)
+    if(NOT libcanard_fetch_POPULATED)
+      FetchContent_Populate(libcanard_fetch)
+    endif()
+    set(LIBOPENCYPHAL_DIR ${libcanard_fetch_SOURCE_DIR})
+  endif()
+
+  set(O1HEAP_DIR ${CMAKE_CURRENT_LIST_DIR}/o1heap)
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/o1heap)
+    FetchContent_Declare(
+      o1heap_fetch
+      URL ${CONFIG_O1HEAP_URL}/${CONFIG_O1HEAP_VERSION}.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/o1heap BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/canutils/libopencyphal/o1heap
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+    FetchContent_GetProperties(o1heap_fetch)
+    if(NOT o1heap_fetch_POPULATED)
+      FetchContent_Populate(o1heap_fetch)
+    endif()
+    set(O1HEAP_DIR ${o1heap_fetch_SOURCE_DIR})
+  endif()
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  nuttx_add_user_library(libopencyphal)
+
+  target_sources(
+    libopencyphal
+    PRIVATE ${LIBOPENCYPHAL_DIR}/libcanard/canard.c
+            ${LIBOPENCYPHAL_DIR}/libcanard/canard_dsdl.c
+            ${O1HEAP_DIR}/o1heap/o1heap.c)
+  target_compile_options(
+    libopencyphal PRIVATE -std=c11 -DCANARD_ASSERT=DEBUGASSERT
+                          -DCANARD_DSDL_CONFIG_LITTLE_ENDIAN=1)
+  target_include_directories(libopencyphal PRIVATE ${O1HEAP_DIR}/o1heap)
+
+endif()


### PR DESCRIPTION
## Summary

migrate apps CMakeLists

- [x] lely-canopen
- [x] libdronecan
- [x] libopencyhal

## Impact
> [!WARNING]
> `nuttx_add_user_library` have unexpected results, I will track and fix in this issue [apache/nuttx/issues#10191](https://github.com/apache/nuttx/issues/10191)
## Testing
sim with enable NET CAN NET_CAN and enbale the corresponding library configuration 
