### PR TITLE
apps: Replace CONFIG_ARCH_HAVE_VFORK with CONFIG_ARCH_HAVE_FORK

### DIFF
--- a/interpreters/bas/Kconfig
+++ b/interpreters/bas/Kconfig
@@ -72,7 +72,7 @@ config INTERPRETER_BAS_HAVE_FTRUNCATE
 config EXAMPLES_BAS_SHELL
 	bool "Shell support"
 	default n
-	depends on ARCH_HAVE_VFORK && EXPERIMENTAL
+	depends on ARCH_HAVE_FORK && EXPERIMENTAL
 	select LIBC_EXECFUNCS
 	select SCHED_WAITPID
 	---help---

--- a/interpreters/bas/bas_statement.c
+++ b/interpreters/bas/bas_statement.c
@@ -1051,7 +1051,7 @@ struct Value *stmt_DOcondition(struct Value *value)
 
 struct Value *stmt_EDIT(struct Value *value)
 {
-#if defined(CONFIG_EXAMPLES_BAS_EDITOR) && defined(CONFIG_EXAMPLES_BAS_SHELL) && defined(CONFIG_ARCH_HAVE_VFORK)
+#if defined(CONFIG_EXAMPLES_BAS_EDITOR) && defined(CONFIG_EXAMPLES_BAS_SHELL) && defined(CONFIG_ARCH_HAVE_FORK)
   long int line;
   struct Pc statementpc = g_pc;
   int status;
@@ -5674,7 +5674,7 @@ struct Value *stmt_SELECTCASE(struct Value *value)
 
 struct Value *stmt_SHELL(struct Value *value)
 {
-#if defined(CONFIG_EXAMPLES_BAS_SHELL) && defined(CONFIG_ARCH_HAVE_VFORK)
+#if defined(CONFIG_EXAMPLES_BAS_SHELL) && defined(CONFIG_ARCH_HAVE_FORK)
   pid_t pid;
   int status;
 

--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -122,7 +122,7 @@ if(CONFIG_TESTING_OSTEST)
     endif()
   endif()
 
-  if(CONFIG_ARCH_HAVE_VFORK)
+  if(CONFIG_ARCH_HAVE_FORK)
     if(CONFIG_SCHED_WAITPID)
       list(APPEND SRCS vfork.c)
     endif()

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -123,7 +123,7 @@ CSRCS += sigev_thread.c
 endif
 endif
 
-ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
+ifeq ($(CONFIG_ARCH_HAVE_FORK),y)
 ifeq ($(CONFIG_SCHED_WAITPID),y)
 CSRCS += vfork.c
 endif

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -256,7 +256,7 @@ void sched_lock_test(void);
 
 /* vfork.c ******************************************************************/
 
-#if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)
+#if defined(CONFIG_ARCH_HAVE_FORK) && defined(CONFIG_SCHED_WAITPID)
 int vfork_test(void);
 #endif
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -580,7 +580,7 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
-#if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)
+#if defined(CONFIG_ARCH_HAVE_FORK) && defined(CONFIG_SCHED_WAITPID)
       printf("\nuser_main: vfork() test\n");
       vfork_test();
 #endif

--- a/testing/ostest/vfork.c
+++ b/testing/ostest/vfork.c
@@ -33,7 +33,7 @@
 
 #include "ostest.h"
 
-#if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)
+#if defined(CONFIG_ARCH_HAVE_FORK) && defined(CONFIG_SCHED_WAITPID)
 
 /****************************************************************************
  * Private Data
@@ -84,4 +84,4 @@ int vfork_test(void)
   return 0;
 }
 
-#endif /* CONFIG_ARCH_HAVE_VFORK && CONFIG_SCHED_WAITPID */
+#endif /* CONFIG_ARCH_HAVE_FORK && CONFIG_SCHED_WAITPID */


### PR DESCRIPTION
## Summary

- Resolves an issue where `vfork_test` was not executed following
   the renaming from CONFIG_ARCH_HAVE_VFORK to CONFIG_ARCH_HAVE_FORK,
   as detailed in https://github.com/apache/nuttx/pull/9755.

## Impact

- Please ** merge ** https://github.com/apache/nuttx/pull/11200 before
   merging this PR.

## Testing

- Successfully tested with rv-virt:smp64, spresense:smp, and sim:smp.