### PR TITLE
Wrong start and end values would make dead cycle. Exchange the values when start value is bigger than end value.

### DIFF
--- a/system/dumpstack/dumpstack.c
+++ b/system/dumpstack/dumpstack.c
@@ -44,6 +44,7 @@ int main(int argc, FAR char *argv[])
 {
   int spid = -1;
   int epid = -1;
+  int tmp = -1;
 
   if (argc == 2)
     {
@@ -58,6 +59,13 @@ int main(int argc, FAR char *argv[])
   if (spid < 0 || epid < 0)
     {
       spid = epid = gettid();
+    }
+
+  if (spid > epid)
+    {
+      tmp = spid;
+      spid = epid;
+      epid = tmp;
     }
 
   do


### PR DESCRIPTION
## Summary

minor fix

## Impact

stackdump

## Testing

manual