### PR TITLE
cmake:refine cmake build for apps/examples

### DIFF
--- a/examples/abntcodi/CMakeLists.txt
+++ b/examples/abntcodi/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/adntcodi/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ABNTCODI)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_ABNTCODI_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ABNTCODI_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_ABNTCODI_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ABNTCODI}
+    SRCS
+    abntcodi_main.c)
+endif()

--- a/examples/adc/CMakeLists.txt
+++ b/examples/adc/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_ADC)
-  nuttx_add_application(NAME adc)
+  nuttx_add_application(
+    NAME
+    adc
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ADC}
+    SRCS
+    adc_main.c)
 endif()

--- a/examples/adjtime/CMakeLists.txt
+++ b/examples/adjtime/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/adjtime/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ADJTIME)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_ADJTIME_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ADJTIME_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_ADJTIME_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ADJTIME}
+    SRCS
+    adjtime_main.c)
+endif()

--- a/examples/adxl372_test/CMakeLists.txt
+++ b/examples/adxl372_test/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_ADXL372_TEST)
-  nuttx_add_application(NAME adxl372_test)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_ADXL372_TEST_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ADXL372_TEST_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_ADXL372_TEST_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ADXL372_TEST}
+    SRCS
+    adxl372_test_main.c)
 endif()

--- a/examples/ajoystick/CMakeLists.txt
+++ b/examples/ajoystick/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_AJOYSTICK)
-  nuttx_add_application(NAME ajoystick)
+  nuttx_add_application(
+    NAME
+    ajoy
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_AJOYSTICK}
+    SRCS
+    ajoy_main.c)
 endif()

--- a/examples/alarm/CMakeLists.txt
+++ b/examples/alarm/CMakeLists.txt
@@ -21,11 +21,13 @@
 if(CONFIG_EXAMPLES_ALARM)
   nuttx_add_application(
     NAME
-    alarm
-    SRCS
-    alarm_main.c
+    ${CONFIG_EXAMPLES_ALARM_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ALARM_PRIORITY}
     STACKSIZE
     ${CONFIG_EXAMPLES_ALARM_STACKSIZE}
-    PRIORITY
-    ${CONFIG_EXAMPLES_ALARM_PRIORITY})
+    MODULE
+    ${CONFIG_EXAMPLES_ALARM}
+    SRCS
+    alarm_main.c)
 endif()

--- a/examples/apa102/CMakeLists.txt
+++ b/examples/apa102/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_APA102)
-  nuttx_add_application(NAME apa102)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_APA102_PROGNAME}
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_APA102}
+    SRCS
+    apa102_main.c)
 endif()

--- a/examples/apds9960/CMakeLists.txt
+++ b/examples/apds9960/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_APDS9960)
-  nuttx_add_application(NAME apds9960)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_APDS9960_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_APDS9960_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_APDS9960_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_APDS9960}
+    SRCS
+    apds9960_main.c)
 endif()

--- a/examples/audio_rttl/CMakeLists.txt
+++ b/examples/audio_rttl/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/audio_rttl/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_AUDIO_SOUND)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_AUDIO_SOUND_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_AUDIO_SOUND_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_AUDIO_SOUND_STACKSIZE}
+    SRCS
+    audio_rttl.c)
+endif()

--- a/examples/bastest/CMakeLists.txt
+++ b/examples/bastest/CMakeLists.txt
@@ -19,5 +19,24 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_BASTEST)
-  nuttx_add_application(NAME bastest)
+  nuttx_add_romfs(
+    NAME
+    bastest
+    PATH
+    ${CMAKE_CURRENT_LIST_DIR}/test
+    HEADER
+    PREFIX
+    bastest
+    NONCONST)
+
+  nuttx_add_application(
+    NAME
+    bastest
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_BASTEST}
+    SRCS
+    bastest_main.c)
+
 endif()

--- a/examples/battery/CMakeLists.txt
+++ b/examples/battery/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/battery/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BATTERY)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_BATTERY_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_BATTERY_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_BATTERY_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_BATTERY}
+    SRCS
+    batt_main.c)
+endif()

--- a/examples/bmi160/CMakeLists.txt
+++ b/examples/bmi160/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/bmi160/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SIXAXIS)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_SIXAXIS_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_SIXAXIS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SIXAXIS_STACKSIZE}
+    SRCS
+    sixaxis_main.c)
+endif()

--- a/examples/bmp180/CMakeLists.txt
+++ b/examples/bmp180/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_BMP180)
-  nuttx_add_application(NAME bmp180)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_BMP180_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_BMP180_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_BMP180_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_BMP180}
+    SRCS
+    bmp180_main.c)
 endif()

--- a/examples/bmp280/CMakeLists.txt
+++ b/examples/bmp280/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/bmp280/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BMP280)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_BMP280_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_BMP280_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_BMP280_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_BMP280}
+    SRCS
+    bmp280_main.c)
+endif()

--- a/examples/buttons/CMakeLists.txt
+++ b/examples/buttons/CMakeLists.txt
@@ -21,11 +21,13 @@
 if(CONFIG_EXAMPLES_BUTTONS)
   nuttx_add_application(
     NAME
-    buttons
-    SRCS
-    buttons_main.c
+    ${CONFIG_EXAMPLES_BUTTONS_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_BUTTONS_PRIORITY}
     STACKSIZE
     ${CONFIG_EXAMPLES_BUTTONS_STACKSIZE}
-    PRIORITY
-    ${CONFIG_EXAMPLES_BUTTONS_PRIORITY})
+    MODULE
+    ${CONFIG_EXAMPLES_BUTTONS}
+    SRCS
+    buttons_main.c)
 endif()

--- a/examples/calib_udelay/CMakeLists.txt
+++ b/examples/calib_udelay/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CALIB_UDELAY)
-  nuttx_add_application(NAME calib_udelay)
+  nuttx_add_application(
+    NAME
+    calib_udelay
+    PRIORITY
+    100
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CALIB_UDELAY}
+    SRCS
+    calib_udelay_main.c)
 endif()

--- a/examples/camera/CMakeLists.txt
+++ b/examples/camera/CMakeLists.txt
@@ -1,0 +1,39 @@
+# ##############################################################################
+# apps/examples/camera/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CAMERA)
+
+  set(CSRCS camera_main.c camera_fileutil.c)
+  if(CONFIG_EXAMPLES_CAMERA_OUTPUT_LCD)
+    list(APPEND CSRCS camera_bkgd.c)
+  endif()
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_CAMERA_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_CAMERA_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_CAMERA_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CAMERA}
+    SRCS
+    ${CSRCS})
+endif()

--- a/examples/can/CMakeLists.txt
+++ b/examples/can/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CAN)
-  nuttx_add_application(NAME can)
+  nuttx_add_application(
+    NAME
+    can
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CAN}
+    SRCS
+    can_main.c)
 endif()

--- a/examples/capture/CMakeLists.txt
+++ b/examples/capture/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/capture/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CAPTURE)
+  nuttx_add_application(
+    NAME
+    cap
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CAPTURE}
+    SRCS
+    cap_main.c)
+endif()

--- a/examples/cbortest/CMakeLists.txt
+++ b/examples/cbortest/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/cbortest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TINYCBOR_TEST)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TINYCBOR_TEST_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TINYCBOR_TEST_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TINYCBOR_TEST_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TINYCBOR_TEST}
+    SRCS
+    cbortest_main.c)
+endif()

--- a/examples/cctype/CMakeLists.txt
+++ b/examples/cctype/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CCTYPE)
-  nuttx_add_application(NAME cctype)
+  nuttx_add_application(
+    NAME
+    cctype
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CCTYPE}
+    SRCS
+    cctype_main.cxx)
 endif()

--- a/examples/charger/CMakeLists.txt
+++ b/examples/charger/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/charger/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CHARGER)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_CHARGER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_CHARGER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_CHARGER_STACKSIZE}
+    SRCS
+    charger_main.c)
+endif()

--- a/examples/chat/CMakeLists.txt
+++ b/examples/chat/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CHAT)
-  nuttx_add_application(NAME chat)
+  nuttx_add_application(
+    NAME
+    chat
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CHAT}
+    SRCS
+    chat_main.c)
 endif()

--- a/examples/chrono/CMakeLists.txt
+++ b/examples/chrono/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/chrono/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CHRONO)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_CHRONO_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_CHRONO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_CHRONO_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CHRONO}
+    SRCS
+    chrono_main.c)
+endif()

--- a/examples/configdata/CMakeLists.txt
+++ b/examples/configdata/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CONFIGDATA)
-  nuttx_add_application(NAME configdata)
+  nuttx_add_application(
+    NAME
+    configdata
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CONFIGDATA}
+    SRCS
+    configdata_main.c)
 endif()

--- a/examples/cordic/CMakeLists.txt
+++ b/examples/cordic/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/cordic/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_CORDIC)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_CORDIC_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_CORDIC_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_CORDIC_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CORDIC}
+    SRCS
+    cordic_main.c)
+endif()

--- a/examples/cpuhog/CMakeLists.txt
+++ b/examples/cpuhog/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CPUHOG)
-  nuttx_add_application(NAME cpuhog)
+  nuttx_add_application(
+    NAME
+    cpuhog
+    PRIORITY
+    ${CONFIG_EXAMPLES_CPUHOG_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_CPUHOG_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_CPUHOG}
+    SRCS
+    cpuhog_main.c)
 endif()

--- a/examples/cromfs/CMakeLists.txt
+++ b/examples/cromfs/CMakeLists.txt
@@ -19,5 +19,5 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_CROMFS)
-  nuttx_add_application(NAME cromfs)
+  nuttx_add_cromfs(NAME example_cromfs PATH ${CMAKE_CURRENT_LIST_DIR}/cromfs)
 endif()

--- a/examples/dac/CMakeLists.txt
+++ b/examples/dac/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_DAC)
-  nuttx_add_application(NAME dac)
+  nuttx_add_application(
+    NAME
+    dac
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_DAC}
+    SRCS
+    dac_main.c)
 endif()

--- a/examples/dhtxx/CMakeLists.txt
+++ b/examples/dhtxx/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_DHTXX)
-  nuttx_add_application(NAME dhtxx)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_DHTXX_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_DHTXX_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_DHTXX_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_DHTXX}
+    SRCS
+    dhtxx_main.c)
 endif()

--- a/examples/discover/CMakeLists.txt
+++ b/examples/discover/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_DISCOVER)
-  nuttx_add_application(NAME discover SRCS discover_main.c)
+  nuttx_add_application(
+    NAME
+    discover
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_DISCOVER}
+    SRCS
+    discover_main.c)
 endif()

--- a/examples/djoystick/CMakeLists.txt
+++ b/examples/djoystick/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_DJOYSTICK)
-  nuttx_add_application(NAME djoystick)
+  nuttx_add_application(
+    NAME
+    djoy
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_DJOYSTICK}
+    SRCS
+    djoy_main.c)
 endif()

--- a/examples/dronecan/CMakeLists.txt
+++ b/examples/dronecan/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# apps/examples/dronecan/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_DRONECAN)
+  set(INCDIR ${NUTTX_APPS_DIR}/canutils/libdronecan/libcanard
+             ${NUTTX_APPS_DIR}/canutils/libdronecan/libcanard/drivers/nuttx)
+  if(CONFIG_CANUTILS_LIBOPENCYPHAL)
+    set(CFLAGS -DcanardInit=dronecanardInit)
+  endif()
+
+  nuttx_add_application(
+    NAME
+    dronecan
+    STACKSIZE
+    ${CONFIG_EXAMPLES_DRONECAN_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_DRONECAN}
+    SRCS
+    canard_main.c
+    INCLUDE_DIRECTORIES
+    ${INCDIR}
+    COMPILE_FLAGS
+    ${CFLAGS})
+endif()

--- a/examples/embedlog/CMakeLists.txt
+++ b/examples/embedlog/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/embedlog/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_EMBEDLOG)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_EMBEDLOG_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_EMBEDLOG_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_EMBEDLOG_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_EMBEDLOG}
+    SRCS
+    embedlog_main.c)
+endif()

--- a/examples/esp32_himem/CMakeLists.txt
+++ b/examples/esp32_himem/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/esp32_himem/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ESP32_HIMEM)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_ESP32_HIMEM_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ESP32_HIMEM_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_ESP32_HIMEM_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ESP32_HIMEM}
+    SRCS
+    esp32_himem_main.c)
+endif()

--- a/examples/etl/CMakeLists.txt
+++ b/examples/etl/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/etl/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ETL)
+  nuttx_add_application(
+    NAME
+    etl
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_HELLOXX}
+    SRCS
+    etl_main.cxx)
+endif()

--- a/examples/fboverlay/CMakeLists.txt
+++ b/examples/fboverlay/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_FBOVERLAY)
-  nuttx_add_application(NAME fboverlay)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_FBOVERLAY_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_FBOVERLAY_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FBOVERLAY_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_FBOVERLAY}
+    SRCS
+    fboverlay_main.c)
 endif()

--- a/examples/flash_test/CMakeLists.txt
+++ b/examples/flash_test/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_FLASH_TEST)
-  nuttx_add_application(NAME flash_test)
+  nuttx_add_application(
+    NAME
+    flash_test
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_FLASH_TEST}
+    SRCS
+    flash_test.c)
 endif()

--- a/examples/fmsynth/CMakeLists.txt
+++ b/examples/fmsynth/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# apps/examples/fmsynth/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FMSYNTH)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_FMSYNTH_KEYBOARD_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_FMSYNTH_KEYBOARD_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FMSYNTH_KEYBOARD_STACKSIZE}
+    SRCS
+    keyboard_main.c)
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_FMSYNTH_MMLPLAYER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_FMSYNTH_MMLPLAYER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FMSYNTH_MMLPLAYER_STACKSIZE}
+    SRCS
+    mmlplayer_main.c)
+
+  target_sources(apps PRIVATE music_scale.c operator_algorithm.c)
+endif()

--- a/examples/ft80x/CMakeLists.txt
+++ b/examples/ft80x/CMakeLists.txt
@@ -19,5 +19,24 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_FT80X)
-  nuttx_add_application(NAME ft80x)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_FT80X_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_FT80X_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FT80X_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_FT80X}
+    SRCS
+    ft80x_main.c)
+
+  set(CSRCS ft80x_coprocessor.c)
+  if(CONFIG_EXAMPLES_FT80X_PRIMITIVES)
+    list(APPEND CSRCS ft80x_primitives.c)
+  endif()
+  if(CONFIG_EXAMPLES_FT80X_EXCLUDE_BITMAPS)
+    list(APPEND CSRCS ft80x_bitmaps.c)
+  endif()
+  target_sources(apps PRIVATE ${CSRCS})
 endif()

--- a/examples/ftpc/CMakeLists.txt
+++ b/examples/ftpc/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_FTPC)
-  nuttx_add_application(NAME ftpc)
+  nuttx_add_application(
+    NAME
+    ftpc
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FTPC_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_FTPC}
+    SRCS
+    ftpc_main.c)
+
+  target_sources(apps PRIVATE ftpc_cmds.c)
 endif()

--- a/examples/fxos8700cq_test/CMakeLists.txt
+++ b/examples/fxos8700cq_test/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/fxos8700cq_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_FXOS8700CQ)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_FXOS8700CQ_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_FXOS8700CQ_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_FXOS8700CQ_STACKSIZE}
+    SRCS
+    fxos8700cq_main.c)
+endif()

--- a/examples/gpio/CMakeLists.txt
+++ b/examples/gpio/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_GPIO)
-  nuttx_add_application(NAME gpio)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_GPIO_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_GPIO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_GPIO_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_GPIO}
+    SRCS
+    gpio_main.c)
 endif()

--- a/examples/gps/CMakeLists.txt
+++ b/examples/gps/CMakeLists.txt
@@ -19,5 +19,17 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_GPS)
-  nuttx_add_application(NAME gps)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_GPS_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_GPS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_GPS_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_GPS}
+    SRCS
+    gps_main.c
+    INCLUDE_DIRECTORIES
+    ${NUTTX_APPS_DIR}/gpsutils/minmea)
 endif()

--- a/examples/hall/CMakeLists.txt
+++ b/examples/hall/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/hall/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_HALL)
+  nuttx_add_application(
+    NAME
+    hall
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_HALL}
+    SRCS
+    hall_main.c)
+endif()

--- a/examples/hdc1008_demo/CMakeLists.txt
+++ b/examples/hdc1008_demo/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/hdc1008/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_HDC1008)
+  nuttx_add_application(
+    NAME
+    hdc1008
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_HDC1008}
+    SRCS
+    hdc1008_main.c)
+endif()

--- a/examples/helloxx/CMakeLists.txt
+++ b/examples/helloxx/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_HELLOXX)
-  nuttx_add_application(NAME helloxx SRCS helloxx_main.cxx)
+  nuttx_add_application(
+    NAME
+    helloxx
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_HELLOXX}
+    SRCS
+    helloxx_main.cxx)
 endif()

--- a/examples/hidkbd/CMakeLists.txt
+++ b/examples/hidkbd/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_HIDKBD)
-  nuttx_add_application(NAME hidkbd)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_HIDKBD_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_HIDKBD_DEFPRIO}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_HIDKBD_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_HIDKBD}
+    SRCS
+    hidkbd_main.c)
 endif()

--- a/examples/hts221_reader/CMakeLists.txt
+++ b/examples/hts221_reader/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/hts221_reader/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_HTS221_READER)
+  nuttx_add_application(
+    NAME
+    hts221_reader
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_HTS221_READER}
+    SRCS
+    hts221_reader_main.c)
+endif()

--- a/examples/i2schar/CMakeLists.txt
+++ b/examples/i2schar/CMakeLists.txt
@@ -19,5 +19,19 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_I2SCHAR)
-  nuttx_add_application(NAME i2schar)
+  nuttx_add_application(
+    NAME
+    i2schar
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_I2SCHAR}
+    SRCS
+    i2schar_main.c)
+  if(CONFIG_EXAMPLES_I2SCHAR_TX)
+    target_sources(apps PRIVATE i2schar_transmitter.c)
+  endif()
+  if(CONFIG_EXAMPLES_I2SCHAR_RX)
+    target_sources(apps PRIVATE i2schar_receiver.c)
+  endif()
 endif()

--- a/examples/i2sloop/CMakeLists.txt
+++ b/examples/i2sloop/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_I2SLOOP)
-  nuttx_add_application(NAME i2sloop)
+  nuttx_add_application(
+    NAME
+    i2sloop
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_I2SLOOP}
+    SRCS
+    i2sloop_main.c)
 endif()

--- a/examples/igmp/CMakeLists.txt
+++ b/examples/igmp/CMakeLists.txt
@@ -19,6 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_IGMP)
-  nuttx_add_application(NAME igmp SRCS igmp.c STACKSIZE
-                        ${CONFIG_DEFAULT_TASK_STACKSIZE})
+  nuttx_add_application(
+    NAME
+    igmp
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_IGMP}
+    SRCS
+    igmp.c)
 endif()

--- a/examples/ina219/CMakeLists.txt
+++ b/examples/ina219/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_INA219)
-  nuttx_add_application(NAME ina219)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_INA219_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_INA219_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_INA219_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_INA219}
+    SRCS
+    ina219_main.c)
 endif()

--- a/examples/ini_dumper/CMakeLists.txt
+++ b/examples/ini_dumper/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/ini_dumper/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_INI_DUMPER)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_INI_DUMPER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_INI_DUMPER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_INI_DUMPER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_INI_DUMPER}
+    SRCS
+    ini_dumper_main.c
+    COMPILE_FLAGS
+    -DINI_HANDLER_LINENO=1)
+endif()

--- a/examples/ipcfg/CMakeLists.txt
+++ b/examples/ipcfg/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/ipcfg/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_IPCFG)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_IPCFG_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_IPCFG_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_IPCFG_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_IPCFG}
+    SRCS
+    ipcfg_main.c)
+endif()

--- a/examples/ipforward/CMakeLists.txt
+++ b/examples/ipforward/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_IPFORWARD)
-  nuttx_add_application(NAME ipforward)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_IPFORWARD_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_IPFORWARD_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_IPFORWARD_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_IPFORWARD}
+    SRCS
+    ipforward.c)
 endif()

--- a/examples/isl29023/CMakeLists.txt
+++ b/examples/isl29023/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/isl29023/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_ISL29023)
+  nuttx_add_application(
+    NAME
+    isl29023
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ISL29023}
+    SRCS
+    isl29023_main.c)
+endif()

--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_JSON)
-  nuttx_add_application(NAME json)
+  nuttx_add_application(
+    NAME
+    json
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_JSON}
+    SRCS
+    json_main.c)
 endif()

--- a/examples/leds/CMakeLists.txt
+++ b/examples/leds/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_LEDS)
-  nuttx_add_application(NAME leds)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_LEDS_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_LEDS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LEDS_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LEDS}
+    SRCS
+    leds_main.c)
 endif()

--- a/examples/libtest/CMakeLists.txt
+++ b/examples/libtest/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# apps/examples/libtest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LIBTEST)
+
+  if(CONFIG_EXAMPLES_LIBTEST_CMDTOOL)
+    nuttx_add_application(
+      NAME
+      ${CONFIG_EXAMPLES_LIBTEST_PROGNAME}
+      PRIORITY
+      ${CONFIG_EXAMPLES_LIBTEST_PRIORITY}
+      STACKSIZE
+      ${CONFIG_EXAMPLES_LIBTEST_STACKSIZE}
+      MODULE
+      ${CONFIG_EXAMPLES_LIBTEST_CMDTOOL}
+      SRCS
+      libtest_main.c)
+  endif()
+
+  nuttx_add_library(libtest STATIC)
+  target_sources(libtest libtest.c)
+
+endif()

--- a/examples/lis3dsh_reader/CMakeLists.txt
+++ b/examples/lis3dsh_reader/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_LIS3DSH_READER)
-  nuttx_add_application(NAME lis3dsh_reader)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_LIS3DSH_READER_PROGNAME}
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LIS3DSH_READER}
+    SRCS
+    lis3dsh_reader_main.c)
 endif()

--- a/examples/lp503x/CMakeLists.txt
+++ b/examples/lp503x/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/lp503x/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LP503X)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_LP503X_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_LP503X_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LP503X_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LP503X}
+    SRCS
+    lp503x_main.c)
+endif()

--- a/examples/lsm303_reader/CMakeLists.txt
+++ b/examples/lsm303_reader/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/lsm303_reader/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LSM303_READER)
+  nuttx_add_application(
+    NAME
+    lsm303_reader
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LSM303_READER}
+    SRCS
+    lsm303_reader_main.c)
+endif()

--- a/examples/lsm330spi_test/CMakeLists.txt
+++ b/examples/lsm330spi_test/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_LSM330SPI_TEST)
-  nuttx_add_application(NAME lsm330spi_test)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_LSM330SPI_TEST_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_LSM330SPI_TEST_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LSM330SPI_TEST_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LSM330SPI_TEST}
+    SRCS
+    lsm330spi_test_main.c)
 endif()

--- a/examples/lsm6dsl_reader/CMakeLists.txt
+++ b/examples/lsm6dsl_reader/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/lsm6dsl_reader/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LSM6DSL_READER)
+  nuttx_add_application(
+    NAME
+    lsm6dsl_reader
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LSM6DSL_READER}
+    SRCS
+    lsm6dsl_reader_main.c)
+endif()

--- a/examples/ltr308/CMakeLists.txt
+++ b/examples/ltr308/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/ltr308/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LTR308)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_LTR308_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_LTR308_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LTR308_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LTR308}
+    SRCS
+    ltr308_main.c)
+endif()

--- a/examples/lvgldemo/CMakeLists.txt
+++ b/examples/lvgldemo/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_LVGLDEMO)
-  nuttx_add_application(NAME lvgldemo)
+  nuttx_add_application(
+    NAME
+    lvgldemo
+    PRIORITY
+    ${CONFIG_EXAMPLES_LVGLDEMO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LVGLDEMO_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LVGLDEMO}
+    SRCS
+    lvgldemo.c)
 endif()

--- a/examples/lvglterm/CMakeLists.txt
+++ b/examples/lvglterm/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/lvglterm/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LVGLTERM)
+  nuttx_add_application(
+    NAME
+    lvglterm
+    PRIORITY
+    ${CONFIG_EXAMPLES_LVGLTERM_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LVGLTERM_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LVGLTERM}
+    SRCS
+    lvglterm.c)
+endif()

--- a/examples/max31855/CMakeLists.txt
+++ b/examples/max31855/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MAX31855)
-  nuttx_add_application(NAME max31855)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MAX31855_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_MAX31855_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_MAX31855_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MAX31855}
+    SRCS
+    max31855_main.c)
 endif()

--- a/examples/media/CMakeLists.txt
+++ b/examples/media/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MEDIA)
-  nuttx_add_application(NAME media)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MEDIA_PROGNAME}
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MEDIA}
+    SRCS
+    media_main.c)
 endif()

--- a/examples/mld/CMakeLists.txt
+++ b/examples/mld/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MLD)
-  nuttx_add_application(NAME mld)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MLD_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_MLD_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_MLD_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MLD}
+    SRCS
+    mld_main.c)
 endif()

--- a/examples/mlx90614/CMakeLists.txt
+++ b/examples/mlx90614/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MLX90614)
-  nuttx_add_application(NAME mlx90614)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MLX90614_PROGNAME}
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MLX90614}
+    SRCS
+    mlx90614_main.c)
 endif()

--- a/examples/mml_parser/CMakeLists.txt
+++ b/examples/mml_parser/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/mml_parser/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MMLPARSER)
+  nuttx_add_application(
+    NAME
+    mmlparser
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MMLPARSER}
+    SRCS
+    mml_parser_main.c)
+endif()

--- a/examples/modbus/CMakeLists.txt
+++ b/examples/modbus/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MODBUS)
-  nuttx_add_application(NAME modbus)
+  nuttx_add_application(
+    NAME
+    modbus
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MODBUS}
+    SRCS
+    modbus_main.c)
 endif()

--- a/examples/modbusmaster/CMakeLists.txt
+++ b/examples/modbusmaster/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/modbusmaster/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MODBUSMASTER)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MODBUSMASTER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_MODBUSMASTER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_MODBUSMASTER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MODBUSMASTER}
+    SRCS
+    mbmaster_main.c)
+endif()

--- a/examples/mqttc/CMakeLists.txt
+++ b/examples/mqttc/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/mqttc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MQTTC)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MQTTC_PROGNAME}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_MQTTC_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MQTTC}
+    SRCS
+    mqttc_pub.c)
+endif()

--- a/examples/mtdpart/CMakeLists.txt
+++ b/examples/mtdpart/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MTDPART)
-  nuttx_add_application(NAME mtdpart SRCS mtdpart_main.c)
+  nuttx_add_application(
+    NAME
+    mtdpart
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MTDPART}
+    SRCS
+    mtdpart_main.c)
 endif()

--- a/examples/mtdrwb/CMakeLists.txt
+++ b/examples/mtdrwb/CMakeLists.txt
@@ -19,6 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_MTDRWB)
-  nuttx_add_application(NAME ${CONFIG_EXAMPLES_MTDRWB_PROGNAME} SRCS
-                        mtdrwb_main.c)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MTDRWB_PROGNAME}
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MTDRWB}
+    SRCS
+    mtdrwb_main.c)
 endif()

--- a/examples/netlink_route/CMakeLists.txt
+++ b/examples/netlink_route/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/netlink_route/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NETLINK_ROUTE)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NETLINK_ROUTE_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NETLINK_ROUTE_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NETLINK_ROUTE_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NETLINK_ROUTE}
+    SRCS
+    netlink_route_main.c)
+endif()

--- a/examples/netloop/CMakeLists.txt
+++ b/examples/netloop/CMakeLists.txt
@@ -19,5 +19,16 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NETLOOP)
-  nuttx_add_application(NAME netloop)
+  nuttx_add_application(
+    NAME
+    netloop
+    PRIORITY
+    ${CONFIG_EXAMPLES_NETLOOP_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NETLOOP_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NETLOOP}
+    SRCS
+    lo_main.c)
+  target_sources(apps PRIVATE lo_listener.c)
 endif()

--- a/examples/netpkt/CMakeLists.txt
+++ b/examples/netpkt/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NETPKT)
-  nuttx_add_application(NAME netpkt)
+  nuttx_add_application(
+    NAME
+    netpkt
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NETPKT}
+    SRCS
+    netpkt_main.c)
 endif()

--- a/examples/nng_test/CMakeLists.txt
+++ b/examples/nng_test/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/nng_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NNG_TEST)
+  nuttx_add_application(
+    NAME
+    pubsub
+    PRIORITY
+    ${CONFIG_EXAMPLES_NNG_TEST_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NNG_TEST_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NNG_TEST}
+    SRCS
+    pubsub.c)
+endif()

--- a/examples/noteprintf/CMakeLists.txt
+++ b/examples/noteprintf/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/noteprintf/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NOTEPRINTF)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NOTEPRINTF_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NOTEPRINTF_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NOTEPRINTF_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NOTEPRINTF}
+    SRCS
+    noteprintf_main.c)
+endif()

--- a/examples/nrf24l01_btle/CMakeLists.txt
+++ b/examples/nrf24l01_btle/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/nrf24l01_btle/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NRF24L01_BTLE)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NRF24L01_BTLE_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NRF24L01_BTLE_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NRF24L01_BTLE_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NRF24L01_BTLE}
+    SRCS
+    nrf24l01_btle.c)
+endif()

--- a/examples/nrf24l01_term/CMakeLists.txt
+++ b/examples/nrf24l01_term/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NRF24L01TERM)
-  nuttx_add_application(NAME nrf24l01_term)
+  nuttx_add_application(
+    NAME
+    nrf24l01_term
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NRF24L01TERM}
+    SRCS
+    nrf24l01_term.c)
 endif()

--- a/examples/null/CMakeLists.txt
+++ b/examples/null/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NULL)
-  nuttx_add_application(NAME null)
+  nuttx_add_application(
+    NAME
+    null
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NULL}
+    SRCS
+    null_main.c)
 endif()

--- a/examples/nunchuck/CMakeLists.txt
+++ b/examples/nunchuck/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NUNCHUCK)
-  nuttx_add_application(NAME nunchuck)
+  nuttx_add_application(
+    NAME
+    nunchuck
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NUNCHUCK}
+    SRCS
+    nunchuck_main.c)
 endif()

--- a/examples/nx/CMakeLists.txt
+++ b/examples/nx/CMakeLists.txt
@@ -19,5 +19,14 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NX)
-  nuttx_add_application(NAME nx)
+  nuttx_add_application(
+    NAME
+    nx
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NX}
+    SRCS
+    nx_main.c)
+  target_sources(apps PRIVATE nx_events.c nx_kbdin.c)
 endif()

--- a/examples/nxdemo/CMakeLists.txt
+++ b/examples/nxdemo/CMakeLists.txt
@@ -19,5 +19,14 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NXDEMO)
-  nuttx_add_application(NAME nxdemo)
+  nuttx_add_application(
+    NAME
+    nxdemo
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NXDEMO}
+    SRCS
+    nxdemo_main.c)
+  target_sources(apps PRIVATE nxdemo_bkgd.c nxdemo_listener.c)
 endif()

--- a/examples/nxhello/CMakeLists.txt
+++ b/examples/nxhello/CMakeLists.txt
@@ -19,5 +19,16 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NXHELLO)
-  nuttx_add_application(NAME nxhello)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NXHELLO_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NXHELLO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NXHELLO_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NXHELLO}
+    SRCS
+    nxhello_main.c)
+  target_sources(apps PRIVATE nxhello_bkgd.c nxhello_listener.c)
 endif()

--- a/examples/nximage/CMakeLists.txt
+++ b/examples/nximage/CMakeLists.txt
@@ -19,5 +19,17 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NXIMAGE)
-  nuttx_add_application(NAME nximage)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NXIMAGE_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NXIMAGE_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NXIMAGE_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NXIMAGE}
+    SRCS
+    nximage_main.c)
+  target_sources(apps PRIVATE nximage_bkgd.c nximage_bitmap.c
+                              nximage_listener.c)
 endif()

--- a/examples/nxlines/CMakeLists.txt
+++ b/examples/nxlines/CMakeLists.txt
@@ -19,6 +19,16 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NXLINES)
-  nuttx_add_application(NAME nxlines SRCS nxlines_bkgd.c nxlines_listener.c
-                        nxlines_main.c)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NXLINES_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NXLINES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NXLINES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NXLINES}
+    SRCS
+    nxlines_main.c)
+  target_sources(apps PRIVATE nxlines_bkgd.c nxlines_listener.c)
 endif()

--- a/examples/nxterm/CMakeLists.txt
+++ b/examples/nxterm/CMakeLists.txt
@@ -19,5 +19,16 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NXTERM)
-  nuttx_add_application(NAME nxterm)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_NXTERM_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_NXTERM_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_NXTERM_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NXTERM}
+    SRCS
+    nxterm_main.c)
+  target_sources(apps PRIVATE nxterm_toolbar.c nxterm_wndo.c nxterm_listener.c)
 endif()

--- a/examples/nxtext/CMakeLists.txt
+++ b/examples/nxtext/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_NXTEXT)
-  nuttx_add_application(NAME nxtext)
+  nuttx_add_application(
+    NAME
+    nxtext
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_NXTEXT}
+    SRCS
+    nxtext_main.c)
+  target_sources(apps PRIVATE nxtext_bkgd.c nxtext_popup.c nxtext_putc.c
+                              nxtext_listener.c)
 endif()

--- a/examples/obd2/CMakeLists.txt
+++ b/examples/obd2/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_OBD2)
-  nuttx_add_application(NAME obd2)
+  nuttx_add_application(
+    NAME
+    obd2
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_OBD2}
+    SRCS
+    obd2_main.c)
 endif()

--- a/examples/oneshot/CMakeLists.txt
+++ b/examples/oneshot/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_ONESHOT)
-  nuttx_add_application(NAME oneshot)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_ONESHOT_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_ONESHOT_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_ONESHOT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ONESHOT}
+    SRCS
+    oneshot_main.c)
 endif()

--- a/examples/opencyphal/CMakeLists.txt
+++ b/examples/opencyphal/CMakeLists.txt
@@ -1,0 +1,38 @@
+# ##############################################################################
+# apps/examples/opencyphal/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_LIBOPENCYPHAL)
+  set(INCDIR ${NUTTX_APPS_DIR}/canutils/libopencyphal/libcanard/libcanard)
+  set(CFLAGS -std=c11)
+  nuttx_add_application(
+    NAME
+    opencyphal
+    STACKSIZE
+    ${CONFIG_EXAMPLES_LIBOPENCYPHAL_DAEMON_STACK_SIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_LIBOPENCYPHAL}
+    SRCS
+    canard_main.c
+    INCLUDE_DIRECTORIES
+    ${INCDIR}
+    COMPILE_FLAGS
+    ${CFLAGS})
+  target_sources(apps PRIVATE socketcan.c)
+endif()

--- a/examples/pca9635/CMakeLists.txt
+++ b/examples/pca9635/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PCA9635)
-  nuttx_add_application(NAME pca9635)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_PCA9635_PROGNAME}
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PCA9635}
+    SRCS
+    pca9635_main.c)
 endif()

--- a/examples/pdcurses/CMakeLists.txt
+++ b/examples/pdcurses/CMakeLists.txt
@@ -19,5 +19,112 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PDCURSES)
-  nuttx_add_application(NAME pdcurses)
+  target_sources(apps PRIVATE tui.c)
+  nuttx_add_application(
+    NAME
+    charset
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    charset_main.c)
+
+  nuttx_add_application(
+    NAME
+    firework
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    firework_main.c)
+
+  nuttx_add_application(
+    NAME
+    newdemo
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    newdemo_main.c)
+
+  nuttx_add_application(
+    NAME
+    panel
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    panel_main.c)
+
+  nuttx_add_application(
+    NAME
+    rain
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    rain_main.c)
+
+  nuttx_add_application(
+    NAME
+    testcurs
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    testcurs_main.c)
+
+  nuttx_add_application(
+    NAME
+    tui
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    tui_main.c)
+
+  nuttx_add_application(
+    NAME
+    worm
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    worm_main.c)
+
+  nuttx_add_application(
+    NAME
+    xmas
+    PRIORITY
+    ${CONFIG_EXAMPLES_PDCURSES_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PDCURSES_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PDCURSES}
+    SRCS
+    xmas_main.c)
 endif()

--- a/examples/pf_ieee802154/CMakeLists.txt
+++ b/examples/pf_ieee802154/CMakeLists.txt
@@ -19,5 +19,28 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PFIEEE802154)
-  nuttx_add_application(NAME pf_ieee802154)
+  target_sources(apps PRIVATE pf_cmdline.c)
+  nuttx_add_application(
+    NAME
+    pfserver
+    PRIORITY
+    ${CONFIG_EXAMPLES_PFIEEE802154_PRIORITY1}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PFIEEE802154_STACKSIZE1}
+    MODULE
+    ${CONFIG_EXAMPLES_PFIEEE802154}
+    SRCS
+    pf_server.c)
+
+  nuttx_add_application(
+    NAME
+    pfclient
+    PRIORITY
+    ${CONFIG_EXAMPLES_PFIEEE802154_PRIORITY1}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PFIEEE802154_STACKSIZE1}
+    MODULE
+    ${CONFIG_EXAMPLES_PFIEEE802154}
+    SRCS
+    pf_client.c)
 endif()

--- a/examples/pipe/CMakeLists.txt
+++ b/examples/pipe/CMakeLists.txt
@@ -19,6 +19,14 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PIPE)
-  nuttx_add_application(NAME pipe)
-
+  nuttx_add_application(
+    NAME
+    pipe
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PIPE}
+    SRCS
+    pipe_main.c)
+  target_sources(apps PRIVATE transfer_test.c interlock_test.c redirect_test.c)
 endif()

--- a/examples/poll/CMakeLists.txt
+++ b/examples/poll/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_POLL)
-  nuttx_add_application(NAME poll)
+  nuttx_add_application(
+    NAME
+    poll
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_POLL}
+    SRCS
+    poll_main.c)
+  target_sources(apps PRIVATE poll_listener.c select_listener.c net_listener.c
+                              net_reader.c)
 endif()

--- a/examples/popen/CMakeLists.txt
+++ b/examples/popen/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_POPEN)
-  nuttx_add_application(NAME popen)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_POPEN_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_POPEN_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_POPEN_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_POPEN}
+    SRCS
+    popen_main.c)
 endif()

--- a/examples/powerled/CMakeLists.txt
+++ b/examples/powerled/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_POWERLED)
-  nuttx_add_application(NAME powerled)
+  nuttx_add_application(
+    NAME
+    powerled
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_POWERLED}
+    SRCS
+    powerled_main.c)
 endif()

--- a/examples/powermonitor/CMakeLists.txt
+++ b/examples/powermonitor/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_POWERMONITOR)
-  nuttx_add_application(NAME powermonitor)
+  nuttx_add_application(
+    NAME
+    powermonitor
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_POWERMONITOR}
+    SRCS
+    powermonitor_main.c)
 endif()

--- a/examples/pppd/CMakeLists.txt
+++ b/examples/pppd/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PPPD)
-  nuttx_add_application(NAME pppd)
+  nuttx_add_application(
+    NAME
+    pppd
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PPPD_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PPPD}
+    SRCS
+    pppd_main.c)
 endif()

--- a/examples/pty_test/CMakeLists.txt
+++ b/examples/pty_test/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PTYTEST)
-  nuttx_add_application(NAME pty_test)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_PTYTEST_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_PTYTEST_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PTYTEST_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PTYTEST}
+    SRCS
+    pty_test.c)
 endif()

--- a/examples/pwfb/CMakeLists.txt
+++ b/examples/pwfb/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ##############################################################################
+# apps/examples/pwfb/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PWFB)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_PWFB_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_PWFB_CLIENT_PRIO}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PWFB_CLIENT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PWFB}
+    SRCS
+    pwfb_main.c
+    INCLUDE_DIRECTORIES
+    ${NUTTX_APPS_DIR}/graphics/nxglyphs/include)
+  target_sources(apps PRIVATE pwfb_events.c pwfb_motion.c)
+endif()

--- a/examples/pwlines/CMakeLists.txt
+++ b/examples/pwlines/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/pwlines/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PWLINES)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_PWLINES_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_PWLINES_CLIENT_PRIO}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_PWLINES_CLIENT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PWLINES}
+    SRCS
+    pwlines_main.c)
+  target_sources(apps PRIVATE pwlines_events.c pwlines_motion.c
+                              pwlines_update.c)
+endif()

--- a/examples/pwm/CMakeLists.txt
+++ b/examples/pwm/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_PWM)
-  nuttx_add_application(NAME pwm)
+  nuttx_add_application(
+    NAME
+    pwm
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PWM}
+    SRCS
+    pwm_main.c)
 endif()

--- a/examples/qencoder/CMakeLists.txt
+++ b/examples/qencoder/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_QENCODER)
-  nuttx_add_application(NAME qencoder)
+  nuttx_add_application(
+    NAME
+    qe
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_QENCODER}
+    SRCS
+    qe_main.c)
 endif()

--- a/examples/random/CMakeLists.txt
+++ b/examples/random/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_RANDOM)
-  nuttx_add_application(NAME random)
+  nuttx_add_application(
+    NAME
+    rand
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RANDOM}
+    SRCS
+    random_main.c)
 endif()

--- a/examples/relays/CMakeLists.txt
+++ b/examples/relays/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_RELAYS)
-  nuttx_add_application(NAME relays)
+  nuttx_add_application(
+    NAME
+    relays
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RELAYS}
+    SRCS
+    relays_main.c)
 endif()

--- a/examples/rfid_readuid/CMakeLists.txt
+++ b/examples/rfid_readuid/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_RFID_READUID)
-  nuttx_add_application(NAME rfid_readuid)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_RFID_READUID_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_RFID_READUID_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_RFID_READUID_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RFID_READUID}
+    SRCS
+    rfid_readuid.c)
 endif()

--- a/examples/rgbled/CMakeLists.txt
+++ b/examples/rgbled/CMakeLists.txt
@@ -19,6 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_RGBLED)
-  nuttx_add_application(NAME rgbled SRCS rgbled.c)
-
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_RGBLED_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_RGBLED_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_RGBLED_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RGBLED}
+    SRCS
+    rgbled.c)
 endif()

--- a/examples/rpmsgsocket/CMakeLists.txt
+++ b/examples/rpmsgsocket/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# apps/examples/rpmsgsocket/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RPMSGSOCKET)
+  nuttx_add_application(
+    NAME
+    rpsock_client
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RPMSGSOCKET}
+    SRCS
+    rpsock_client.c)
+  nuttx_add_application(
+    NAME
+    rpsock_server
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RPMSGSOCKET}
+    SRCS
+    rpsock_server.c)
+endif()

--- a/examples/scd41/CMakeLists.txt
+++ b/examples/scd41/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/scd41/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SCD41)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_SCD41_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_SCD41_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SCD41_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SCD41}
+    SRCS
+    scd41_main.c)
+endif()

--- a/examples/sendmail/CMakeLists.txt
+++ b/examples/sendmail/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SENDMAIL)
-  nuttx_add_application(NAME sendmail)
+  nuttx_add_application(
+    NAME
+    sendmail
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SENDMAIL}
+    SRCS
+    sendmail_main.c)
 endif()

--- a/examples/serialblaster/CMakeLists.txt
+++ b/examples/serialblaster/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SERIALBLASTER)
-  nuttx_add_application(NAME serialblaster)
+  nuttx_add_application(
+    NAME
+    serialblaster
+    PRIORITY
+    ${CONFIG_EXAMPLES_SERIALBLASTER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SERIALBLASTER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SERIALBLASTER}
+    SRCS
+    serialblaster_main.c)
 endif()

--- a/examples/serialrx/CMakeLists.txt
+++ b/examples/serialrx/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SERIALRX)
-  nuttx_add_application(NAME serialrx)
+  nuttx_add_application(
+    NAME
+    serialrx
+    PRIORITY
+    ${CONFIG_EXAMPLES_SERIALRX_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SERIALRX_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SERIALRX}
+    SRCS
+    serialrx_main.c)
 endif()

--- a/examples/serloop/CMakeLists.txt
+++ b/examples/serloop/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SERLOOP)
-  nuttx_add_application(NAME serloop)
+  nuttx_add_application(
+    NAME
+    serloop
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SERLOOP}
+    SRCS
+    serloop_main.c)
 endif()

--- a/examples/sht3x/CMakeLists.txt
+++ b/examples/sht3x/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/sht3x/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SHT3X)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_SHT3X_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_SHT3X_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SHT3X_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SHT3X}
+    SRCS
+    sht3x_main.c)
+endif()

--- a/examples/slcd/CMakeLists.txt
+++ b/examples/slcd/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SLCD)
-  nuttx_add_application(NAME slcd)
+  nuttx_add_application(
+    NAME
+    slcd
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SLCD}
+    SRCS
+    slcd_main.c)
 endif()

--- a/examples/smps/CMakeLists.txt
+++ b/examples/smps/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SMPS)
-  nuttx_add_application(NAME smps)
+  nuttx_add_application(
+    NAME
+    smps
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SMPS}
+    SRCS
+    smps_main.c)
 endif()

--- a/examples/stat/CMakeLists.txt
+++ b/examples/stat/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_STAT)
-  nuttx_add_application(NAME stat)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_STAT_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_STAT_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_STAT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_STAT}
+    SRCS
+    stat_main.c)
 endif()

--- a/examples/sx127x_demo/CMakeLists.txt
+++ b/examples/sx127x_demo/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/sx127x_demo/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SX127X)
+  nuttx_add_application(
+    NAME
+    sx127x
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SX127X}
+    SRCS
+    sx127x_demo.c)
+endif()

--- a/examples/system/CMakeLists.txt
+++ b/examples/system/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SYSTEM)
-  nuttx_add_application(NAME system)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_SYSTEM_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_SYSTEM_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SYSTEM_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_SYSTEM}
+    SRCS
+    system_main.c)
 endif()

--- a/examples/tcp_ipc_client/CMakeLists.txt
+++ b/examples/tcp_ipc_client/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/tcp_ipc_client/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TCP_IPC_CLIENT)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TCP_IPC_CLIENT_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TCP_IPC_CLIENT_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TCP_IPC_CLIENT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TCP_IPC_CLIENT}
+    SRCS
+    tcp_ipc_client_main.c)
+endif()

--- a/examples/tcp_ipc_server/CMakeLists.txt
+++ b/examples/tcp_ipc_server/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ##############################################################################
+# apps/examples/tcp_ipc_server/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TCP_IPC_SERVER)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TCP_IPC_SERVER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TCP_IPC_SERVER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TCP_IPC_SERVER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TCP_IPC_SERVER}
+    SRCS
+    tcp_ipc_server_main.c
+    INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_LIST_DIR}/lorawan)
+  target_sources(apps PRIVATE uart_lorawan_layer.c protocol.c)
+endif()

--- a/examples/tcpecho/CMakeLists.txt
+++ b/examples/tcpecho/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_TCPECHO)
-  nuttx_add_application(NAME tcpecho)
+  nuttx_add_application(
+    NAME
+    tcpecho
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TCPECHO}
+    SRCS
+    tcpecho_main.c)
 endif()

--- a/examples/telnetd/CMakeLists.txt
+++ b/examples/telnetd/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_TELNETD)
-  nuttx_add_application(NAME telnetd SRCS telnetd.c)
+  nuttx_add_application(
+    NAME
+    telnetd
+    PRIORITY
+    ${CONFIG_EXAMPLES_TELNETD_DAEMONPRIO}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TELNETD_DAEMONSTACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TELNETD}
+    SRCS
+    telnetd.c)
 endif()

--- a/examples/termios/CMakeLists.txt
+++ b/examples/termios/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/termios/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TERMIOS)
+  nuttx_add_application(
+    NAME
+    termios
+    PRIORITY
+    ${CONFIG_EXAMPLES_TERMIOS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TERMIOS_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TERMIOS}
+    SRCS
+    termios_main.c)
+endif()

--- a/examples/tiff/CMakeLists.txt
+++ b/examples/tiff/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_TIFF)
-  nuttx_add_application(NAME tiff)
+  nuttx_add_application(
+    NAME
+    tiff
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TIFF}
+    SRCS
+    tiff_main.c)
 endif()

--- a/examples/timer/CMakeLists.txt
+++ b/examples/timer/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_TIMER)
-  nuttx_add_application(NAME timer)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TIMER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TIMER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TIMER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TIMER}
+    SRCS
+    timer_main.c)
 endif()

--- a/examples/timer_gpio/CMakeLists.txt
+++ b/examples/timer_gpio/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/timer_gpio/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TIMER_GPIO)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TIMER_GPIO_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TIMER_GPIO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TIMER_GPIO_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TIMER_GPIO}
+    SRCS
+    timer_gpio_main.c)
+endif()

--- a/examples/touchscreen/CMakeLists.txt
+++ b/examples/touchscreen/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_TOUCHSCREEN)
-  nuttx_add_application(NAME touchscreen)
+  nuttx_add_application(
+    NAME
+    tc
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TOUCHSCREEN}
+    SRCS
+    tc_main.c)
 endif()

--- a/examples/udgram/CMakeLists.txt
+++ b/examples/udgram/CMakeLists.txt
@@ -19,5 +19,27 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_UDGRAM)
-  nuttx_add_application(NAME udgram)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_UDGRAM_CLIENT_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_UDGRAM_CLIENT_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_UDGRAM_CLIENT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_UDGRAM}
+    SRCS
+    udgram_client.c)
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_UDGRAM_SERVER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_UDGRAM_SERVER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_UDGRAM_SERVER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_UDGRAM}
+    SRCS
+    udgram_server.c)
 endif()

--- a/examples/uid/CMakeLists.txt
+++ b/examples/uid/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/uid/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_UID)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_UID_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_UID_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_UID_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_UID}
+    SRCS
+    uid_main.c)
+endif()

--- a/examples/usbserial/CMakeLists.txt
+++ b/examples/usbserial/CMakeLists.txt
@@ -23,8 +23,9 @@ if(CONFIG_EXAMPLES_USBSERIAL)
     NAME
     usbserial
     STACKSIZE
-    2048
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_USBSERIAL}
     SRCS
-    host.c
     usbserial_main.c)
 endif()

--- a/examples/userfs/CMakeLists.txt
+++ b/examples/userfs/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_USERFS)
-  nuttx_add_application(NAME userfs)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_USERFS_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_USERFS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_USERFS_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_USERFS}
+    SRCS
+    userfs_main.c)
 endif()

--- a/examples/ustream/CMakeLists.txt
+++ b/examples/ustream/CMakeLists.txt
@@ -19,5 +19,23 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_USTREAM)
-  nuttx_add_application(NAME ustream)
+  nuttx_add_application(
+    NAME
+    client
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_USTREAM}
+    SRCS
+    ustream_client.c)
+
+  nuttx_add_application(
+    NAME
+    server
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_AJOYSTICK}
+    SRCS
+    ustream_server.c)
 endif()

--- a/examples/veml6070/CMakeLists.txt
+++ b/examples/veml6070/CMakeLists.txt
@@ -19,5 +19,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_VEML6070)
-  nuttx_add_application(NAME veml6070)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_VEML6070_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_VEML6070_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_VEML6070_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_VEML6070}
+    SRCS
+    veml6070_main.c)
 endif()

--- a/examples/watchdog/CMakeLists.txt
+++ b/examples/watchdog/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_WATCHDOG)
-  nuttx_add_application(NAME watchdog)
+  nuttx_add_application(
+    NAME
+    wdog
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_WATCHDOG}
+    SRCS
+    watchdog_main.c)
 endif()

--- a/examples/watched/CMakeLists.txt
+++ b/examples/watched/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ##############################################################################
+# apps/examples/watched/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WATCHED)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_WATCHED_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_WATCHED_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_WATCHED_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_WATCHED}
+    SRCS
+    watched_main.c)
+  target_sources(apps PRIVATE watched.c)
+endif()

--- a/examples/watcher/CMakeLists.txt
+++ b/examples/watcher/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ##############################################################################
+# apps/examples/watcher/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WATCHER)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_WATCHER_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_WATCHER_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_WATCHER_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_WATCHER}
+    SRCS
+    watcher_main.c)
+  target_sources(apps PRIVATE ramdisk.c wdt.c task_mn.c)
+endif()

--- a/examples/wget/CMakeLists.txt
+++ b/examples/wget/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_WGET)
-  nuttx_add_application(NAME wget SRCS wget_main.c)
+  nuttx_add_application(
+    NAME
+    wget
+    STACKSIZE
+    ${CONFIG_EXAMPLES_WGET_STACKSIZ}
+    MODULE
+    ${CONFIG_EXAMPLES_WGET}
+    SRCS
+    wget_main.c)
 endif()

--- a/examples/wgetjson/CMakeLists.txt
+++ b/examples/wgetjson/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_WGETJSON)
-  nuttx_add_application(NAME wgetjson)
+  nuttx_add_application(
+    NAME
+    wgetjson
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_WGETJSON}
+    SRCS
+    wgetjson_main.c)
 endif()

--- a/examples/ws2812/CMakeLists.txt
+++ b/examples/ws2812/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/ws2812/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WS2812)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_WS2812_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_WS2812_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_WS2812_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_WS2812}
+    SRCS
+    ws2812_main.c)
+endif()

--- a/examples/ws2812esp32rmt/CMakeLists.txt
+++ b/examples/ws2812esp32rmt/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/ws2812esp32rmt/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_WS2812_ESP32_RMT)
+  nuttx_add_application(
+    NAME
+    ws2812esp32rmt
+    PRIORITY
+    ${CONFIG_EXAMPLES_WS2812_ESP32_RMT_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_WS2812_ESP32_RMT_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_WS2812_ESP32_RMT}
+    SRCS
+    ws2812esp32rmt_main.c)
+endif()

--- a/examples/xbc_test/CMakeLists.txt
+++ b/examples/xbc_test/CMakeLists.txt
@@ -23,5 +23,15 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_XBC_TEST)
-  nuttx_add_application(NAME xbc_test)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_XBC_TEST_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_XBC_TEST_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_XBC_TEST_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_XBC_TEST}
+    SRCS
+    xbc_test_main.c)
 endif()

--- a/examples/xmlrpc/CMakeLists.txt
+++ b/examples/xmlrpc/CMakeLists.txt
@@ -19,5 +19,14 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_XMLRPC)
-  nuttx_add_application(NAME xmlrpc)
+  nuttx_add_application(
+    NAME
+    xmlrpc
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_XMLRPC}
+    SRCS
+    xmlrpc_main.c)
+  target_sources(apps PRIVATE calls.c)
 endif()

--- a/examples/zerocross/CMakeLists.txt
+++ b/examples/zerocross/CMakeLists.txt
@@ -19,5 +19,13 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_ZEROCROSS)
-  nuttx_add_application(NAME zerocross)
+  nuttx_add_application(
+    NAME
+    zerocross
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_ZEROCROSS}
+    SRCS
+    zerocross_main.c)
 endif()


### PR DESCRIPTION
## Summary

Enable the cmake build configuration of most examples directories applications

## Impact

## Testing
sim
