### PR TITLE
Application.mk:define main entry MAINNAME relatively

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -127,22 +127,6 @@ CXXFLAGS += ${INCDIR_PREFIX}"$(APPDIR)$(DELIM)include"
 
 NUTTXLIB ?= $(call CONVERT_PATH,$(TOPDIR)$(DELIM)staging)
 
-# Function to get entry index
-
-define GETINDEX
-	$(eval i=1)
-	$(eval entry=)
-	$(foreach e,$(2), \
-	  $(if $(filter $(notdir $(1)),$(notdir $(e))), \
-	    $(eval entry=$(1)), \
-	    $(if $(entry), \
-	      ,$(eval i=$(shell expr $(i) + 1)) \
-	    ) \
-	  ) \
-	)
-	$(i)
-endef
-
 # SPLITVARIABLE - Split long variables into specified batches
 # Usage: $(call SPLITVARIABLE, variable-def, variable-ref, batch-size)
 #

--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -145,10 +145,10 @@ $(WBIN): $(WOBJS)
 	$(shell mkdir -p $(APPDIR)/wasm)
 	$(Q) $(WAR) $@ $(filter-out $(MAINSRC:=$(SUFFIX).wo),$^)
 	$(foreach main,$(MAINSRC), \
-	  $(eval mainindex=$(strip $(call GETINDEX,$(main),$(MAINSRC)))) \
-	$(eval dstname=$(shell echo $(main:=$(SUFFIX).wo) | sed -e 's/\//_/g')) \
+	  $(eval progname=$(strip $(PROGNAME_$(main:=$(SUFFIX)$(OBJEXT))))) \
+	  $(eval dstname=$(shell echo $(main:=$(SUFFIX).wo) | sed -e 's/\//_/g')) \
 	  $(shell cp -rf $(strip $(main:=$(SUFFIX).wo)) \
-	    $(strip $(APPDIR)/wasm/$(word $(mainindex),$(PROGNAME))#$(WASM_INITIAL_MEMORY)#$(STACKSIZE)#$(PRIORITY)#$(WAMR_MODE)#$(dstname)) \
+	    $(strip $(APPDIR)/wasm/$(progname)#$(WASM_INITIAL_MEMORY)#$(STACKSIZE)#$(PRIORITY)#$(WAMR_MODE)#$(dstname)) \
 	   ) \
 	 )
 


### PR DESCRIPTION
## Summary

> this patch fix issue https://github.com/apache/nuttx-apps/issues/633 

- issue
when a program has **multiple** `MAINSRC` for **incremental compilation**, the `PROGNAME` of the compiled file may generate errors
```
 -------------------- compile definition error ---------------------
 cc -c -g CFLAGS INCLUDEDIR -Dmain=funA_main funB.c -o funB.c.path.o
                             ^^^^  ^^^^^^    ^^^^
-------------------------------------------------------------------
```
- solution
 we use the `MAINOBJ:PROGNAME` mapping variable to define the main entry name, for example:
```makefile
# this is Makefile in apps/examples/myapp for some app
# two programs need to be compiled
MAINSRC = demoA.c demoB.c
PROGNAME = runA runB
``` 
```makefile
# In Application.mk, we will automatically define variables
# prefixed with 'PROGKEY_' or 'ELFPROGKEY_'
# which used depends on builtin or elf

PROGKEY_home.apps.examples.myapp.demoA.o := runA
PROGKEY_apps.examples.myapp.demoB.o := runB

ELFPROGKEY_/home/apps/bin/runA :=  apps.examples.myapp.demoA.o
ELFPROGKEY_/home/apps/bin/runB :=  apps.examples.myapp.demoB.o
``` 
**Use the mapped variable and cooperate with the target `$@`, so that the mismatch situation can be solved.**
## Impact
compilation and incremental compilation of **all applications** (include ELF mode)

## Testing
CI build