### PR TITLE
examples/bme680: Added test program for the BME680 sensor

### DIFF
--- a/examples/bme680/CMakeLists.txt
+++ b/examples/bme680/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/bme680/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_BME680)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_BME680_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_BME680_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_BME680_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_BME680}
+    SRCS
+    bme680_main.c)
+endif()

--- a/examples/bme680/Kconfig
+++ b/examples/bme680/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_BME680
+	tristate "BME680 sensor example"
+	default n
+	depends on SENSORS_BME680
+	---help---
+		Enable the BME680 example
+
+if EXAMPLES_BME680
+
+config EXAMPLES_BME680_PROGNAME
+	string "Program name"
+	default "bme680"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_BME680_PRIORITY
+	int "BME680 task priority"
+	default 100
+
+config EXAMPLES_BME680_STACKSIZE
+	int "BME680 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/bme680/Make.defs
+++ b/examples/bme680/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/bme680/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_BME680),)
+CONFIGURED_APPS += $(APPDIR)/examples/bme680
+endif

--- a/examples/bme680/Makefile
+++ b/examples/bme680/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/bme680/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# BME680 Barometer sensor example built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_BME680_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_BME680_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_BME680_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_BME680)
+
+# BME680 Barometer sensor example
+
+MAINSRC = bme680_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/bme680/bme680_main.c
+++ b/examples/bme680/bme680_main.c
@@ -1,0 +1,176 @@
+/****************************************************************************
+ * apps/examples/bme680/bme680_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/sensors/sensor.h>
+#include <nuttx/sensors/bme680.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <time.h>
+
+#define NB_LOWERHALFS 3
+
+/* Structure used when polling the sub-sensors */
+
+struct data
+{
+  void *data_struct;
+  uint16_t data_size;
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * bme680_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int baro_fd;
+  int hum_fd;
+  int gas_fd;
+  uint16_t seconds;
+  int ret;
+
+  /* This example works when all of the sub-sensors of
+   * the BME680 are enabled.
+   */
+
+  struct sensor_baro baro_data;
+  struct sensor_humi humi_data;
+  struct sensor_gas gas_data;
+
+  /* Open each lowerhalf file to be able to read the data.
+   * When the pressure measurement is deactivated, sensor_temp0 should
+   * be opened instead (to get the temperature measurement).
+   */
+
+  baro_fd = open("/dev/uorb/sensor_baro0", O_RDONLY | O_NONBLOCK);
+  if (baro_fd < 0)
+    {
+      printf("Failed to open barometer lowerhalf.\n");
+      return -1;
+    }
+
+  hum_fd = open("/dev/uorb/sensor_humi0", O_RDONLY | O_NONBLOCK);
+  if (hum_fd < 0)
+    {
+      printf("Failed to open humidity sensor lowerhalf.\n");
+      return -1;
+    }
+
+  gas_fd = open("/dev/uorb/sensor_gas0", O_RDONLY | O_NONBLOCK);
+  if (gas_fd < 0)
+    {
+      printf("Failed to open gas lowerhalf.\n");
+      return -1;
+    }
+
+  /* Configure the sensor */
+
+  struct bme680_config_s config;
+
+  /* Set oversampling */
+
+  config.temp_os = BME680_OS_2X;
+  config.press_os = BME680_OS_16X;
+  config.filter_coef = BME680_FILTER_COEF3;
+  config.hum_os = BME680_OS_1X;
+
+  /* Set heater parameters */
+
+  config.target_temp = 300;     /* degrees Celsius */
+  config.amb_temp = 30;         /* degrees Celsius */
+  config.heater_duration = 100; /* milliseconds */
+
+  config.nb_conv = 0;
+
+  ret = ioctl(baro_fd, SNIOC_CALIBRATE, &config);
+
+  struct pollfd pfds[] = {
+    {.fd = baro_fd, .events = POLLIN},
+    {.fd = hum_fd, .events = POLLIN},
+    {.fd = gas_fd, .events = POLLIN}
+  };
+
+  struct data sensor_data[] = {
+    {.data_struct = &baro_data, .data_size = sizeof(struct sensor_baro)},
+    {.data_struct = &humi_data, .data_size = sizeof(struct sensor_humi)},
+    {.data_struct = &gas_data, .data_size = sizeof(struct sensor_gas)}
+  };
+
+  seconds = 5 * 60;
+
+  /* Wait ~5 minutes for the sensor to accomodate to the surroundings.
+   * The first measurements are not accurate. The longer the wait, the more
+   * accurate the results are.
+   */
+
+  while (seconds > 0)
+    {
+      ret = poll(pfds, NB_LOWERHALFS, -1);
+      if (ret < 0)
+        {
+          perror("Could not poll sensor.");
+          return ret;
+        }
+
+      /* Go through lowerhalfs and read the data */
+
+      for (int i = 0; i < NB_LOWERHALFS; i++)
+        {
+          if (pfds[i].revents & POLLIN)
+            {
+              ret = read(pfds[i].fd, sensor_data[i].data_struct,
+                                     sensor_data[i].data_size);
+
+              if (ret != sensor_data[i].data_size)
+                {
+                  perror("Could not read from sub-sensor.");
+                  return ret;
+                }
+            }
+        }
+
+      seconds -= 3;
+    }
+
+  printf("Temperature [C] = %f\n"
+         "Pressure [hPa] = %f\n"
+         "Humidity [rH] = %f\n"
+         "Gas resistance [kOhm] = %f\n",
+         baro_data.temperature, baro_data.pressure,
+         humi_data.humidity, gas_data.gas_resistance);
+
+  close(baro_fd);
+  close(hum_fd);
+  close(gas_fd);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
This is a usage example for the bme680 when all its sub-sensors are enabled and it can be easily modified to accomodate other configurations.

## Testing
Testing was done on the esp32-sparrow board.

