### PR TITLE
rptun/ping: print invalid arguments error

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -538,6 +538,7 @@ static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
       if (argv[3] == 0 || argv[4] == 0 ||
           argv[5] == 0 || argv[6] == 0)
         {
+          nsh_error(vtbl, g_fmtargrequired);
           return ERROR;
         }
 


### PR DESCRIPTION
## Summary
rptun/ping: print invalid arguments error

## Impact

## Testing
nrf53
