### PR TITLE
rptun/ping: fix invalid use of nsh_error after 31421db6f

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -538,7 +538,7 @@ static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
       if (argv[3] == 0 || argv[4] == 0 ||
           argv[5] == 0 || argv[6] == 0)
         {
-          nsh_error(vtbl, g_fmtargrequired);
+          nsh_error(vtbl, g_fmtargrequired, argv[0]);
           return ERROR;
         }
 


### PR DESCRIPTION
## Summary
rptun/ping: fix invalid use of nsh_error after 31421db6f

reported by CI https://github.com/apache/nuttx/actions/runs/5924486445/job/16062219720#step:7:525:
```
 Error: nsh_syscmds.c:541:27: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
          nsh_error(vtbl, g_fmtargrequired);
                          ^~~~~~~~~~~~~~~~
./nsh_console.h:54:49: note: expanded from macro 'nsh_error'
#  define nsh_error(v, ...)     (v)->error(v, ##__VA_ARGS__)
                                                ^~~~~~~~~~~
nsh_syscmds.c:541:27: note: treat the string as an argument to avoid this
          nsh_error(vtbl, g_fmtargrequired);
                          ^
                          "%s", 
./nsh_console.h:54:49: note: expanded from macro 'nsh_error'
#  define nsh_error(v, ...)     (v)->error(v, ##__VA_ARGS__)
```
## Impact

## Testing
CI, I don't get this error locally
