### PR TITLE
nshlib/nsh_timcmds.c: Suppress warning about unused variable (errfmt)

### DIFF
--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -367,7 +367,7 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *newtime = NULL;
-  FAR const char *errfmt;
+  FAR const char *errfmt unused_data;
   bool utc = false;
   int option;
   int ret;


### PR DESCRIPTION
## Summary
Fixes following warning:

CC:  grp/lib_getgrbufr.c nsh_timcmds.c: In function 'cmd_date': nsh_timcmds.c:370:19: warning: variable 'errfmt' set but not used [-Wunused-but-set-variable]
  370 |   FAR const char *errfmt;
      |
## Impact
Fixes build warning
## Testing
Code compiles without the warning
