### PR TITLE
toywasm: bump to v33

### DIFF
--- a/interpreters/toywasm/Makefile
+++ b/interpreters/toywasm/Makefile
@@ -86,7 +86,7 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/lib
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libwasi
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libdyld
 
-TOYWASM_VERSION  = 6f67aec18ce8f824479e305c17464bd4df1dd7ae
+TOYWASM_VERSION  = e03d1f61d3f3163da76b33c4c770dbf0d2024324
 TOYWASM_UNPACK   = toywasm
 TOYWASM_TARBALL  = $(TOYWASM_VERSION).zip
 TOYWASM_URL_BASE = https://github.com/yamt/toywasm/archive/

--- a/interpreters/toywasm/include/toywasm_version.h
+++ b/interpreters/toywasm/include/toywasm_version.h
@@ -21,6 +21,6 @@
 #if !defined(_TOYWASM_VERSION_H)
 #define _TOYWASM_VERSION_H
 
-#define TOYWASM_VERSION "v31.0.0"
+#define TOYWASM_VERSION "v33.0.0-4-ge03d1f6"
 
 #endif /* !defined(_TOYWASM_VERSION_H) */


### PR DESCRIPTION
## Summary
toywasm: bump to v33

## Impact

## Testing
tested on sim/macos/x86-64
build-tested esp32-devkitc
