### PR TITLE
nshlib/nsh_console.h: Add nsh_none, where empty output can be forwarded

### DIFF
--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -51,20 +51,19 @@
 #define nsh_exit(v,s)          (v)->exit(v,s)
 
 #ifdef CONFIG_CPP_HAVE_VARARGS
-#  define nsh_error(v, ...)     (v)->error(v, ##__VA_ARGS__)
-#  define nsh_output(v, ...)    (v)->output(v, ##__VA_ARGS__)
+#  define nsh_error(v, ...)    (v)->error(v, ##__VA_ARGS__)
+#  define nsh_output(v, ...)   (v)->output(v, ##__VA_ARGS__)
+#  define nsh_none(v, ...)     \
+     do { if (0) nsh_output_none(v, ##__VA_ARGS__); } while (0)
 #else
-#  define nsh_error             vtbl->error
-#  define nsh_output            vtbl->output
+#  define nsh_error            vtbl->error
+#  define nsh_output           vtbl->output
+#  define nsh_none             (void)
 #endif
 
 #ifdef CONFIG_NSH_DISABLE_ERROR_PRINT
 #  undef nsh_error
-#  ifdef CONFIG_CPP_HAVE_VARARGS
-#    define nsh_error(v, ...) (void)(v)
-#  else
-#    define nsh_error         (void)(vtbl)
-#  endif
+#  define nsh_error            nsh_none
 #endif
 
 /* Size of info to be saved in call to nsh_redirect
@@ -182,6 +181,19 @@ struct console_stdio_s
 /****************************************************************************
  * Public Data
  ****************************************************************************/
+
+/****************************************************************************
+ * Inline functions
+ ****************************************************************************/
+
+#ifdef CONFIG_CPP_HAVE_VARARGS
+/* Can be used to suppress any nsh output */
+
+static inline void nsh_output_none(FAR struct nsh_vtbl_s *vtbl, ...)
+{
+  UNUSED(vtbl);
+}
+#endif
 
 /****************************************************************************
  * Public Function Prototypes

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -367,7 +367,7 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *newtime = NULL;
-  FAR const char *errfmt unused_data;
+  FAR const char *errfmt;
   bool utc = false;
   int option;
   int ret;


### PR DESCRIPTION
## Summary
Adds way to forward any output into nothingness. Handles CONFIG_NSH_DISABLE_ERROR_PRINT case gracefully for any
amount of arguments.
## Impact
Only nsh_error output, when CONFIG_NSH_DISABLE_ERROR_PRINT is set
## Testing
Build passes, output works when enabled, output is silent when not
