### PR TITLE
cmake:replace custom_patch_target with PATCH_COMMAND

### DIFF
--- a/benchmarks/coremark/CMakeLists.txt
+++ b/benchmarks/coremark/CMakeLists.txt
@@ -26,10 +26,20 @@ if(CONFIG_BENCHMARK_COREMARK)
 
   set(COREMARKAPP_DIR ${CMAKE_CURRENT_LIST_DIR}/coremark)
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/coremark)
-    FetchContent_Declare(coremark
-                         URL https://github.com/eembc/coremark/archive/main.zip)
-    FetchContent_MakeAvailable(coremark)
-    set(COREMARKAPP_DIR ${coremark_SOURCE_DIR})
+    FetchContent_Declare(
+      coremark_fetch
+      URL https://github.com/eembc/coremark/archive/main.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/coremark BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/benchmarks/coremark/coremark
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(coremark_fetch)
+    if(NOT coremark_fetch_POPULATED)
+      FetchContent_Populate(coremark_fetch)
+    endif()
+
+    set(COREMARKAPP_DIR ${coremark_fetch_SOURCE_DIR})
   endif()
 
   if(CONFIG_COREMARK_MULTITHREAD_OVERRIDE)

--- a/canutils/lely-canopen/CMakeLists.txt
+++ b/canutils/lely-canopen/CMakeLists.txt
@@ -34,6 +34,8 @@ if(CONFIG_CANUTILS_LELYCANOPEN)
           ${CMAKE_CURRENT_LIST_DIR}/lely-canopen
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/canutils/lely-canopen/lely-canopen
+      PATCH_COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/lely-canopen <
+                    ${CMAKE_CURRENT_LIST_DIR}/0001-NuttX-port.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -45,17 +47,6 @@ if(CONFIG_CANUTILS_LELYCANOPEN)
 
     set(LELYCANOPEN_DIR ${lelycanopen_fetch_SOURCE_DIR})
 
-    if(NOT EXISTS ${LELYCANOPEN_DIR}/.lelycanopen_patch)
-      add_custom_command(
-        OUTPUT ${LELYCANOPEN_DIR}/.lelycanopen_patch
-        COMMAND touch ${LELYCANOPEN_DIR}/.lelycanopen_patch
-        COMMAND
-          patch -p1 -d ${LELYCANOPEN_DIR} <
-          ${CMAKE_CURRENT_LIST_DIR}/0001-NuttX-port.patch > /dev/null || (exit 0
-                                                                         ))
-      add_custom_target(lelycanopen_patch
-                        DEPENDS ${LELYCANOPEN_DIR}/.lelycanopen_patch)
-    endif()
   endif()
 
   nuttx_add_library(lelycanopen STATIC)
@@ -228,8 +219,5 @@ if(CONFIG_CANUTILS_LELYCANOPEN)
   target_compile_options(lelycanopen PRIVATE ${CFLAGS})
   target_sources(lelycanopen PRIVATE ${CSRCS})
   target_include_directories(lelycanopen PRIVATE ${INCDIR})
-  if(TARGET lelycanopen_patch)
-    add_dependencies(lelycanopen lelycanopen_patch)
-  endif()
 
 endif()

--- a/crypto/libsodium/CMakeLists.txt
+++ b/crypto/libsodium/CMakeLists.txt
@@ -33,6 +33,11 @@ if(CONFIG_LIBSODIUM)
       URL ${LIBSODIUM_URL}/${CONFIG_LIBSODIUM_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/libsodium BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/crypto/libsodium/libsodium
+      PATCH_COMMAND
+        patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libsodium <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-fix-multiple-definition-bug-in-libsodium-test.patch
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libsodium <
+        ${CMAKE_CURRENT_LIST_DIR}/0002-fix-cannot-find-file-sodium-version.h.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -43,21 +48,6 @@ if(CONFIG_LIBSODIUM)
     endif()
     set(LIBSODIUM_DIR ${libsodium_fetch_SOURCE_DIR})
 
-    if(NOT EXISTS ${LIBSODIUM_DIR}/.libsodium_patch)
-      add_custom_command(
-        OUTPUT ${LIBSODIUM_DIR}/.libsodium_patch
-        COMMAND touch ${LIBSODIUM_DIR}/.libsodium_patch
-        COMMAND
-          patch -p1 -d ${LIBSODIUM_DIR} <
-          ${CMAKE_CURRENT_LIST_DIR}/0001-fix-multiple-definition-bug-in-libsodium-test.patch
-          > /dev/null || (exit 0)
-        COMMAND
-          patch -p1 -d ${LIBSODIUM_DIR} <
-          ${CMAKE_CURRENT_LIST_DIR}/0002-fix-cannot-find-file-sodium-version.h.patch
-          > /dev/null || (exit 0))
-      add_custom_target(libsodium_patch
-                        DEPENDS ${LIBSODIUM_DIR}/.libsodium_patch)
-    endif()
   endif()
 
   # ############################################################################
@@ -89,10 +79,6 @@ if(CONFIG_LIBSODIUM)
   target_sources(libsodium PRIVATE ${CSRCS})
   target_include_directories(libsodium PRIVATE ${INCDIR})
   target_compile_options(libsodium PRIVATE ${CFLAGS})
-
-  if(TARGET libsodium_patch)
-    add_dependencies(libsodium libsodium_patch)
-  endif()
 
   # ############################################################################
   # Applications Configuration

--- a/crypto/libtomcrypt/CMakeLists.txt
+++ b/crypto/libtomcrypt/CMakeLists.txt
@@ -34,30 +34,22 @@ if(CONFIG_CRYPTO_LIBTOMCRYPT)
       URL ${CONFIG_LIBTOMCRYPT_URL}/v${CONFIG_LIBTOMCRYPT_VERSION}.zip
           SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/libtomcrypt BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/crypto/libtomcrypt/libtomcrypt
+      PATCH_COMMAND
+        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/digit-bit.patch && patch -p0 -d
+        ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/ltcrypt-flush.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
     FetchContent_GetProperties(libtomcrypt_fetch)
 
-    if(NOT libtomcrypt_POPULATED)
+    if(NOT libtomcrypt_fetch_POPULATED)
       FetchContent_Populate(libtomcrypt_fetch)
     endif()
 
     set(LIBTOMCRYPT_DIR ${libtomcrypt_fetch_SOURCE_DIR})
 
-    if(NOT EXISTS ${LIBTOMCRYPT_DIR}/.libtomcrypt_patch)
-      add_custom_command(
-        OUTPUT ${LIBTOMCRYPT_DIR}/.libtomcrypt_patch
-        COMMAND touch ${LIBTOMCRYPT_DIR}/.libtomcrypt_patch
-        COMMAND patch -p1 -d ${LIBTOMCRYPT_DIR} <
-                ${CMAKE_CURRENT_LIST_DIR}/digit-bit.patch > /dev/null || (exit 0
-                                                                         )
-        COMMAND
-          patch -p1 -d ${LIBTOMCRYPT_DIR} <
-          ${CMAKE_CURRENT_LIST_DIR}/ltcrypt-flush.patch > /dev/null || (exit 0))
-      add_custom_target(libtomcrypt_patch
-                        DEPENDS ${LIBTOMCRYPT_DIR}/.libtomcrypt_patch)
-    endif()
   endif()
 
   nuttx_add_library(libtomcrypt STATIC)
@@ -537,7 +529,5 @@ if(CONFIG_CRYPTO_LIBTOMCRYPT)
     PRIVATE $<GENEX_EVAL:$<TARGET_PROPERTY:libtommath,INCLUDE_DIRECTORIES>>)
   target_compile_definitions(libtomcrypt PRIVATE LTC_SOURCE LTM_DESC)
   target_compile_options(libtomcrypt PRIVATE -Wno-deprecated-declarations)
-  if(TARGET libtomcrypt_patch)
-    add_dependencies(libtomcrypt libtomcrypt_patch)
-  endif()
+
 endif()

--- a/crypto/mbedtls/CMakeLists.txt
+++ b/crypto/mbedtls/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CONFIG_CRYPTO_MBEDTLS)
 
   set(MBEDTLS_DIR ${CMAKE_CURRENT_LIST_DIR}/mbedtls)
 
-  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/mbedtls/.git)
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/mbedtls)
     FetchContent_Declare(
       mbedtls_fetch
       URL ${MBEDTLS_URL}/v${CONFIG_MBEDTLS_VERSION}.zip SOURCE_DIR

--- a/crypto/tinycrypt/CMakeLists.txt
+++ b/crypto/tinycrypt/CMakeLists.txt
@@ -37,6 +37,9 @@ if(CONFIG_TINYCRYPT)
       tinycrypt_fetch
       URL ${TINYCRYPT_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/tinycrypt
           BINARY_DIR ${CMAKE_BINARY_DIR}/apps/crypto/tinycrypt/tinycrypt
+      PATCH_COMMAND
+        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/tinycrypt <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-TinyCrypt-test-resolve-compile-error.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -46,18 +49,6 @@ if(CONFIG_TINYCRYPT)
       FetchContent_Populate(tinycrypt_fetch)
     endif()
     set(TINYCRYPT_DIR ${tinycrypt_fetch_SOURCE_DIR})
-
-    if(NOT EXISTS ${TINYCRYPT_DIR}/.tinycrypt_patch)
-      add_custom_command(
-        OUTPUT ${TINYCRYPT_DIR}/.tinycrypt_patch
-        COMMAND touch ${TINYCRYPT_DIR}/.tinycrypt_patch
-        COMMAND
-          patch -p0 -d ${TINYCRYPT_DIR} <
-          ${CMAKE_CURRENT_LIST_DIR}/0001-TinyCrypt-test-resolve-compile-error.patch
-          > /dev/null || (exit 0))
-      add_custom_target(tinycrypt_patch
-                        DEPENDS ${TINYCRYPT_DIR}/.tinycrypt_patch)
-    endif()
 
   endif()
 
@@ -316,8 +307,5 @@ if(CONFIG_TINYCRYPT)
   target_include_directories(tinycrypt PRIVATE ${INCDIR})
   if(CFLAGS)
     target_compile_options(tinycrypt PRIVATE ${CFLAGS})
-  endif()
-  if(TARGET tinycrypt_patch)
-    add_dependencies(tinycrypt tinycrypt_patch)
   endif()
 endif()

--- a/math/libtommath/CMakeLists.txt
+++ b/math/libtommath/CMakeLists.txt
@@ -29,10 +29,19 @@ if(CONFIG_MATH_LIBTOMMATH)
 
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/libtommath)
     FetchContent_Declare(
-      libtommath URL ${CONFIG_LIBTOMMATH_URL}/v${CONFIG_LIBTOMMATH_VERSION}.zip)
-    FetchContent_MakeAvailable(libtommath)
+      libtommath_fetch
+      URL ${CONFIG_LIBTOMMATH_URL}/v${CONFIG_LIBTOMMATH_VERSION}.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/libtommath BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/math/libtommath/libtommath
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
 
-    set(LIBTOMMATH_DIR ${libtommath_SOURCE_DIR})
+    FetchContent_GetProperties(libtommath_fetch)
+    if(NOT libtommath_fetch_POPULATED)
+      FetchContent_Populate(libtommath_fetch)
+    endif()
+
+    set(LIBTOMMATH_DIR ${libtommath_fetch_SOURCE_DIR})
   endif()
 
   # ############################################################################

--- a/system/argtable3/CMakeLists.txt
+++ b/system/argtable3/CMakeLists.txt
@@ -21,7 +21,7 @@
 if(CONFIG_SYSTEM_ARGTABLE3)
   nuttx_add_library(argtable3)
 
-  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/argtable3/.git)
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/argtable3)
 
     if(NOT CONFIG_SYSTEM_ARGTABLE3_URL)
       set(CONFIG_SYSTEM_ARGTABLE3_URL


### PR DESCRIPTION
## Summary
> this patch is another part of this  issue https://github.com/apache/nuttx/issues/10241
- delete the .git condition that cause duplication of fetching stage.
- replace custom_patch_target with PATCH_COMMAND.
- remove custom_patch_target dependencies.
- when fetch a lib during cmake configure phase,it will download into `/cmake-build-dir/_dep/lib_src/` directory.
every time the build directory is deleted,the download will be repeated. this patch also fixes these problem.

related to:https://github.com/apache/nuttx/pull/10379
## Impact

## Testing
fetch for the first time and compile repeated
