### PR TITLE
mbedtls: mbedtls_selftest depends on MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT

### DIFF
--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -109,6 +109,15 @@ config MBEDTLS_SSL_DTLS_BADMAC_LIMIT
 	bool "Enable support for a limit of records with bad MAC."
 	default n
 
+config MBEDTLS_SSL_DTLS_CONNECTION_ID
+	bool "Enable the Connection ID extension."
+	default n
+
+config MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT
+	bool "Enable the standard version of DTLS Connection ID feature."
+	depends on MBEDTLS_SSL_DTLS_CONNECTION_ID
+	default n
+
 endif # MBEDTLS_SSL_PROTO_DTLS
 
 config MBEDTLS_SSL_ALPN


### PR DESCRIPTION
 when enable MBEDTLS_SLEFTEST it will import parts related to ssl and need to define MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT
