### PR TITLE
benchmarks/coremark: fix no coremark in bin

### DIFF
--- a/benchmarks/coremark/Makefile
+++ b/benchmarks/coremark/Makefile
@@ -115,6 +115,6 @@ MAINSRC += core_main.c
 
 # Build with WebAssembly when CONFIG_INTERPRETERS_WAMR is enabled
 
-WASM_BUILD = y
+WASM_BUILD = both
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
fix no coremark in bin register

## Impact
re regsiter coremark in building with CONFIG_INTERPRETERS_WAMR enabled.
![image](https://github.com/apache/nuttx-apps/assets/109520220/9fee69fe-b6b6-48ad-a425-677e67de2313)


## Testing
Pass Vela CI

