### PR TITLE
Application.mk: Remove warning that program names mismatch

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -93,7 +93,7 @@ ifneq ($(BUILD_MODULE),y)
   OBJS += $(MAINCOBJ) $(MAINCXXOBJ) $(MAINRUSTOBJ) $(MAINZIGOBJ)
 endif
 
-ifneq ($(PROGNAME),)
+ifneq ($(strip $(PROGNAME)),)
   PROGOBJ := $(MAINCOBJ) $(MAINCXXOBJ) $(MAINRUSTOBJ)
   ifneq ($(words $(PROGOBJ)), $(words $(PROGNAME)))
     $(warning "program names $(PROGNAME) does not match mainsrcs $(PROGOBJ)")


### PR DESCRIPTION
## Summary
Avoid warning when PROGNAME contains space blank.

## Impact
None

## Testing

