### PR TITLE
add macro for ecc

### DIFF
--- a/crypto/tinycrypt/Kconfig
+++ b/crypto/tinycrypt/Kconfig
@@ -43,9 +43,14 @@ config TINYCRYPT_SHA256_HMAC_PRNG
 		This option enables support for pseudo-random number
 		generator.
 
+config TINYCRYPT_ECC
+	bool
+	default n
+
 config TINYCRYPT_ECC_DH
 	bool "ECC_DH anonymous key agreement protocol"
 	default n
+	select TINYCRYPT_ECC
 	---help---
 		This option enables support for the Elliptic curve
 		Diffie-Hellman anonymous key agreement protocol.
@@ -56,6 +61,7 @@ config TINYCRYPT_ECC_DH
 config TINYCRYPT_ECC_DSA
 	bool "ECC_DSA digital signature algorithm"
 	default n
+	select TINYCRYPT_ECC
 	---help---
 		This option enables support for the Elliptic Curve Digital
 		Signature Algorithm (ECDSA).

--- a/crypto/tinycrypt/Makefile
+++ b/crypto/tinycrypt/Makefile
@@ -47,8 +47,11 @@ distclean::
 endif
 
 CSRCS += tinycrypt/lib/source/utils.c
+
+ifeq ($(CONFIG_TINYCRYPT_ECC),y)
 CSRCS += tinycrypt/lib/source/ecc.c
 CSRCS += tinycrypt/lib/source/ecc_platform_specific.c
+endif
 
 ifeq ($(CONFIG_TINYCRYPT_ECC_DH),y)
 	CSRCS += tinycrypt/lib/source/ecc_dh.c


### PR DESCRIPTION
## Summary

application may use micro-ecc for some ecc operation, which may be faster than tinycrypt, due to assemble code, but both of them have same function definition, cause build error on there case.

## Impact

new option

## Testing

internal test