### PR TITLE
testing: fix visual studio Compiler Error C2057

### DIFF
--- a/testing/ostest/mqueue.c
+++ b/testing/ostest/mqueue.c
@@ -49,7 +49,7 @@
 #else
   /* Message length is the size of the message plus the null terminator */
 
-#  define TEST_MSGLEN       (strlen(TEST_MESSAGE)+1)
+#  define TEST_MSGLEN       sizeof(TEST_MESSAGE)
 #endif
 
 #define TEST_SEND_NMSGS     (10)

--- a/testing/ostest/timedmqueue.c
+++ b/testing/ostest/timedmqueue.c
@@ -49,7 +49,7 @@
 #else
 /* Message length is the size of the message plus the null terminator */
 
-#  define TEST_MSGLEN         (strlen(TEST_MESSAGE)+1)
+#  define TEST_MSGLEN         sizeof(TEST_MESSAGE)
 #endif
 
 #define TEST_SEND_NMSGS     (10)


### PR DESCRIPTION

## Summary

testing: fix visual studio Compiler Error C2057

expected constant expression
The context requires a constant expression, an expression whose value is known at compile time. The compiler must know the size of a type at compile time in order to allocate space for an instance of that type.

Reference:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2057?view=msvc-170

Signed-off-by: chao an anchao@xiaomi.com


## Impact

N/A

## Testing

 visual studio 2023 + cmake