### PR TITLE
apps/rpsock_client: Fix rpsock_client.c [-Wformat=] warning

### DIFF
--- a/examples/rpmsgsocket/rpsock_client.c
+++ b/examples/rpmsgsocket/rpsock_client.c
@@ -201,7 +201,7 @@ static int rpsock_unsync_test(struct rpsock_arg_s *args)
                   if (intp[i] != ALIGN_UP(total) / sizeof(uint32_t) + i)
                     {
                       printf("client check fail total %d, \
-                              i %d, %08x, %08x\n",
+                              i %d, %08" PRIx32 ", %08x\n",
                               ALIGN_UP(total), i, intp[i],
                               ALIGN_UP(total) / sizeof(uint32_t) + i);
                     }


### PR DESCRIPTION
## Summary

Fix warning:
CC:  rpsock_client.c rpsock_client.c: In function 'rpsock_unsync_test': rpsock_client.c:203:30: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  203 |                       printf("client check fail total %d, \
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  204 |                               i %d, %08x, %08x\n",
      |                               ~~~~~~~~~~~~~~~~~~~
  205 |                               ALIGN_UP(total), i, intp[i],
      |                                                   ~~~~~~~
      |                                                       |
      |                                                       uint32_t {aka long unsigned int}

## Impact

warning fix

## Testing

ci