### PR TITLE
apps/nshlib: Add the pidof command and API nsh_getpid

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -490,6 +490,11 @@ config NSH_DISABLE_PASSWD
 	default DEFAULT_SMALL
 	depends on NSH_LOGIN_PASSWD && !FSUTILS_PASSWD_READONLY
 
+config NSH_DISABLE_PIDOF
+	bool "Disable pidof"
+	default DEFAULT_SMALL
+	depends on FS_PROCFS
+
 config NSH_DISABLE_PMCONFIG
 	bool "Disable pmconfig"
 	default DEFAULT_SMALL

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -576,9 +576,8 @@
  */
 
 #if defined(CONFIG_NSH_DISABLE_LS) && defined(CONFIG_NSH_DISABLE_PS) && \
-    defined(CONFIG_NSH_DISABLE_FDINFO) && \
-    defined(CONFIG_NSH_DISABLE_RPTUN) && \
-    defined(CONFIG_NSH_DISABLE_PMCONFIG)
+    defined(CONFIG_NSH_DISABLE_RPTUN) && defined(CONFIG_NSH_DISABLE_PMCONFIG) && \
+    defined(CONFIG_NSH_DISABLE_FDINFO) && defined(CONFIG_NSH_DISABLE_PIDOF)
 #  undef NSH_HAVE_FOREACH_DIRENTRY
 #endif
 
@@ -955,6 +954,9 @@ void nsh_usbtrace(void);
 #endif
 #ifndef CONFIG_NSH_DISABLE_PS
   int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+  int cmd_pidof(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_FDINFO)
   int cmd_fdinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
@@ -1379,6 +1381,28 @@ int nsh_writefile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                          FAR const char *dirpath,
                          nsh_direntry_handler_t handler, void *pvarg);
+#endif
+
+/****************************************************************************
+ * Name: nsh_getpid
+ *
+ * Description:
+ *   Obtain pid through process name
+ *
+ * Input Parameters:
+ *   vtbl    - NSH session data
+ *   name    - the name of the process
+ *   pids    - allocated array for storing pid
+ *   count   - the maximum number of pids obtained
+ *
+ * Returned value:
+ *   the actual number of pids obtained
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+ssize_t nsh_getpid(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
+                   FAR pid_t *pids, size_t count);
 #endif
 
 /****************************************************************************

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -435,6 +435,10 @@ static const struct cmdmap_s g_cmdmap[] =
 #  endif
 #endif
 
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+  CMD_MAP("pidof",   cmd_pidof, 2, 2, "<name>"),
+#endif
+
 #if defined(CONFIG_PM) && !defined(CONFIG_NSH_DISABLE_PMCONFIG)
   CMD_MAP("pmconfig", cmd_pmconfig, 1, 4,
     "[stay|relax] [normal|idle|standby|sleep] [domain]"),

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -40,6 +40,74 @@
 #include "nsh_console.h"
 
 /****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct getpid_arg_s
+{
+  FAR const char *name;
+  FAR pid_t *pids;
+  size_t count;
+  size_t next;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getpid_callback
+ *
+ * Description:
+ *   It is a callback function of nsh_getpid
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+static int getpid_callback(FAR struct nsh_vtbl_s *vtbl,
+                           FAR const char *dirpath,
+                           FAR struct dirent *entryp, FAR void *pvarg)
+{
+  FAR struct getpid_arg_s *arg = (FAR struct getpid_arg_s *)pvarg;
+  char buffer[PATH_MAX];
+  int fd;
+  int len;
+
+  if (arg->next == arg->count)
+    {
+      return -E2BIG;
+    }
+
+  /* Match the name of the process */
+
+  snprintf(buffer, sizeof(buffer), "%s/%s/cmdline", dirpath, entryp->d_name);
+
+  fd = open(buffer, O_RDONLY);
+  if (fd < 0)
+    {
+      return 0;
+    }
+
+  len = read(fd, buffer, sizeof(buffer));
+  close(fd);
+  if (len < 0)
+    {
+      return -errno;
+    }
+
+  buffer[len] = '\0';
+  len = strlen(arg->name);
+  if (strncmp(buffer, arg->name, len) == 0 &&
+      (isspace(buffer[len]) || buffer[len] == '\0'))
+    {
+        arg->pids[arg->next++] = atoi(entryp->d_name);
+    }
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -516,5 +584,48 @@ FAR char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
     }
 
   return strdup(vtbl->iobuffer);
+}
+#endif
+
+/****************************************************************************
+ * Name: nsh_getpid
+ *
+ * Description:
+ *   Obtain pid through process name
+ *
+ * Input Parameters:
+ *   vtbl    - NSH session data
+ *   name    - the name of the process
+ *   pids    - allocated array for storing pid
+ *   count   - the maximum number of pids obtained
+ *
+ * Returned value:
+ *   the actual number of pids obtained
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+ssize_t nsh_getpid(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
+                   FAR pid_t *pids, size_t count)
+{
+  struct getpid_arg_s argv =
+    {
+      name,
+      pids,
+      count,
+      0
+    };
+
+  if (NULL == name || pids == NULL)
+    {
+      return -EINVAL;
+    }
+
+  /* No need to determine the return value */
+
+  nsh_foreach_direntry(vtbl, "pidof", CONFIG_NSH_PROC_MOUNTPOINT,
+                       getpid_callback, &argv);
+
+  return argv.next;
 }
 #endif

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <sys/sysinfo.h>
+#include <sys/param.h>
 #include <time.h>
 
 #include "nsh.h"
@@ -666,6 +667,34 @@ int cmd_ps(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   return nsh_foreach_direntry(vtbl, "ps", CONFIG_NSH_PROC_MOUNTPOINT,
                               ps_callback, NULL);
+}
+#endif
+
+/****************************************************************************
+ * Name: cmd_pidof
+ ****************************************************************************/
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+int cmd_pidof(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
+{
+  FAR const char *name = argv[argc - 1];
+  pid_t pids[8];
+  ssize_t ret;
+  int i;
+
+  ret = nsh_getpid(vtbl, name, pids, nitems(pids));
+  if (ret <= 0)
+    {
+      nsh_error(vtbl, g_fmtnosuch, argv[0], "task",  name);
+      return ERROR;
+    }
+
+  for (i = 0; i < ret; i++)
+    {
+      nsh_output(vtbl, "%d ", pids[i]);
+    }
+
+  return OK;
 }
 #endif
 


### PR DESCRIPTION
## Summary
Add the API "nsh_getpid" in "nsh_fsutils. c" and the nsh command pidof
Currently, it only supports querying the pid of specific process names.

## Impact
None

## Testing
pidof 'Idle Task'
