### PR TITLE
nshlib/nsh_consolemain: detect null pointer

### DIFF
--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -65,6 +65,10 @@ int nsh_consolemain(int argc, FAR char *argv[])
   int ret;
 
   DEBUGASSERT(pstate != NULL);
+  if (pstate == NULL)
+    {
+      return -ENOMEM;
+    }
 
   /* Execute the session */
 


### PR DESCRIPTION
## Summary

Properly returns `-ENOMEM` from `nsh_consolemain` if the `pstate` is `NULL`.

This issue occured in PX4 when the mavlink shell was opened some time after boot.
This calls `nsh_newconsole`, which calls `zalloc(804)`:

```c
FAR struct console_stdio_s *nsh_newconsole(bool isctty)
{
  FAR struct console_stdio_s *pstate =
    (FAR struct console_stdio_s *)zalloc(sizeof(struct console_stdio_s));

  if (pstate)
    {
        /* ... */
    }

  return pstate;
}
```

```
(gdb) bt
#0  nsh_newconsole (isctty=isctty@entry=true) at nsh_console.c:441
#1  0x08011244 in nsh_consolemain (argc=argc@entry=0, argv=argv@entry=0x0) at nsh_consolemain.c:69
#2  0x080e2d0a in MavlinkShell::shell_start_thread (argc=<optimized out>, argv=<optimized out>) at src/modules/mavlink/modules__mavlink_unity.cpp:12472
#3  0x08017956 in nxtask_startup (entrypt=entrypt@entry=0x80e2cf9 <MavlinkShell::shell_start_thread(int, char**)>, argc=1, argv=0x2005b298) at sched/task_startup.c:70
#4  0x0800c2aa in nxtask_start () at task/task_start.c:134
#5  0x00000000 in ?? ()
```

However, the heap could not allocate 804B anymore and returned a nullptr.
This nullptr was never checked because it's not a debug build:

```c
int nsh_consolemain(int argc, FAR char *argv[])
{
  FAR struct console_stdio_s *pstate = nsh_newconsole(true);
  int ret;

  DEBUGASSERT(pstate != NULL); /// <<<<<<<<<<<<<<<<<

  /* Execute the start-up script */
  nsh_initscript(&pstate->cn_vtbl);

and was thus passed along as a vtbl pointer to be dereferenced later and bus fault.

int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
               FAR const char *path)
{
  FAR char *fullpath;
  FAR FILE *savestream;
  FAR char *buffer;
  FAR char *pret;
  int ret = ERROR;

  /* The path to the script may relative to the current working directory */
  fullpath = nsh_getfullpath(vtbl, path);
  if (!fullpath)
    {
      return ERROR;
    }

  /* Get a reference to the common input buffer */
  buffer = nsh_linebuffer(vtbl); /// <<<<<<<<<<<<<<<<<<<<<<<<<
```

I cannot reproduce the heap exhaustion locally, however, I can reproduce this exact error when I forcibly set pstate = 0:

```
(gdb) bt
#0  0x0801370e in nsh_script (vtbl=vtbl@entry=0x0, cmd=cmd@entry=0x81888e9 "sysinit", path=path@entry=0x81888da "/etc/init.d/rc.sysinit") at nsh_script.c:83
#1  0x0801382c in nsh_script_redirect (path=0x81888da "/etc/init.d/rc.sysinit", cmd=0x81888e9 "sysinit", vtbl=vtbl@entry=0x0) at nsh_script.c:55
#2  0x0801124a in nsh_consolemain (argc=argc@entry=0, argv=argv@entry=0x0) at nsh_consolemain.c:83
#3  0x080e2d0a in MavlinkShell::shell_start_thread (argc=<optimized out>, argv=<optimized out>) at /Users/niklaut/dev/ROS2_Hardfault/PX4-Autopilot/build/px4_fmu-v5x_default/src/modules/mavlink/modules__mavlink_unity.cpp:12472
#4  0x08017956 in nxtask_startup (entrypt=entrypt@entry=0x80e2cf9 <MavlinkShell::shell_start_thread(int, char**)>, argc=1, argv=0x2005b3f8) at sched/task_startup.c:70
#5  0x0800c2aa in nxtask_start () at task/task_start.c:134
#6  0x00000000 in ?? ()
(gdb) si
halted: PC: 0x08013710
0x08013710	92	  fullpath = nsh_getfullpath(vtbl, path);

(gdb) s
halted: PC: 0x0800ffdc
nsh_getfullpath (vtbl=vtbl@entry=0x0, relpath=relpath@entry=0x81888da "/etc/init.d/rc.sysinit") at nsh_envcmds.c:185
185	{

(gdb) fin
Run till exit from #0  nsh_getfullpath (vtbl=vtbl@entry=0x0, relpath=relpath@entry=0x81888da "/etc/init.d/rc.sysinit") at nsh_envcmds.c:185
nsh_script (vtbl=vtbl@entry=0x0, cmd=cmd@entry=0x81888e9 "sysinit", path=path@entry=0x81888da "/etc/init.d/rc.sysinit") at nsh_script.c:93
93	  if (!fullpath)
Value returned is $3 = 0x2005bf20 "/etc/init.d/rc.sysinit"

(gdb) s
halted: PC: 0x08013718
halted: PC: 0x0801371a
100	  buffer = nsh_linebuffer(vtbl);

(gdb) si
halted: PC: 0x08008208
exception_common () at armv7-m/arm_exception.S:144
144		mrs		r0, ipsr				/* R0=exception number */
```

## Impact

This can cause a hardfault any time there's heap exhaustion (either real or due to fragmentation), it should be backported to all versions.

## Testing

Tested manually via GDB by forcibly returning NULL from zalloc in `nsh_consolemain`. This reliably reproduces the hardfault in `nsh_newconsole` when accessing address `0x18` (r4 + 24).

```
   │0x8013700 <nsh_script>          stmdb  sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
   │0x8013704 <nsh_script+4>        mov    r5, r1
   │0x8013706 <nsh_script+6>        mov    r1, r2
   │0x8013708 <nsh_script+8>        mov    r4, r0
   │0x801370a <nsh_script+10>       vpush  {d8}
   │0x801370e <nsh_script+14>       sub    sp, #12
   │0x8013710 <nsh_script+16>       bl     0x800ffdc <nsh_getfullpath>
   │0x8013714 <nsh_script+20>       vmov   s16, r0
   │0x8013718 <nsh_script+24>       cbz    r0, 0x801375e <nsh_script+94>
  >│0x801371a <nsh_script+26>       ldr    r3, [r4, #24]
   │0x801371c <nsh_script+28>       mov    r0, r4
   │0x801371e <nsh_script+30>       blx    r3
```

cc @davids5 