### PR TITLE
cmake:migrate apps CMakeLists for fsutils

### DIFF
--- a/fsutils/inih/CMakeLists.txt
+++ b/fsutils/inih/CMakeLists.txt
@@ -1,0 +1,88 @@
+# ##############################################################################
+# apps/fsutils/inih/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_INIH)
+
+  # ############################################################################
+  # Config and Fetch inih lib
+  # ############################################################################
+  set(INIH_DIR ${CMAKE_CURRENT_LIST_DIR}/inih-r42)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/inih-r42)
+    set(INIH_URL https://github.com/benhoyt/inih/archive/r42.tar.gz)
+    FetchContent_Declare(
+      inih_fetch
+      URL ${INIH_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/inih-r42 BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/fsutils/inih/inih-r42
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(inih_fetch)
+    if(NOT inih_fetch_POPULATED)
+      FetchContent_Populate(inih_fetch)
+    endif()
+
+    set(INIH_DIR ${inih_fetch_SOURCE_DIR})
+  endif()
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+
+  set(CFLAGS
+      -DINI_MAX_LINE=${CONFIG_INIH_MAX_LINE} -DINI_ALLOW_BOM=0
+      -DINI_ALLOW_INLINE_COMMENTS=1 -DINI_STOP_ON_FIRST_ERROR=0
+      -DINI_HANDLER_LINENO=1)
+
+  if(CONFIG_INIH_MULTI_LINE_ENTRIES)
+    list(APPEND CFLAGS -DINI_ALLOW_MULTILINE=1)
+  else()
+    list(APPEND CFLAGS -DINI_ALLOW_MULTILINE=0)
+  endif()
+
+  if(CONFIG_INIH_USE_MALLOC)
+    list(APPEND CFLAGS -DINI_USE_STACK=0 -DINI_ALLOW_REALLOC=1
+         -DINI_INITIAL_ALLOC=${CONFIG_INIH_INITIAL_ALLOC})
+  else()
+    list(APPEND CFLAGS -DINI_USE_STACK=1 -DINI_ALLOW_REALLOC=0)
+  endif()
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  file(GLOB CSRCS ${LIBTOMMATH_DIR}/*.c)
+  set(CSRCS ${INIH_DIR}/ini.c)
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${INIH_DIR})
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  nuttx_add_library(inih STATIC)
+  target_compile_options(inih PRIVATE ${CFLAGS})
+  target_sources(inih PRIVATE ${CSRCS})
+  target_include_directories(inih PRIVATE ${INCDIR})
+
+endif()

--- a/fsutils/ipcfg/CMakeLists.txt
+++ b/fsutils/ipcfg/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/fsutils/inifile/CMakeLists.txt
+# apps/fsutils/ipcfg/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,13 @@
 #
 # ##############################################################################
 
-if(CONFIG_FSUTILS_INIFILE)
-  target_sources(apps PRIVATE inifile.c)
+if(CONFIG_FSUTILS_IPCFG)
+  target_sources(apps PRIVATE ipcfg.c)
+
+  if(CONFIG_IPCFG_BINARY)
+    target_sources(apps PRIVATE ipcfg_binary.c)
+  else()
+    target_sources(apps PRIVATE ipcfg_text.c)
+  endif()
+
 endif()

--- a/fsutils/libtinycbor/CMakeLists.txt
+++ b/fsutils/libtinycbor/CMakeLists.txt
@@ -1,0 +1,78 @@
+# ##############################################################################
+# apps/fsutils/libtinycbor/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_FSUTILS_TINYCBOR_LIB)
+
+  # ############################################################################
+  # Config and Fetch libtinycbor
+  # ############################################################################
+  set(TINYCBOR_DIR ${CMAKE_CURRENT_LIST_DIR}/tinycbor)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/tinycbor)
+    set(TINYCBOR_VERSION 3cba6b11aaa0f6f674cd56ebaa573c4b65f71ee7)
+    set(TINYCBOR_URL
+        https://github.com/intel/tinycbor/archive/${TINYCBOR_VERSION}.zip)
+    file(DOWNLOAD ${TINYCBOR_URL} ${CMAKE_CURRENT_LIST_DIR}/tinycbor.zip)
+    execute_process(COMMAND unzip -o -j tinycbor.zip -d ${TINYCBOR_DIR}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+    execute_process(COMMAND patch -Np1 -i fix_open_memstream.patch
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+  endif()
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+
+  set(CFLAGS -std=c99)
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  set(CSRCS
+      ${TINYCBOR_DIR}/cborencoder.c
+      ${TINYCBOR_DIR}/cborencoder_close_container_checked.c
+      ${TINYCBOR_DIR}/cborencoder_float.c
+      ${TINYCBOR_DIR}/cborerrorstrings.c
+      ${TINYCBOR_DIR}/cborparser.c
+      ${TINYCBOR_DIR}/cborparser_dup_string.c
+      ${TINYCBOR_DIR}/cborparser_float.c
+      ${TINYCBOR_DIR}/cborpretty.c
+      ${TINYCBOR_DIR}/cborpretty_stdio.c
+      ${TINYCBOR_DIR}/cbortojson.c
+      ${TINYCBOR_DIR}/cborvalidation.c
+      ${TINYCBOR_DIR}/open_memstream.c)
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  set(INCDIR ${CMAKE_CURRENT_LIST_DIR})
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  nuttx_add_library(tinycbor STATIC)
+  target_sources(tinycbor PRIVATE ${CSRCS})
+  target_include_directories(tinycbor PRIVATE ${INCDIR})
+  target_compile_options(tinycbor PRIVATE ${CFLAGS})
+
+endif()

--- a/fsutils/mkgpt/CMakeLists.txt
+++ b/fsutils/mkgpt/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/fsutils/inifile/CMakeLists.txt
+# apps/fsutils/mkgpt/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,16 @@
 #
 # ##############################################################################
 
-if(CONFIG_FSUTILS_INIFILE)
-  target_sources(apps PRIVATE inifile.c)
+if(CONFIG_FSUTILS_MKGPT)
+  nuttx_add_application(
+    NAME
+    mkgpt
+    PRIORITY
+    100
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_FSUTILS_MKGPT}
+    SRCS
+    mkgpt.c)
 endif()

--- a/fsutils/mkmbr/CMakeLists.txt
+++ b/fsutils/mkmbr/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/fsutils/inifile/CMakeLists.txt
+# apps/fsutils/mkmbr/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,16 @@
 #
 # ##############################################################################
 
-if(CONFIG_FSUTILS_INIFILE)
-  target_sources(apps PRIVATE inifile.c)
+if(CONFIG_FSUTILS_MKMBR)
+  nuttx_add_application(
+    NAME
+    mkmbr
+    PRIORITY
+    100
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_FSUTILS_MKMBR}
+    SRCS
+    mkmbr.c)
 endif()


### PR DESCRIPTION
## Summary
migrate cmake build 
- inifile
- inih
- ipcfg
- libtinycbor
- mkgpt
- mkmbr
## Impact

## Testing
CMake build eanble CONFIG_FSUTILS_INIFILE, CONFIG_FSUTILS_INIH,CONFIG_FSUTILS_IPCFG,CONFIG_FSUTILS_TINYCBOR_LIB,CONFIG_FSUTILS_MKGPT,CONFIG_FSUTILS_MKMBR
