### PR TITLE
Fix wrong parameter size

### DIFF
--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -446,12 +446,15 @@ int main(int argc, FAR char *argv[])
 
   while (!cu->force_exit)
     {
-      int ch = getc(stdin);
+      char ch;
+      int c = getc(stdin);
 
-      if (ch < 0)
+      if (c < 0)
         {
           continue;
         }
+
+      ch = c;
 
       if (nobreak == 1)
         {


### PR DESCRIPTION
## Summary
Type int expects 4 bytes for function write(). Type char expects 1 byte which matches the real usage of function write().

## Impact

## Testing

ci
