### PR TITLE
Application.mk:execute archive in batches

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -209,7 +209,10 @@ $(ZIGOBJS): %$(ZIGEXT)$(SUFFIX)$(OBJEXT): %$(ZIGEXT)
 		$(call ELFCOMPILEZIG, $<, $@), $(call COMPILEZIG, $<, $@))
 
 archive:
-	$(call ARCHIVE_ADD, $(call CONVERT_PATH,$(BIN)), $(OBJS))
+	$(call SPLITVARIABLE,ALL_OBJS,$(OBJS),100)
+	$(foreach BATCH, $(ALL_OBJS_TOTAL), \
+		$(call ARCHIVE_ADD, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH))) \
+	)
 
 ifeq ($(BUILD_MODULE),y)
 


### PR DESCRIPTION
## Summary
related to https://github.com/apache/nuttx-apps/pull/1853
a large number of objs caused an error that the parameters were too long in the archive stage.
## Impact

## Testing
CI build
