### PR TITLE
ltp/makefile: apply that patch that to fix the build warning in ltp

### DIFF
--- a/testing/ltp/0001-pthread_rwlock_unlock-follow-linux.patch
+++ b/testing/ltp/0001-pthread_rwlock_unlock-follow-linux.patch
@@ -8,10 +8,10 @@ Signed-off-by: Shoukui Zhang <zhangshoukui@xiaomi.com>
  .../conformance/interfaces/pthread_rwlock_unlock/4-1.c          | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c b/ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
 index 2db9e4cc6..5d7c2c565 100644
---- a/ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
-+++ b/ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_unlock/4-1.c
 @@ -31,7 +31,7 @@ int main(void)
  	static pthread_rwlock_t rwlock;
  	int rc;

--- a/testing/ltp/0002-Use-ifdef-instead-of-if-for-__linux__.patch
+++ b/testing/ltp/0002-Use-ifdef-instead-of-if-for-__linux__.patch
@@ -7,10 +7,10 @@ Subject: [PATCH 2/2] Use #ifdef instead of #if for __linux__
  .../conformance/interfaces/sem_timedwait/3-1.c                  | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/ltp/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c b/ltp/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c b/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
 index fb6f2e6cb..739fe86a5 100644
---- a/ltp/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
-+++ b/ltp/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
+--- a/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/sem_timedwait/3-1.c
 @@ -15,7 +15,7 @@
  #include <sys/stat.h>
  #include <sys/types.h>

--- a/testing/ltp/0003-LTP-Re-init-static-variable-to-avoid-errors-during-m.patch
+++ b/testing/ltp/0003-LTP-Re-init-static-variable-to-avoid-errors-during-m.patch
@@ -1,0 +1,46 @@
+From f7b61dd11c404f5268fcf651744388c10f47d974 Mon Sep 17 00:00:00 2001
+From: Huang Qi <huangqi3@xiaomi.com>
+Date: Thu, 28 Jan 2021 13:29:25 +0800
+Subject: [PATCH 06/21] LTP: Re-init static variable to avoid errors during
+ multiple runs
+
+MIRTOS-361
+
+Signed-off-by: Huang Qi <huangqi3@xiaomi.com>
+Change-Id: I81fb72b33a3381dfe18c0193e56bcd3d67a3a5eb
+---
+ .../conformance/interfaces/pthread_cond_signal/2-1.c           | 3 +++
+ .../conformance/interfaces/pthread_cond_signal/4-1.c           | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
+index ff62336c9..c00cb4731 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/2-1.c
+@@ -101,6 +101,9 @@ int main(void)
+ 	struct sigaction act;
+ 	pthread_mutexattr_t ma;
+ 
++	waken_num = 0;
++	start_num = 0;
++
+ 	if (pthread_mutexattr_init(&ma) != 0) {
+ 		fprintf(stderr, "Fail to initialize mutex attribute\n");
+ 		return PTS_UNRESOLVED;
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
+index 36dc91ec9..bbb7acfcf 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_signal/4-1.c
+@@ -79,6 +79,9 @@ int main(void)
+ 	int i, rc;
+ 	struct sigaction act;
+ 
++	waken_num = 0;
++	start_num = 0;
++
+ 	if (pthread_mutex_init(&td.mutex, NULL) != 0) {
+ 		fprintf(stderr, "Fail to initialize mutex\n");
+ 		return PTS_UNRESOLVED;
+-- 
+2.40.1
+

--- a/testing/ltp/0004-test-update-ltp-test-case.patch
+++ b/testing/ltp/0004-test-update-ltp-test-case.patch
@@ -1,0 +1,38 @@
+From b4547e5b68ac33f00c5298874024ad2934b75184 Mon Sep 17 00:00:00 2001
+From: nietingting <nietingting@xiaomi.com>
+Date: Thu, 11 Nov 2021 18:52:03 +0800
+Subject: [PATCH 08/21] test: update ltp test case
+
+N/A
+
+Signed-off-by: nietingting <nietingting@xiaomi.com>
+Change-Id: Ib57a56725b21ecbc06b60eb81a685bfae404c03b
+---
+ .../open_posix_testsuite/functional/mqueues/send_rev_2.c      | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c b/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
+index a0a49d159..22ecbb224 100644
+--- a/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
++++ b/testcases/open_posix_testsuite/functional/mqueues/send_rev_2.c
+@@ -43,7 +43,7 @@ static int *send_1(void *mq)
+ 
+ 	printf("Enter into send_1 \n");
+ 	for (i = 0; i < MAX_MSG; i++) {
+-		if (-1 == mq_send(mq1, s_msg_ptr[i], MSG_SIZE, i)) {
++		if (-1 == mq_send(mq1, s_msg_ptr[i], strlen(s_msg_ptr[i]) + 1, i)) {
+ 			perror("mq_send doesn't return success \n");
+ 			pthread_exit((void *)1);
+ 		}
+@@ -61,7 +61,7 @@ static int *send_2(void *mq)
+ 
+ 	printf("Enter into send_2 \n");
+ 	for (i = 0; i < MAX_MSG; i++) {
+-		if (-1 == mq_send(mq2, s_msg_ptr[i], MSG_SIZE, i)) {
++		if (-1 == mq_send(mq2, s_msg_ptr[i], strlen(s_msg_ptr[i]) + 1, i)) {
+ 			perror("mq_send doesn't return success \n");
+ 			pthread_exit((void *)1);
+ 		}
+-- 
+2.40.1
+

--- a/testing/ltp/0005-ltp-update-pthread_cond_timedwait-testcase.patch
+++ b/testing/ltp/0005-ltp-update-pthread_cond_timedwait-testcase.patch
@@ -1,0 +1,34 @@
+From 5f15436267648a2edeb945a0e588d3f7675ce668 Mon Sep 17 00:00:00 2001
+From: haopengxiang <haopengxiang@xiaomi.com>
+Date: Thu, 6 Jan 2022 20:09:48 +0800
+Subject: [PATCH 09/21] ltp: update pthread_cond_timedwait testcase
+
+VELAPLATFO-616
+
+add initialization of mutex and cond in pthread_cond_timedwait_4_3
+
+Change-Id: Id15957334955b98210bf96d2d2467919ea730ef9
+Signed-off-by: haopengxiang <haopengxiang@xiaomi.com>
+---
+ .../conformance/interfaces/pthread_cond_timedwait/4-3.c      | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/4-3.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/4-3.c
+index 5a49ffc35..305ab0454 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/4-3.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_cond_timedwait/4-3.c
+@@ -69,7 +69,10 @@ typedef struct {
+ static struct {
+ 	pthread_mutex_t mtx;
+ 	pthread_cond_t cnd;
+-} data;
++} data = {
++	PTHREAD_MUTEX_INITIALIZER,
++	PTHREAD_COND_INITIALIZER
++};
+ 
+ /* the following function keeps on sending the signal to the process */
+ static void *sendsig(void *arg)
+-- 
+2.40.1
+

--- a/testing/ltp/0006-test-modified-ltp-rwlock-need-init.patch
+++ b/testing/ltp/0006-test-modified-ltp-rwlock-need-init.patch
@@ -1,0 +1,29 @@
+From 1559537d64e4324b16ccf6ea9eaaa572653f6f6e Mon Sep 17 00:00:00 2001
+From: anjiahao <anjiahao@xiaomi.com>
+Date: Tue, 22 Feb 2022 11:21:24 +0800
+Subject: [PATCH 10/21] [test]:modified ltp,rwlock need init
+
+VELAPLATFO-806
+
+Signed-off-by: anjiahao <anjiahao@xiaomi.com>
+Change-Id: I446226f2f33cb146e8f39935128204f6a918720d
+---
+ .../interfaces/pthread_rwlock_trywrlock/speculative/3-1.c       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
+index cc0d3a296..da1baa1ef 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_rwlock_trywrlock/speculative/3-1.c
+@@ -23,7 +23,7 @@
+ int main(void)
+ {
+ 
+-	static pthread_rwlock_t rwlock;
++	static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+ 	int rc;
+ 
+ 	/* Call without initializing rwlock */
+-- 
+2.40.1
+

--- a/testing/ltp/0007-pthread_kill-add-usleep-aviod-semcount-overturn.patch
+++ b/testing/ltp/0007-pthread_kill-add-usleep-aviod-semcount-overturn.patch
@@ -1,0 +1,32 @@
+From 026162a24a0ed7f11c55c22e03501a4f6bb3dc94 Mon Sep 17 00:00:00 2001
+From: anjiahao <anjiahao@xiaomi.com>
+Date: Tue, 10 Jan 2023 11:50:03 +0800
+Subject: [PATCH 14/21] pthread_kill:add usleep aviod semcount overturn
+
+VELAPLATFO-4504
+
+A short-term infinite loop will cause semcount
+to exceed the limit in sem_post
+
+Signed-off-by: anjiahao <anjiahao@xiaomi.com>
+Change-Id: I25c8e10ce4166f0b681f462157a02f8a6add2ebb
+---
+ .../conformance/interfaces/pthread_kill/8-1.c                   | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/8-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/8-1.c
+index f1d05edbe..4a12ee0ab 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/8-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_kill/8-1.c
+@@ -198,6 +198,8 @@ static void *test(void *arg LTP_ATTRIBUTE_UNUSED)
+ 			UNRESOLVED(ret,
+ 				   "pthread_kill returned an unexpected error");
+ 		}
++
++		usleep(10000);
+ 	}
+ 
+ 	return NULL;
+-- 
+2.40.1
+

--- a/testing/ltp/0008-test-ltp-fix-ltp_interfaces_sigaction_23_10-deadloop.patch
+++ b/testing/ltp/0008-test-ltp-fix-ltp_interfaces_sigaction_23_10-deadloop.patch
@@ -1,0 +1,30 @@
+From 77955874b3c97f1db2bc261ce3ddb76873cdaab7 Mon Sep 17 00:00:00 2001
+From: guohao15 <guohao15@xiaomi.com>
+Date: Mon, 8 May 2023 20:19:37 +0800
+Subject: [PATCH 15/21] test:ltp fix ltp_interfaces_sigaction_23_10 deadloop at
+ second run
+
+VELAPLATFO-7303
+
+Signed-off-by: guohao15 <guohao15@xiaomi.com>
+Change-Id: Ib441191da3e3380ed5e54b2914ffec8d3307b173
+---
+ .../conformance/interfaces/sigaction/23-10.c                    | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-10.c b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-10.c
+index 9274e1154..8a0039f14 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-10.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/sigaction/23-10.c
+@@ -123,6 +123,8 @@ int main(void)
+ 
+ 	struct sigaction sa;
+ 
++        called = 0;
++
+ 	/* Initialize output */
+ 	output_init();
+ 
+-- 
+2.40.1
+

--- a/testing/ltp/0009-ltp-modify-user-code-for-fdcheck-compatibility.patch
+++ b/testing/ltp/0009-ltp-modify-user-code-for-fdcheck-compatibility.patch
@@ -1,0 +1,23 @@
+From 936342de79e8a92727c56d2bf87eb651be061570 Mon Sep 17 00:00:00 2001
+From: hujun5 <hujun5@xiaomi.com>
+Date: Thu, 8 Jun 2023 15:07:46 +0800
+Subject: [PATCH] ltp: modify user code for fdcheck compatibility
+
+Signed-off-by: hujun5 <hujun5@xiaomi.com>
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/mq_close/3-3.c b/testcases/open_posix_testsuite/conformance/interfaces/mq_close/3-3.c
+index d5d8265bd..e33797d57 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/mq_close/3-3.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/mq_close/3-3.c
+@@ -23,7 +23,7 @@
+ int main(void)
+ {
+ 	/* Use some arbitrary but high number for the descriptor.  */
+-	if (mq_close((mqd_t) 274) != -1) {
++	if (mq_close((mqd_t) (OPEN_MAX - 1)) != -1) {
+ 		printf("mq_close() did not return -1 on invalid descriptor\n");
+ 		printf("Test FAILED\n");
+ 		return PTS_FAIL;
+-- 
+2.40.1
+

--- a/testing/ltp/0010-ltp-fix-build-warning.patch
+++ b/testing/ltp/0010-ltp-fix-build-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c b/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
+index 14ad4ea2c..2133b721a 100644
+--- a/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
++++ b/testcases/open_posix_testsuite/stress/threads/sem_open/s-c1.c
+@@ -399,7 +399,7 @@ int main(int argc, char *argv[])
+  * The function returns 0 when r1 is the best for all cases (latency is constant) and !0 otherwise.
+  */
+ 
+-static struct row {
++struct row {
+ 	long X;			/* the X values -- copied from function argument */
+ 	long Y_o;		/* the Y values -- copied from function argument */
+ 	long Y_c;		/* the Y values -- copied from function argument */

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -270,8 +270,16 @@ $(LTP_UNPACK): ltp-$(LTPS_VERSION).zip
 	$(Q) echo "dowload $(LTP_DOWNLOAD_URL)$(LTPS_VERSION).zip"
 	$(Q) unzip -o ltp.zip
 	$(Q) mv ltp-$(LTPS_VERSION) $(LTP_UNPACK)
-	$(Q) patch -p1 < 0001-pthread_rwlock_unlock-follow-linux.patch
-	$(Q) patch -p1 < 0002-Use-ifdef-instead-of-if-for-__linux__.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0001-pthread_rwlock_unlock-follow-linux.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0002-Use-ifdef-instead-of-if-for-__linux__.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0003-LTP-Re-init-static-variable-to-avoid-errors-during-m.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0004-test-update-ltp-test-case.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0005-ltp-update-pthread_cond_timedwait-testcase.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0006-test-modified-ltp-rwlock-need-init.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0007-pthread_kill-add-usleep-aviod-semcount-overturn.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0008-test-ltp-fix-ltp_interfaces_sigaction_23_10-deadloop.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0009-ltp-modify-user-code-for-fdcheck-compatibility.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0010-ltp-fix-build-warning.patch
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(LTP_UNPACK)/.git),)


### PR DESCRIPTION
## Summary
apply that patch that to fix the build warning in ltp

the origin ltp testcases has many build warnings which consider error in Nuttx, thus to apply the patches to fix these build warnings
## Impact

## Testing

