### PR TITLE
system/nxlooper: Initialize `audio_caps_s` to 0

### DIFF
--- a/system/nxlooper/nxlooper.c
+++ b/system/nxlooper/nxlooper.c
@@ -1053,6 +1053,7 @@ int nxlooper_loopback(FAR struct nxlooper_s *plooper, int format,
       goto err_out_record;
     }
 
+  memset(&caps, 0, sizeof(struct audio_caps_s));
   caps.ac_len = sizeof(caps);
   caps.ac_type = AUDIO_TYPE_INPUT;
   caps.ac_subtype = AUDIO_TYPE_QUERY;


### PR DESCRIPTION
## Summary

* system/nxlooper: Initialize `audio_caps_s` to 0

This prevents unspecified values from being passed to the lower interfaces of the audio subsystem.

## Impact

Preventing erroneous behavior.

## Testing

Internal CI testing + ESP32-S3 with `esp32s3-devkit:nxlooper` (yet to be submitted). 