### PR TITLE
mqttc: add mbedtls MQTTC support

### DIFF
--- a/examples/mqttc/Kconfig
+++ b/examples/mqttc/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_MQTTC
 	tristate "Enable MQTT-C Example"
 	default n
-	depends on NETUTILS_MQTTC
+	depends on NETUTILS_MQTTC && !NETUTILS_MQTTC_WITH_MBEDTLS
 	---help---
 		Enable a simple MQTT-C publisher example
 

--- a/netutils/mqttc/Kconfig
+++ b/netutils/mqttc/Kconfig
@@ -11,6 +11,20 @@ config NETUTILS_MQTTC
 
 if NETUTILS_MQTTC
 
+config NETUTILS_MQTTC_EXAMPLE
+	tristate "Enable MQTT-C example"
+	default n
+	---help---
+		Enable MQTT-C example
+
+if NETUTILS_MQTTC_EXAMPLE
+
+config NETUTILS_MQTTC_EXAMPLE_STACKSIZE
+	int "Task's stack size"
+	default 8192
+
+endif
+
 config NETUTILS_MQTTC_WITH_MBEDTLS
 	bool "Enable MQTT-C with mbedtls"
 	default n

--- a/netutils/mqttc/Makefile
+++ b/netutils/mqttc/Makefile
@@ -50,4 +50,35 @@ distclean::
 	$(call DELDIR, $(MQTTC_UNPACK))
 endif
 
+ifneq ($(CONFIG_NETUTILS_MQTTC_EXAMPLE),)
+CFLAGS += -Wno-return-type
+
+PRIORITY  = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_NETUTILS_MQTTC_EXAMPLE_STACKSIZE)
+MODULE    = $(CONFIG_NETUTILS_MQTTC_EXAMPLE)
+
+# MQTT-C mbedtls example source code
+ifneq ($(CONFIG_NETUTILS_MQTTC_WITH_MBEDTLS),)
+PROGNAME  = mqttc_mbedtls_pub
+MAINSRC   = $(MQTTC_UNPACK)$(DELIM)examples$(DELIM)mbedtls_publisher.c
+else
+PROGNAME  = mqttc_posix_pub
+MAINSRC   = $(MQTTC_UNPACK)$(DELIM)examples$(DELIM)simple_publisher.c
+$(MQTTC_UNPACK)$(DELIM)examples$(DELIM)simple_publisher.c_CFLAGS += \
+            -Dopen_nb_socket=pub_open_nb_socket \
+            -Dexit_example=pub_exit_example \
+            -Dpublish_callback=pub_publish_callback \
+            -Dclient_refresher=pub_client_refresher
+
+PROGNAME += mqttc_posix_sub
+MAINSRC  += $(MQTTC_UNPACK)$(DELIM)examples$(DELIM)simple_subscriber.c
+$(MQTTC_UNPACK)$(DELIM)examples$(DELIM)simple_subscriber.c_CFLAGS += \
+            -Dopen_nb_socket=sub_open_nb_socket \
+            -Dexit_example=sub_exit_example \
+            -Dpublish_callback=sub_publish_callback \
+            -Dclient_refresher=sub_client_refresher
+endif
+
+endif
+
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
The mqttc demo under example path can not support mbedtls api. Because of the MQTT-C source code already contains many types of link examples, so we added the corresponding makefile to support mbedtls mqttc connections publisher and posix mqttc connections publisher and subscriber.
## Impact

## Testing
sim:local
