### PR TITLE
Add loading of ET_DYN shared object test to sotest

### DIFF
--- a/examples/sotest/lib/Makefile
+++ b/examples/sotest/lib/Makefile
@@ -24,8 +24,8 @@ ALL_SUBDIRS = sotest
 BUILD_SUBDIRS = sotest
 
 ifneq ($(CONFIG_MODLIB_MAXDEPEND),0)
-ALL_SUBDIRS += modprint
-BUILD_SUBDIRS += modprint
+ALL_SUBDIRS += modprint dynload
+BUILD_SUBDIRS += modprint dynload
 endif
 
 SOTEST_DIR = $(APPDIR)/examples/sotest

--- a/examples/sotest/lib/dynload/.gitignore
+++ b/examples/sotest/lib/dynload/.gitignore
@@ -1,0 +1,1 @@
+/dynload

--- a/examples/sotest/lib/dynload/Makefile
+++ b/examples/sotest/lib/dynload/Makefile
@@ -1,0 +1,55 @@
+############################################################################
+# apps/examples/sotest/lib/dynload/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+ifeq ($(CONFIG_EXAMPLES_SOTEST_LIBC),y)
+LDLIBPATH +=  -L $(NUTTXLIB)
+endif
+
+ifeq ($(CONFIG_EXAMPLES_SOTEST_LIBC),y)
+LDLIBS += -lc
+endif
+
+BIN = dynload
+
+SRCS = $(BIN).c
+OBJS = $(SRCS:.c=$(OBJEXT))
+
+all: $(BIN)
+.PHONY: all clean install
+
+$(OBJS): %$(OBJEXT): %.c
+	@echo "MODULECC: $<"
+	$(Q) $(MODULECC) -c $(CMODULEFLAGS) $(SHCCFLAGS) $< -o $@
+
+$(BIN): $(OBJS)
+	@echo "MODULELD: $<"
+	$(Q) $(MODULELD) $(SHMODULEFLAGS) $(LDLIBPATH) -o $@ $^ $(LDLIBS)
+
+$(FSROOT_DIR)/$(BIN): $(BIN)
+	$(Q) mkdir -p $(FSROOT_DIR)
+	$(Q) install $(BIN) $(FSROOT_DIR)/$(BIN)
+
+install: $(FSROOT_DIR)/$(BIN)
+
+clean:
+	$(call DELFILE, $(BIN))
+	$(call CLEAN)

--- a/examples/sotest/lib/dynload/dynload.c
+++ b/examples/sotest/lib/dynload/dynload.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * apps/examples/sotest/lib/dynload/dynload.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <nuttx/symtab.h>
+#include <nuttx/lib/modlib.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+int dynload(int);
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dynload
+ ****************************************************************************/
+
+int dynload(int a)
+{
+  return a + 10;
+}

--- a/examples/sotest/sotest_main.c
+++ b/examples/sotest/sotest_main.c
@@ -105,6 +105,7 @@ int main(int argc, FAR char *argv[])
   char devname[32];
 #if CONFIG_MODLIB_MAXDEPEND > 0
   FAR void *handle1;
+  FAR void *handle3;
 #endif
   FAR void *handle2;
   CODE void (*testfunc)(FAR const char *msg);
@@ -170,6 +171,32 @@ int main(int argc, FAR char *argv[])
       fprintf(stderr, "ERROR: dlopen(/modprint) failed\n");
       exit(EXIT_FAILURE);
     }
+
+  handle3 = dlopen(BINDIR "/dynload", RTLD_NOW | RTLD_LOCAL);
+  if (handle3 == NULL)
+    {
+      fprintf(stderr, "ERROR: dlopen(/dynload) failed - %s\n",
+              strerror(errno));
+      exit(EXIT_FAILURE);
+    }
+  else
+    {
+      int (*dynload)(int);
+      dynload = dlsym(handle3, "dynload");
+      if (dynload != NULL)
+        {
+          int a = dynload(32);
+          printf("dynload returned %d which is the %s answer\n",
+                 a, (a == 42 ? "correct" : "incorrect"));
+        }
+      else
+        {
+          fprintf(stderr, "ERROR: dlsym(dynload) failed - %s\n",
+                  strerror(errno));
+          exit(EXIT_FAILURE);
+        }
+    }
+
 #endif
 
   /* Install the second test shared library  */
@@ -271,6 +298,13 @@ int main(int argc, FAR char *argv[])
   if (ret < 0)
     {
       fprintf(stderr, "ERROR: dlclose(handle1) failed: %d\n", ret);
+      exit(EXIT_FAILURE);
+    }
+
+  ret = dlclose(handle3);
+  if (ret < 0)
+    {
+      fprintf(stderr, "ERROR: dlclose(handle3) failed: %d\n", ret);
       exit(EXIT_FAILURE);
     }
 #endif


### PR DESCRIPTION
* examples/sotest/lib/Makefile
  - Add dynload directory to build

* examples/sotest/lib/dynload/Makefile
  - Build the dynload shared object test

* examples/sotest/lib/dynload/dynload.c
  - Test case for loading of ET_DYN shared objects

* examples/sotest/lib/dynload/.gitignore
  - Exclude built object from git

* examples/sotest/sotest_main.c
  - Load and invoke the dynload test

## Summary

Support of ET_DYN shared objects was added to NuttX, this PR adds a test.

## Impact

New test `dynload` is built.

## Testing

Run `sotest` and the `dynload` shared object will be loaded, a symbol located and invoked, and the module unloaded.