### PR TITLE
testing/crypto: fix aescbc crash when update iv

### DIFF
--- a/testing/crypto/aescbc.c
+++ b/testing/crypto/aescbc.c
@@ -95,6 +95,7 @@ static int syscrypt(FAR const char *key, size_t klen,
   struct crypt_op cryp;
   int cryptodev_fd = -1;
   int fd = -1;
+  char tmp_iv[16];
 
   if ((fd = open("/dev/crypto", O_RDWR, 0)) < 0)
     {
@@ -119,13 +120,14 @@ static int syscrypt(FAR const char *key, size_t klen,
     }
 
   memset(&cryp, 0, sizeof(cryp));
+  memcpy(tmp_iv, iv, 16);
   cryp.ses = session.ses;
   cryp.op = encrypt ? COP_ENCRYPT : COP_DECRYPT;
   cryp.flags = 0;
   cryp.len = len;
   cryp.src = (caddr_t) in;
   cryp.dst = (caddr_t) out;
-  cryp.iv = (caddr_t) iv;
+  cryp.iv = (caddr_t) tmp_iv;
   cryp.mac = 0;
   if (ioctl(cryptodev_fd, CIOCCRYPT, &cryp) == -1)
     {


### PR DESCRIPTION
iv content always should be updated when performing encryption operation, so need update testing case
Signed-off-by: makejian <makejian@xiaomi.com>

