### PR TITLE
lte/alt1250: Fix usrsock_bind error by uninitialized value

### DIFF
--- a/lte/alt1250/alt1250_usockif.c
+++ b/lte/alt1250/alt1250_usockif.c
@@ -76,6 +76,7 @@ static int send_dataack(int fd, uint32_t ackxid, int32_t ackresult,
 
   dataack.reqack.head.msgid = USRSOCK_MESSAGE_RESPONSE_DATA_ACK;
   dataack.reqack.head.flags = 0;
+  dataack.reqack.head.events = 0;
   dataack.reqack.xid = ackxid;
   dataack.reqack.result = ackresult;
 
@@ -359,6 +360,7 @@ int usockif_sendack(int fd, int32_t usock_result, uint32_t usock_xid,
 
   ack.head.msgid = USRSOCK_MESSAGE_RESPONSE_ACK;
   ack.head.flags = inprogress ? USRSOCK_MESSAGE_FLAG_REQ_IN_PROGRESS : 0;
+  ack.head.events = 0;
   ack.xid = usock_xid;
   ack.result = usock_result;
 

--- a/lte/alt1250/alt1250_usockif.c
+++ b/lte/alt1250/alt1250_usockif.c
@@ -267,6 +267,7 @@ int usockif_readreqioctl(int fd, FAR struct usrsock_request_buff_s *buf)
         rsize = sizeof(struct lte_ioctl_data_s);
         break;
       case SIOCSIFFLAGS:
+      case SIOCGIFFLAGS:
         rsize = sizeof(struct ifreq);
         break;
       case SIOCDENYINETSOCK:

--- a/lte/alt1250/usock_handlers/alt1250_ioctlhdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctlhdlr.c
@@ -66,6 +66,7 @@ int usockreq_ioctl(FAR struct alt1250_s *dev,
       switch (request->cmd)
         {
           case FIONBIO:
+          case SIOCGIFFLAGS:
 
             /* ALT1250 doesn't use this command. Only return OK. */
 


### PR DESCRIPTION
## Summary
Fix usrsock_bind error by uninitialized value.
lte/alt1250: Fix issue that ifconfig does not work.

## Impact
lte/alt1250

## Testing

