### PR TITLE
c++ compatibility: rename usages of reserved c++ keyword 'public' and 'this'

### DIFF
--- a/crypto/mbedtls/include/mbedtls/mbedtls_config.h
+++ b/crypto/mbedtls/include/mbedtls/mbedtls_config.h
@@ -2964,7 +2964,7 @@
  * \def MBEDTLS_LMS_PRIVATE
  *
  * Enable LMS private-key operations and signing code. Functions enabled by
- *this
+ * this
  * option are experimental, and should not be used in production.
  *
  * Requires: MBEDTLS_LMS_C

--- a/interpreters/bas/bas_auto.c
+++ b/interpreters/bas/bas_auto.c
@@ -50,34 +50,34 @@
 
 /* interpretation methods */
 
-struct Auto *Auto_new(struct Auto *this)
+struct Auto *Auto_new(struct Auto *self)
 {
-  this->stackPointer = 0;
-  this->stackCapacity = 0;
-  this->framePointer = 0;
-  this->frameSize = 0;
-  this->onerror.line = -1;
-  this->erl = 0;
-  Value_new_NIL(&this->err);
-  Value_new_NIL(&this->lastdet);
-  this->begindata.line = -1;
-  this->slot = (union AutoSlot *)0;
-  this->cur = this->all = (struct Symbol *)0;
-  return this;
+  self->stackPointer = 0;
+  self->stackCapacity = 0;
+  self->framePointer = 0;
+  self->frameSize = 0;
+  self->onerror.line = -1;
+  self->erl = 0;
+  Value_new_NIL(&self->err);
+  Value_new_NIL(&self->lastdet);
+  self->begindata.line = -1;
+  self->slot = (union AutoSlot *)0;
+  self->cur = self->all = (struct Symbol *)0;
+  return self;
 }
 
-void Auto_destroy(struct Auto *this)
+void Auto_destroy(struct Auto *self)
 {
   struct Symbol *l;
 
-  Value_destroy(&this->err);
-  Value_destroy(&this->lastdet);
-  if (this->stackCapacity)
+  Value_destroy(&self->err);
+  Value_destroy(&self->lastdet);
+  if (self->stackCapacity)
     {
-      free(this->slot);
+      free(self->slot);
     }
 
-  for (l = this->all; l != (struct Symbol *)0; )
+  for (l = self->all; l != (struct Symbol *)0; )
     {
       struct Symbol *f;
 
@@ -88,135 +88,135 @@ void Auto_destroy(struct Auto *this)
     }
 }
 
-struct Var *Auto_pushArg(struct Auto *this)
+struct Var *Auto_pushArg(struct Auto *self)
 {
-  if ((this->stackPointer + 1) >= this->stackCapacity)
+  if ((self->stackPointer + 1) >= self->stackCapacity)
     {
-      this->slot =
-        realloc(this->slot,
-                sizeof(this->slot[0]) *
-                (this->
-                 stackCapacity ? (this->stackCapacity =
-                                  this->stackPointer +
-                                  INCREASE_STACK) : (this->stackCapacity =
+      self->slot =
+        realloc(self->slot,
+                sizeof(self->slot[0]) *
+                (self->
+                 stackCapacity ? (self->stackCapacity =
+                                  self->stackPointer +
+                                  INCREASE_STACK) : (self->stackCapacity =
                                                      INCREASE_STACK)));
     }
 
-  return &this->slot[this->stackPointer++].var;
+  return &self->slot[self->stackPointer++].var;
 }
 
-void Auto_pushFuncRet(struct Auto *this, int firstarg, struct Pc *pc)
+void Auto_pushFuncRet(struct Auto *self, int firstarg, struct Pc *pc)
 {
-  if (this->stackPointer + 2 >= this->stackCapacity)
+  if (self->stackPointer + 2 >= self->stackCapacity)
     {
-      this->slot =
-        realloc(this->slot,
-                sizeof(this->slot[0]) *
-                (this->
-                 stackCapacity ? (this->stackCapacity =
-                                  this->stackCapacity +
-                                  INCREASE_STACK) : (this->stackCapacity =
+      self->slot =
+        realloc(self->slot,
+                sizeof(self->slot[0]) *
+                (self->
+                 stackCapacity ? (self->stackCapacity =
+                                  self->stackCapacity +
+                                  INCREASE_STACK) : (self->stackCapacity =
                                                      INCREASE_STACK)));
     }
 
-  this->slot[this->stackPointer].retException.onerror = this->onerror;
-  this->slot[this->stackPointer].retException.resumeable = this->resumeable;
-  ++this->stackPointer;
-  this->slot[this->stackPointer].retFrame.pc = *pc;
-  this->slot[this->stackPointer].retFrame.framePointer = this->framePointer;
-  this->slot[this->stackPointer].retFrame.frameSize = this->frameSize;
-  ++this->stackPointer;
-  this->framePointer = firstarg;
-  this->frameSize = this->stackPointer - firstarg;
-  this->onerror.line = -1;
+  self->slot[self->stackPointer].retException.onerror = self->onerror;
+  self->slot[self->stackPointer].retException.resumeable = self->resumeable;
+  ++self->stackPointer;
+  self->slot[self->stackPointer].retFrame.pc = *pc;
+  self->slot[self->stackPointer].retFrame.framePointer = self->framePointer;
+  self->slot[self->stackPointer].retFrame.frameSize = self->frameSize;
+  ++self->stackPointer;
+  self->framePointer = firstarg;
+  self->frameSize = self->stackPointer - firstarg;
+  self->onerror.line = -1;
 }
 
-void Auto_pushGosubRet(struct Auto *this, struct Pc *pc)
+void Auto_pushGosubRet(struct Auto *self, struct Pc *pc)
 {
-  if ((this->stackPointer + 1) >= this->stackCapacity)
+  if ((self->stackPointer + 1) >= self->stackCapacity)
     {
-      this->slot =
-        realloc(this->slot,
-                sizeof(this->slot[0]) *
-                (this->
-                 stackCapacity ? (this->stackCapacity =
-                                  this->stackPointer +
-                                  INCREASE_STACK) : (this->stackCapacity =
+      self->slot =
+        realloc(self->slot,
+                sizeof(self->slot[0]) *
+                (self->
+                 stackCapacity ? (self->stackCapacity =
+                                  self->stackPointer +
+                                  INCREASE_STACK) : (self->stackCapacity =
                                                      INCREASE_STACK)));
     }
 
-  this->slot[this->stackPointer].retFrame.pc = *pc;
-  ++this->stackPointer;
+  self->slot[self->stackPointer].retFrame.pc = *pc;
+  ++self->stackPointer;
 }
 
-struct Var *Auto_local(struct Auto *this, int l)
+struct Var *Auto_local(struct Auto *self, int l)
 {
-  assert(this->frameSize > (l + 2));
-  return &(this->slot[this->framePointer + l].var);
+  assert(self->frameSize > (l + 2));
+  return &(self->slot[self->framePointer + l].var);
 }
 
-int Auto_funcReturn(struct Auto *this, struct Pc *pc)
+int Auto_funcReturn(struct Auto *self, struct Pc *pc)
 {
   int retException;
   int retFrame;
   int i;
 
-  if (this->stackPointer == 0)
+  if (self->stackPointer == 0)
     {
       return 0;
     }
 
-  assert(this->frameSize);
-  retFrame = this->framePointer + this->frameSize - 1;
-  retException = this->framePointer + this->frameSize - 2;
-  assert(retException >= 0 && retFrame < this->stackPointer);
-  for (i = 0; i < this->frameSize - 2; ++i)
+  assert(self->frameSize);
+  retFrame = self->framePointer + self->frameSize - 1;
+  retException = self->framePointer + self->frameSize - 2;
+  assert(retException >= 0 && retFrame < self->stackPointer);
+  for (i = 0; i < self->frameSize - 2; ++i)
     {
-      Var_destroy(&this->slot[this->framePointer + i].var);
+      Var_destroy(&self->slot[self->framePointer + i].var);
     }
 
-  this->stackPointer = this->framePointer;
+  self->stackPointer = self->framePointer;
   if (pc != (struct Pc *)0)
     {
-      *pc = this->slot[retFrame].retFrame.pc;
+      *pc = self->slot[retFrame].retFrame.pc;
     }
 
-  this->frameSize = this->slot[retFrame].retFrame.frameSize;
-  this->framePointer = this->slot[retFrame].retFrame.framePointer;
-  this->onerror = this->slot[retException].retException.onerror;
+  self->frameSize = self->slot[retFrame].retFrame.frameSize;
+  self->framePointer = self->slot[retFrame].retFrame.framePointer;
+  self->onerror = self->slot[retException].retException.onerror;
   return 1;
 }
 
-int Auto_gosubReturn(struct Auto *this, struct Pc *pc)
+int Auto_gosubReturn(struct Auto *self, struct Pc *pc)
 {
-  if (this->stackPointer <= this->framePointer + this->frameSize)
+  if (self->stackPointer <= self->framePointer + self->frameSize)
     {
       return 0;
     }
 
-  --this->stackPointer;
+  --self->stackPointer;
   if (pc)
     {
-      *pc = this->slot[this->stackPointer].retFrame.pc;
+      *pc = self->slot[self->stackPointer].retFrame.pc;
     }
 
   return 1;
 }
 
-void Auto_frameToError(struct Auto *this,
+void Auto_frameToError(struct Auto *self,
                        struct Program *program, struct Value *v)
 {
   struct Pc p;
   int framePointer;
   int frameSize;
   int retFrame;
-  int i = this->stackPointer;
+  int i = self->stackPointer;
 
-  framePointer = this->framePointer;
-  frameSize = this->frameSize;
+  framePointer = self->framePointer;
+  frameSize = self->frameSize;
   while (i > framePointer + frameSize)
     {
-      p = this->slot[--i].retFrame.pc;
+      p = self->slot[--i].retFrame.pc;
       Value_errorSuffix(v, _("Called"));
       Program_PCtoError(program, &p, v);
     }
@@ -224,28 +224,28 @@ void Auto_frameToError(struct Auto *this,
   if (i)
     {
       retFrame = framePointer + frameSize - 1;
-      p = this->slot[retFrame].retFrame.pc;
+      p = self->slot[retFrame].retFrame.pc;
       Value_errorSuffix(v, _("Proc Called"));
       Program_PCtoError(program, &p, v);
     }
 }
 
-void Auto_setError(struct Auto *this, long int line,
+void Auto_setError(struct Auto *self, long int line,
                    struct Pc *pc, struct Value *v)
 {
-  this->erpc = *pc;
-  this->erl = line;
-  Value_destroy(&this->err);
-  Value_clone(&this->err, v);
+  self->erpc = *pc;
+  self->erl = line;
+  Value_destroy(&self->err);
+  Value_clone(&self->err, v);
 }
 
 /* compilation methods */
 
-int Auto_find(struct Auto *this, struct Identifier *ident)
+int Auto_find(struct Auto *self, struct Identifier *ident)
 {
   struct Symbol *find;
 
-  for (find = this->cur; find != (struct Symbol *)0; find = find->next)
+  for (find = self->cur; find != (struct Symbol *)0; find = find->next)
     {
       const char *s = ident->name;
       const char *r = find->name;
@@ -266,12 +266,12 @@ int Auto_find(struct Auto *this, struct Identifier *ident)
   return 0;
 }
 
-int Auto_variable(struct Auto *this, const struct Identifier *ident)
+int Auto_variable(struct Auto *self, const struct Identifier *ident)
 {
   struct Symbol **tail;
   int offset;
 
-  for (offset = 0, tail = &this->cur;
+  for (offset = 0, tail = &self->cur;
        *tail != (struct Symbol *)0;
        tail = &(*tail)->next, ++offset)
     {
@@ -301,21 +301,21 @@ int Auto_variable(struct Auto *this, const struct Identifier *ident)
    */
 
   (*tail)->u.local.offset =
-    offset - (this->cur->u.local.type == V_VOID ? 1 : 0);
+    offset - (self->cur->u.local.type == V_VOID ? 1 : 0);
   return 1;
 }
 
-enum ValueType Auto_argType(const struct Auto *this, int l)
+enum ValueType Auto_argType(const struct Auto *self, int l)
 {
   struct Symbol *find;
   int offset;
 
-  if (this->cur->u.local.type == V_VOID)
+  if (self->cur->u.local.type == V_VOID)
     {
       ++l;
     }
 
-  for (offset = 0, find = this->cur; l != offset;
+  for (offset = 0, find = self->cur; l != offset;
        find = find->next, ++offset)
     {
       assert(find != (struct Symbol *)0);
@@ -325,11 +325,11 @@ enum ValueType Auto_argType(const struct Auto *this, int l)
   return find->u.local.type;
 }
 
-enum ValueType Auto_varType(const struct Auto *this, struct Symbol *sym)
+enum ValueType Auto_varType(const struct Auto *self, struct Symbol *sym)
 {
   struct Symbol *find;
 
-  for (find = this->cur;
+  for (find = self->cur;
        find->u.local.offset != sym->u.local.offset;
        find = find->next)
     {
@@ -340,11 +340,11 @@ enum ValueType Auto_varType(const struct Auto *this, struct Symbol *sym)
   return find->u.local.type;
 }
 
-void Auto_funcEnd(struct Auto *this)
+void Auto_funcEnd(struct Auto *self)
 {
   struct Symbol **tail;
 
-  for (tail = &this->all; *tail != NULL; tail = &(*tail)->next);
-  *tail = this->cur;
-  this->cur = (struct Symbol *)0;
+  for (tail = &self->all; *tail != NULL; tail = &(*tail)->next);
+  *tail = self->cur;
+  self->cur = (struct Symbol *)0;
 }

--- a/interpreters/bas/bas_auto.h
+++ b/interpreters/bas/bas_auto.h
@@ -80,21 +80,21 @@ union AutoSlot
  * Public Function Prototypes
  ****************************************************************************/
 
-struct Auto *Auto_new(struct Auto *this);
-void Auto_destroy(struct Auto *this);
-struct Var *Auto_pushArg(struct Auto *this);
-void Auto_pushFuncRet(struct Auto *this, int firstarg, struct Pc *pc);
-void Auto_pushGosubRet(struct Auto *this, struct Pc *pc);
-struct Var *Auto_local(struct Auto *this, int l);
-int Auto_funcReturn(struct Auto *this, struct Pc *pc);
-int Auto_gosubReturn(struct Auto *this, struct Pc *pc);
-void Auto_frameToError(struct Auto *this, struct Program *program, struct Value *v);
-void Auto_setError(struct Auto *this, long int line, struct Pc *pc, struct Value *v);
+struct Auto *Auto_new(struct Auto *self);
+void Auto_destroy(struct Auto *self);
+struct Var *Auto_pushArg(struct Auto *self);
+void Auto_pushFuncRet(struct Auto *self, int firstarg, struct Pc *pc);
+void Auto_pushGosubRet(struct Auto *self, struct Pc *pc);
+struct Var *Auto_local(struct Auto *self, int l);
+int Auto_funcReturn(struct Auto *self, struct Pc *pc);
+int Auto_gosubReturn(struct Auto *self, struct Pc *pc);
+void Auto_frameToError(struct Auto *self, struct Program *program, struct Value *v);
+void Auto_setError(struct Auto *self, long int line, struct Pc *pc, struct Value *v);
 
-int Auto_find(struct Auto *this, struct Identifier *ident);
-int Auto_variable(struct Auto *this, const struct Identifier *ident);
-enum ValueType Auto_argType(const struct Auto *this, int l);
-enum ValueType Auto_varType(const struct Auto *this, struct Symbol *sym);
-void Auto_funcEnd(struct Auto *this);
+int Auto_find(struct Auto *self, struct Identifier *ident);
+int Auto_variable(struct Auto *self, const struct Identifier *ident);
+enum ValueType Auto_argType(const struct Auto *self, int l);
+enum ValueType Auto_varType(const struct Auto *self, struct Symbol *sym);
+void Auto_funcEnd(struct Auto *self);
 
 #endif /* __APPS_EXAMPLES_BAS_BAS_AUTO_H */

--- a/interpreters/bas/bas_global.c
+++ b/interpreters/bas/bas_global.c
@@ -1995,7 +1995,7 @@ static unsigned int hash(const char *s)
   return h % GLOBAL_HASHSIZE;
 }
 
-static void builtin(struct Global *this,
+static void builtin(struct Global *self,
                     const char *ident, enum ValueType type,
                     struct Value *(*func) (struct Value * value,
                                            struct Auto * stack),
@@ -2006,7 +2006,7 @@ static void builtin(struct Global *this,
   int i;
   va_list ap;
 
-  for (r = &this->table[hash(ident)];
+  for (r = &self->table[hash(ident)];
        *r != (struct Symbol *)0 && cistrcmp((*r)->name, ident);
        r = &((*r)->next));
 
@@ -2046,192 +2046,192 @@ static void builtin(struct Global *this,
  * Public Functions
  ****************************************************************************/
 
-struct Global *Global_new(struct Global *this)
+struct Global *Global_new(struct Global *self)
 {
-  builtin(this, "abs", V_REAL, fn_abs, 1, (int)V_REAL);
-  builtin(this, "asc", V_INTEGER, fn_asc, 1, (int)V_STRING);
-  builtin(this, "atn", V_REAL, fn_atn, 1, (int)V_REAL);
-  builtin(this, "bin$", V_STRING, fn_bini, 1, (int)V_INTEGER);
-  builtin(this, "bin$", V_STRING, fn_bind, 1, (int)V_REAL);
-  builtin(this, "bin$", V_STRING, fn_binii, 2,
+  builtin(self, "abs", V_REAL, fn_abs, 1, (int)V_REAL);
+  builtin(self, "asc", V_INTEGER, fn_asc, 1, (int)V_STRING);
+  builtin(self, "atn", V_REAL, fn_atn, 1, (int)V_REAL);
+  builtin(self, "bin$", V_STRING, fn_bini, 1, (int)V_INTEGER);
+  builtin(self, "bin$", V_STRING, fn_bind, 1, (int)V_REAL);
+  builtin(self, "bin$", V_STRING, fn_binii, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "bin$", V_STRING, fn_bindi, 2, (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "bin$", V_STRING, fn_binid, 2, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "bin$", V_STRING, fn_bindd, 2, (int)V_REAL, (int)V_REAL);
-  builtin(this, "chr$", V_STRING, fn_chr, 1, (int)V_INTEGER);
-  builtin(this, "cint", V_REAL, fn_cint, 1, (int)V_REAL);
-  builtin(this, "code", V_INTEGER, fn_asc, 1, (int)V_STRING);
-  builtin(this, "command$", V_STRING, fn_command, 0);
-  builtin(this, "command$", V_STRING, fn_commandi, 1, (int)V_INTEGER);
-  builtin(this, "command$", V_STRING, fn_commandd, 1, (int)V_REAL);
-  builtin(this, "cos", V_REAL, fn_cos, 1, (int)V_REAL);
-  builtin(this, "cvi", V_INTEGER, fn_cvi, 1, (int)V_STRING);
-  builtin(this, "cvs", V_REAL, fn_cvs, 1, (int)V_STRING);
-  builtin(this, "cvd", V_REAL, fn_cvd, 1, (int)V_STRING);
-  builtin(this, "date$", V_STRING, fn_date, 0);
-  builtin(this, "dec$", V_STRING, fn_dec, 2, (int)V_REAL, (int)V_STRING);
-  builtin(this, "dec$", V_STRING, fn_dec, 2, (int)V_INTEGER, (int)V_STRING);
-  builtin(this, "dec$", V_STRING, fn_dec, 2, (int)V_STRING, (int)V_STRING);
-  builtin(this, "deg", V_REAL, fn_deg, 1, (int)V_REAL);
-  builtin(this, "det", V_REAL, fn_det, 0);
-  builtin(this, "edit$", V_STRING, fn_edit, 2,
+  builtin(self, "bin$", V_STRING, fn_bindi, 2, (int)V_REAL, (int)V_INTEGER);
+  builtin(self, "bin$", V_STRING, fn_binid, 2, (int)V_INTEGER, (int)V_REAL);
+  builtin(self, "bin$", V_STRING, fn_bindd, 2, (int)V_REAL, (int)V_REAL);
+  builtin(self, "chr$", V_STRING, fn_chr, 1, (int)V_INTEGER);
+  builtin(self, "cint", V_REAL, fn_cint, 1, (int)V_REAL);
+  builtin(self, "code", V_INTEGER, fn_asc, 1, (int)V_STRING);
+  builtin(self, "command$", V_STRING, fn_command, 0);
+  builtin(self, "command$", V_STRING, fn_commandi, 1, (int)V_INTEGER);
+  builtin(self, "command$", V_STRING, fn_commandd, 1, (int)V_REAL);
+  builtin(self, "cos", V_REAL, fn_cos, 1, (int)V_REAL);
+  builtin(self, "cvi", V_INTEGER, fn_cvi, 1, (int)V_STRING);
+  builtin(self, "cvs", V_REAL, fn_cvs, 1, (int)V_STRING);
+  builtin(self, "cvd", V_REAL, fn_cvd, 1, (int)V_STRING);
+  builtin(self, "date$", V_STRING, fn_date, 0);
+  builtin(self, "dec$", V_STRING, fn_dec, 2, (int)V_REAL, (int)V_STRING);
+  builtin(self, "dec$", V_STRING, fn_dec, 2, (int)V_INTEGER, (int)V_STRING);
+  builtin(self, "dec$", V_STRING, fn_dec, 2, (int)V_STRING, (int)V_STRING);
+  builtin(self, "deg", V_REAL, fn_deg, 1, (int)V_REAL);
+  builtin(self, "det", V_REAL, fn_det, 0);
+  builtin(self, "edit$", V_STRING, fn_edit, 2,
           (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "environ$", V_STRING, fn_environi, 1, (int)V_INTEGER);
-  builtin(this, "environ$", V_STRING, fn_environd, 1, (int)V_REAL);
-  builtin(this, "environ$", V_STRING, fn_environs, 1, (int)V_STRING);
-  builtin(this, "eof", V_INTEGER, fn_eof, 1, (int)V_INTEGER);
-  builtin(this, "erl", V_INTEGER, fn_erl, 0);
-  builtin(this, "err", V_INTEGER, fn_err, 0);
-  builtin(this, "exp", V_REAL, fn_exp, 1, (int)V_REAL);
-  builtin(this, "false", V_INTEGER, fn_false, 0);
-  builtin(this, "find$", V_STRING, fn_find, 1, (int)V_STRING);
-  builtin(this, "find$", V_STRING, fn_findi, 2,
+  builtin(self, "environ$", V_STRING, fn_environi, 1, (int)V_INTEGER);
+  builtin(self, "environ$", V_STRING, fn_environd, 1, (int)V_REAL);
+  builtin(self, "environ$", V_STRING, fn_environs, 1, (int)V_STRING);
+  builtin(self, "eof", V_INTEGER, fn_eof, 1, (int)V_INTEGER);
+  builtin(self, "erl", V_INTEGER, fn_erl, 0);
+  builtin(self, "err", V_INTEGER, fn_err, 0);
+  builtin(self, "exp", V_REAL, fn_exp, 1, (int)V_REAL);
+  builtin(self, "false", V_INTEGER, fn_false, 0);
+  builtin(self, "find$", V_STRING, fn_find, 1, (int)V_STRING);
+  builtin(self, "find$", V_STRING, fn_findi, 2,
           (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "find$", V_STRING, fn_findd, 2, (int)V_STRING, (int)V_REAL);
-  builtin(this, "fix", V_REAL, fn_fix, 1, (int)V_REAL);
-  builtin(this, "frac", V_REAL, fn_frac, 1, (int)V_REAL);
-  builtin(this, "freefile", V_INTEGER, fn_freefile, 0);
-  builtin(this, "fp", V_REAL, fn_frac, 1, (int)V_REAL);
-  builtin(this, "hex$", V_STRING, fn_hexi, 1, (int)V_INTEGER);
-  builtin(this, "hex$", V_STRING, fn_hexd, 1, (int)V_REAL);
-  builtin(this, "hex$", V_STRING, fn_hexii, 2,
+  builtin(self, "find$", V_STRING, fn_findd, 2, (int)V_STRING, (int)V_REAL);
+  builtin(self, "fix", V_REAL, fn_fix, 1, (int)V_REAL);
+  builtin(self, "frac", V_REAL, fn_frac, 1, (int)V_REAL);
+  builtin(self, "freefile", V_INTEGER, fn_freefile, 0);
+  builtin(self, "fp", V_REAL, fn_frac, 1, (int)V_REAL);
+  builtin(self, "hex$", V_STRING, fn_hexi, 1, (int)V_INTEGER);
+  builtin(self, "hex$", V_STRING, fn_hexd, 1, (int)V_REAL);
+  builtin(self, "hex$", V_STRING, fn_hexii, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "hex$", V_STRING, fn_hexdi, 2, (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "hex$", V_STRING, fn_hexid, 2, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "hex$", V_STRING, fn_hexdd, 2, (int)V_REAL, (int)V_REAL);
-  builtin(this, "inkey$", V_STRING, fn_inkey, 0);
-  builtin(this, "inkey$", V_STRING, fn_inkeyi, 1, (int)V_INTEGER);
-  builtin(this, "inkey$", V_STRING, fn_inkeyd, 1, (int)V_REAL);
-  builtin(this, "inkey$", V_STRING, fn_inkeyii, 2,
+  builtin(self, "hex$", V_STRING, fn_hexdi, 2, (int)V_REAL, (int)V_INTEGER);
+  builtin(self, "hex$", V_STRING, fn_hexid, 2, (int)V_INTEGER, (int)V_REAL);
+  builtin(self, "hex$", V_STRING, fn_hexdd, 2, (int)V_REAL, (int)V_REAL);
+  builtin(self, "inkey$", V_STRING, fn_inkey, 0);
+  builtin(self, "inkey$", V_STRING, fn_inkeyi, 1, (int)V_INTEGER);
+  builtin(self, "inkey$", V_STRING, fn_inkeyd, 1, (int)V_REAL);
+  builtin(self, "inkey$", V_STRING, fn_inkeyii, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "inkey$", V_STRING, fn_inkeyid, 2,
+  builtin(self, "inkey$", V_STRING, fn_inkeyid, 2,
           (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "inkey$", V_STRING, fn_inkeydi, 2,
+  builtin(self, "inkey$", V_STRING, fn_inkeydi, 2,
           (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "inkey$", V_STRING, fn_inkeydd, 2,
+  builtin(self, "inkey$", V_STRING, fn_inkeydd, 2,
           (int)V_REAL, (int)V_REAL);
-  builtin(this, "inp", V_INTEGER, fn_inp, 1, (int)V_INTEGER);
-  builtin(this, "input$", V_STRING, fn_input1, 1, (int)V_INTEGER);
-  builtin(this, "input$", V_STRING, fn_input2, 2,
+  builtin(self, "inp", V_INTEGER, fn_inp, 1, (int)V_INTEGER);
+  builtin(self, "input$", V_STRING, fn_input1, 1, (int)V_INTEGER);
+  builtin(self, "input$", V_STRING, fn_input2, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "instr", V_INTEGER, fn_instr2, 2,
+  builtin(self, "instr", V_INTEGER, fn_instr2, 2,
           (int)V_STRING, (int)V_STRING);
-  builtin(this, "instr", V_INTEGER, fn_instr3iss, 3,
+  builtin(self, "instr", V_INTEGER, fn_instr3iss, 3,
           (int)V_INTEGER, (int)V_STRING, (int)V_STRING);
-  builtin(this, "instr", V_INTEGER, fn_instr3ssi, 3,
+  builtin(self, "instr", V_INTEGER, fn_instr3ssi, 3,
           (int)V_STRING, (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "instr", V_INTEGER, fn_instr3dss, 3,
+  builtin(self, "instr", V_INTEGER, fn_instr3dss, 3,
           (int)V_REAL, (int)V_STRING, (int)V_STRING);
-  builtin(this, "instr", V_INTEGER, fn_instr3ssd, 3,
+  builtin(self, "instr", V_INTEGER, fn_instr3ssd, 3,
           (int)V_STRING, (int)V_STRING, (int)V_REAL);
-  builtin(this, "instr", V_INTEGER, fn_instr4ii, 4,
+  builtin(self, "instr", V_INTEGER, fn_instr4ii, 4,
           (int)V_STRING, (int)V_STRING, (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "instr", V_INTEGER, fn_instr4id, 4,
+  builtin(self, "instr", V_INTEGER, fn_instr4id, 4,
           (int)V_STRING, (int)V_STRING, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "instr", V_INTEGER, fn_instr4di, 4,
+  builtin(self, "instr", V_INTEGER, fn_instr4di, 4,
           (int)V_STRING, (int)V_STRING, (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "instr", V_INTEGER, fn_instr4dd, 4,
+  builtin(self, "instr", V_INTEGER, fn_instr4dd, 4,
           (int)V_STRING, (int)V_STRING, (int)V_REAL, (int)V_REAL);
-  builtin(this, "int", V_REAL, fn_int, 1, (int)V_REAL);
-  builtin(this, "int%", V_INTEGER, fn_intp, 1, (int)V_REAL);
-  builtin(this, "ip", V_REAL, fn_fix, 1, (int)V_REAL);
-  builtin(this, "lcase$", V_STRING, fn_lcase, 1, (int)V_STRING);
-  builtin(this, "lower$", V_STRING, fn_lcase, 1, (int)V_STRING);
-  builtin(this, "left$", V_STRING, fn_left, 2,
+  builtin(self, "int", V_REAL, fn_int, 1, (int)V_REAL);
+  builtin(self, "int%", V_INTEGER, fn_intp, 1, (int)V_REAL);
+  builtin(self, "ip", V_REAL, fn_fix, 1, (int)V_REAL);
+  builtin(self, "lcase$", V_STRING, fn_lcase, 1, (int)V_STRING);
+  builtin(self, "lower$", V_STRING, fn_lcase, 1, (int)V_STRING);
+  builtin(self, "left$", V_STRING, fn_left, 2,
           (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "len", V_INTEGER, fn_len, 1, (int)V_STRING);
-  builtin(this, "loc", V_INTEGER, fn_loc, 1, (int)V_INTEGER);
-  builtin(this, "lof", V_INTEGER, fn_lof, 1, (int)V_INTEGER);
-  builtin(this, "log", V_REAL, fn_log, 1, (int)V_REAL);
-  builtin(this, "log10", V_REAL, fn_log10, 1, (int)V_REAL);
-  builtin(this, "log2", V_REAL, fn_log2, 1, (int)V_REAL);
-  builtin(this, "ltrim$", V_STRING, fn_ltrim, 1, (int)V_STRING);
-  builtin(this, "match", V_INTEGER, fn_match, 3,
+  builtin(self, "len", V_INTEGER, fn_len, 1, (int)V_STRING);
+  builtin(self, "loc", V_INTEGER, fn_loc, 1, (int)V_INTEGER);
+  builtin(self, "lof", V_INTEGER, fn_lof, 1, (int)V_INTEGER);
+  builtin(self, "log", V_REAL, fn_log, 1, (int)V_REAL);
+  builtin(self, "log10", V_REAL, fn_log10, 1, (int)V_REAL);
+  builtin(self, "log2", V_REAL, fn_log2, 1, (int)V_REAL);
+  builtin(self, "ltrim$", V_STRING, fn_ltrim, 1, (int)V_STRING);
+  builtin(self, "match", V_INTEGER, fn_match, 3,
           (int)V_STRING, (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "max", V_INTEGER, fn_maxii, 2,
+  builtin(self, "max", V_INTEGER, fn_maxii, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "max", V_REAL, fn_maxdi, 2, (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "max", V_REAL, fn_maxid, 2, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "max", V_REAL, fn_maxdd, 2, (int)V_REAL, (int)V_REAL);
-  builtin(this, "mid$", V_STRING, fn_mid2i, 2,
+  builtin(self, "max", V_REAL, fn_maxdi, 2, (int)V_REAL, (int)V_INTEGER);
+  builtin(self, "max", V_REAL, fn_maxid, 2, (int)V_INTEGER, (int)V_REAL);
+  builtin(self, "max", V_REAL, fn_maxdd, 2, (int)V_REAL, (int)V_REAL);
+  builtin(self, "mid$", V_STRING, fn_mid2i, 2,
           (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "mid$", V_STRING, fn_mid2d, 2, (int)V_STRING, (int)V_REAL);
-  builtin(this, "mid$", V_STRING, fn_mid3ii, 3,
+  builtin(self, "mid$", V_STRING, fn_mid2d, 2, (int)V_STRING, (int)V_REAL);
+  builtin(self, "mid$", V_STRING, fn_mid3ii, 3,
           (int)V_STRING, (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "mid$", V_STRING, fn_mid3id, 3,
+  builtin(self, "mid$", V_STRING, fn_mid3id, 3,
           (int)V_STRING, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "mid$", V_STRING, fn_mid3di, 3,
+  builtin(self, "mid$", V_STRING, fn_mid3di, 3,
           (int)V_STRING, (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "mid$", V_STRING, fn_mid3dd, 3,
+  builtin(self, "mid$", V_STRING, fn_mid3dd, 3,
           (int)V_STRING, (int)V_REAL, (int)V_REAL);
-  builtin(this, "min", V_INTEGER, fn_minii, 2,
+  builtin(self, "min", V_INTEGER, fn_minii, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "min", V_REAL, fn_mindi, 2, (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "min", V_REAL, fn_minid, 2, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "min", V_REAL, fn_mindd, 2, (int)V_REAL, (int)V_REAL);
-  builtin(this, "mki$", V_STRING, fn_mki, 1, (int)V_INTEGER);
-  builtin(this, "mks$", V_STRING, fn_mks, 1, (int)V_REAL);
-  builtin(this, "mkd$", V_STRING, fn_mkd, 1, (int)V_REAL);
-  builtin(this, "oct$", V_STRING, fn_oct, 1, (int)V_INTEGER);
-  builtin(this, "peek", V_INTEGER, fn_peek, 1, (int)V_INTEGER);
-  builtin(this, "pi", V_REAL, fn_pi, 0);
-  builtin(this, "pos", V_INTEGER, fn_pos, 1, (int)V_INTEGER);
-  builtin(this, "pos", V_INTEGER, fn_pos, 1, (int)V_REAL);
-  builtin(this, "pos", V_INTEGER, fn_instr3ssi, 3,
+  builtin(self, "min", V_REAL, fn_mindi, 2, (int)V_REAL, (int)V_INTEGER);
+  builtin(self, "min", V_REAL, fn_minid, 2, (int)V_INTEGER, (int)V_REAL);
+  builtin(self, "min", V_REAL, fn_mindd, 2, (int)V_REAL, (int)V_REAL);
+  builtin(self, "mki$", V_STRING, fn_mki, 1, (int)V_INTEGER);
+  builtin(self, "mks$", V_STRING, fn_mks, 1, (int)V_REAL);
+  builtin(self, "mkd$", V_STRING, fn_mkd, 1, (int)V_REAL);
+  builtin(self, "oct$", V_STRING, fn_oct, 1, (int)V_INTEGER);
+  builtin(self, "peek", V_INTEGER, fn_peek, 1, (int)V_INTEGER);
+  builtin(self, "pi", V_REAL, fn_pi, 0);
+  builtin(self, "pos", V_INTEGER, fn_pos, 1, (int)V_INTEGER);
+  builtin(self, "pos", V_INTEGER, fn_pos, 1, (int)V_REAL);
+  builtin(self, "pos", V_INTEGER, fn_instr3ssi, 3,
           (int)V_STRING, (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "pos", V_INTEGER, fn_instr3ssd, 3,
+  builtin(self, "pos", V_INTEGER, fn_instr3ssd, 3,
           (int)V_STRING, (int)V_STRING, (int)V_REAL);
-  builtin(this, "rad", V_REAL, fn_rad, 1, (int)V_REAL);
-  builtin(this, "right$", V_STRING, fn_right, 2,
+  builtin(self, "rad", V_REAL, fn_rad, 1, (int)V_REAL);
+  builtin(self, "right$", V_STRING, fn_right, 2,
           (int)V_STRING, (int)V_INTEGER);
-  builtin(this, "rnd", V_INTEGER, fn_rnd, 0);
-  builtin(this, "rnd", V_INTEGER, fn_rndd, 1, (int)V_REAL);
-  builtin(this, "rnd", V_INTEGER, fn_rndi, 1, (int)V_INTEGER);
-  builtin(this, "rtrim$", V_STRING, fn_rtrim, 1, (int)V_STRING);
-  builtin(this, "seg$", V_STRING, fn_mid3ii, 3,
+  builtin(self, "rnd", V_INTEGER, fn_rnd, 0);
+  builtin(self, "rnd", V_INTEGER, fn_rndd, 1, (int)V_REAL);
+  builtin(self, "rnd", V_INTEGER, fn_rndi, 1, (int)V_INTEGER);
+  builtin(self, "rtrim$", V_STRING, fn_rtrim, 1, (int)V_STRING);
+  builtin(self, "seg$", V_STRING, fn_mid3ii, 3,
           (int)V_STRING, (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "seg$", V_STRING, fn_mid3id, 3,
+  builtin(self, "seg$", V_STRING, fn_mid3id, 3,
           (int)V_STRING, (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "seg$", V_STRING, fn_mid3di, 3, (int)V_STRING, (int)V_REAL,
+  builtin(self, "seg$", V_STRING, fn_mid3di, 3, (int)V_STRING, (int)V_REAL,
           (int)V_INTEGER);
-  builtin(this, "seg$", V_STRING, fn_mid3dd, 3, (int)V_STRING, (int)V_REAL,
+  builtin(self, "seg$", V_STRING, fn_mid3dd, 3, (int)V_STRING, (int)V_REAL,
           (int)V_REAL);
-  builtin(this, "sgn", V_INTEGER, fn_sgn, 1, (int)V_REAL);
-  builtin(this, "sin", V_REAL, fn_sin, 1, (int)V_REAL);
-  builtin(this, "space$", V_STRING, fn_space, 1, (int)V_INTEGER);
-  builtin(this, "sqr", V_REAL, fn_sqr, 1, (int)V_REAL);
-  builtin(this, "str$", V_STRING, fn_str, 1, (int)V_REAL);
-  builtin(this, "str$", V_STRING, fn_str, 1, (int)V_INTEGER);
-  builtin(this, "string$", V_STRING, fn_stringii, 2,
+  builtin(self, "sgn", V_INTEGER, fn_sgn, 1, (int)V_REAL);
+  builtin(self, "sin", V_REAL, fn_sin, 1, (int)V_REAL);
+  builtin(self, "space$", V_STRING, fn_space, 1, (int)V_INTEGER);
+  builtin(self, "sqr", V_REAL, fn_sqr, 1, (int)V_REAL);
+  builtin(self, "str$", V_STRING, fn_str, 1, (int)V_REAL);
+  builtin(self, "str$", V_STRING, fn_str, 1, (int)V_INTEGER);
+  builtin(self, "string$", V_STRING, fn_stringii, 2,
           (int)V_INTEGER, (int)V_INTEGER);
-  builtin(this, "string$", V_STRING, fn_stringid, 2,
+  builtin(self, "string$", V_STRING, fn_stringid, 2,
           (int)V_INTEGER, (int)V_REAL);
-  builtin(this, "string$", V_STRING, fn_stringdi, 2,
+  builtin(self, "string$", V_STRING, fn_stringdi, 2,
           (int)V_REAL, (int)V_INTEGER);
-  builtin(this, "string$", V_STRING, fn_stringdd, 2,
+  builtin(self, "string$", V_STRING, fn_stringdd, 2,
           (int)V_REAL, (int)V_REAL);
-  builtin(this, "string$", V_STRING, fn_stringis, 2,
+  builtin(self, "string$", V_STRING, fn_stringis, 2,
           (int)V_INTEGER, (int)V_STRING);
-  builtin(this, "string$", V_STRING, fn_stringds, 2,
+  builtin(self, "string$", V_STRING, fn_stringds, 2,
           (int)V_REAL, (int)V_STRING);
-  builtin(this, "strip$", V_STRING, fn_strip, 1, (int)V_STRING);
-  builtin(this, "tan", V_REAL, fn_tan, 1, (int)V_REAL);
-  builtin(this, "time", V_INTEGER, fn_timei, 0);
-  builtin(this, "time$", V_STRING, fn_times, 0);
-  builtin(this, "timer", V_REAL, fn_timer, 0);
-  builtin(this, "tl$", V_STRING, fn_tl, 1, (int)V_STRING);
-  builtin(this, "true", V_INTEGER, fn_true, 0);
-  builtin(this, "ucase$", V_STRING, fn_ucase, 1, (int)V_STRING);
-  builtin(this, "upper$", V_STRING, fn_ucase, 1, (int)V_STRING);
-  builtin(this, "val", V_REAL, fn_val, 1, (int)V_STRING);
-  return this;
+  builtin(self, "strip$", V_STRING, fn_strip, 1, (int)V_STRING);
+  builtin(self, "tan", V_REAL, fn_tan, 1, (int)V_REAL);
+  builtin(self, "time", V_INTEGER, fn_timei, 0);
+  builtin(self, "time$", V_STRING, fn_times, 0);
+  builtin(self, "timer", V_REAL, fn_timer, 0);
+  builtin(self, "tl$", V_STRING, fn_tl, 1, (int)V_STRING);
+  builtin(self, "true", V_INTEGER, fn_true, 0);
+  builtin(self, "ucase$", V_STRING, fn_ucase, 1, (int)V_STRING);
+  builtin(self, "upper$", V_STRING, fn_ucase, 1, (int)V_STRING);
+  builtin(self, "val", V_REAL, fn_val, 1, (int)V_STRING);
+  return self;
 }
 
-int Global_find(struct Global *this, struct Identifier *ident, int oparen)
+int Global_find(struct Global *self, struct Identifier *ident, int oparen)
 {
   struct Symbol **r;
 
-  for (r = &this->table[hash(ident->name)];
+  for (r = &self->table[hash(ident->name)];
        *r != (struct Symbol *)0 &&
        ((((*r)->type == GLOBALVAR && oparen) ||
          ((*r)->type == GLOBALARRAY && !oparen)) ||
@@ -2246,13 +2246,13 @@ int Global_find(struct Global *this, struct Identifier *ident, int oparen)
   return 1;
 }
 
-int Global_variable(struct Global *this, struct Identifier *ident,
+int Global_variable(struct Global *self, struct Identifier *ident,
                     enum ValueType type, enum SymbolType symbolType,
                     int redeclare)
 {
   struct Symbol **r;
 
-  for (r = &this->table[hash(ident->name)];
+  for (r = &self->table[hash(ident->name)];
        *r != (struct Symbol *)0 && ((*r)->type != symbolType ||
                                     cistrcmp((*r)->name, ident->name));
        r = &((*r)->next));
@@ -2296,13 +2296,13 @@ int Global_variable(struct Global *this, struct Identifier *ident,
   return 1;
 }
 
-int Global_function(struct Global *this, struct Identifier *ident,
+int Global_function(struct Global *self, struct Identifier *ident,
                     enum ValueType type, struct Pc *deffn, struct Pc *begin,
                     int argLength, enum ValueType *argTypes)
 {
   struct Symbol **r;
 
-  for (r = &this->table[hash(ident->name)];
+  for (r = &self->table[hash(ident->name)];
        *r != (struct Symbol *)0 && cistrcmp((*r)->name, ident->name);
        r = &((*r)->next));
 
@@ -2326,12 +2326,12 @@ int Global_function(struct Global *this, struct Identifier *ident,
   return 1;
 }
 
-void Global_endfunction(struct Global *this, struct Identifier *ident,
+void Global_endfunction(struct Global *self, struct Identifier *ident,
                         struct Pc *end)
 {
   struct Symbol **r;
 
-  for (r = &this->table[hash(ident->name)];
+  for (r = &self->table[hash(ident->name)];
        *r != (struct Symbol *)0 && cistrcmp((*r)->name, ident->name);
        r = &((*r)->next));
 
@@ -2339,7 +2339,7 @@ void Global_endfunction(struct Global *this, struct Identifier *ident,
   (*r)->u.sub.u.def.scope.end = *end;
 }
 
-void Global_clear(struct Global *this)
+void Global_clear(struct Global *self)
 {
   int i;
 
@@ -2347,7 +2347,7 @@ void Global_clear(struct Global *this)
     {
       struct Symbol *v;
 
-      for (v = this->table[i]; v; v = v->next)
+      for (v = self->table[i]; v; v = v->next)
         {
           if (v->type == GLOBALVAR || v->type == GLOBALARRAY)
             {
@@ -2357,13 +2357,13 @@ void Global_clear(struct Global *this)
     }
 }
 
-void Global_clearFunctions(struct Global *this)
+void Global_clearFunctions(struct Global *self)
 {
   int i;
 
   for (i = 0; i < GLOBAL_HASHSIZE; ++i)
     {
-      struct Symbol **v = &this->table[i], *w;
+      struct Symbol **v = &self->table[i], *w;
       struct Symbol *sym;
 
       while (*v)
@@ -2394,13 +2394,13 @@ void Global_clearFunctions(struct Global *this)
     }
 }
 
-void Global_destroy(struct Global *this)
+void Global_destroy(struct Global *self)
 {
   int i;
 
   for (i = 0; i < GLOBAL_HASHSIZE; ++i)
     {
-      struct Symbol *v = this->table[i], *w;
+      struct Symbol *v = self->table[i], *w;
       struct Symbol *sym;
 
       while (v)
@@ -2466,6 +2466,6 @@ void Global_destroy(struct Global *this)
           v = w;
         }
 
-      this->table[i] = (struct Symbol *)0;
+      self->table[i] = (struct Symbol *)0;
     }
 }

--- a/interpreters/bas/bas_global.h
+++ b/interpreters/bas/bas_global.h
@@ -61,17 +61,17 @@ struct Global
  * Public Function Prototypes
  ****************************************************************************/
 
-struct Global *Global_new(struct Global *this);
-void Global_destroy(struct Global *this);
-void Global_clear(struct Global *this);
-void Global_clearFunctions(struct Global *this);
-int Global_find(struct Global *this, struct Identifier *ident, int oparen);
-int Global_function(struct Global *this, struct Identifier *ident,
+struct Global *Global_new(struct Global *self);
+void Global_destroy(struct Global *self);
+void Global_clear(struct Global *self);
+void Global_clearFunctions(struct Global *self);
+int Global_find(struct Global *self, struct Identifier *ident, int oparen);
+int Global_function(struct Global *self, struct Identifier *ident,
                     enum ValueType type, struct Pc *deffn, struct Pc *begin,
                     int argTypesLength, enum ValueType *argTypes);
-void Global_endfunction(struct Global *this, struct Identifier *ident,
+void Global_endfunction(struct Global *self, struct Identifier *ident,
                         struct Pc *end);
-int Global_variable(struct Global *this, struct Identifier *ident,
+int Global_variable(struct Global *self, struct Identifier *ident,
                     enum ValueType type, enum SymbolType symbolType,
                     int redeclare);
 

--- a/interpreters/bas/bas_program.c
+++ b/interpreters/bas/bas_program.c
@@ -214,153 +214,153 @@ static void printName(const void *k, struct Program *p, int chn)
  * Public Functions
  ****************************************************************************/
 
-struct Program *Program_new(struct Program *this)
+struct Program *Program_new(struct Program *self)
 {
-  this->trace = 0;
-  this->size = 0;
-  this->numbered = 1;
-  this->capacity = 0;
-  this->runnable = 0;
-  this->unsaved = 0;
-  this->code = (struct Token **)0;
-  this->scope = (struct Scope *)0;
-  String_new(&this->name);
-  return this;
+  self->trace = 0;
+  self->size = 0;
+  self->numbered = 1;
+  self->capacity = 0;
+  self->runnable = 0;
+  self->unsaved = 0;
+  self->code = (struct Token **)0;
+  self->scope = (struct Scope *)0;
+  String_new(&self->name);
+  return self;
 }
 
-void Program_destroy(struct Program *this)
+void Program_destroy(struct Program *self)
 {
-  while (this->size)
+  while (self->size)
     {
-      Token_destroy(this->code[--this->size]);
+      Token_destroy(self->code[--self->size]);
     }
 
-  if (this->capacity)
+  if (self->capacity)
     {
-      free(this->code);
+      free(self->code);
     }
 
-  this->code = (struct Token **)0;
-  this->scope = (struct Scope *)0;
-  String_destroy(&this->name);
+  self->code = (struct Token **)0;
+  self->scope = (struct Scope *)0;
+  String_destroy(&self->name);
 }
 
-void Program_norun(struct Program *this)
+void Program_norun(struct Program *self)
 {
-  this->runnable = 0;
-  this->scope = (struct Scope *)0;
+  self->runnable = 0;
+  self->scope = (struct Scope *)0;
 }
 
-void Program_store(struct Program *this, struct Token *line, long int where)
+void Program_store(struct Program *self, struct Token *line, long int where)
 {
   int i;
 
   assert(line->type == T_INTEGER || line->type == T_UNNUMBERED);
-  this->runnable = 0;
-  this->unsaved = 1;
+  self->runnable = 0;
+  self->unsaved = 1;
   if (line->type == T_UNNUMBERED)
     {
-      this->numbered = 0;
+      self->numbered = 0;
     }
 
   if (where)
     {
       int last = -1;
 
-      for (i = 0; i < this->size; ++i)
+      for (i = 0; i < self->size; ++i)
         {
-          assert(this->code[i]->type == T_INTEGER ||
-                 this->code[i]->type == T_UNNUMBERED);
-          if (where > last && where < this->code[i]->u.integer)
+          assert(self->code[i]->type == T_INTEGER ||
+                 self->code[i]->type == T_UNNUMBERED);
+          if (where > last && where < self->code[i]->u.integer)
             {
-              if ((this->size + 1) >= this->capacity)
+              if ((self->size + 1) >= self->capacity)
                 {
-                  this->code =
-                    realloc(this->code,
+                  self->code =
+                    realloc(self->code,
                             sizeof(struct Token *) *
-                            (this->capacity ? (this->capacity *=
-                                               2) : (this->capacity = 256)));
+                            (self->capacity ? (self->capacity *=
+                                               2) : (self->capacity = 256)));
                 }
 
-              memmove(&this->code[i + 1], &this->code[i],
-                      (this->size - i) * sizeof(struct Token *));
-              this->code[i] = line;
-              ++this->size;
+              memmove(&self->code[i + 1], &self->code[i],
+                      (self->size - i) * sizeof(struct Token *));
+              self->code[i] = line;
+              ++self->size;
               return;
             }
-          else if (where == this->code[i]->u.integer)
+          else if (where == self->code[i]->u.integer)
             {
-              Token_destroy(this->code[i]);
-              this->code[i] = line;
+              Token_destroy(self->code[i]);
+              self->code[i] = line;
               return;
             }
 
-          last = this->code[i]->u.integer;
+          last = self->code[i]->u.integer;
         }
     }
   else
     {
-      i = this->size;
+      i = self->size;
     }
 
-  if ((this->size + 1) >= this->capacity)
+  if ((self->size + 1) >= self->capacity)
     {
-      this->code =
-        realloc(this->code,
+      self->code =
+        realloc(self->code,
                 sizeof(struct Token *) *
-                (this->capacity ? (this->capacity *= 2)
-                 : (this->capacity = 256)));
+                (self->capacity ? (self->capacity *= 2)
+                 : (self->capacity = 256)));
     }
 
-  this->code[i] = line;
-  ++this->size;
+  self->code[i] = line;
+  ++self->size;
 }
 
-void Program_delete(struct Program *this, const struct Pc *from,
+void Program_delete(struct Program *self, const struct Pc *from,
                     const struct Pc *to)
 {
   int i;
   int first;
   int last;
 
-  this->runnable = 0;
-  this->unsaved = 1;
+  self->runnable = 0;
+  self->unsaved = 1;
   first = from ? from->line : 0;
-  last = to ? to->line : this->size - 1;
+  last = to ? to->line : self->size - 1;
   for (i = first; i <= last; ++i)
     {
-      Token_destroy(this->code[i]);
+      Token_destroy(self->code[i]);
     }
 
-  if ((last + 1) != this->size)
+  if ((last + 1) != self->size)
     {
-      memmove(&this->code[first], &this->code[last + 1],
-              (this->size - last + 1) * sizeof(struct Token *));
+      memmove(&self->code[first], &self->code[last + 1],
+              (self->size - last + 1) * sizeof(struct Token *));
     }
 
-  this->size -= (last - first + 1);
+  self->size -= (last - first + 1);
 }
 
-void Program_addScope(struct Program *this, struct Scope *scope)
+void Program_addScope(struct Program *self, struct Scope *scope)
 {
   struct Scope *s;
 
-  s = this->scope;
-  this->scope = scope;
+  s = self->scope;
+  self->scope = scope;
   scope->next = s;
 }
 
-struct Pc *Program_goLine(struct Program *this, long int line, struct Pc *pc)
+struct Pc *Program_goLine(struct Program *self, long int line, struct Pc *pc)
 {
   int i;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      if (this->code[i]->type == T_INTEGER &&
-          line == this->code[i]->u.integer)
+      if (self->code[i]->type == T_INTEGER &&
+          line == self->code[i]->u.integer)
         {
           pc->line = i;
-          pc->token = this->code[i] + 1;
+          pc->token = self->code[i] + 1;
           return pc;
         }
     }
@@ -368,18 +368,18 @@ struct Pc *Program_goLine(struct Program *this, long int line, struct Pc *pc)
   return (struct Pc *)0;
 }
 
-struct Pc *Program_fromLine(struct Program *this, long int line,
+struct Pc *Program_fromLine(struct Program *self, long int line,
                             struct Pc *pc)
 {
   int i;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      if (this->code[i]->type == T_INTEGER &&
-          this->code[i]->u.integer >= line)
+      if (self->code[i]->type == T_INTEGER &&
+          self->code[i]->u.integer >= line)
         {
           pc->line = i;
-          pc->token = this->code[i] + 1;
+          pc->token = self->code[i] + 1;
           return pc;
         }
     }
@@ -387,17 +387,17 @@ struct Pc *Program_fromLine(struct Program *this, long int line,
   return (struct Pc *)0;
 }
 
-struct Pc *Program_toLine(struct Program *this, long int line, struct Pc *pc)
+struct Pc *Program_toLine(struct Program *self, long int line, struct Pc *pc)
 {
   int i;
 
-  for (i = this->size - 1; i >= 0; --i)
+  for (i = self->size - 1; i >= 0; --i)
     {
-      if (this->code[i]->type == T_INTEGER &&
-          this->code[i]->u.integer <= line)
+      if (self->code[i]->type == T_INTEGER &&
+          self->code[i]->u.integer <= line)
         {
           pc->line = i;
-          pc->token = this->code[i] + 1;
+          pc->token = self->code[i] + 1;
           return pc;
         }
     }
@@ -405,13 +405,13 @@ struct Pc *Program_toLine(struct Program *this, long int line, struct Pc *pc)
   return (struct Pc *)0;
 }
 
-int Program_scopeCheck(struct Program *this, struct Pc *pc, struct Pc *fn)
+int Program_scopeCheck(struct Program *self, struct Pc *pc, struct Pc *fn)
 {
   struct Scope *scope;
 
   if (fn == (struct Pc *)0)     /* jump from global block must go to global pc */
     {
-      for (scope = this->scope; scope; scope = scope->next)
+      for (scope = self->scope; scope; scope = scope->next)
         {
           if (pc->line < scope->begin.line)
             {
@@ -467,10 +467,10 @@ int Program_scopeCheck(struct Program *this, struct Pc *pc, struct Pc *fn)
   return 0;
 }
 
-struct Pc *Program_dataLine(struct Program *this, long int line,
+struct Pc *Program_dataLine(struct Program *self, long int line,
                             struct Pc *pc)
 {
-  if ((pc = Program_goLine(this, line, pc)) == (struct Pc *)0)
+  if ((pc = Program_goLine(self, line, pc)) == (struct Pc *)0)
     {
       return (struct Pc *)0;
     }
@@ -490,10 +490,10 @@ struct Pc *Program_dataLine(struct Program *this, long int line,
   return pc;
 }
 
-struct Pc *Program_imageLine(struct Program *this, long int line,
+struct Pc *Program_imageLine(struct Program *self, long int line,
                              struct Pc *pc)
 {
-  if ((pc = Program_goLine(this, line, pc)) == (struct Pc *)0)
+  if ((pc = Program_goLine(self, line, pc)) == (struct Pc *)0)
     {
       return (struct Pc *)0;
     }
@@ -519,16 +519,16 @@ struct Pc *Program_imageLine(struct Program *this, long int line,
   return pc;
 }
 
-long int Program_lineNumber(const struct Program *this, const struct Pc *pc)
+long int Program_lineNumber(const struct Program *self, const struct Pc *pc)
 {
   if (pc->line == -1)
     {
       return 0;
     }
 
-  if (this->numbered)
+  if (self->numbered)
     {
-      return (this->code[pc->line]->u.integer);
+      return (self->code[pc->line]->u.integer);
     }
   else
     {
@@ -536,30 +536,30 @@ long int Program_lineNumber(const struct Program *this, const struct Pc *pc)
     }
 }
 
-struct Pc *Program_beginning(struct Program *this, struct Pc *pc)
+struct Pc *Program_beginning(struct Program *self, struct Pc *pc)
 {
-  if (this->size == 0)
+  if (self->size == 0)
     {
       return (struct Pc *)0;
     }
   else
     {
       pc->line = 0;
-      pc->token = this->code[0] + 1;
+      pc->token = self->code[0] + 1;
       return pc;
     }
 }
 
-struct Pc *Program_end(struct Program *this, struct Pc *pc)
+struct Pc *Program_end(struct Program *self, struct Pc *pc)
 {
-  if (this->size == 0)
+  if (self->size == 0)
     {
       return (struct Pc *)0;
     }
   else
     {
-      pc->line = this->size - 1;
-      pc->token = this->code[this->size - 1];
+      pc->line = self->size - 1;
+      pc->token = self->code[self->size - 1];
       while (pc->token->type != T_EOL)
         {
           ++pc->token;
@@ -569,31 +569,31 @@ struct Pc *Program_end(struct Program *this, struct Pc *pc)
     }
 }
 
-struct Pc *Program_nextLine(struct Program *this, struct Pc *pc)
+struct Pc *Program_nextLine(struct Program *self, struct Pc *pc)
 {
-  if (pc->line + 1 == this->size)
+  if (pc->line + 1 == self->size)
     {
       return (struct Pc *)0;
     }
   else
     {
-      pc->token = this->code[++pc->line] + 1;
+      pc->token = self->code[++pc->line] + 1;
       return pc;
     }
 }
 
-int Program_skipEOL(struct Program *this, struct Pc *pc, int dev, int tr)
+int Program_skipEOL(struct Program *self, struct Pc *pc, int dev, int tr)
 {
   if (pc->token->type == T_EOL)
     {
-      if (pc->line == -1 || pc->line + 1 == this->size)
+      if (pc->line == -1 || pc->line + 1 == self->size)
         {
           return 0;
         }
       else
         {
-          pc->token = this->code[++pc->line] + 1;
-          Program_trace(this, pc, dev, tr);
+          pc->token = self->code[++pc->line] + 1;
+          Program_trace(self, pc, dev, tr);
           return 1;
         }
     }
@@ -603,32 +603,32 @@ int Program_skipEOL(struct Program *this, struct Pc *pc, int dev, int tr)
     }
 }
 
-void Program_trace(struct Program *this, struct Pc *pc, int dev, int tr)
+void Program_trace(struct Program *self, struct Pc *pc, int dev, int tr)
 {
-  if (tr && this->trace && pc->line != -1)
+  if (tr && self->trace && pc->line != -1)
     {
       char buf[40];
 
       snprintf(buf, sizeof(buf), "<%ld>\n",
-               this->code[pc->line]->u.integer);
+               self->code[pc->line]->u.integer);
       FS_putChars(dev, buf);
     }
 }
 
-void Program_PCtoError(struct Program *this, struct Pc *pc, struct Value *v)
+void Program_PCtoError(struct Program *self, struct Pc *pc, struct Value *v)
 {
   struct String s;
 
   String_new(&s);
   if (pc->line >= 0)
     {
-      if (pc->line < (this->size - 1) || pc->token->type != T_EOL)
+      if (pc->line < (self->size - 1) || pc->token->type != T_EOL)
         {
           String_appendPrintf(&s, _(" in line %ld at:\n"),
-                              Program_lineNumber(this, pc));
-          Token_toString(this->code[pc->line], (struct Token *)0, &s,
+                              Program_lineNumber(self, pc));
+          Token_toString(self->code[pc->line], (struct Token *)0, &s,
                          (int *)0, -1);
-          Token_toString(this->code[pc->line], pc->token, &s, (int *)0, -1);
+          Token_toString(self->code[pc->line], pc->token, &s, (int *)0, -1);
           String_appendPrintf(&s, "^\n");
         }
       else
@@ -653,7 +653,7 @@ void Program_PCtoError(struct Program *this, struct Pc *pc, struct Value *v)
   String_destroy(&s);
 }
 
-struct Value *Program_merge(struct Program *this, int dev,
+struct Value *Program_merge(struct Program *self, int dev,
                             struct Value *value)
 {
   struct String s;
@@ -672,12 +672,12 @@ struct Value *Program_merge(struct Program *this, int dev,
           line = Token_newCode(s.character);
           if (line->type == T_INTEGER && line->u.integer > 0)
             {
-              Program_store(this, line,
-                            this->numbered ? line->u.integer : 0);
+              Program_store(self, line,
+                            self->numbered ? line->u.integer : 0);
             }
           else if (line->type == T_UNNUMBERED)
             {
-              Program_store(this, line, 0);
+              Program_store(self, line, 0);
             }
           else
             {
@@ -698,19 +698,19 @@ struct Value *Program_merge(struct Program *this, int dev,
   return (struct Value *)0;
 }
 
-int Program_lineNumberWidth(struct Program *this)
+int Program_lineNumberWidth(struct Program *self)
 {
   int i;
   int w = 0;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      if (this->code[i]->type == T_INTEGER)
+      if (self->code[i]->type == T_INTEGER)
         {
           int nw;
           int ln;
 
-          for (ln = this->code[i]->u.integer, nw = 1; ln /= 10; ++nw);
+          for (ln = self->code[i]->u.integer, nw = 1; ln /= 10; ++nw);
           if (nw > w)
             {
               w = nw;
@@ -721,7 +721,7 @@ int Program_lineNumberWidth(struct Program *this)
   return w;
 }
 
-struct Value *Program_list(struct Program *this, int dev, int watchIntr,
+struct Value *Program_list(struct Program *self, int dev, int watchIntr,
                            struct Pc *from, struct Pc *to,
                            struct Value *value)
 {
@@ -730,11 +730,11 @@ struct Value *Program_list(struct Program *this, int dev, int watchIntr,
   int indent = 0;
   struct String s;
 
-  w = Program_lineNumberWidth(this);
-  for (i = 0; i < this->size; ++i)
+  w = Program_lineNumberWidth(self);
+  for (i = 0; i < self->size; ++i)
     {
       String_new(&s);
-      Token_toString(this->code[i], (struct Token *)0, &s, &indent, w);
+      Token_toString(self->code[i], (struct Token *)0, &s, &indent, w);
       if ((from == (struct Pc *)0 || from->line <= i) &&
           (to == (struct Pc *)0 || to->line >= i))
         {
@@ -750,14 +750,14 @@ struct Value *Program_list(struct Program *this, int dev, int watchIntr,
   return (struct Value *)0;
 }
 
-struct Value *Program_analyse(struct Program *this, struct Pc *pc,
+struct Value *Program_analyse(struct Program *self, struct Pc *pc,
                               struct Value *value)
 {
   int i;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      pc->token = this->code[i];
+      pc->token = self->code[i];
       pc->line = i;
       if (pc->token->type == T_INTEGER || pc->token->type == T_UNNUMBERED)
         {
@@ -819,14 +819,14 @@ struct Value *Program_analyse(struct Program *this, struct Pc *pc,
   return (struct Value *)0;
 }
 
-void Program_renum(struct Program *this, int first, int inc)
+void Program_renum(struct Program *self, int first, int inc)
 {
   int i;
   struct Token *token;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      for (token = this->code[i]; token->type != T_EOL; )
+      for (token = self->code[i]; token->type != T_EOL; )
         {
           if (token->type == T_GOTO || token->type == T_GOSUB ||
               token->type == T_RESTORE || token->type == T_RESUME ||
@@ -837,7 +837,7 @@ void Program_renum(struct Program *this, int first, int inc)
                 {
                   struct Pc dst;
 
-                  if (Program_goLine(this, token->u.integer, &dst))
+                  if (Program_goLine(self, token->u.integer, &dst))
                     {
                       token->u.integer = first + dst.line * inc;
                     }
@@ -860,30 +860,30 @@ void Program_renum(struct Program *this, int first, int inc)
         }
     }
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      assert(this->code[i]->type == T_INTEGER ||
-             this->code[i]->type == T_UNNUMBERED);
-      this->code[i]->type = T_INTEGER;
-      this->code[i]->u.integer = first + i * inc;
+      assert(self->code[i]->type == T_INTEGER ||
+             self->code[i]->type == T_UNNUMBERED);
+      self->code[i]->type = T_INTEGER;
+      self->code[i]->u.integer = first + i * inc;
     }
 
-  this->numbered = 1;
-  this->runnable = 0;
-  this->unsaved = 1;
+  self->numbered = 1;
+  self->runnable = 0;
+  self->unsaved = 1;
 }
 
-void Program_unnum(struct Program *this)
+void Program_unnum(struct Program *self)
 {
   char *ref;
   int i;
   struct Token *token;
 
-  ref = malloc(this->size);
-  memset(ref, 0, this->size);
-  for (i = 0; i < this->size; ++i)
+  ref = malloc(self->size);
+  memset(ref, 0, self->size);
+  for (i = 0; i < self->size; ++i)
     {
-      for (token = this->code[i]; token->type != T_EOL; ++token)
+      for (token = self->code[i]; token->type != T_EOL; ++token)
         {
           if (token->type == T_GOTO || token->type == T_GOSUB ||
               token->type == T_RESTORE || token->type == T_RESUME)
@@ -893,7 +893,7 @@ void Program_unnum(struct Program *this)
                 {
                   struct Pc dst;
 
-                  if (Program_goLine(this, token->u.integer, &dst))
+                  if (Program_goLine(self, token->u.integer, &dst))
                     {
                       ref[dst.line] = 1;
                     }
@@ -912,32 +912,32 @@ void Program_unnum(struct Program *this)
         }
     }
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      assert(this->code[i]->type == T_INTEGER ||
-             this->code[i]->type == T_UNNUMBERED);
+      assert(self->code[i]->type == T_INTEGER ||
+             self->code[i]->type == T_UNNUMBERED);
       if (!ref[i])
         {
-          this->code[i]->type = T_UNNUMBERED;
-          this->numbered = 0;
+          self->code[i]->type = T_UNNUMBERED;
+          self->numbered = 0;
         }
     }
 
   free(ref);
-  this->runnable = 0;
-  this->unsaved = 1;
+  self->runnable = 0;
+  self->unsaved = 1;
 }
 
-int Program_setname(struct Program *this, const char *filename)
+int Program_setname(struct Program *self, const char *filename)
 {
-  if (this->name.length)
+  if (self->name.length)
     {
-      String_delete(&this->name, 0, this->name.length);
+      String_delete(&self->name, 0, self->name.length);
     }
 
   if (filename)
     {
-      return String_appendChars(&this->name, filename);
+      return String_appendChars(&self->name, filename);
     }
   else
     {
@@ -945,7 +945,7 @@ int Program_setname(struct Program *this, const char *filename)
     }
 }
 
-void Program_xref(struct Program *this, int chn)
+void Program_xref(struct Program *self, int chn)
 {
   struct Pc pc;
   struct Xref *func;
@@ -954,17 +954,17 @@ void Program_xref(struct Program *this, int chn)
   struct Xref *goto_;
   int nl = 0;
 
-  assert(this->runnable);
+  assert(self->runnable);
   func = (struct Xref *)0;
   var = (struct Xref *)0;
   gosub = (struct Xref *)0;
   goto_ = (struct Xref *)0;
 
-  for (pc.line = 0; pc.line < this->size; ++pc.line)
+  for (pc.line = 0; pc.line < self->size; ++pc.line)
     {
       struct On *on;
 
-      for (on = (struct On *)0, pc.token = this->code[pc.line];
+      for (on = (struct On *)0, pc.token = self->code[pc.line];
            pc.token->type != T_EOL; ++pc.token)
         {
           switch (pc.token->type)
@@ -1021,9 +1021,9 @@ void Program_xref(struct Program *this, int chn)
         }
     }
 
-  for (pc.line = 0; pc.line < this->size; ++pc.line)
+  for (pc.line = 0; pc.line < self->size; ++pc.line)
     {
-      for (pc.token = this->code[pc.line]; pc.token->type != T_EOL;
+      for (pc.token = self->code[pc.line]; pc.token->type != T_EOL;
            ++pc.token)
         {
           switch (pc.token->type)
@@ -1075,7 +1075,7 @@ void Program_xref(struct Program *this, int chn)
   if (func)
     {
       FS_putChars(chn, _("Function Referenced in line\n"));
-      Xref_print(func, printName, this, chn);
+      Xref_print(func, printName, self, chn);
       Xref_destroy(func);
       nl = 1;
     }
@@ -1088,7 +1088,7 @@ void Program_xref(struct Program *this, int chn)
         }
 
       FS_putChars(chn, _("Variable Referenced in line\n"));
-      Xref_print(var, printName, this, chn);
+      Xref_print(var, printName, self, chn);
       Xref_destroy(func);
       nl = 1;
     }
@@ -1101,7 +1101,7 @@ void Program_xref(struct Program *this, int chn)
         }
 
       FS_putChars(chn, _("Gosub    Referenced in line\n"));
-      Xref_print(gosub, printLine, this, chn);
+      Xref_print(gosub, printLine, self, chn);
       Xref_destroy(gosub);
       nl = 1;
     }
@@ -1114,7 +1114,7 @@ void Program_xref(struct Program *this, int chn)
         }
 
       FS_putChars(chn, _("Goto     Referenced in line\n"));
-      Xref_print(goto_, printLine, this, chn);
+      Xref_print(goto_, printLine, self, chn);
       Xref_destroy(goto_);
     }
 }

--- a/interpreters/bas/bas_program.h
+++ b/interpreters/bas/bas_program.h
@@ -37,45 +37,45 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-struct Program *Program_new(struct Program *this);
-void Program_destroy(struct Program *this);
-void Program_norun(struct Program *this);
-void Program_store(struct Program *this, struct Token *line,
+struct Program *Program_new(struct Program *self);
+void Program_destroy(struct Program *self);
+void Program_norun(struct Program *self);
+void Program_store(struct Program *self, struct Token *line,
                    long int where);
-void Program_delete(struct Program *this, const struct Pc *from,
+void Program_delete(struct Program *self, const struct Pc *from,
                     const struct Pc *to);
-void Program_addScope(struct Program *this, struct Scope *scope);
-struct Pc *Program_goLine(struct Program *this, long int line,
+void Program_addScope(struct Program *self, struct Scope *scope);
+struct Pc *Program_goLine(struct Program *self, long int line,
                           struct Pc *pc);
-struct Pc *Program_fromLine(struct Program *this, long int line,
+struct Pc *Program_fromLine(struct Program *self, long int line,
                             struct Pc *pc);
-struct Pc *Program_toLine(struct Program *this, long int line,
+struct Pc *Program_toLine(struct Program *self, long int line,
                           struct Pc *pc);
-int Program_scopeCheck(struct Program *this, struct Pc *pc, struct Pc *fn);
-struct Pc *Program_dataLine(struct Program *this, long int line,
+int Program_scopeCheck(struct Program *self, struct Pc *pc, struct Pc *fn);
+struct Pc *Program_dataLine(struct Program *self, long int line,
                             struct Pc *pc);
-struct Pc *Program_imageLine(struct Program *this, long int line,
+struct Pc *Program_imageLine(struct Program *self, long int line,
                              struct Pc *pc);
-long int Program_lineNumber(const struct Program *this,
+long int Program_lineNumber(const struct Program *self,
                             const struct Pc *pc);
-struct Pc *Program_beginning(struct Program *this, struct Pc *pc);
-struct Pc *Program_end(struct Program *this, struct Pc *pc);
-struct Pc *Program_nextLine(struct Program *this, struct Pc *pc);
-int Program_skipEOL(struct Program *this, struct Pc *pc, int dev, int tr);
-void Program_trace(struct Program *this, struct Pc *pc, int dev, int tr);
-void Program_PCtoError(struct Program *this, struct Pc *pc,
+struct Pc *Program_beginning(struct Program *self, struct Pc *pc);
+struct Pc *Program_end(struct Program *self, struct Pc *pc);
+struct Pc *Program_nextLine(struct Program *self, struct Pc *pc);
+int Program_skipEOL(struct Program *self, struct Pc *pc, int dev, int tr);
+void Program_trace(struct Program *self, struct Pc *pc, int dev, int tr);
+void Program_PCtoError(struct Program *self, struct Pc *pc,
                        struct Value *v);
-struct Value *Program_merge(struct Program *this, int dev,
+struct Value *Program_merge(struct Program *self, int dev,
                             struct Value *value);
-int Program_lineNumberWidth(struct Program *this);
-struct Value *Program_list(struct Program *this, int dev, int watchIntr,
+int Program_lineNumberWidth(struct Program *self);
+struct Value *Program_list(struct Program *self, int dev, int watchIntr,
                            struct Pc *from, struct Pc *to,
                            struct Value *value);
-struct Value *Program_analyse(struct Program *this, struct Pc *pc,
+struct Value *Program_analyse(struct Program *self, struct Pc *pc,
                               struct Value *value);
-void Program_renum(struct Program *this, int first, int inc);
-void Program_unnum(struct Program *this);
-int Program_setname(struct Program *this, const char *filename);
-void Program_xref(struct Program *this, int chn);
+void Program_renum(struct Program *self, int first, int inc);
+void Program_unnum(struct Program *self);
+int Program_setname(struct Program *self, const char *filename);
+void Program_xref(struct Program *self, int chn);
 
 #endif /* __APPS_EXAMPLES_BAS_BAS_PROGRAM_H */

--- a/interpreters/bas/bas_str.c
+++ b/interpreters/bas/bas_str.c
@@ -57,41 +57,41 @@ int cistrcmp(const char *s, const char *r)
   return ((tolower(*s) - tolower(*r)));
 }
 
-struct String *String_new(struct String *this)
+struct String *String_new(struct String *self)
 {
-  assert(this != (struct String *)0);
-  this->length = 0;
-  this->character = (char *)0;
-  this->field = (struct StringField *)0;
-  return this;
+  assert(self != (struct String *)0);
+  self->length = 0;
+  self->character = (char *)0;
+  self->field = (struct StringField *)0;
+  return self;
 }
 
-void String_destroy(struct String *this)
+void String_destroy(struct String *self)
 {
-  assert(this != (struct String *)0);
-  if (this->field)
+  assert(self != (struct String *)0);
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
-  if (this->length)
+  if (self->length)
     {
-      free(this->character);
+      free(self->character);
     }
 }
 
-int String_joinField(struct String *this, struct StringField *field,
+int String_joinField(struct String *self, struct StringField *field,
                      char *character, size_t length)
 {
   struct String **n;
 
-  assert(this != (struct String *)0);
-  if (this->field)
+  assert(self != (struct String *)0);
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
-  this->field = field;
+  self->field = field;
   if ((n =
        (struct String **)realloc(field->refStrings,
                                  sizeof(struct String *) * (field->refCount +
@@ -102,30 +102,30 @@ int String_joinField(struct String *this, struct StringField *field,
     }
 
   field->refStrings = n;
-  field->refStrings[field->refCount] = this;
+  field->refStrings[field->refCount] = self;
   ++field->refCount;
-  if (this->length)
+  if (self->length)
     {
-      free(this->character);
+      free(self->character);
     }
 
-  this->character = character;
-  this->length = length;
+  self->character = character;
+  self->length = length;
   return 0;
 }
 
-void String_leaveField(struct String *this)
+void String_leaveField(struct String *self)
 {
   struct StringField *field;
   int i;
   struct String **ref;
 
-  assert(this != (struct String *)0);
-  field = this->field;
+  assert(self != (struct String *)0);
+  field = self->field;
   assert(field != (struct StringField *)0);
   for (i = 0, ref = field->refStrings; i < field->refCount; ++i, ++ref)
     {
-      if (*ref == this)
+      if (*ref == self)
         {
           int further = --field->refCount - i;
 
@@ -134,9 +134,9 @@ void String_leaveField(struct String *this)
               memmove(ref, ref + 1, further * sizeof(struct String **));
             }
 
-          this->character = (char *)0;
-          this->length = 0;
-          this->field = (struct StringField *)0;
+          self->character = (char *)0;
+          self->length = 0;
+          self->field = (struct StringField *)0;
           return;
         }
     }
@@ -144,59 +144,59 @@ void String_leaveField(struct String *this)
   assert(0);
 }
 
-struct String *String_clone(struct String *this, const struct String *original)
+struct String *String_clone(struct String *self, const struct String *original)
 {
-  assert(this != (struct String *)0);
-  String_new(this);
-  String_appendString(this, original);
-  return this;
+  assert(self != (struct String *)0);
+  String_new(self);
+  String_appendString(self, original);
+  return self;
 }
 
-int String_size(struct String *this, size_t length)
+int String_size(struct String *self, size_t length)
 {
   char *n;
 
-  assert(this != (struct String *)0);
-  if (this->field)
+  assert(self != (struct String *)0);
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
   if (length)
     {
-      if (length > this->length)
+      if (length > self->length)
         {
-          if ((n = realloc(this->character, length + 1)) == (char *)0)
+          if ((n = realloc(self->character, length + 1)) == (char *)0)
             {
               return -1;
             }
 
-          this->character = n;
+          self->character = n;
         }
 
-      this->character[length] = '\0';
+      self->character[length] = '\0';
     }
   else
     {
-      if (this->length)
+      if (self->length)
         {
-          free(this->character);
+          free(self->character);
         }
 
-      this->character = (char *)0;
+      self->character = (char *)0;
     }
 
-  this->length = length;
+  self->length = length;
   return 0;
 }
 
-int String_appendString(struct String *this, const struct String *app)
+int String_appendString(struct String *self, const struct String *app)
 {
-  size_t oldlength = this->length;
+  size_t oldlength = self->length;
 
-  if (this->field)
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
   if (app->length == 0)
@@ -204,146 +204,146 @@ int String_appendString(struct String *this, const struct String *app)
       return 0;
     }
 
-  if (String_size(this, this->length + app->length) == -1)
+  if (String_size(self, self->length + app->length) == -1)
     {
       return -1;
     }
 
-  memcpy(this->character + oldlength, app->character, app->length);
+  memcpy(self->character + oldlength, app->character, app->length);
   return 0;
 }
 
-int String_appendChar(struct String *this, char ch)
+int String_appendChar(struct String *self, char ch)
 {
-  size_t oldlength = this->length;
+  size_t oldlength = self->length;
 
-  if (this->field)
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
-  if (String_size(this, this->length + 1) == -1)
+  if (String_size(self, self->length + 1) == -1)
     {
       return -1;
     }
 
-  this->character[oldlength] = ch;
+  self->character[oldlength] = ch;
   return 0;
 }
 
-int String_appendChars(struct String *this, const char *ch)
+int String_appendChars(struct String *self, const char *ch)
 {
-  size_t oldlength = this->length;
+  size_t oldlength = self->length;
   size_t chlen = strlen(ch);
 
-  if (this->field)
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
-  if (String_size(this, this->length + chlen) == -1)
+  if (String_size(self, self->length + chlen) == -1)
     {
       return -1;
     }
 
-  memcpy(this->character + oldlength, ch, chlen);
+  memcpy(self->character + oldlength, ch, chlen);
   return 0;
 }
 
-int String_appendPrintf(struct String *this, const char *fmt, ...)
+int String_appendPrintf(struct String *self, const char *fmt, ...)
 {
   char buf[1024];
   size_t l, j;
   va_list ap;
 
-  if (this->field)
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
   va_start(ap, fmt);
   l = vsprintf(buf, fmt, ap);
   va_end(ap);
-  j = this->length;
-  if (String_size(this, j + l) == -1)
+  j = self->length;
+  if (String_size(self, j + l) == -1)
     {
       return -1;
     }
 
-  memcpy(this->character + j, buf, l);
+  memcpy(self->character + j, buf, l);
   return 0;
 }
 
-int String_insertChar(struct String *this, size_t where, char ch)
+int String_insertChar(struct String *self, size_t where, char ch)
 {
-  size_t oldlength = this->length;
+  size_t oldlength = self->length;
 
-  if (this->field)
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
   assert(where < oldlength);
-  if (String_size(this, this->length + 1) == -1)
+  if (String_size(self, self->length + 1) == -1)
     {
       return -1;
     }
 
-  memmove(this->character + where + 1, this->character + where,
+  memmove(self->character + where + 1, self->character + where,
           oldlength - where);
-  this->character[where] = ch;
+  self->character[where] = ch;
   return 0;
 }
 
-int String_delete(struct String *this, size_t where, size_t len)
+int String_delete(struct String *self, size_t where, size_t len)
 {
-  size_t oldlength = this->length;
+  size_t oldlength = self->length;
 
-  if (this->field)
+  if (self->field)
     {
-      String_leaveField(this);
+      String_leaveField(self);
     }
 
   assert(where < oldlength);
   assert(len > 0);
   if ((where + len) < oldlength)
     {
-      memmove(this->character + where, this->character + where + len,
+      memmove(self->character + where, self->character + where + len,
               oldlength - where - len);
     }
 
-  this->character[this->length -= len] = '\0';
+  self->character[self->length -= len] = '\0';
   return 0;
 }
 
-void String_ucase(struct String *this)
+void String_ucase(struct String *self)
 {
   size_t i;
 
-  for (i = 0; i < this->length; ++i)
+  for (i = 0; i < self->length; ++i)
     {
-      this->character[i] = toupper(this->character[i]);
+      self->character[i] = toupper(self->character[i]);
     }
 }
 
-void String_lcase(struct String *this)
+void String_lcase(struct String *self)
 {
   size_t i;
 
-  for (i = 0; i < this->length; ++i)
+  for (i = 0; i < self->length; ++i)
     {
-      this->character[i] = tolower(this->character[i]);
+      self->character[i] = tolower(self->character[i]);
     }
 }
 
-int String_cmp(const struct String *this, const struct String *s)
+int String_cmp(const struct String *self, const struct String *s)
 {
   size_t pos;
   int res;
   const char *thisch, *sch;
 
-  for (pos = 0, thisch = this->character, sch = s->character;
-       pos < this->length && pos < s->length; ++pos, ++thisch, ++sch)
+  for (pos = 0, thisch = self->character, sch = s->character;
+       pos < self->length && pos < s->length; ++pos, ++thisch, ++sch)
     {
       if ((res = (*thisch - *sch)))
         {
@@ -351,74 +351,74 @@ int String_cmp(const struct String *this, const struct String *s)
         }
     }
 
-  return (this->length - s->length);
+  return (self->length - s->length);
 }
 
-void String_lset(struct String *this, const struct String *s)
+void String_lset(struct String *self, const struct String *s)
 {
   size_t copy;
 
-  copy = (this->length < s->length ? this->length : s->length);
+  copy = (self->length < s->length ? self->length : s->length);
   if (copy)
     {
-      memcpy(this->character, s->character, copy);
+      memcpy(self->character, s->character, copy);
     }
 
-  if (copy < this->length)
+  if (copy < self->length)
     {
-      memset(this->character + copy, ' ', this->length - copy);
+      memset(self->character + copy, ' ', self->length - copy);
     }
 }
 
-void String_rset(struct String *this, const struct String *s)
+void String_rset(struct String *self, const struct String *s)
 {
   size_t copy;
 
-  copy = (this->length < s->length ? this->length : s->length);
+  copy = (self->length < s->length ? self->length : s->length);
   if (copy)
     {
-      memcpy(this->character + this->length - copy, s->character, copy);
+      memcpy(self->character + self->length - copy, s->character, copy);
     }
 
-  if (copy < this->length)
+  if (copy < self->length)
     {
-      memset(this->character, ' ', this->length - copy);
+      memset(self->character, ' ', self->length - copy);
     }
 }
 
-void String_set(struct String *this, size_t pos, const struct String *s,
+void String_set(struct String *self, size_t pos, const struct String *s,
                 size_t length)
 {
-  if (this->length >= pos)
+  if (self->length >= pos)
     {
-      if (this->length < (pos + length))
+      if (self->length < (pos + length))
         {
-          length = this->length - pos;
+          length = self->length - pos;
         }
 
       if (length)
         {
-          memcpy(this->character + pos, s->character, length);
+          memcpy(self->character + pos, s->character, length);
         }
     }
 }
 
-struct StringField *StringField_new(struct StringField *this)
+struct StringField *StringField_new(struct StringField *self)
 {
-  this->refStrings = (struct String **)0;
-  this->refCount = 0;
-  return this;
+  self->refStrings = (struct String **)0;
+  self->refCount = 0;
+  return self;
 }
 
-void StringField_destroy(struct StringField *this)
+void StringField_destroy(struct StringField *self)
 {
   int i;
 
-  for (i = this->refCount; i > 0;)
+  for (i = self->refCount; i > 0;)
     {
-      String_leaveField(this->refStrings[--i]);
+      String_leaveField(self->refStrings[--i]);
     }
 
-  this->refCount = -1;
-  free(this->refStrings);
+  self->refCount = -1;
+  free(self->refStrings);
 }

--- a/interpreters/bas/bas_str.h
+++ b/interpreters/bas/bas_str.h
@@ -55,29 +55,29 @@ struct StringField
 
 int cistrcmp(const char *s, const char *r);
 
-struct String *String_new(struct String *this);
-void String_destroy(struct String *this);
-int String_joinField(struct String *this, struct StringField *field,
+struct String *String_new(struct String *self);
+void String_destroy(struct String *self);
+int String_joinField(struct String *self, struct StringField *field,
                      char *character, size_t length);
-void String_leaveField(struct String *this);
-struct String *String_clone(struct String *this, const struct String *clon);
-int String_appendString(struct String *this, const struct String *app);
-int String_appendChar(struct String *this, char ch);
-int String_appendChars(struct String *this, const char *ch);
-int String_appendPrintf(struct String *this, const char *fmt, ...)
+void String_leaveField(struct String *self);
+struct String *String_clone(struct String *self, const struct String *clon);
+int String_appendString(struct String *self, const struct String *app);
+int String_appendChar(struct String *self, char ch);
+int String_appendChars(struct String *self, const char *ch);
+int String_appendPrintf(struct String *self, const char *fmt, ...)
     printf_like(2, 3);
-int String_insertChar(struct String *this, size_t where, char ch);
-int String_delete(struct String *this, size_t where, size_t len);
-void String_ucase(struct String *this);
-void String_lcase(struct String *this);
-int String_size(struct String *this, size_t length);
-int String_cmp(const struct String *this, const struct String *s);
-void String_lset(struct String *this, const struct String *s);
-void String_rset(struct String *this, const struct String *s);
-void String_set(struct String *this, size_t pos, const struct String *s,
+int String_insertChar(struct String *self, size_t where, char ch);
+int String_delete(struct String *self, size_t where, size_t len);
+void String_ucase(struct String *self);
+void String_lcase(struct String *self);
+int String_size(struct String *self, size_t length);
+int String_cmp(const struct String *self, const struct String *s);
+void String_lset(struct String *self, const struct String *s);
+void String_rset(struct String *self, const struct String *s);
+void String_set(struct String *self, size_t pos, const struct String *s,
                 size_t length);
 
-struct StringField *StringField_new(struct StringField *this);
-void StringField_destroy(struct StringField *this);
+struct StringField *StringField_new(struct StringField *self);
+void StringField_destroy(struct StringField *self);
 
 #endif /* __APPS_EXAMPLES_BAS_BAS_STR_H */

--- a/interpreters/bas/bas_value.c
+++ b/interpreters/bas/bas_value.c
@@ -218,89 +218,89 @@ double Value_vald(const char *s, char **end, int *overflow)
   return d;
 }
 
-struct Value *Value_new_NIL(struct Value *this)
+struct Value *Value_new_NIL(struct Value *self)
 {
-  assert(this != (struct Value *)0);
-  this->type = V_NIL;
-  return this;
+  assert(self != (struct Value *)0);
+  self->type = V_NIL;
+  return self;
 }
 
-struct Value *Value_new_ERROR(struct Value *this, int code,
+struct Value *Value_new_ERROR(struct Value *self, int code,
                               const char *error, ...)
 {
   va_list ap;
   char buf[128];
 
-  assert(this != (struct Value *)0);
+  assert(self != (struct Value *)0);
   va_start(ap, error);
   vsprintf(buf, error, ap);
   va_end(ap);
-  this->type = V_ERROR;
-  this->u.error.code = code;
-  this->u.error.msg  = strdup(buf);
-  return this;
+  self->type = V_ERROR;
+  self->u.error.code = code;
+  self->u.error.msg  = strdup(buf);
+  return self;
 }
 
-struct Value *Value_new_INTEGER(struct Value *this, int n)
+struct Value *Value_new_INTEGER(struct Value *self, int n)
 {
-  assert(this != (struct Value *)0);
-  this->type = V_INTEGER;
-  this->u.integer = n;
-  return this;
+  assert(self != (struct Value *)0);
+  self->type = V_INTEGER;
+  self->u.integer = n;
+  return self;
 }
 
-struct Value *Value_new_REAL(struct Value *this, double n)
+struct Value *Value_new_REAL(struct Value *self, double n)
 {
-  assert(this != (struct Value *)0);
-  this->type = V_REAL;
-  this->u.real = n;
-  return this;
+  assert(self != (struct Value *)0);
+  self->type = V_REAL;
+  self->u.real = n;
+  return self;
 }
 
-struct Value *Value_new_STRING(struct Value *this)
+struct Value *Value_new_STRING(struct Value *self)
 {
-  assert(this != (struct Value *)0);
-  this->type = V_STRING;
-  String_new(&this->u.string);
-  return this;
+  assert(self != (struct Value *)0);
+  self->type = V_STRING;
+  String_new(&self->u.string);
+  return self;
 }
 
-struct Value *Value_new_VOID(struct Value *this)
+struct Value *Value_new_VOID(struct Value *self)
 {
-  assert(this != (struct Value *)0);
-  this->type = V_VOID;
-  return this;
+  assert(self != (struct Value *)0);
+  self->type = V_VOID;
+  return self;
 }
 
-struct Value *Value_new_null(struct Value *this, enum ValueType type)
+struct Value *Value_new_null(struct Value *self, enum ValueType type)
 {
-  assert(this != (struct Value *)0);
+  assert(self != (struct Value *)0);
   switch (type)
     {
     case V_INTEGER:
       {
-        this->type = V_INTEGER;
-        this->u.integer = 0;
+        self->type = V_INTEGER;
+        self->u.integer = 0;
         break;
       }
 
     case V_REAL:
       {
-        this->type = V_REAL;
-        this->u.real = 0.0;
+        self->type = V_REAL;
+        self->u.real = 0.0;
         break;
       }
 
     case V_STRING:
       {
-        this->type = V_STRING;
-        String_new(&this->u.string);
+        self->type = V_STRING;
+        String_new(&self->u.string);
         break;
       }
 
     case V_VOID:
       {
-        this->type = V_VOID;
+        self->type = V_VOID;
         break;
       }
 
@@ -308,21 +308,21 @@ struct Value *Value_new_null(struct Value *this, enum ValueType type)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-int Value_isNull(const struct Value *this)
+int Value_isNull(const struct Value *self)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
-      return (this->u.integer == 0);
+      return (self->u.integer == 0);
 
     case V_REAL:
-      return (this->u.real == 0.0);
+      return (self->u.real == 0.0);
 
     case V_STRING:
-      return (this->u.string.length == 0);
+      return (self->u.string.length == 0);
 
     default:
       assert(0);
@@ -331,13 +331,13 @@ int Value_isNull(const struct Value *this)
   return -1;
 }
 
-void Value_destroy(struct Value *this)
+void Value_destroy(struct Value *self)
 {
-  assert(this != (struct Value *)0);
-  switch (this->type)
+  assert(self != (struct Value *)0);
+  switch (self->type)
     {
     case V_ERROR:
-      free(this->u.error.msg);
+      free(self->u.error.msg);
       break;
 
     case V_INTEGER:
@@ -350,7 +350,7 @@ void Value_destroy(struct Value *this)
       break;
 
     case V_STRING:
-      String_destroy(&this->u.string);
+      String_destroy(&self->u.string);
       break;
 
     case V_VOID:
@@ -360,49 +360,49 @@ void Value_destroy(struct Value *this)
       assert(0);
     }
 
-  this->type = 0;
+  self->type = 0;
 }
 
-struct Value *Value_clone(struct Value *this, const struct Value *original)
+struct Value *Value_clone(struct Value *self, const struct Value *original)
 {
-  assert(this != (struct Value *)0);
+  assert(self != (struct Value *)0);
   assert(original != (struct Value *)0);
 
   switch (original->type)
     {
     case V_ERROR:
       {
-        this->u.error.msg = strdup(original->u.error.msg);
-        this->u.error.code = original->u.error.code;
+        self->u.error.msg = strdup(original->u.error.msg);
+        self->u.error.code = original->u.error.code;
         break;
       }
 
     case V_INTEGER:
-      this->u.integer = original->u.integer;
+      self->u.integer = original->u.integer;
       break;
 
     case V_NIL:
       break;
 
     case V_REAL:
-      this->u.real = original->u.real;
+      self->u.real = original->u.real;
       break;
 
     case V_STRING:
-      String_clone(&this->u.string, &original->u.string);
+      String_clone(&self->u.string, &original->u.string);
       break;
 
     default:
       assert(0);
     }
 
-  this->type = original->type;
-  return this;
+  self->type = original->type;
+  return self;
 }
 
-struct Value *Value_uplus(struct Value *this, int calc)
+struct Value *Value_uplus(struct Value *self, int calc)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
     case V_REAL:
@@ -412,8 +412,8 @@ struct Value *Value_uplus(struct Value *this, int calc)
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDUOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDUOPERAND);
         break;
       }
 
@@ -421,18 +421,18 @@ struct Value *Value_uplus(struct Value *this, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_uneg(struct Value *this, int calc)
+struct Value *Value_uneg(struct Value *self, int calc)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
       {
         if (calc)
           {
-            this->u.integer = -this->u.integer;
+            self->u.integer = -self->u.integer;
           }
         break;
       }
@@ -441,15 +441,15 @@ struct Value *Value_uneg(struct Value *this, int calc)
       {
         if (calc)
           {
-            this->u.real = -this->u.real;
+            self->u.real = -self->u.real;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDUOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDUOPERAND);
         break;
       }
 
@@ -457,36 +457,36 @@ struct Value *Value_uneg(struct Value *this, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_unot(struct Value *this, int calc)
+struct Value *Value_unot(struct Value *self, int calc)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
       {
         if (calc)
           {
-            this->u.integer = ~this->u.integer;
+            self->u.integer = ~self->u.integer;
           }
         break;
       }
 
     case V_REAL:
       {
-        Value_retype(this, V_INTEGER);
+        Value_retype(self, V_INTEGER);
         if (calc)
           {
-            this->u.integer = ~this->u.integer;
+            self->u.integer = ~self->u.integer;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDUOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDUOPERAND);
         break;
       }
 
@@ -494,31 +494,31 @@ struct Value *Value_unot(struct Value *this, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_add(struct Value *this, struct Value *x, int calc)
+struct Value *Value_add(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer += x->u.integer;
+            self->u.integer += x->u.integer;
           }
         break;
       }
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            this->u.real += x->u.real;
+            self->u.real += x->u.real;
           }
         break;
       }
@@ -527,7 +527,7 @@ struct Value *Value_add(struct Value *this, struct Value *x, int calc)
       {
         if (calc)
           {
-            String_appendString(&this->u.string, &x->u.string);
+            String_appendString(&self->u.string, &x->u.string);
           }
         break;
       }
@@ -536,39 +536,39 @@ struct Value *Value_add(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_sub(struct Value *this, struct Value *x, int calc)
+struct Value *Value_sub(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer -= x->u.integer;
+            self->u.integer -= x->u.integer;
           }
         break;
       }
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            this->u.real -= x->u.real;
+            self->u.real -= x->u.real;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -576,20 +576,20 @@ struct Value *Value_sub(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_mult(struct Value *this, struct Value *x, int calc)
+struct Value *Value_mult(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer *= x->u.integer;
+            self->u.integer *= x->u.integer;
           }
 
         break;
@@ -597,19 +597,19 @@ struct Value *Value_mult(struct Value *this, struct Value *x, int calc)
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            this->u.real *= x->u.real;
+            self->u.real *= x->u.real;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -617,27 +617,27 @@ struct Value *Value_mult(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_div(struct Value *this, struct Value *x, int calc)
+struct Value *Value_div(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
             if (x->u.real == 0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "Division by zero");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "Division by zero");
               }
             else
               {
-                this->u.real /= x->u.real;
+                self->u.real /= x->u.real;
               }
           }
         break;
@@ -645,18 +645,18 @@ struct Value *Value_div(struct Value *this, struct Value *x, int calc)
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
             if (x->u.real == 0.0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "Division by zero");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "Division by zero");
               }
             else
               {
-                this->u.real /= x->u.real;
+                self->u.real /= x->u.real;
               }
           }
         break;
@@ -664,8 +664,8 @@ struct Value *Value_div(struct Value *this, struct Value *x, int calc)
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -673,27 +673,27 @@ struct Value *Value_div(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_idiv(struct Value *this, struct Value *x, int calc)
+struct Value *Value_idiv(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
             if (x->u.integer == 0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "Division by zero");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "Division by zero");
               }
             else
               {
-                this->u.integer /= x->u.integer;
+                self->u.integer /= x->u.integer;
               }
           }
         break;
@@ -701,18 +701,18 @@ struct Value *Value_idiv(struct Value *this, struct Value *x, int calc)
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
             if (x->u.real == 0.0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "Division by zero");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "Division by zero");
               }
             else
               {
-                this->u.real = Value_trunc(this->u.real / x->u.real);
+                self->u.real = Value_trunc(self->u.real / x->u.real);
               }
           }
         break;
@@ -720,8 +720,8 @@ struct Value *Value_idiv(struct Value *this, struct Value *x, int calc)
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -729,27 +729,27 @@ struct Value *Value_idiv(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_mod(struct Value *this, struct Value *x, int calc)
+struct Value *Value_mod(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
             if (x->u.integer == 0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "Modulo by zero");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "Modulo by zero");
               }
             else
               {
-                this->u.integer %= x->u.integer;
+                self->u.integer %= x->u.integer;
               }
           }
         break;
@@ -757,18 +757,18 @@ struct Value *Value_mod(struct Value *this, struct Value *x, int calc)
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
             if (x->u.real == 0.0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "Modulo by zero");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "Modulo by zero");
               }
             else
               {
-                this->u.real = fmod(this->u.real, x->u.real);
+                self->u.real = fmod(self->u.real, x->u.real);
               }
           }
         break;
@@ -776,8 +776,8 @@ struct Value *Value_mod(struct Value *this, struct Value *x, int calc)
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -785,33 +785,33 @@ struct Value *Value_mod(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_pow(struct Value *this, struct Value *x, int calc)
+struct Value *Value_pow(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            if (this->u.integer == 0 && x->u.integer == 0)
+            if (self->u.integer == 0 && x->u.integer == 0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "0^0");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "0^0");
               }
             else if (x->u.integer > 0)
               {
-                this->u.integer = pow(this->u.integer, x->u.integer);
+                self->u.integer = pow(self->u.integer, x->u.integer);
               }
             else
               {
-                long int thisi = this->u.integer;
-                Value_destroy(this);
-                Value_new_REAL(this, pow(thisi, x->u.integer));
+                long int thisi = self->u.integer;
+                Value_destroy(self);
+                Value_new_REAL(self, pow(thisi, x->u.integer));
               }
           }
         break;
@@ -819,18 +819,18 @@ struct Value *Value_pow(struct Value *this, struct Value *x, int calc)
 
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            if (this->u.real == 0.0 && x->u.real == 0.0)
+            if (self->u.real == 0.0 && x->u.real == 0.0)
               {
-                Value_destroy(this);
-                Value_new_ERROR(this, UNDEFINED, "0^0");
+                Value_destroy(self);
+                Value_new_ERROR(self, UNDEFINED, "0^0");
               }
             else
               {
-                this->u.real = pow(this->u.real, x->u.real);
+                self->u.real = pow(self->u.real, x->u.real);
               }
           }
         break;
@@ -838,8 +838,8 @@ struct Value *Value_pow(struct Value *this, struct Value *x, int calc)
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -847,29 +847,29 @@ struct Value *Value_pow(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_and(struct Value *this, struct Value *x, int calc)
+struct Value *Value_and(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer &= x->u.integer;
+            self->u.integer &= x->u.integer;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -877,29 +877,29 @@ struct Value *Value_and(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_or(struct Value *this, struct Value *x, int calc)
+struct Value *Value_or(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer |= x->u.integer;
+            self->u.integer |= x->u.integer;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -907,29 +907,29 @@ struct Value *Value_or(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_xor(struct Value *this, struct Value *x, int calc)
+struct Value *Value_xor(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer ^= x->u.integer;
+            self->u.integer ^= x->u.integer;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -937,29 +937,29 @@ struct Value *Value_xor(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_eqv(struct Value *this, struct Value *x, int calc)
+struct Value *Value_eqv(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = ~(this->u.integer ^ x->u.integer);
+            self->u.integer = ~(self->u.integer ^ x->u.integer);
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -967,29 +967,29 @@ struct Value *Value_eqv(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_imp(struct Value *this, struct Value *x, int calc)
+struct Value *Value_imp(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
     case V_REAL:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (~this->u.integer) | x->u.integer;
+            self->u.integer = (~self->u.integer) | x->u.integer;
           }
         break;
       }
 
     case V_STRING:
       {
-        Value_destroy(this);
-        Value_new_ERROR(this, INVALIDOPERAND);
+        Value_destroy(self);
+        Value_new_ERROR(self, INVALIDOPERAND);
         break;
       }
 
@@ -997,20 +997,20 @@ struct Value *Value_imp(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_lt(struct Value *this, struct Value *x, int calc)
+struct Value *Value_lt(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (this->u.integer < x->u.integer) ? -1 : 0;
+            self->u.integer = (self->u.integer < x->u.integer) ? -1 : 0;
           }
         break;
       }
@@ -1019,19 +1019,19 @@ struct Value *Value_lt(struct Value *this, struct Value *x, int calc)
       {
         int v;
 
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            v = (this->u.real < x->u.real) ? -1 : 0;
+            v = (self->u.real < x->u.real) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1041,15 +1041,15 @@ struct Value *Value_lt(struct Value *this, struct Value *x, int calc)
 
         if (calc)
           {
-            v = (String_cmp(&this->u.string, &x->u.string) < 0) ? -1 : 0;
+            v = (String_cmp(&self->u.string, &x->u.string) < 0) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1057,20 +1057,20 @@ struct Value *Value_lt(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_le(struct Value *this, struct Value *x, int calc)
+struct Value *Value_le(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (this->u.integer <= x->u.integer) ? -1 : 0;
+            self->u.integer = (self->u.integer <= x->u.integer) ? -1 : 0;
           }
         break;
       }
@@ -1079,19 +1079,19 @@ struct Value *Value_le(struct Value *this, struct Value *x, int calc)
       {
         int v;
 
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            v = (this->u.real <= x->u.real) ? -1 : 0;
+            v = (self->u.real <= x->u.real) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1101,15 +1101,15 @@ struct Value *Value_le(struct Value *this, struct Value *x, int calc)
 
         if (calc)
           {
-            v = (String_cmp(&this->u.string, &x->u.string) <= 0) ? -1 : 0;
+            v = (String_cmp(&self->u.string, &x->u.string) <= 0) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1117,20 +1117,20 @@ struct Value *Value_le(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_eq(struct Value *this, struct Value *x, int calc)
+struct Value *Value_eq(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (this->u.integer == x->u.integer) ? -1 : 0;
+            self->u.integer = (self->u.integer == x->u.integer) ? -1 : 0;
           }
         break;
       }
@@ -1139,19 +1139,19 @@ struct Value *Value_eq(struct Value *this, struct Value *x, int calc)
       {
         int v;
 
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            v = (this->u.real == x->u.real) ? -1 : 0;
+            v = (self->u.real == x->u.real) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1161,15 +1161,15 @@ struct Value *Value_eq(struct Value *this, struct Value *x, int calc)
 
         if (calc)
           {
-            v = (String_cmp(&this->u.string, &x->u.string) == 0) ? -1 : 0;
+            v = (String_cmp(&self->u.string, &x->u.string) == 0) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1177,20 +1177,20 @@ struct Value *Value_eq(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_ge(struct Value *this, struct Value *x, int calc)
+struct Value *Value_ge(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (this->u.integer >= x->u.integer) ? -1 : 0;
+            self->u.integer = (self->u.integer >= x->u.integer) ? -1 : 0;
           }
         break;
       }
@@ -1199,19 +1199,19 @@ struct Value *Value_ge(struct Value *this, struct Value *x, int calc)
       {
         int v;
 
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            v = (this->u.real >= x->u.real) ? -1 : 0;
+            v = (self->u.real >= x->u.real) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1221,15 +1221,15 @@ struct Value *Value_ge(struct Value *this, struct Value *x, int calc)
 
         if (calc)
           {
-            v = (String_cmp(&this->u.string, &x->u.string) >= 0) ? -1 : 0;
+            v = (String_cmp(&self->u.string, &x->u.string) >= 0) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1237,20 +1237,20 @@ struct Value *Value_ge(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_gt(struct Value *this, struct Value *x, int calc)
+struct Value *Value_gt(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (this->u.integer > x->u.integer) ? -1 : 0;
+            self->u.integer = (self->u.integer > x->u.integer) ? -1 : 0;
           }
         break;
       }
@@ -1259,19 +1259,19 @@ struct Value *Value_gt(struct Value *this, struct Value *x, int calc)
       {
         int v;
 
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            v = (this->u.real > x->u.real) ? -1 : 0;
+            v = (self->u.real > x->u.real) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1281,15 +1281,15 @@ struct Value *Value_gt(struct Value *this, struct Value *x, int calc)
 
         if (calc)
           {
-            v = (String_cmp(&this->u.string, &x->u.string) > 0) ? -1 : 0;
+            v = (String_cmp(&self->u.string, &x->u.string) > 0) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1297,20 +1297,20 @@ struct Value *Value_gt(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct Value *Value_ne(struct Value *this, struct Value *x, int calc)
+struct Value *Value_ne(struct Value *self, struct Value *x, int calc)
 {
-  switch (Value_commonType[this->type][x->type])
+  switch (Value_commonType[self->type][x->type])
     {
     case V_INTEGER:
       {
-        VALUE_RETYPE(this, V_INTEGER);
+        VALUE_RETYPE(self, V_INTEGER);
         VALUE_RETYPE(x, V_INTEGER);
         if (calc)
           {
-            this->u.integer = (this->u.integer != x->u.integer) ? -1 : 0;
+            self->u.integer = (self->u.integer != x->u.integer) ? -1 : 0;
           }
         break;
       }
@@ -1319,19 +1319,19 @@ struct Value *Value_ne(struct Value *this, struct Value *x, int calc)
       {
         int v;
 
-        VALUE_RETYPE(this, V_REAL);
+        VALUE_RETYPE(self, V_REAL);
         VALUE_RETYPE(x, V_REAL);
         if (calc)
           {
-            v = (this->u.real != x->u.real) ? -1 : 0;
+            v = (self->u.real != x->u.real) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1341,15 +1341,15 @@ struct Value *Value_ne(struct Value *this, struct Value *x, int calc)
 
         if (calc)
           {
-            v = String_cmp(&this->u.string, &x->u.string) ? -1 : 0;
+            v = String_cmp(&self->u.string, &x->u.string) ? -1 : 0;
           }
         else
           {
             v = 0;
           }
 
-        Value_destroy(this);
-        Value_new_INTEGER(this, v);
+        Value_destroy(self);
+        Value_new_INTEGER(self, v);
         break;
       }
 
@@ -1357,27 +1357,27 @@ struct Value *Value_ne(struct Value *this, struct Value *x, int calc)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-int Value_exitFor(struct Value *this,
+int Value_exitFor(struct Value *self,
                   struct Value *limit, struct Value *step)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
       return
         (step->u.integer < 0
-         ? (this->u.integer < limit->u.integer)
-         : (this->u.integer > limit->u.integer));
+         ? (self->u.integer < limit->u.integer)
+         : (self->u.integer > limit->u.integer));
 
     case V_REAL:
       return
         (step->u.real < 0.0
-         ? (this->u.real < limit->u.real) : (this->u.real > limit->u.real));
+         ? (self->u.real < limit->u.real) : (self->u.real > limit->u.real));
 
     case V_STRING:
-      return (String_cmp(&this->u.string, &limit->u.string) > 0);
+      return (String_cmp(&self->u.string, &limit->u.string) > 0);
 
     default:
       assert(0);
@@ -1386,53 +1386,53 @@ int Value_exitFor(struct Value *this,
   return -1;
 }
 
-void Value_errorPrefix(struct Value *this, const char *prefix)
+void Value_errorPrefix(struct Value *self, const char *prefix)
 {
   size_t prefixlen;
   size_t msglen;
 
-  assert(this->type == V_ERROR);
+  assert(self->type == V_ERROR);
   prefixlen = strlen(prefix);
-  msglen = strlen(this->u.error.msg);
-  this->u.error.msg = realloc(this->u.error.msg, prefixlen + msglen + 1);
-  memmove(this->u.error.msg + prefixlen, this->u.error.msg, msglen);
-  memcpy(this->u.error.msg, prefix, prefixlen);
+  msglen = strlen(self->u.error.msg);
+  self->u.error.msg = realloc(self->u.error.msg, prefixlen + msglen + 1);
+  memmove(self->u.error.msg + prefixlen, self->u.error.msg, msglen);
+  memcpy(self->u.error.msg, prefix, prefixlen);
 }
 
-void Value_errorSuffix(struct Value *this, const char *suffix)
+void Value_errorSuffix(struct Value *self, const char *suffix)
 {
   size_t suffixlen;
   size_t msglen;
 
-  assert(this->type == V_ERROR);
+  assert(self->type == V_ERROR);
   suffixlen = strlen(suffix);
-  msglen = strlen(this->u.error.msg);
-  this->u.error.msg = realloc(this->u.error.msg, suffixlen + msglen + 1);
-  memcpy(this->u.error.msg + msglen, suffix, suffixlen + 1);
+  msglen = strlen(self->u.error.msg);
+  self->u.error.msg = realloc(self->u.error.msg, suffixlen + msglen + 1);
+  memcpy(self->u.error.msg + msglen, suffix, suffixlen + 1);
 }
 
-struct Value *Value_new_typeError(struct Value *this, enum ValueType t1,
+struct Value *Value_new_typeError(struct Value *self, enum ValueType t1,
                                   enum ValueType t2)
 {
   assert(typestr[t1]);
   assert(typestr[t2]);
-  return Value_new_ERROR(this, TYPEMISMATCH1,
+  return Value_new_ERROR(self, TYPEMISMATCH1,
                          _(typestr[t1]), _(typestr[t2]));
 }
 
-static void retypeError(struct Value *this, enum ValueType to)
+static void retypeError(struct Value *self, enum ValueType to)
 {
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
 
   assert(typestr[thisType]);
   assert(typestr[to]);
-  Value_destroy(this);
-  Value_new_ERROR(this, TYPEMISMATCH1, _(typestr[thisType]), _(typestr[to]));
+  Value_destroy(self);
+  Value_new_ERROR(self, TYPEMISMATCH1, _(typestr[thisType]), _(typestr[to]));
 }
 
-struct Value *Value_retype(struct Value *this, enum ValueType type)
+struct Value *Value_retype(struct Value *self, enum ValueType type)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
       {
@@ -1442,17 +1442,17 @@ struct Value *Value_retype(struct Value *this, enum ValueType type)
             break;
 
           case V_REAL:
-            this->u.real = this->u.integer;
-            this->type = type;
+            self->u.real = self->u.integer;
+            self->type = type;
             break;
 
           case V_VOID:
-            Value_destroy(this);
-            Value_new_VOID(this);
+            Value_destroy(self);
+            Value_new_VOID(self);
             break;
 
           default:
-            retypeError(this, type);
+            retypeError(self, type);
             break;
           }
         break;
@@ -1466,12 +1466,12 @@ struct Value *Value_retype(struct Value *this, enum ValueType type)
           {
           case V_INTEGER:
             {
-              this->u.integer = Value_toi(this->u.real, &overflow);
-              this->type = V_INTEGER;
+              self->u.integer = Value_toi(self->u.real, &overflow);
+              self->type = V_INTEGER;
               if (overflow)
                 {
-                  Value_destroy(this);
-                  Value_new_ERROR(this, OUTOFRANGE, typestr[V_INTEGER]);
+                  Value_destroy(self);
+                  Value_new_ERROR(self, OUTOFRANGE, typestr[V_INTEGER]);
                 }
               break;
             }
@@ -1480,12 +1480,12 @@ struct Value *Value_retype(struct Value *this, enum ValueType type)
             break;
 
           case V_VOID:
-            Value_destroy(this);
-            Value_new_VOID(this);
+            Value_destroy(self);
+            Value_new_VOID(self);
             break;
 
           default:
-            retypeError(this, type);
+            retypeError(self, type);
             break;
           }
         break;
@@ -1499,12 +1499,12 @@ struct Value *Value_retype(struct Value *this, enum ValueType type)
             break;
 
           case V_VOID:
-            Value_destroy(this);
-            Value_new_VOID(this);
+            Value_destroy(self);
+            Value_new_VOID(self);
             break;
 
           default:
-            retypeError(this, type);
+            retypeError(self, type);
             break;
           }
         break;
@@ -1518,7 +1518,7 @@ struct Value *Value_retype(struct Value *this, enum ValueType type)
             break;
 
           default:
-            retypeError(this, type);
+            retypeError(self, type);
           }
         break;
       }
@@ -1530,20 +1530,20 @@ struct Value *Value_retype(struct Value *this, enum ValueType type)
       assert(0);
     }
 
-  return this;
+  return self;
 }
 
-struct String *Value_toString(struct Value *this, struct String *s, char pad,
+struct String *Value_toString(struct Value *self, struct String *s, char pad,
                               int headingsign, size_t width, int commas,
                               int dollar, int dollarleft, int precision,
                               int exponent, int trailingsign)
 {
   size_t oldlength = s->length;
 
-  switch (this->type)
+  switch (self->type)
     {
     case V_ERROR:
-      String_appendChars(s, this->u.error.msg);
+      String_appendChars(s, self->u.error.msg);
       break;
 
     case V_REAL:
@@ -1554,14 +1554,14 @@ struct String *Value_toString(struct Value *this, struct String *s, char pad,
         size_t totalwidth = width;
 
         String_new(&buf);
-        if (this->type == V_INTEGER)
+        if (self->type == V_INTEGER)
           {
-            if (this->u.integer < 0)
+            if (self->u.integer < 0)
               {
                 sign = -1;
-                this->u.integer = -this->u.integer;
+                self->u.integer = -self->u.integer;
               }
-            else if (this->u.integer == 0)
+            else if (self->u.integer == 0)
               {
                 sign = 0;
               }
@@ -1572,12 +1572,12 @@ struct String *Value_toString(struct Value *this, struct String *s, char pad,
           }
         else
           {
-            if (this->u.real < 0.0)
+            if (self->u.real < 0.0)
               {
                 sign = -1;
-                this->u.real = -this->u.real;
+                self->u.real = -self->u.real;
               }
-            else if (this->u.real == 0.0)
+            else if (self->u.real == 0.0)
               {
                 sign = 0;
               }
@@ -1620,25 +1620,25 @@ struct String *Value_toString(struct Value *this, struct String *s, char pad,
           }
 
         totalwidth += exponent;
-        if (this->type == V_INTEGER)
+        if (self->type == V_INTEGER)
           {
             if (precision > 0 || exponent)
               {
-                format_double(&buf, (double)this->u.integer, width,
+                format_double(&buf, (double)self->u.integer, width,
                               precision, exponent);
               }
             else if (precision == 0)
               {
-                String_appendPrintf(&buf, "%lu.", this->u.integer);
+                String_appendPrintf(&buf, "%lu.", self->u.integer);
               }
             else
               {
-                String_appendPrintf(&buf, "%lu", this->u.integer);
+                String_appendPrintf(&buf, "%lu", self->u.integer);
               }
           }
         else
           {
-            format_double(&buf, this->u.real, width, precision, exponent);
+            format_double(&buf, self->u.real, width, precision, exponent);
           }
 
         if (commas)
@@ -1703,21 +1703,21 @@ struct String *Value_toString(struct Value *this, struct String *s, char pad,
         if (width > 0)
           {
             size_t blanks =
-              (this->u.string.length <
-               width ? (width - this->u.string.length) : 0);
+              (self->u.string.length <
+               width ? (width - self->u.string.length) : 0);
 
             String_size(s, oldlength + width);
-            memcpy(s->character + oldlength, this->u.string.character,
-                   blanks ? this->u.string.length : width);
+            memcpy(s->character + oldlength, self->u.string.character,
+                   blanks ? self->u.string.length : width);
             if (blanks)
               {
-                memset(s->character + oldlength + this->u.string.length, ' ',
+                memset(s->character + oldlength + self->u.string.length, ' ',
                        blanks);
               }
           }
         else
           {
-            String_appendString(s, &this->u.string);
+            String_appendString(s, &self->u.string);
           }
         break;
       }
@@ -1730,7 +1730,7 @@ struct String *Value_toString(struct Value *this, struct String *s, char pad,
   return s;
 }
 
-struct Value *Value_toStringUsing(struct Value *this, struct String *s,
+struct Value *Value_toStringUsing(struct Value *self, struct String *s,
                                   struct String *using, size_t * usingpos)
 {
   char pad = ' ';
@@ -1762,8 +1762,8 @@ struct Value *Value_toStringUsing(struct Value *this, struct String *s,
               }
             else
               {
-                Value_destroy(this);
-                return Value_new_ERROR(this, MISSINGCHARACTER);
+                Value_destroy(self);
+                return Value_new_ERROR(self, MISSINGCHARACTER);
               }
 
             break;
@@ -1796,8 +1796,8 @@ struct Value *Value_toStringUsing(struct Value *this, struct String *s,
               }
             else
               {
-                Value_destroy(this);
-                return Value_new_ERROR(this, IOERROR,
+                Value_destroy(self);
+                return Value_new_ERROR(self, IOERROR,
                                        _("unpaired \\ in format"));
               }
 
@@ -1879,8 +1879,8 @@ struct Value *Value_toStringUsing(struct Value *this, struct String *s,
 
                 if (width == 1 && precision == 0)
                   {
-                    Value_destroy(this);
-                    return Value_new_ERROR(this, BADFORMAT);
+                    Value_destroy(self);
+                    return Value_new_ERROR(self, BADFORMAT);
                   }
               }
 
@@ -1925,9 +1925,9 @@ struct Value *Value_toStringUsing(struct Value *this, struct String *s,
     }
 
 work:
-  Value_toString(this, s, pad, headingsign, width, commas, dollar,
+  Value_toString(self, s, pad, headingsign, width, commas, dollar,
                  dollarleft, precision, exponent, trailingsign);
-  if ((this->type == V_INTEGER || this->type == V_REAL) && width == 0 &&
+  if ((self->type == V_INTEGER || self->type == V_REAL) && width == 0 &&
       precision == -1)
     {
       String_appendChar(s, ' ');
@@ -1946,8 +1946,8 @@ work:
               }
             else
               {
-                Value_destroy(this);
-                return Value_new_ERROR(this, MISSINGCHARACTER);
+                Value_destroy(self);
+                return Value_new_ERROR(self, MISSINGCHARACTER);
               }
             break;
           }
@@ -1960,7 +1960,7 @@ work:
         case '+':
         case '#':
         case '.':
-          return this;
+          return self;
 
         default:
           {
@@ -1969,15 +1969,15 @@ work:
         }
     }
 
-  return this;
+  return self;
 }
 
-struct String *Value_toWrite(struct Value *this, struct String *s)
+struct String *Value_toWrite(struct Value *self, struct String *s)
 {
-  switch (this->type)
+  switch (self->type)
     {
     case V_INTEGER:
-      String_appendPrintf(s, "%ld", this->u.integer);
+      String_appendPrintf(s, "%ld", self->u.integer);
       break;
 
     case V_REAL:
@@ -1987,7 +1987,7 @@ struct String *Value_toWrite(struct Value *this, struct String *s)
         int n;
         int o;
 
-        x = (this->u.real < 0.0 ? -this->u.real : this->u.real);
+        x = (self->u.real < 0.0 ? -self->u.real : self->u.real);
         while (x > 1.0 && p > 0)
           {
             x /= 10.0;
@@ -1995,7 +1995,7 @@ struct String *Value_toWrite(struct Value *this, struct String *s)
           }
 
         o = s->length;
-        String_appendPrintf(s, "%.*f", p, this->u.real);
+        String_appendPrintf(s, "%.*f", p, self->u.real);
         n = s->length;
         if (memchr(s->character + o, '.', n - o))
           {
@@ -2014,8 +2014,8 @@ struct String *Value_toWrite(struct Value *this, struct String *s)
 
     case V_STRING:
       {
-        size_t l = this->u.string.length;
-        char *data = this->u.string.character;
+        size_t l = self->u.string.length;
+        char *data = self->u.string.character;
 
         String_appendChar(s, '"');
         while (l--)

--- a/interpreters/bas/bas_value.h
+++ b/interpreters/bas/bas_value.h
@@ -101,53 +101,53 @@ long int Value_toi(double d, int *overflow);
 long int Value_vali(const char *s, char **end, int *overflow);
 double Value_vald(const char *s, char **end, int *overflow);
 
-struct Value *Value_new_NIL(struct Value *this);
-struct Value *Value_new_ERROR(struct Value *this, int code,
+struct Value *Value_new_NIL(struct Value *self);
+struct Value *Value_new_ERROR(struct Value *self, int code,
                               const char *error, ...) printf_like(3, 4);
-struct Value *Value_new_INTEGER(struct Value *this, int n);
-struct Value *Value_new_REAL(struct Value *this, double n);
-struct Value *Value_new_STRING(struct Value *this);
-struct Value *Value_new_VOID(struct Value *this);
-struct Value *Value_new_null(struct Value *this, enum ValueType type);
-int Value_isNull(const struct Value *this);
-void Value_destroy(struct Value *this);
-void Value_errorPrefix(struct Value *this, const char *prefix);
-void Value_errorSuffix(struct Value *this, const char *suffix);
-struct Value *Value_new_typeError(struct Value *this, enum ValueType t1,
+struct Value *Value_new_INTEGER(struct Value *self, int n);
+struct Value *Value_new_REAL(struct Value *self, double n);
+struct Value *Value_new_STRING(struct Value *self);
+struct Value *Value_new_VOID(struct Value *self);
+struct Value *Value_new_null(struct Value *self, enum ValueType type);
+int Value_isNull(const struct Value *self);
+void Value_destroy(struct Value *self);
+void Value_errorPrefix(struct Value *self, const char *prefix);
+void Value_errorSuffix(struct Value *self, const char *suffix);
+struct Value *Value_new_typeError(struct Value *self, enum ValueType t1,
                                   enum ValueType t2);
-struct Value *Value_retype(struct Value *this, enum ValueType type);
-struct Value *Value_clone(struct Value *this, const struct Value *original);
-struct Value *Value_uplus(struct Value *this, int calc);
-struct Value *Value_uneg(struct Value *this, int calc);
-struct Value *Value_unot(struct Value *this, int calc);
-struct Value *Value_add(struct Value *this, struct Value *x, int calc);
-struct Value *Value_sub(struct Value *this, struct Value *x, int calc);
-struct Value *Value_mult(struct Value *this, struct Value *x, int calc);
-struct Value *Value_div(struct Value *this, struct Value *x, int calc);
-struct Value *Value_idiv(struct Value *this, struct Value *x, int calc);
-struct Value *Value_mod(struct Value *this, struct Value *x, int calc);
-struct Value *Value_pow(struct Value *this, struct Value *x, int calc);
-struct Value *Value_and(struct Value *this, struct Value *x, int calc);
-struct Value *Value_or(struct Value *this, struct Value *x, int calc);
-struct Value *Value_xor(struct Value *this, struct Value *x, int calc);
-struct Value *Value_eqv(struct Value *this, struct Value *x, int calc);
-struct Value *Value_imp(struct Value *this, struct Value *x, int calc);
-struct Value *Value_lt(struct Value *this, struct Value *x, int calc);
-struct Value *Value_le(struct Value *this, struct Value *x, int calc);
-struct Value *Value_eq(struct Value *this, struct Value *s, int calc);
-struct Value *Value_ge(struct Value *this, struct Value *x, int calc);
-struct Value *Value_gt(struct Value *this, struct Value *x, int calc);
-struct Value *Value_ne(struct Value *this, struct Value *x, int calc);
-int Value_exitFor(struct Value *this, struct Value *limit,
+struct Value *Value_retype(struct Value *self, enum ValueType type);
+struct Value *Value_clone(struct Value *self, const struct Value *original);
+struct Value *Value_uplus(struct Value *self, int calc);
+struct Value *Value_uneg(struct Value *self, int calc);
+struct Value *Value_unot(struct Value *self, int calc);
+struct Value *Value_add(struct Value *self, struct Value *x, int calc);
+struct Value *Value_sub(struct Value *self, struct Value *x, int calc);
+struct Value *Value_mult(struct Value *self, struct Value *x, int calc);
+struct Value *Value_div(struct Value *self, struct Value *x, int calc);
+struct Value *Value_idiv(struct Value *self, struct Value *x, int calc);
+struct Value *Value_mod(struct Value *self, struct Value *x, int calc);
+struct Value *Value_pow(struct Value *self, struct Value *x, int calc);
+struct Value *Value_and(struct Value *self, struct Value *x, int calc);
+struct Value *Value_or(struct Value *self, struct Value *x, int calc);
+struct Value *Value_xor(struct Value *self, struct Value *x, int calc);
+struct Value *Value_eqv(struct Value *self, struct Value *x, int calc);
+struct Value *Value_imp(struct Value *self, struct Value *x, int calc);
+struct Value *Value_lt(struct Value *self, struct Value *x, int calc);
+struct Value *Value_le(struct Value *self, struct Value *x, int calc);
+struct Value *Value_eq(struct Value *self, struct Value *s, int calc);
+struct Value *Value_ge(struct Value *self, struct Value *x, int calc);
+struct Value *Value_gt(struct Value *self, struct Value *x, int calc);
+struct Value *Value_ne(struct Value *self, struct Value *x, int calc);
+int Value_exitFor(struct Value *self, struct Value *limit,
                   struct Value *step);
-struct String *Value_toString(struct Value *this, struct String *s,
+struct String *Value_toString(struct Value *self, struct String *s,
                               char pad, int headingsign, size_t width,
                               int commas, int dollar, int dollarleft,
                               int precision, int exponent,
                               int trailingsign);
-struct Value *Value_toStringUsing(struct Value *this, struct String *s,
+struct Value *Value_toStringUsing(struct Value *self, struct String *s,
                                   struct String *using, size_t *usingpos);
-struct String *Value_toWrite(struct Value *this, struct String *s);
+struct String *Value_toWrite(struct Value *self, struct String *s);
 struct Value *Value_nullValue(enum ValueType type);
 
 #endif /* __APPS_EXAMPLES_BAS_BAS_VALUE_H */

--- a/interpreters/bas/bas_var.c
+++ b/interpreters/bas/bas_var.c
@@ -46,141 +46,141 @@
  * Public Functions
  ****************************************************************************/
 
-struct Var *Var_new(struct Var *this, enum ValueType type, unsigned int dim,
+struct Var *Var_new(struct Var *self, enum ValueType type, unsigned int dim,
                     const unsigned int *geometry, int base)
 {
   unsigned int i;
   size_t newsize;
 
-  this->type = type;
-  this->dim = dim;
-  this->base = base;
-  for (newsize = this->size = 1, dim = 0; dim < this->dim; ++dim)
+  self->type = type;
+  self->dim = dim;
+  self->base = base;
+  for (newsize = self->size = 1, dim = 0; dim < self->dim; ++dim)
     {
-      if ((newsize *= geometry[dim]) < this->size)
+      if ((newsize *= geometry[dim]) < self->size)
         return (struct Var *)0;
-      this->size = newsize;
+      self->size = newsize;
     }
 
-  if ((newsize *= sizeof(struct Value)) < this->size)
+  if ((newsize *= sizeof(struct Value)) < self->size)
     {
       return (struct Var *)0;
     }
 
-  if ((this->value = malloc(newsize)) == (struct Value *)0)
+  if ((self->value = malloc(newsize)) == (struct Value *)0)
     {
       return (struct Var *)0;
     }
 
   if (dim)
     {
-      this->geometry = malloc(sizeof(unsigned int) * dim);
+      self->geometry = malloc(sizeof(unsigned int) * dim);
       for (i = 0; i < dim; ++i)
         {
-          this->geometry[i] = geometry[i];
+          self->geometry[i] = geometry[i];
         }
     }
   else
     {
-      this->geometry = (unsigned int *)0;
+      self->geometry = (unsigned int *)0;
     }
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      Value_new_null(&(this->value[i]), type);
+      Value_new_null(&(self->value[i]), type);
     }
 
-  return this;
+  return self;
 }
 
-struct Var *Var_new_scalar(struct Var *this)
+struct Var *Var_new_scalar(struct Var *self)
 {
-  this->dim = 0;
-  this->size = 1;
-  this->geometry = (unsigned int *)0;
-  this->value = malloc(sizeof(struct Value));
-  return this;
+  self->dim = 0;
+  self->size = 1;
+  self->geometry = (unsigned int *)0;
+  self->value = malloc(sizeof(struct Value));
+  return self;
 }
 
-void Var_destroy(struct Var *this)
+void Var_destroy(struct Var *self)
 {
-  while (this->size--)
+  while (self->size--)
     {
-      Value_destroy(&(this->value[this->size]));
+      Value_destroy(&(self->value[self->size]));
     }
 
-  free(this->value);
-  this->value = (struct Value *)0;
-  this->size = 0;
-  this->dim = 0;
-  if (this->geometry)
+  free(self->value);
+  self->value = (struct Value *)0;
+  self->size = 0;
+  self->dim = 0;
+  if (self->geometry)
     {
-      free(this->geometry);
-      this->geometry = (unsigned int *)0;
+      free(self->geometry);
+      self->geometry = (unsigned int *)0;
     }
 }
 
-void Var_retype(struct Var *this, enum ValueType type)
+void Var_retype(struct Var *self, enum ValueType type)
 {
   unsigned int i;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      Value_destroy(&(this->value[i]));
-      Value_new_null(&(this->value[i]), type);
+      Value_destroy(&(self->value[i]));
+      Value_new_null(&(self->value[i]), type);
     }
 }
 
-struct Value *Var_value(struct Var *this, unsigned int dim, int idx[],
+struct Value *Var_value(struct Var *self, unsigned int dim, int idx[],
                         struct Value *value)
 {
   unsigned int offset;
   unsigned int i;
 
-  assert(this->value);
-  if (dim != this->dim)
+  assert(self->value);
+  if (dim != self->dim)
     {
       return Value_new_ERROR(value, DIMENSION);
     }
 
   for (offset = 0, i = 0; i < dim; ++i)
     {
-      if (idx[i] < this->base || (idx[i] - this->base) >= this->geometry[i])
+      if (idx[i] < self->base || (idx[i] - self->base) >= self->geometry[i])
         {
           return Value_new_ERROR(value, OUTOFRANGE, _("array index"));
         }
 
-      offset = offset * this->geometry[i] + (idx[i] - this->base);
+      offset = offset * self->geometry[i] + (idx[i] - self->base);
     }
 
-  assert(offset < this->size);
-  return this->value + offset;
+  assert(offset < self->size);
+  return self->value + offset;
 }
 
-void Var_clear(struct Var *this)
+void Var_clear(struct Var *self)
 {
   size_t i;
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      Value_destroy(&(this->value[i]));
+      Value_destroy(&(self->value[i]));
     }
 
-  if (this->geometry)
+  if (self->geometry)
     {
-      free(this->geometry);
-      this->geometry = (unsigned int *)0;
-      this->size = 1;
-      this->dim = 0;
+      free(self->geometry);
+      self->geometry = (unsigned int *)0;
+      self->size = 1;
+      self->dim = 0;
     }
 
-  Value_new_null(&(this->value[0]), this->type);
+  Value_new_null(&(self->value[0]), self->type);
 }
 
-struct Value *Var_mat_assign(struct Var *this, struct Var *x, struct Value *err,
+struct Value *Var_mat_assign(struct Var *self, struct Var *x, struct Value *err,
                              int work)
 {
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
 
   if (work)
     {
@@ -190,13 +190,13 @@ struct Value *Var_mat_assign(struct Var *this, struct Var *x, struct Value *err,
 
       assert(x->base == 0 || x->base == 1);
       assert(x->dim == 1 || x->dim == 2);
-      if (this == x)
+      if (self == x)
         {
           return (struct Value *)0;
         }
 
-      Var_destroy(this);
-      Var_new(this, thisType, x->dim, x->geometry, x->base);
+      Var_destroy(self);
+      Var_new(self, thisType, x->dim, x->geometry, x->base);
       g0 = x->geometry[0];
       g1 = x->dim == 1 ? unused + 1 : x->geometry[1];
       for (i = unused; i < g0; ++i)
@@ -205,27 +205,27 @@ struct Value *Var_mat_assign(struct Var *this, struct Var *x, struct Value *err,
             {
               unsigned int element = x->dim == 1 ? i : i * g1 + j;
 
-              Value_destroy(&(this->value[element]));
-              Value_clone(&(this->value[element]), &(x->value[element]));
-              Value_retype(&(this->value[element]), thisType);
+              Value_destroy(&(self->value[element]));
+              Value_clone(&(self->value[element]), &(x->value[element]));
+              Value_retype(&(self->value[element]), thisType);
             }
         }
     }
   else
     {
-      if (Value_commonType[this->type][x->type] == V_ERROR)
+      if (Value_commonType[self->type][x->type] == V_ERROR)
         {
-          return Value_new_typeError(err, this->type, x->type);
+          return Value_new_typeError(err, self->type, x->type);
         }
     }
 
   return (struct Value *)0;
 }
 
-struct Value *Var_mat_addsub(struct Var *this, struct Var *x, struct Var *y,
+struct Value *Var_mat_addsub(struct Var *self, struct Var *x, struct Var *y,
                              int add, struct Value *err, int work)
 {
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
   struct Value foo, bar;
 
   if (work)
@@ -243,10 +243,10 @@ struct Value *Var_mat_addsub(struct Var *this, struct Var *x, struct Var *y,
           return Value_new_ERROR(err, DIMENSION);
         }
 
-      if (this != x && this != y)
+      if (self != x && self != y)
         {
-          Var_destroy(this);
-          Var_new(this, thisType, x->dim, x->geometry, x->base);
+          Var_destroy(self);
+          Var_new(self, thisType, x->dim, x->geometry, x->base);
         }
 
       g0 = x->geometry[0];
@@ -276,8 +276,8 @@ struct Value *Var_mat_addsub(struct Var *this, struct Var *x, struct Var *y,
                 }
 
               Value_destroy(&bar);
-              Value_destroy(&(this->value[element]));
-              this->value[element] = *Value_retype(&foo, thisType);
+              Value_destroy(&(self->value[element]));
+              self->value[element] = *Value_retype(&foo, thisType);
             }
         }
     }
@@ -304,10 +304,10 @@ struct Value *Var_mat_addsub(struct Var *this, struct Var *x, struct Var *y,
   return (struct Value *)0;
 }
 
-struct Value *Var_mat_mult(struct Var *this, struct Var *x, struct Var *y,
+struct Value *Var_mat_mult(struct Var *self, struct Var *x, struct Var *y,
                            struct Value *err, int work)
 {
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
   struct Var foo;
 
   if (work)
@@ -354,8 +354,8 @@ struct Value *Var_mat_mult(struct Var *this, struct Var *x, struct Var *y,
             }
         }
 
-      Var_destroy(this);
-      *this = foo;
+      Var_destroy(self);
+      *self = foo;
     }
   else
     {
@@ -372,10 +372,10 @@ struct Value *Var_mat_mult(struct Var *this, struct Var *x, struct Var *y,
   return (struct Value *)0;
 }
 
-struct Value *Var_mat_scalarMult(struct Var *this, struct Value *factor,
+struct Value *Var_mat_scalarMult(struct Var *self, struct Value *factor,
                                  struct Var *x, int work)
 {
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
 
   if (work)
     {
@@ -385,10 +385,10 @@ struct Value *Var_mat_scalarMult(struct Var *this, struct Value *factor,
 
       assert(x->base == 0 || x->base == 1);
       assert(x->dim == 1 || x->dim == 2);
-      if (this != x)
+      if (self != x)
         {
-          Var_destroy(this);
-          Var_new(this, thisType, x->dim, x->geometry, 0);
+          Var_destroy(self);
+          Var_new(self, thisType, x->dim, x->geometry, 0);
         }
 
       g0 = x->geometry[0];
@@ -409,14 +409,14 @@ struct Value *Var_mat_scalarMult(struct Var *this, struct Value *factor,
                   return factor;
                 }
 
-              Value_destroy(&(this->value[element]));
-              this->value[element] = *Value_retype(&foo, thisType);
+              Value_destroy(&(self->value[element]));
+              self->value[element] = *Value_retype(&foo, thisType);
             }
         }
     }
   else
     {
-      if (Value_mult(factor, this->value, 0)->type == V_ERROR)
+      if (Value_mult(factor, self->value, 0)->type == V_ERROR)
         {
           return factor;
         }
@@ -425,10 +425,10 @@ struct Value *Var_mat_scalarMult(struct Var *this, struct Value *factor,
   return (struct Value *)0;
 }
 
-void Var_mat_transpose(struct Var *this, struct Var *x)
+void Var_mat_transpose(struct Var *self, struct Var *x)
 {
   unsigned int geometry[2];
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
   unsigned int i, j;
   struct Var foo;
 
@@ -446,14 +446,14 @@ void Var_mat_transpose(struct Var *this, struct Var *x)
         }
     }
 
-  Var_destroy(this);
-  *this = foo;
+  Var_destroy(self);
+  *self = foo;
 }
 
-struct Value *Var_mat_invert(struct Var *this, struct Var *x, struct Value *det,
+struct Value *Var_mat_invert(struct Var *self, struct Var *x, struct Value *det,
                              struct Value *err)
 {
-  enum ValueType thisType = this->type;
+  enum ValueType thisType = self->type;
   int n, i, j, k, max;
   double t, *a, *u, d;
   int unused = 1 - x->base;
@@ -581,26 +581,26 @@ struct Value *Var_mat_invert(struct Var *this, struct Var *x, struct Value *det,
     }
 
   free(a);
-  if (this != x)
+  if (self != x)
     {
-      Var_destroy(this);
-      Var_new(this, thisType, 2, x->geometry, x->base);
+      Var_destroy(self);
+      Var_new(self, thisType, 2, x->geometry, x->base);
     }
 
   for (i = 0; i < n; ++i)
     {
       for (j = 0; j < n; ++j)
         {
-          Value_destroy(&this->value[(i + unused) * (n + unused) + j + unused]);
+          Value_destroy(&self->value[(i + unused) * (n + unused) + j + unused]);
           if (thisType == V_INTEGER)
             {
-              Value_new_INTEGER(&this->value
+              Value_new_INTEGER(&self->value
                                 [(i + unused) * (n + unused) + j + unused],
                                 u[i * n + j]);
             }
           else
             {
-              Value_new_REAL(&this->
+              Value_new_REAL(&self->
                              value[(i + unused) * (n + unused) + j + unused],
                              u[i * n + j]);
             }
@@ -621,15 +621,15 @@ struct Value *Var_mat_invert(struct Var *this, struct Var *x, struct Value *det,
   return (struct Value *)0;
 }
 
-struct Value *Var_mat_redim(struct Var *this, unsigned int dim,
+struct Value *Var_mat_redim(struct Var *self, unsigned int dim,
                             const unsigned int *geometry, struct Value *err)
 {
   unsigned int i, j, size;
   struct Value *value;
-  int unused = 1 - this->base;
+  int unused = 1 - self->base;
   int g0, g1;
 
-  if (this->dim > 0 && this->dim != dim)
+  if (self->dim > 0 && self->dim != dim)
     {
       return Value_new_ERROR(err, DIMENSION);
     }
@@ -646,39 +646,39 @@ struct Value *Var_mat_redim(struct Var *this, unsigned int dim,
     {
       for (j = 0; j < g1; ++j)
         {
-          if (this->dim == 0 || i < unused || (dim == 2 && j < unused) ||
-              i >= this->geometry[0] || (this->dim == 2 &&
-                                         j >= this->geometry[1]))
+          if (self->dim == 0 || i < unused || (dim == 2 && j < unused) ||
+              i >= self->geometry[0] || (self->dim == 2 &&
+                                         j >= self->geometry[1]))
             {
-              Value_new_null(&(value[i * g1 + j]), this->type);
+              Value_new_null(&(value[i * g1 + j]), self->type);
             }
           else
             {
               Value_clone(&value[dim == 1 ? i : i * g1 + j],
-                          &this->value[dim ==
-                                       1 ? i : i * this->geometry[1] + j]);
+                          &self->value[dim ==
+                                       1 ? i : i * self->geometry[1] + j]);
             }
         }
     }
 
-  for (i = 0; i < this->size; ++i)
+  for (i = 0; i < self->size; ++i)
     {
-      Value_destroy(&this->value[i]);
+      Value_destroy(&self->value[i]);
     }
 
-  free(this->value);
-  if (this->geometry == (unsigned int *)0)
+  free(self->value);
+  if (self->geometry == (unsigned int *)0)
     {
-      this->geometry = malloc(sizeof(unsigned int) * dim);
+      self->geometry = malloc(sizeof(unsigned int) * dim);
     }
 
   for (i = 0; i < dim; ++i)
     {
-      this->geometry[i] = geometry[i];
+      self->geometry[i] = geometry[i];
     }
 
-  this->dim = dim;
-  this->size = size;
-  this->value = value;
+  self->dim = dim;
+  self->size = size;
+  self->value = value;
   return (struct Value *)0;
 }

--- a/interpreters/bas/bas_var.h
+++ b/interpreters/bas/bas_var.h
@@ -36,7 +36,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define VAR_SCALAR_VALUE(this) ((this)->value)
+#define VAR_SCALAR_VALUE(self) ((self)->value)
 
 /****************************************************************************
  * Public Types
@@ -56,26 +56,26 @@ struct Var
  * Public Function Prototypes
  ****************************************************************************/
 
-struct Var *Var_new(struct Var *this, enum ValueType type, unsigned int dim,
+struct Var *Var_new(struct Var *self, enum ValueType type, unsigned int dim,
                     const unsigned int *geometry, int base);
-struct Var *Var_new_scalar(struct Var *this);
-void Var_destroy(struct Var *this);
-void Var_retype(struct Var *this, enum ValueType type);
-struct Value *Var_value(struct Var *this, unsigned int dim, int idx[],
+struct Var *Var_new_scalar(struct Var *self);
+void Var_destroy(struct Var *self);
+void Var_retype(struct Var *self, enum ValueType type);
+struct Value *Var_value(struct Var *self, unsigned int dim, int idx[],
                         struct Value *value);
-void Var_clear(struct Var *this);
-struct Value *Var_mat_assign(struct Var *this, struct Var *x,
+void Var_clear(struct Var *self);
+struct Value *Var_mat_assign(struct Var *self, struct Var *x,
                              struct Value *err, int work);
-struct Value *Var_mat_addsub(struct Var *this, struct Var *x, struct Var *y,
+struct Value *Var_mat_addsub(struct Var *self, struct Var *x, struct Var *y,
                              int add, struct Value *err, int work);
-struct Value *Var_mat_mult(struct Var *this, struct Var *x, struct Var *y,
+struct Value *Var_mat_mult(struct Var *self, struct Var *x, struct Var *y,
                            struct Value *err, int work);
-struct Value *Var_mat_scalarMult(struct Var *this, struct Value *factor,
+struct Value *Var_mat_scalarMult(struct Var *self, struct Value *factor,
                                  struct Var *x, int work);
-void Var_mat_transpose(struct Var *this, struct Var *x);
-struct Value *Var_mat_invert(struct Var *this, struct Var *x,
+void Var_mat_transpose(struct Var *self, struct Var *x);
+struct Value *Var_mat_invert(struct Var *self, struct Var *x,
                              struct Value *det, struct Value *err);
-struct Value *Var_mat_redim(struct Var *this, unsigned int dim,
+struct Value *Var_mat_redim(struct Var *self, unsigned int dim,
                             const unsigned int *geometry,
                             struct Value *err);
 

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -766,7 +766,7 @@ int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     }
 
   lib_stream_putc(&stream, '\n');
-  nsh_write(vtbl, stream.buffer, stream.public.nput);
+  nsh_write(vtbl, stream.buffer, stream.common.nput);
   return OK;
 }
 #endif

--- a/system/hex2bin/hex2bin_main.c
+++ b/system/hex2bin/hex2bin_main.c
@@ -227,7 +227,7 @@ int main(int argc, FAR char *argv[])
 
   /* And do the deed */
 
-  ret = hex2bin(&stdinstream.public, &stdoutstream.public,
+  ret = hex2bin(&stdinstream.common, &stdoutstream.common,
                 (uint32_t)baseaddr, (uint32_t)endpaddr,
                 (enum hex2bin_swap_e)swap);
   if (ret < 0)

--- a/system/hex2bin/hex2mem_main.c
+++ b/system/hex2bin/hex2mem_main.c
@@ -210,7 +210,7 @@ int main(int argc, FAR char *argv[])
 
   /* And do the deed */
 
-  ret = hex2bin(&stdinstream.public, &memoutstream.public,
+  ret = hex2bin(&stdinstream.common, &memoutstream.common,
                 (uint32_t)baseaddr, (uint32_t)endpaddr,
                 (enum hex2bin_swap_e)swap);
   if (ret < 0)


### PR DESCRIPTION
## Summary
Complementary apps PR of https://github.com/apache/nuttx/pull/10565.
Rename stream struct fields named `public` and functions parameters named `this` in `streams.h` and `rtt.h` so C++ compilers won't fail to compile them (these are [reserved keywords](https://en.cppreference.com/w/cpp/keyword) in C++). This fixes the issue called out by https://github.com/apache/nuttx/issues/10556

## Impact
`lib/libc/stream`, `segger/rtt.h`
## Testing
- Successfully compiled `nsh` app for IMXRT after I:
  - modified it to include [segger/rtt.h](https://github.com/apache/nuttx/blob/master/include/nuttx/segger/rtt.h)
  - set the following [segger Kconfigs](https://github.com/apache/nuttx/blob/master/drivers/segger/Kconfig):  `STREAM_RTT`, `SEGGER_RTT`

