### PR TITLE
apps/build: Restore ARLOCK to improve compile speed in incremental case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,11 @@
 *.sym
 *.su
 *~
+.built
 .context
 .depend
 .kconfig
+/*.lock
 /bin
 /boot_romfsimg.h
 /external

--- a/Application.mk
+++ b/Application.mk
@@ -142,7 +142,7 @@ VPATH += :.
 
 # Targets follow
 
-all:: $(OBJS)
+all:: .built
 	@:
 .PHONY: clean depend distclean
 .PRECIOUS: $(BIN)
@@ -208,11 +208,12 @@ $(ZIGOBJS): %$(ZIGEXT)$(SUFFIX)$(OBJEXT): %$(ZIGEXT)
 	$(if $(and $(CONFIG_BUILD_LOADABLE), $(CELFFLAGS)), \
 		$(call ELFCOMPILEZIG, $<, $@), $(call COMPILEZIG, $<, $@))
 
-archive:
+.built: $(OBJS)
 	$(call SPLITVARIABLE,ALL_OBJS,$(OBJS),100)
 	$(foreach BATCH, $(ALL_OBJS_TOTAL), \
-		$(call ARCHIVE_ADD, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH))) \
+		$(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH))) \
 	)
+	$(Q) touch $@
 
 ifeq ($(BUILD_MODULE),y)
 
@@ -295,6 +296,7 @@ depend:: .depend
 	@:
 
 clean::
+	$(call DELFILE, .built)
 	$(call CLEAN)
 
 distclean:: clean

--- a/Directory.mk
+++ b/Directory.mk
@@ -24,6 +24,7 @@ include $(APPDIR)/Make.defs
 
 SUBDIRS       := $(dir $(wildcard */Makefile))
 CONFIGSUBDIRS := $(filter-out $(dir $(wildcard */Kconfig)),$(SUBDIRS))
+CLEANSUBDIRS  := $(dir $(wildcard *$(DELIM).built))
 CLEANSUBDIRS  += $(dir $(wildcard */.depend))
 CLEANSUBDIRS  += $(dir $(wildcard */.kconfig))
 CLEANSUBDIRS  := $(sort $(CLEANSUBDIRS))

--- a/Make.defs
+++ b/Make.defs
@@ -152,3 +152,7 @@ define SPLITVARIABLE
 		$(eval $(PREFIX)_$(idx)=$(wordlist $(FROMINDEX), $(shell expr $(FROMINDEX) + $(BATCH_SIZE) - 1), $(2))) \
 	)
 endef
+
+define ARLOCK
+	flock $1.lock $(call ARCHIVE, $1, $(2))
+endef

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,7 @@ SYMTABOBJ = $(SYMTABSRC:.c=$(OBJEXT))
 # We first remove libapps.a before letting the other rules add objects to it
 # so that we ensure libapps.a does not contain objects from prior build
 
-all:
-	$(RM) $(BIN)
-	$(MAKE) $(BIN)
+all: $(BIN)
 
 .PHONY: import install dirlinks export .depdirs preconfig depend clean distclean
 .PHONY: context clean_context context_all register register_all
@@ -74,9 +72,6 @@ ifeq ($(CONFIG_BUILD_KERNEL),y)
 install: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_install)
 
 $(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
-	$(Q) for app in ${CONFIGURED_APPS}; do \
-		$(MAKE) -C "$${app}" archive ; \
-	done
 
 .import: $(BIN)
 	$(Q) install libapps.a $(APPDIR)$(DELIM)import$(DELIM)libs
@@ -96,21 +91,14 @@ else
 ifeq ($(CONFIG_BUILD_LOADABLE),)
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 $(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
-	$(Q) for %%G in ($(CONFIGURED_APPS)) do ( $(MAKE) -C %%G archive )
 else
 $(BIN): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
-	$(Q) for app in ${CONFIGURED_APPS}; do \
-		$(MAKE) -C "$${app}" archive ; \
-	done
 	$(call LINK_WASM)
 endif
 
 else
 
 $(SYMTABSRC): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
-	$(Q) for app in ${CONFIGURED_APPS}; do \
-		$(MAKE) -C "$${app}" archive ; \
-	done
 	$(Q) $(MAKE) install
 	$(Q) $(APPDIR)$(DELIM)tools$(DELIM)mksymtab.sh $(BINDIR) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
@@ -119,7 +107,7 @@ $(SYMTABOBJ): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@, -fno-lto -fno-builtin)
 
 $(BIN): $(SYMTABOBJ)
-	$(call ARCHIVE_ADD, $(call CONVERT_PATH,$(BIN)), $^)
+	$(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $^)
 	$(call LINK_WASM)
 
 endif # !CONFIG_BUILD_LOADABLE
@@ -208,6 +196,7 @@ clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 	$(call CLEAN)
 
 distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
+	$(call DELFILE, *.lock)
 	$(call DELFILE, .depend)
 	$(call DELFILE, $(SYMTABSRC))
 	$(call DELFILE, $(SYMTABOBJ))


### PR DESCRIPTION

## Summary

apps/build: Restore ARLOCK to improve compile speed in incremental case

To solve the issue of carrying object files from previous builds, Matias changed the archiving process to re-archive libapps.a on every compilation, if libapps.a carries more object files, incremental compilation will waste too many time in re-archiving, compared with the previous implement, this is a degradation of the build system.  Referring to mature engineering projects such as cmake, if there is configuration or source file changed, the best solution should be to reconfigure the environment.

Revert this PR to ensure the compilation speed during incremental compilation.


https://github.com/apache/nuttx-apps/pull/380
```
|  commit 18137c0fec3cea30871f29238e11ea0f4e8523da
|  Author: Matias N <matias@protobits.dev>
|  Date:   Sat Sep 12 00:36:23 2020 -0300
|
|      Fix: ensure archive files do not carry object files from prior builds
|
|      This is the corresponding change to the one on main NuttX repo. In this
|      case this involves splitting the build of libapps.a into: a) building
|      all applications (which is safely parallelizable), b) adding each
|      application's object files to the archive in turns (serial by nature).
|
|      This removes the need for the flock used to protect the parallel build.
```

## Impact

Build system
Depends on: https://github.com/apache/nuttx/pull/10576

## Testing

Testing:

```
sim:nsh
-------------------------------
|   Patched    |  Current
-------------------------------
|$ time make   |  $ time make
|real 0m1.270s |  real 0m1.728s
|user 0m0.971s |  user 0m1.276s
|sys  0m0.363s |  sys  0m0.530s
-------------------------------
```

```
Private project (20+ 3rd library needs archive to libapps.a) 
-------------------------------
|   Patched     |  Current
-------------------------------
|$ time make    |  $ time make
|real 0m21.181s |  real 0m39.721s
|user 0m14.638s |  user 0m24.837s
|sys  0m6.919s  |  sys  0m14.394s
-------------------------------
```