### PR TITLE
crypto/mbedtls: fix build break on sha256.c

### DIFF
--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -38,7 +38,18 @@ MBEDTLS_UNPACKPROGDIR = $(MBEDTLS_UNPACKNAME)$(DELIM)programs
 # This lets Mbed TLS better use some of the POSIX features we have
 CFLAGS += ${DEFINE_PREFIX}__unix__
 
-library/bignum.c_CFLAGS += -fno-lto
+mbedtls/library/bignum.c_CFLAGS += -fno-lto
+
+# Build break on Assemble compiler if -fno-omit-frame-pointer and -O3 enabled at same time
+# {standard input}: Assembler messages:
+# {standard input}:2560: Error: branch out of range
+# make[2]: *** [apps/Application.mk:170: mbedtls/library/sha256.o] Error 1
+
+ifeq ($(CONFIG_FRAME_POINTER),y)
+  ifeq ($(CONFIG_DEBUG_OPTLEVEL),"-O3")
+    mbedtls/library/sha256.c_CFLAGS += -O2
+  endif
+endif
 
 ifeq ($(CONFIG_ARCH_SIM),y)
   CFLAGS += -O0


### PR DESCRIPTION


## Summary

crypto/mbedtls: fix build break on sha256.c

Build break on Assemble compiler if -fno-omit-frame-pointer and -O3 enabled at same time

```
{standard input}: Assembler messages:
{standard input}:2560: Error: branch out of range
make[2]: *** [apps/Application.mk:170: mbedtls/library/sha256.o] Error 1
```

## Impact

N/A

## Testing

ci-check