### PR TITLE
Ltp Makefile:fix make macro error block on Mac

### DIFF
--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -270,6 +270,11 @@ CFLAGS += -Wno-unused-variable -Wno-unused-function -Wno-unused-but-set-variable
 # Should be removed if possible in the future
 CFLAGS += -Wno-incompatible-pointer-types -Wno-overflow -Wno-int-to-pointer-cast
 
+# Specific compilation errors ignored in MacOS platform
+ifneq ($(CONFIG_HOST_MACOS),)
+CFLAGS += -Wno-integer-overflow -Wno-absolute-value
+endif
+
 ltp-$(LTPS_VERSION).zip:
 	$(call DOWNLOAD,$(LTP_DOWNLOAD_URL),$(LTPS_VERSION).zip, ltp.zip)
 

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -222,7 +222,7 @@ MAINWORDS += "main("
 
 LTP_ORIGS := $(shell find $(TESTDIR) -name *.c)
 ifneq ($(LTP_ORIGS),)
-$(call SPLITVARIABLE,ORIGS_SPILT,$(LTP_ORIGS),200)
+$(eval $(call SPLITVARIABLE,ORIGS_SPILT,$(LTP_ORIGS),200))
 $(foreach BATCH, $(ORIGS_SPILT_TOTAL), \
 	$(foreach word, $(BLACKWORDS), $(eval BLACKLIST+=$(shell grep -lr $(word) $(ORIGS_SPILT_$(BATCH))))) \
 )
@@ -232,7 +232,7 @@ $(foreach src, $(BLACKSRCS), $(eval BLACKLIST+=$(filter %$(src),$(LTP_ORIGS))))
 
 LTP_ORIGS := $(filter-out $(BLACKLIST), $(LTP_ORIGS))
 ifneq ($(LTP_ORIGS),)
-$(call SPLITVARIABLE,ORIGS_SPILT,$(LTP_ORIGS),200)
+$(eval $(call SPLITVARIABLE,ORIGS_SPILT,$(LTP_ORIGS),200))
 $(foreach BATCH, $(ORIGS_SPILT_TOTAL), \
 	$(foreach word, $(MAINWORDS), $(eval LTP_MAINCSRCS+=$(shell grep -lr $(word) $(ORIGS_SPILT_$(BATCH))))) \
 )
@@ -240,7 +240,7 @@ endif
 
 LTP_CSRCS := $(filter-out $(LTP_MAINCSRCS), $(LTP_ORIGS))
 ifneq ($(LTP_MAINCSRCS),)
-$(call SPLITVARIABLE,MAINCSRC_SPILT,$(LTP_MAINCSRCS),50)
+$(eval $(call SPLITVARIABLE,MAINCSRC_SPILT,$(LTP_MAINCSRCS),50))
 $(foreach BATCH, $(MAINCSRC_SPILT_TOTAL), \
 	$(eval PROGNAME+=$(basename $(shell echo $(MAINCSRC_SPILT_$(BATCH)) | xargs -n 1 | awk -F "[/]" '{print "ltp_"$$(NF-2)"_"$$(NF-1)"_"$$(NF)}' | sed s/-/_/g))) \
 )


### PR DESCRIPTION
## Summary
fix the Makefile mac compiler error found by https://github.com/apache/nuttx/pull/10543
## Impact

## Testing
ci

