### PR TITLE
nxcamera: Fix compilation warnings caused by format issues

### DIFF
--- a/system/nxcamera/nxcamera_main.c
+++ b/system/nxcamera/nxcamera_main.c
@@ -157,7 +157,8 @@ static int nxcamera_cmd_stream(FAR struct nxcamera_s *pcam, FAR char *parg)
       0
     };
 
-  sscanf(parg, "%hd %hd %d %4s", &width, &height, &framerate, cc);
+  sscanf(parg, "%"SCNu16" %"SCNu16" %"SCNu32" %4s",
+                &width, &height, &framerate, cc);
   format = v4l2_fourcc(cc[0], cc[1], cc[2], cc[3]);
 
   /* Try to stream raw data with settings specified */


### PR DESCRIPTION
## Summary

nxcamera_main.c:160:26: warning: format '%d' expects argument of type 'int *', but argument 5 has type 'uint32_t *' {aka 'long unsigned int *'} [-Wformat=]
```
  160 |   sscanf(parg, "%hd %hd %d %4s", &width, &height, &framerate, cc);
      |                         ~^                        ~~~~~~~~~~
      |                          |                        |
      |                          int *                    uint32_t * {aka long unsigned int *}
      |                         %ld
```

## Impact

nxcamera

## Testing

ci