### PR TITLE
mbedtls-alt/md5: add md5 alternative implementation

### DIFF
--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -578,6 +578,11 @@ config MBEDTLS_AES_ALT
 	select MBEDTLS_ALT
 	default n
 
+config MBEDTLS_MD5_ALT
+	bool "Enable Mbedt TLS MD5 module alted by nuttx crypto"
+	select MBEDTLS_ALT
+	default n
+
 config MBEDTLS_SHA1_ALT
 	bool "Enable Mbedt TLS SHA1 module alted by nuttx crypto"
 	select MBEDTLS_ALT

--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -105,6 +105,10 @@ ifeq ($(CONFIG_MBEDTLS_AES_ALT),y)
 CSRCS += $(APPDIR)/crypto/mbedtls/source/aes_alt.c
 endif
 
+ifeq ($(CONFIG_MBEDTLS_MD5_ALT),y)
+CSRCS += $(APPDIR)/crypto/mbedtls/source/md5_alt.c
+endif
+
 ifeq ($(CONFIG_MBEDTLS_SHA1_ALT),y)
 CSRCS += $(APPDIR)/crypto/mbedtls/source/sha1_alt.c
 endif

--- a/crypto/mbedtls/include/mbedtls/mbedtls_config.h
+++ b/crypto/mbedtls/include/mbedtls/mbedtls_config.h
@@ -367,8 +367,11 @@
  * #define MBEDTLS_NIST_KW_ALT
  * #define MBEDTLS_MD2_ALT
  * #define MBEDTLS_MD4_ALT
- * #define MBEDTLS_MD5_ALT
- * #define MBEDTLS_POLY1305_ALT
+ */
+#ifdef CONFIG_MBEDTLS_MD5_ALT
+#define MBEDTLS_MD5_ALT
+#endif
+/* #define MBEDTLS_POLY1305_ALT
  * #define MBEDTLS_RIPEMD160_ALT
  * #define MBEDTLS_RSA_ALT
  */

--- a/crypto/mbedtls/include/md5_alt.h
+++ b/crypto/mbedtls/include/md5_alt.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+ * apps/crypto/mbedtls/include/md5_alt.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ ****************************************************************************/
+
+#ifndef __APPS_CRYPTO_MBEDTLS_INCLUDE_MD5_ALT_H
+#define __APPS_CRYPTO_MBEDTLS_INCLUDE_MD5_ALT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "dev_alt.h"
+
+#define mbedtls_md5_context cryptodev_context_t
+
+#endif /* __APPS_CRYPTO_MBEDTLS_INCLUDE_MD5_ALT_H */

--- a/crypto/mbedtls/source/md5_alt.c
+++ b/crypto/mbedtls/source/md5_alt.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * apps/crypto/mbedtls/source/md5_alt.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "mbedtls/md5.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void mbedtls_md5_clone(FAR mbedtls_md5_context *dst,
+                       FAR const mbedtls_md5_context *src)
+{
+  cryptodev_clone(dst, src);
+}
+
+void mbedtls_md5_init(FAR mbedtls_md5_context *ctx)
+{
+  cryptodev_init(ctx);
+}
+
+void mbedtls_md5_free(FAR mbedtls_md5_context *ctx)
+{
+  cryptodev_free(ctx);
+}
+
+int mbedtls_md5_starts(FAR mbedtls_md5_context *ctx)
+{
+  ctx->session.mac = CRYPTO_MD5;
+  return cryptodev_get_session(ctx);
+}
+
+int mbedtls_md5_update(FAR mbedtls_md5_context *ctx,
+                       FAR const unsigned char *input,
+                       size_t ilen)
+{
+  ctx->crypt.op = COP_ENCRYPT;
+  ctx->crypt.flags |= COP_FLAG_UPDATE;
+  ctx->crypt.src = (caddr_t)input;
+  ctx->crypt.len = ilen;
+  return cryptodev_crypt(ctx);
+}
+
+int mbedtls_md5_finish(FAR mbedtls_md5_context *ctx,
+                       unsigned char output[16])
+{
+  int ret;
+
+  ctx->crypt.op = COP_ENCRYPT;
+  ctx->crypt.flags = 0;
+  ctx->crypt.mac = (caddr_t)output;
+  ret = cryptodev_crypt(ctx);
+  cryptodev_free_session(ctx);
+  return ret;
+}


### PR DESCRIPTION
add md5 alternative implementation via /dev/crypto
Signed-off-by: makejian <makejian@xiaomi.com>

