### PR TITLE
system/fastboot: Fix command comparation

### DIFF
--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -146,8 +146,8 @@ static const struct fastboot_cmd_s g_fast_cmd[] =
   { "download:",          fastboot_download         },
   { "erase:",             fastboot_erase            },
   { "flash:",             fastboot_flash            },
-  { "reboot",             fastboot_reboot           },
-  { "reboot-bootloader",  fastboot_reboot_bootloader}
+  { "reboot-bootloader",  fastboot_reboot_bootloader},
+  { "reboot",             fastboot_reboot           }
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Fix command comparation.
e.g. The command is "reboot-bootloader", but will match and break when compared  with "reboot"

## Impact
apps/system/fastboot

## Testing
|CMD|Result|
|--|--|
|fastboot reboot|OK|
|fastboot reboot-bootloader|OK|
|fastboot flash \<PARTITION\> \<IMG_FILE\> (, and download) | OK|
|fastboot getvar \<VAR\>| OK|
|fastboot erase \<PARTITION\> | OK|


