### PR TITLE
makefile/archive: fix build break if object target is split to multi-part

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -211,7 +211,7 @@ $(ZIGOBJS): %$(ZIGEXT)$(SUFFIX)$(OBJEXT): %$(ZIGEXT)
 .built: $(OBJS)
 	$(call SPLITVARIABLE,ALL_OBJS,$(OBJS),100)
 	$(foreach BATCH, $(ALL_OBJS_TOTAL), \
-		$(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH))) \
+		$(shell $(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH)))) \
 	)
 	$(Q) touch $@
 


### PR DESCRIPTION
## Summary

makefile/archive: fix build break if object target is split to multi-part


## Impact


N/A

## Testing

ci-check