### PR TITLE
lte/alt1250: Fix bug that name resolution failed for a long time

### DIFF
--- a/lte/alt1250/callback_handlers/alt1250_evt.c
+++ b/lte/alt1250/callback_handlers/alt1250_evt.c
@@ -1238,6 +1238,31 @@ static uint64_t lte_set_report_netinfo_exec_cb(FAR void *cb,
         sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
       dns_add_nameserver((FAR const struct sockaddr *)&dnsaddr[i], addrlen);
     }
+
+  if (info->pdn_num > 0)
+    {
+      FAR lte_pdn_t *pdn = &info->pdn_stat[0];
+      FAR lte_ipaddr_t *ipaddr = &pdn->address[0];
+
+      /* ALT1250 can only connect one PDN, so check the first PDN. */
+
+      if ((pdn->ipaddr_num == 1) && (ipaddr->ip_type == LTE_IPTYPE_V4))
+        {
+          dns_set_queryfamily(AF_INET);
+        }
+      else if ((pdn->ipaddr_num == 1) && (ipaddr->ip_type == LTE_IPTYPE_V6))
+        {
+          dns_set_queryfamily(AF_INET6);
+        }
+      else
+        {
+          dns_set_queryfamily(AF_UNSPEC);
+        }
+    }
+  else
+    {
+      dns_set_queryfamily(AF_UNSPEC);
+    }
 #endif
 
   if (callback)


### PR DESCRIPTION

## Summary

Fix bug that name resolution failed for a long time under particular cases. If a DNS query for IPv6 succeeds and IPv4 fails, only the answer of the IPv6 query is saved in the cache. If only IPv4 is given from LTE, name resolution will fail while the answer is saved in the cache. Therefore, the ALT1250 daemon sets the given IP type to the DNS client, which can only send DNS queries for that IP type.

## Impact
Only alt1250 daemon.

## Testing
Test with Spresense LTE board.

