### PR TITLE
feature: implement simple spinlock test

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -132,6 +132,10 @@ if(CONFIG_TESTING_OSTEST)
     list(APPEND SRCS setjmp.c)
   endif()
 
+  if(CONFIG_SPINLOCK)
+    list(APPEND SRCS spinlock.c)
+  endif()
+
   target_sources(apps PRIVATE ${SRCS})
 
   nuttx_add_application(NAME ostest SRCS ostest_main.c)

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -133,4 +133,8 @@ ifeq ($(CONFIG_ARCH_SETJMP_H),y)
 CSRCS += setjmp.c
 endif
 
+ifeq ($(CONFIG_SPINLOCK),y)
+CSRCS += spinlock.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -254,6 +254,12 @@ void priority_inheritance(void);
 
 void sched_lock_test(void);
 
+/* spinlock.c ***************************************************************/
+
+#if defined(CONFIG_SPINLOCK)
+void spinlock_test(void);
+#endif
+
 /* vfork.c ******************************************************************/
 
 #if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -585,6 +585,12 @@ static int user_main(int argc, char *argv[])
       vfork_test();
 #endif
 
+#if defined(CONFIG_SPINLOCK)
+      printf("\nuser_main: spinlock test\n");
+      spinlock_test();
+      check_test_memory_usage();
+#endif
+
       /* Compare memory usage at time ostest_main started until
        * user_main exits.  These should not be identical, but should
        * be similar enough that we can detect any serious OS memory

--- a/testing/ostest/spinlock.c
+++ b/testing/ostest/spinlock.c
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * apps/testing/ostest/spinlock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <assert.h>
+#include <errno.h>
+#include <nuttx/spinlock.h>
+
+#include "ostest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static spinlock_t lock = SP_UNLOCKED;
+
+static pthread_t g_thread1;
+static pthread_t g_thread2;
+
+static int g_result = 0;
+
+static FAR void thread_spinlock(FAR void *parameter)
+{
+  int pid = *(int *)parameter;
+
+  for (int i = 0; i < 10; i++)
+    {
+      printf("pid %d get lock g_result:%d\n", pid, g_result);
+      spin_lock(&lock);
+      g_result++;
+      spin_unlock(&lock);
+      printf("pid %d release lock g_result:%d\n", pid, g_result);
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void spinlock_test(void)
+{
+  int status;
+  g_result = 0;
+
+  status = pthread_create(&g_thread1, NULL,
+                          (void *)thread_spinlock, &g_thread1);
+  if (status != 0)
+    {
+      printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
+              status);
+      ASSERT(false);
+    }
+
+  status = pthread_create(&g_thread2, NULL,
+                          (void *)thread_spinlock, &g_thread2);
+  if (status != 0)
+    {
+      printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
+              status);
+      ASSERT(false);
+    }
+
+  pthread_join(g_thread1, NULL);
+  pthread_join(g_thread2, NULL);
+
+  assert(g_result == 20);
+}

--- a/testing/ostest/spinlock.c
+++ b/testing/ostest/spinlock.c
@@ -42,33 +42,38 @@ static spinlock_t lock = SP_UNLOCKED;
 static pthread_t g_thread1;
 static pthread_t g_thread2;
 
+#ifdef CONFIG_RW_SPINLOCK
+static pthread_t g_thread3;
+static rwlock_t rw_lock = RW_SP_UNLOCKED;
+#endif
+
 static int g_result = 0;
 
-static FAR void thread_spinlock(FAR void *parameter)
+static FAR void *thread_native_spinlock(FAR FAR void *parameter)
 {
-  int pid = *(int *)parameter;
+  int pid = *(FAR int *)parameter;
 
   for (int i = 0; i < 10; i++)
     {
-      printf("pid %d get lock g_result:%d\n", pid, g_result);
+      printf("pid %d try to get lock g_result:%d\n", pid, g_result);
       spin_lock(&lock);
       g_result++;
       spin_unlock(&lock);
       printf("pid %d release lock g_result:%d\n", pid, g_result);
     }
+
+  return NULL;
 }
 
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-void spinlock_test(void)
+static FAR void test_native_spinlock(void)
 {
   int status;
   g_result = 0;
+  lock = SP_UNLOCKED;
+  spin_initialize(&lock, SP_UNLOCKED);
 
   status = pthread_create(&g_thread1, NULL,
-                          (void *)thread_spinlock, &g_thread1);
+                          thread_native_spinlock, &g_thread1);
   if (status != 0)
     {
       printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
@@ -77,7 +82,7 @@ void spinlock_test(void)
     }
 
   status = pthread_create(&g_thread2, NULL,
-                          (void *)thread_spinlock, &g_thread2);
+                          thread_native_spinlock, &g_thread2);
   if (status != 0)
     {
       printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
@@ -89,4 +94,92 @@ void spinlock_test(void)
   pthread_join(g_thread2, NULL);
 
   assert(g_result == 20);
+}
+
+#if defined(CONFIG_RW_SPINLOCK)
+static void FAR *thread_read_spinlock(FAR void *parameter)
+{
+  int pid = *(FAR int *)parameter;
+  int test;
+
+  for (int i = 0; i < 10; ++i)
+    {
+      printf("pid %d try to get read lock g_result:%d\n", pid, g_result);
+      read_lock(&rw_lock);
+      test = g_result + 1;
+      read_unlock(&rw_lock);
+      printf("pid %d release read lock g_result+1:%d\n", pid, test);
+    }
+
+  return NULL;
+}
+
+static void FAR *thread_wrt_spinlock(FAR void *parameter)
+{
+  int pid = *(FAR int *)parameter;
+
+  for (int i = 0; i < 10; ++i)
+    {
+      printf("pid %d try to get write lock g_result:%d\n", pid, g_result);
+      write_lock(&rw_lock);
+      g_result++;
+      write_unlock(&rw_lock);
+      printf("pid %d release write lock g_result:%d\n", pid, g_result);
+    }
+  write_trylock(&rw_lock);
+  return NULL;
+}
+
+static FAR void test_rw_spinlock(void)
+{
+  int status;
+  g_result = 0;
+  rwlock_init(&rw_lock);
+
+  status = pthread_create(&g_thread1, NULL,
+                          thread_read_spinlock, &g_thread1);
+  if (status != 0)
+    {
+      printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
+              status);
+      ASSERT(false);
+    }
+
+  status = pthread_create(&g_thread2, NULL,
+                          thread_read_spinlock, &g_thread2);
+  if (status != 0)
+    {
+      printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
+              status);
+      ASSERT(false);
+    }
+
+  status = pthread_create(&g_thread3, NULL,
+                          thread_wrt_spinlock, &g_thread3);
+  if (status != 0)
+    {
+      printf("spinlock_test: ERROR pthread_create failed, status=%d\n",
+              status);
+      ASSERT(false);
+    }
+
+  pthread_join(g_thread1, NULL);
+  pthread_join(g_thread2, NULL);
+  pthread_join(g_thread3, NULL);
+
+  assert(g_result == 10);
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void spinlock_test(void)
+{
+  test_native_spinlock();
+
+#if defined(CONFIG_RW_SPINLOCK)
+  test_rw_spinlock();
+#endif
 }


### PR DESCRIPTION
## Summary
feature: implement simple spinlock test

Two threads use share variable and the variable should be same as excepted.

## Impact
ostest if config spinlock
## Testing
./tools/configure.sh -l qemu-armv8a:nsh_smp
ostest

sim:ostest

