### PR TITLE
Fix typo of uint8_t in printip

### DIFF
--- a/netutils/pppd/ipcp.c
+++ b/netutils/pppd/ipcp.c
@@ -87,7 +87,7 @@ static const uint8_t g_ipcplist[] =
 #if PPP_DEBUG
 void printip(struct in_addr ip2)
 {
-  FAR unt8_t *ip = (FAR uint8_t *)&ip2.s_addr;
+  FAR uint8_t *ip = (FAR uint8_t *)&ip2.s_addr;
   DEBUG1((" %u.%u.%u.%u ", ip[0], ip[1], ip[2], ip[3]));
 }
 #else


### PR DESCRIPTION
## Summary
Fixed typo in printip
## Impact
pppd could not build with PPP_DEBUG enabled.
## Testing

