### PR TITLE
pmconfig: check domain if invaild return error avoid to crash

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -253,6 +253,11 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (argc == 2)
         {
           ctrl.domain = atoi(argv[1]);
+          if (ctrl.domain < 0 || ctrl.domain >= CONFIG_PM_NDOMAINS)
+            {
+              nsh_error(vtbl, g_fmtargrange, argv[1]);
+              return ERROR;
+            }
         }
 
       ctrl.action = BOARDIOC_PM_QUERYSTATE;
@@ -275,6 +280,11 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (argc == 4)
         {
           ctrl.domain = atoi(argv[3]);
+          if (ctrl.domain < 0 || ctrl.domain >= CONFIG_PM_NDOMAINS)
+            {
+              nsh_error(vtbl, g_fmtargrange, argv[3]);
+              return ERROR;
+            }
         }
 
       if (strcmp(argv[1], "stay") == 0)


### PR DESCRIPTION
## Summary
check domain if invaild return error avoid to crash

## Impact

## Testing
self test
