### PR TITLE
Fixes compiler warnings while printing uint32_t and int32_t values.

### DIFF
--- a/examples/ina226/ina226_main.c
+++ b/examples/ina226/ina226_main.c
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -70,7 +71,8 @@ int main(int argc, FAR char *argv[])
           break;
         }
 
-      printf("U=%12u uV I=%12d uA\n", sample.voltage, sample.current);
+      printf("U=%12"PRIu32 "uV I=%12"PRIi32 "uA\n", sample.voltage,
+             sample.current);
 
       usleep(500000);
     }


### PR DESCRIPTION
## Summary
Fixes compiler warnings while printing uint32_t and int32_t values.

## Impact
None.

## Testing
Not tested. I don't have a board with INA226.
