### PR TITLE
libuv: fix build error

### DIFF
--- a/system/libuv/0001-libuv-port-for-nuttx.patch
+++ b/system/libuv/0001-libuv-port-for-nuttx.patch
@@ -270,7 +270,7 @@ new file mode 100644
 index 00000000..298bd2f8
 --- /dev/null
 +++ b/src/unix/nuttx.c
-@@ -0,0 +1,302 @@
+@@ -0,0 +1,303 @@
 +/* Copyright Xiaomi, Inc. and other Node contributors. All rights reserved.
 + * Permission is hereby granted, free of charge, to any person obtaining a copy
 + * of this software and associated documentation files (the "Software"), to
@@ -550,6 +550,7 @@ index 00000000..298bd2f8
 +
 +uv__global_t* uv__global_get(void) {
 +  static int index = -1;
++  static const uv_once_t once = UV_ONCE_INIT;
 +  uv__global_t* global = NULL;
 +
 +  if (index < 0) {
@@ -561,8 +562,8 @@ index 00000000..298bd2f8
 +    if (global == NULL) {
 +      global = (uv__global_t*)uv__calloc(1, sizeof(uv__global_t));
 +      if (global) {
-+          global->once = UV_ONCE_INIT;
-+          global->uv__signal_global_init_guard = UV_ONCE_INIT;
++          global->once = once;
++          global->uv__signal_global_init_guard = once;
 +          global->uv__signal_lock_pipefd[0] = -1;
 +          global->uv__signal_lock_pipefd[1] = -1;
 +          task_tls_set_value(index, (uintptr_t)global);


### PR DESCRIPTION
## Summary

If UV_ONCE_INIT is a struct, the following errors will occur:

libuv/src/unix/nuttx.c: In function 'uv__global_get': /home/hujun5/downloads1/vela_sim/apps/system/libuv/libuv/include/uv/unix.h:136:22: error: expected expression before '{' token
  136 | #define UV_ONCE_INIT PTHREAD_ONCE_INIT
      |                      ^~~~~~~~~~~~~~~~~
libuv/src/unix/nuttx.c:287:26: note: in expansion of macro 'UV_ONCE_INIT'
  287 |           global->once = UV_ONCE_INIT;
      |                          ^~~~~~~~~~~~
/home/hujun5/downloads1/vela_sim/apps/system/libuv/libuv/include/uv/unix.h:136:22: error: expected expression before '{' token
  136 | #define UV_ONCE_INIT PTHREAD_ONCE_INIT
      |                      ^~~~~~~~~~~~~~~~~
libuv/src/unix/nuttx.c:288:50: note: in expansion of macro 'UV_ONCE_INIT'
  288 |           global->uv__signal_global_init_guard = UV_ONCE_INIT;

## Impact

libuv

## Testing

ci