### PR TITLE
Fix ./drivertest_rtc.c:43:10: fatal error: nuttx/time.h: No such file or directory

### DIFF
--- a/testing/drivertest/drivertest_rtc.c
+++ b/testing/drivertest/drivertest_rtc.c
@@ -40,7 +40,7 @@
 #include <cmocka.h>
 #include <syslog.h>
 #include <nuttx/timers/rtc.h>
-#include <nuttx/time.h>
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

## Impact

drivertest

## Testing

internal ci