### PR TITLE
nsh_alias.c: unalias -a command does not work correctly

### DIFF
--- a/nshlib/nsh_alias.c
+++ b/nshlib/nsh_alias.c
@@ -408,7 +408,7 @@ int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   /* If '-a' is provided, then just wipe them all */
 
-  if ((option = getopt(argc, argv, "a")) != ERROR)
+  if ((option = getopt(argc, argv, "a")) == 'a')
     {
       alias_removeall(vtbl);
       return ret;


### PR DESCRIPTION
## Summary
getopt returns the argument if it is found, so testing against != ERROR is wrong. Testing against 'a' in this case is correct (no other
arguments are possible)

## Impact
Fix trivial bug in alias handling (remove all aliases command)

## Testing
unalias -a works
