### PR TITLE
Fix nsh_altconsole.c:152:41: error: implicit declaration of function 'strlen'

### DIFF
--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <debug.h>
+#include <string.h>
 
 #include "nsh.h"
 #include "nsh_console.h"


### PR DESCRIPTION
## Summary

## Impact

## Testing

ci