### PR TITLE
Fix drivertest_watchdog.c:284:33: error: storage size of 'reset_cause' isn't known

### DIFF
--- a/testing/drivertest/drivertest_watchdog.c
+++ b/testing/drivertest/drivertest_watchdog.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <sys/boardctl.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -42,7 +43,6 @@
 #include <cmocka.h>
 #include <time.h>
 #include <nuttx/timers/watchdog.h>
-#include <nuttx/board.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

## Impact

drivertest

## Testing

internal test