### PR TITLE
examples/can: TX and RX structs assigned 0 at startup

### DIFF
--- a/examples/can/can_main.c
+++ b/examples/can/can_main.c
@@ -139,7 +139,11 @@ int main(int argc, FAR char *argv[])
   struct canioc_bittiming_s bt;
 
 #ifdef CONFIG_EXAMPLES_CAN_WRITE
-  struct can_msg_s txmsg;
+  struct can_msg_s txmsg =
+  {
+    0
+  };
+
 #ifdef CONFIG_CAN_EXTID
   bool extended = true;
   uint32_t msgid;
@@ -154,7 +158,11 @@ int main(int argc, FAR char *argv[])
   int i;
 
 #ifdef CONFIG_EXAMPLES_CAN_READ
-  struct can_msg_s rxmsg;
+  struct can_msg_s rxmsg =
+  {
+    0
+  };
+
 #endif
 
   size_t msgsize;


### PR DESCRIPTION
## Summary
Junk data in TX and RX structs creates a header mismatch problem in esp32s2 twai example. To solve this, structs assigned 0 at startup.

- examples/can: TX and RX structs assigned 0 at startup

## Impact
Only can example

## Testing

[ESP32-S2 Saola with using `esp32s2-saola-1:twai` configuration and `can` example](https://github.com/apache/nuttx/pull/10823)
