### PR TITLE
nxscope: support for RTT serial interface

### DIFF
--- a/examples/foc/foc_nxscope.c
+++ b/examples/foc/foc_nxscope.c
@@ -42,7 +42,7 @@
 #  error CONFIG_LOGGING_NXSCOPE_DISABLE_PUTLOCK must be set to proper operation.
 #endif
 
-#ifdef CONFIG_LOGGING_NXSCOPE_INTF_SERIAL
+#if defined(CONFIG_LOGGING_NXSCOPE_INTF_SERIAL) && !defined(CONFIG_SERIAL_RTT)
 #  ifndef CONFIG_SERIAL_TERMIOS
 #    error CONFIG_SERIAL_TERMIOS must be set to proper operation.
 #  endif

--- a/examples/nxscope/Kconfig
+++ b/examples/nxscope/Kconfig
@@ -33,6 +33,8 @@ config EXAMPLES_NXSCOPE_SERIAL_PATH
 config EXAMPLES_NXSCOPE_SERIAL_BAUD
 	int "nxscope serial baud"
 	default 115200
+	---help---
+		Ignored if set to 0 (for example for RTT interface)
 
 config EXAMPLES_NXSCOPE_CDCACM
 	bool "nxscope CDCACM device support"

--- a/include/logging/nxscope/nxscope_intf.h
+++ b/include/logging/nxscope/nxscope_intf.h
@@ -85,7 +85,7 @@ struct nxscope_ser_cfg_s
 {
   FAR char *path;               /* Device path */
   bool      nonblock;           /* Nonblocking operation */
-  speed_t   baud;               /* Baud rate */
+  speed_t   baud;               /* Baud rate. Ignored if set to 0 */
 };
 #endif
 

--- a/logging/nxscope/nxscope_iser.c
+++ b/logging/nxscope/nxscope_iser.c
@@ -207,15 +207,16 @@ int nxscope_ser_init(FAR struct nxscope_intf_s *intf,
   tcgetattr(priv->fd, &tio);
 
 #ifdef CONFIG_SERIAL_TERMIOS
-  /* Configure a baud rate */
-
-  DEBUGASSERT(priv->cfg->baud > 0);
-
-  ret = cfsetspeed(&tio, priv->cfg->baud);
-  if (ret < 0)
+  if (priv->cfg->baud > 0)
     {
-      _err("ERROR: failed to set baud rate %d\n", errno);
-      goto errout;
+      /* Configure a baud rate */
+
+      ret = cfsetspeed(&tio, priv->cfg->baud);
+      if (ret < 0)
+        {
+          _err("ERROR: failed to set baud rate %d\n", errno);
+          goto errout;
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

- nxscope/serial: ignore baud configuration if set to 0
- examples/foc: allow nxscope transfer over RTT interface
  For UART serial interface TERMIOS is required, but for RTT serial interface it's not

## Impact
nxscope data stream over RTT is now possible. 
Much more powerful debugging tool than data stream over UART/USB.

## Testing
nxscope example on nrf52832-dk (built-in jlink)
foc exampe with nxscope enabled on b-g431b-esc1 (on-board stlink replaced with jlink)
