### PR TITLE
lte/alt1250: Change error code from ENOTSUP to EAFNOSUPPORT

### DIFF
--- a/lte/alt1250/usock_handlers/alt1250_sms.c
+++ b/lte/alt1250/usock_handlers/alt1250_sms.c
@@ -728,7 +728,7 @@ int alt1250_sms_init(FAR struct alt1250_s *dev, FAR struct usock_s *usock,
   if (IS_SMS_UNAVAIL_FWVERSION(dev))
     {
       dbg_alt1250("This ALT1250 FW version does not support SMS.\n");
-      *usock_result = -ENOTSUP;
+      *usock_result = -EAFNOSUPPORT;
       return REP_SEND_ACK_WOFREE;
     }
 


### PR DESCRIPTION
## Summary

ENOTSUP is now a special error code to fallback to the kernel network stack. Therefore, change the error code from ENOTSUP to EAFNOSUPPORT.

## Impact
Only alt1250 daemon.

## Testing
Test with Spresense LTE Board.
