### PR TITLE
examples/foc: add support for streaming modulation state

### DIFF
--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -129,7 +129,7 @@ static int foc_handler_run(FAR struct foc_motor_b16_s *motor,
 
   foc_handler_state_b16(&motor->handler,
                         &motor->foc_state,
-                        NULL);
+                        &motor->mod_state);
 
   return ret;
 }
@@ -258,6 +258,24 @@ static void foc_fixed16_nxscope(FAR struct foc_nxscope_s *nxs,
 #if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_VDQCOMP)
   ptr = (FAR b16_t *)&motor->vdq_comp;
   nxscope_put_vb16_t(&nxs->nxs, i++, ptr, 2);
+#endif
+#if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_SVM3)
+  b16_t svm3_tmp[4];
+
+  /* Convert sector to b16_t.
+   * Normally, a sector value is an integer in the range 1-6 but we convert
+   * it to b16_t and range to 0.1-0.6. This is to send the entire SVM3 state
+   * as b16_t array and scale the sector value closer to PWM duty values
+   * (range 0.0 to 0.5) which makes it easier to visualize the data later.
+   */
+
+  svm3_tmp[0] = b16mulb16(itob16(motor->mod_state.sector), ftob16(0.1f));
+  svm3_tmp[1] = motor->mod_state.d_u;
+  svm3_tmp[2] = motor->mod_state.d_v;
+  svm3_tmp[3] = motor->mod_state.d_w;
+
+  ptr = svm3_tmp;
+  nxscope_put_vfloat(&nxs->nxs, i++, ptr, 4);
 #endif
 
   nxscope_unlock(&nxs->nxs);

--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -127,7 +127,9 @@ static int foc_handler_run(FAR struct foc_motor_b16_s *motor,
 
   /* Get FOC handler state */
 
-  foc_handler_state_b16(&motor->handler, &motor->foc_state);
+  foc_handler_state_b16(&motor->handler,
+                        &motor->foc_state,
+                        NULL);
 
   return ret;
 }

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -127,7 +127,9 @@ static int foc_handler_run(FAR struct foc_motor_f32_s *motor,
 
   /* Get FOC handler state */
 
-  foc_handler_state_f32(&motor->handler, &motor->foc_state);
+  foc_handler_state_f32(&motor->handler,
+                        &motor->foc_state,
+                        NULL);
 
   return ret;
 }

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -129,7 +129,7 @@ static int foc_handler_run(FAR struct foc_motor_f32_s *motor,
 
   foc_handler_state_f32(&motor->handler,
                         &motor->foc_state,
-                        NULL);
+                        &motor->mod_state);
 
   return ret;
 }
@@ -259,6 +259,24 @@ static void foc_float_nxscope(FAR struct foc_nxscope_s *nxs,
 #if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_VDQCOMP)
   ptr = (FAR float *)&motor->vdq_comp;
   nxscope_put_vfloat(&nxs->nxs, i++, ptr, 2);
+#endif
+#if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_SVM3)
+  float svm3_tmp[4];
+
+  /* Convert sector to float.
+   * Normally, a sector value is an integer in the range 1-6 but we convert
+   * it to float and range to 0.1-0.6. This is to send the entire SVM3 state
+   * as float array and scale the sector value closer to PWM duty values
+   * (range 0.0 to 0.5) which makes it easier to visualize the data later.
+   */
+
+  svm3_tmp[0] = (float)motor->mod_state.sector * 0.1f;
+  svm3_tmp[1] = motor->mod_state.d_u;
+  svm3_tmp[2] = motor->mod_state.d_v;
+  svm3_tmp[3] = motor->mod_state.d_w;
+
+  ptr = svm3_tmp;
+  nxscope_put_vfloat(&nxs->nxs, i++, ptr, 4);
 #endif
 
   nxscope_unlock(&nxs->nxs);

--- a/examples/foc/foc_motor_b16.h
+++ b/examples/foc/foc_motor_b16.h
@@ -80,6 +80,9 @@ struct foc_motor_b16_s
   /* FOC data ***************************************************************/
 
   struct foc_state_b16_s        foc_state;    /* FOC controller sate */
+#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+  struct svm3_state_b16_s       mod_state;    /* Modulation state */
+#endif
   foc_handler_b16_t             handler;      /* FOC controller */
   dq_frame_b16_t                dq_ref;       /* DQ reference */
   dq_frame_b16_t                vdq_comp;     /* DQ voltage compensation */

--- a/examples/foc/foc_motor_f32.h
+++ b/examples/foc/foc_motor_f32.h
@@ -80,6 +80,9 @@ struct foc_motor_f32_s
   /* FOC data ***************************************************************/
 
   struct foc_state_f32_s        foc_state;    /* FOC controller sate */
+#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+  struct svm3_state_f32_s       mod_state;    /* Modulation state */
+#endif
   foc_handler_f32_t             handler;      /* FOC controller */
   dq_frame_f32_t                dq_ref;       /* DQ reference */
   dq_frame_f32_t                vdq_comp;     /* DQ voltage compensation */

--- a/examples/foc/foc_nxscope.c
+++ b/examples/foc/foc_nxscope.c
@@ -236,6 +236,9 @@ int foc_nxscope_init(FAR struct foc_nxscope_s *nxs)
 #if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_VDQCOMP)
       nxscope_chan_init(&nxs->nxs, i++, "vdqcomp", u.u8, 2, 0);
 #endif
+#if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_SVM3)
+      nxscope_chan_init(&nxs->nxs, i++, "svm3", u.u8, 4, 0);
+#endif
 
       if (i > CONFIG_EXAMPLES_FOC_NXSCOPE_CHANNELS)
         {

--- a/examples/foc/foc_nxscope.h
+++ b/examples/foc/foc_nxscope.h
@@ -51,6 +51,7 @@
 #define FOC_NXSCOPE_SPPOS      (1 << 13)  /* Position setpoint */
 #define FOC_NXSCOPE_DQREF      (1 << 14)  /* DQ reference */
 #define FOC_NXSCOPE_VDQCOMP    (1 << 15)  /* VDQ compensation */
+#define FOC_NXSCOPE_SVM3       (1 << 16)  /* Space-vector modulation sector */
                                           /* Max 32-bit */
 
 /****************************************************************************

--- a/include/industry/foc/fixed16/foc_handler.h
+++ b/include/industry/foc/fixed16/foc_handler.h
@@ -104,6 +104,11 @@ struct foc_modulation_ops_b16_s
   CODE void (*run)(FAR foc_handler_b16_t *h,
                    FAR ab_frame_b16_t *v_ab_mod,
                    FAR b16_t *duty);
+
+  /* Get modulation state */
+
+  CODE void (*state_get)(FAR foc_handler_b16_t *h,
+                         FAR void *state);
 };
 
 /* Current/voltage controller operations */
@@ -235,7 +240,8 @@ void foc_handler_cfg_b16(FAR foc_handler_b16_t *h,
  ****************************************************************************/
 
 void foc_handler_state_b16(FAR foc_handler_b16_t *h,
-                           FAR struct foc_state_b16_s *state);
+                           FAR struct foc_state_b16_s *state,
+                           FAR void *mod_state);
 
 #ifdef CONFIG_INDUSTRY_FOC_HANDLER_PRINT
 /****************************************************************************

--- a/include/industry/foc/float/foc_handler.h
+++ b/include/industry/foc/float/foc_handler.h
@@ -104,6 +104,11 @@ struct foc_modulation_ops_f32_s
   CODE void (*run)(FAR foc_handler_f32_t *h,
                    FAR ab_frame_f32_t *v_ab_mod,
                    FAR float *duty);
+
+  /* Get modulation state */
+
+  CODE void (*state_get)(FAR foc_handler_f32_t *h,
+                         FAR void *state);
 };
 
 /* Current/voltage controller operations */
@@ -236,7 +241,8 @@ void foc_handler_cfg_f32(FAR foc_handler_f32_t *h,
  ****************************************************************************/
 
 void foc_handler_state_f32(FAR foc_handler_f32_t *h,
-                           FAR struct foc_state_f32_s *state);
+                           FAR struct foc_state_f32_s *state,
+                           FAR void *mod_state);
 
 #ifdef CONFIG_INDUSTRY_FOC_HANDLER_PRINT
 /****************************************************************************

--- a/industry/foc/fixed16/foc_handler.c
+++ b/industry/foc/fixed16/foc_handler.c
@@ -310,18 +310,25 @@ errout:
  *   Get FOC handler state (fixed16)
  *
  * Input Parameter:
- *   h     - pointer to FOC handler
- *   state - pointer to FOC state data
+ *   h         - pointer to FOC handler
+ *   state     - pointer to FOC state data
+ *   mod_state - pointer to modulation state data (optional)
  *
  ****************************************************************************/
 
 void foc_handler_state_b16(FAR foc_handler_b16_t *h,
-                           FAR struct foc_state_b16_s *state)
+                           FAR struct foc_state_b16_s *state,
+                           FAR void *mod_state)
 {
   DEBUGASSERT(h);
   DEBUGASSERT(state);
 
   h->ops.ctrl->state_get(h, state);
+
+  if (mod_state)
+    {
+      h->ops.mod->state_get(h, mod_state);
+    }
 }
 
 #ifdef CONFIG_INDUSTRY_FOC_HANDLER_PRINT

--- a/industry/foc/fixed16/foc_svm3.c
+++ b/industry/foc/fixed16/foc_svm3.c
@@ -73,6 +73,8 @@ static void foc_modulation_vbase_get_b16(FAR foc_handler_b16_t *h,
 static void foc_modulation_run_b16(FAR foc_handler_b16_t *h,
                                    FAR ab_frame_b16_t *v_ab_mod,
                                    FAR b16_t *duty);
+static void foc_modulation_state_b16(FAR foc_handler_b16_t *h,
+                                     FAR void *v_priv);
 
 /****************************************************************************
  * Public Data
@@ -88,6 +90,7 @@ struct foc_modulation_ops_b16_s g_foc_mod_svm3_b16 =
   .current   = foc_modulation_current_b16,
   .vbase_get = foc_modulation_vbase_get_b16,
   .run       = foc_modulation_run_b16,
+  .state_get = foc_modulation_state_b16,
 };
 
 /****************************************************************************
@@ -243,7 +246,7 @@ static void foc_modulation_current_b16(FAR foc_handler_b16_t *h,
 }
 
 /****************************************************************************
- * Name: foc_modulation_b16
+ * Name: foc_modulation_run_b16
  *
  * Description:
  *   Handle the SVM3 modulation (fixed16)
@@ -285,4 +288,34 @@ static void foc_modulation_run_b16(FAR foc_handler_b16_t *h,
   f_saturate_b16(&duty[0], 0, svm->cfg.pwm_duty_max);
   f_saturate_b16(&duty[1], 0, svm->cfg.pwm_duty_max);
   f_saturate_b16(&duty[2], 0, svm->cfg.pwm_duty_max);
+}
+
+/****************************************************************************
+ * Name: foc_modulation_state_b16
+ *
+ * Description:
+ *   Get the SVM3 modulation state (fixed16)
+ *
+ * Input Parameter:
+ *   h     - pointer to FOC handler
+ *   state - pointer to modulation specific data
+ *
+ ****************************************************************************/
+
+static void foc_modulation_state_b16(FAR foc_handler_b16_t *h,
+                                     FAR void *state)
+{
+  FAR struct foc_svm3mod_b16_s *svm = NULL;
+
+  DEBUGASSERT(h);
+  DEBUGASSERT(state);
+
+  /* Get modulation data */
+
+  DEBUGASSERT(h->modulation);
+  svm = h->modulation;
+
+  /* Copy data */
+
+  memcpy(state, &svm->state, sizeof(struct svm3_state_b16_s));
 }

--- a/industry/foc/float/foc_handler.c
+++ b/industry/foc/float/foc_handler.c
@@ -310,18 +310,25 @@ errout:
  *   Get FOC handler state (float32)
  *
  * Input Parameter:
- *   h     - pointer to FOC handler
- *   state - pointer to FOC state data
+ *   h         - pointer to FOC handler
+ *   state     - pointer to FOC state data
+ *   mod_state - pointer to modulation state data (optional)
  *
  ****************************************************************************/
 
 void foc_handler_state_f32(FAR foc_handler_f32_t *h,
-                           FAR struct foc_state_f32_s *state)
+                           FAR struct foc_state_f32_s *state,
+                           FAR void *mod_state)
 {
   DEBUGASSERT(h);
   DEBUGASSERT(state);
 
   h->ops.ctrl->state_get(h, state);
+
+  if (mod_state)
+    {
+      h->ops.mod->state_get(h, mod_state);
+    }
 }
 
 #ifdef CONFIG_INDUSTRY_FOC_HANDLER_PRINT

--- a/industry/foc/float/foc_svm3.c
+++ b/industry/foc/float/foc_svm3.c
@@ -73,6 +73,8 @@ static void foc_modulation_vbase_get_f32(FAR foc_handler_f32_t *h,
 static void foc_modulation_run_f32(FAR foc_handler_f32_t *h,
                                    FAR ab_frame_f32_t *v_ab_mod,
                                    FAR float *duty);
+static void foc_modulation_state_f32(FAR foc_handler_f32_t *h,
+                                     FAR void *v_priv);
 
 /****************************************************************************
  * Public Data
@@ -88,6 +90,7 @@ struct foc_modulation_ops_f32_s g_foc_mod_svm3_f32 =
   .current   = foc_modulation_current_f32,
   .vbase_get = foc_modulation_vbase_get_f32,
   .run       = foc_modulation_run_f32,
+  .state_get = foc_modulation_state_f32,
 };
 
 /****************************************************************************
@@ -243,7 +246,7 @@ static void foc_modulation_current_f32(FAR foc_handler_f32_t *h,
 }
 
 /****************************************************************************
- * Name: foc_modulation_f32
+ * Name: foc_modulation_run_f32
  *
  * Description:
  *   Handle the SVM3 modulation (float32)
@@ -285,4 +288,34 @@ static void foc_modulation_run_f32(FAR foc_handler_f32_t *h,
   f_saturate(&duty[0], 0.0f, svm->cfg.pwm_duty_max);
   f_saturate(&duty[1], 0.0f, svm->cfg.pwm_duty_max);
   f_saturate(&duty[2], 0.0f, svm->cfg.pwm_duty_max);
+}
+
+/****************************************************************************
+ * Name: foc_modulation_state_f32
+ *
+ * Description:
+ *   Get the SVM3 modulation state (float32)
+ *
+ * Input Parameter:
+ *   h     - pointer to FOC handler
+ *   state - pointer to modulation specific data
+ *
+ ****************************************************************************/
+
+static void foc_modulation_state_f32(FAR foc_handler_f32_t *h,
+                                     FAR void *state)
+{
+  FAR struct foc_svm3mod_f32_s *svm = NULL;
+
+  DEBUGASSERT(h);
+  DEBUGASSERT(state);
+
+  /* Get modulation data */
+
+  DEBUGASSERT(h->modulation);
+  svm = h->modulation;
+
+  /* Copy data */
+
+  memcpy(state, &svm->state, sizeof(struct svm3_state_f32_s));
 }

--- a/logging/nxscope/nxscope.c
+++ b/logging/nxscope/nxscope.c
@@ -353,7 +353,7 @@ static int nxscope_div_req(FAR struct nxscope_s *s,
             {
               _err("ERROR: invalid div bulk dlen = %d\n", dlen);
               ret = -EINVAL;
-               goto errout;
+              goto errout;
             }
 
           /* Write configuration */


### PR DESCRIPTION
## Summary

- logging/nxscope/nxscope.c: fix indentation
- industrail/foc: add an interface that returns the modulation state
- examples/foc: support svm3 state with nxscope

## Impact
useful for debugging and demonstrating SVM3 operations

## Testing
foc example on b-g431b-esc1 with RTT transfer

Below SVM3 modulation state data stream (sampling rate 1kHz) visualized with PlotJuggler:
<img width="1920" alt="2023-10-04_12-22" src="https://github.com/apache/nuttx-apps/assets/6563055/374f610d-fafe-4a33-822e-8b288cf000fd">
