### PR TITLE
interpreters/wamr: Don't select ARCH_USE_TEXT_HEAP automatically

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -33,7 +33,6 @@ endif # INTERPRETERS_IWASM_TASK
 
 config INTERPRETERS_WAMR_AOT
 	bool "Enable AOT"
-	select ARCH_USE_TEXT_HEAP if ARCH_HAVE_TEXT_HEAP
 	default n
 
 choice


### PR DESCRIPTION
## Summary

follow the kernel side change:
https://github.com/apache/nuttx/pull/10871

## Impact

same as before

## Testing

ci