### PR TITLE
examples: Split hello example into hello and hello_wasm

### DIFF
--- a/examples/hello_wasm/Kconfig
+++ b/examples/hello_wasm/Kconfig
@@ -1,0 +1,29 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_HELLO_WASM
+	tristate "\"Hello, WebAssembly!\" example"
+	default n
+	---help---
+		Enable the \"Hello, WebAssembly!\" example
+
+if EXAMPLES_HELLO_WASM
+
+config EXAMPLES_HELLO_WASM_PROGNAME
+	string "Program name"
+	default "hello_wasm"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_HELLO_WASM__PRIORITY
+	int "Hello wasm task priority"
+	default 100
+
+config EXAMPLES_HELLO_WASM_STACKSIZE
+	int "Hello wasm stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/hello_wasm/Make.defs
+++ b/examples/hello_wasm/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/examples/hello/Makefile
+# apps/examples/hello_wasm/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,17 +18,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
-# Hello, World! built-in application info
-
-PROGNAME  = $(CONFIG_EXAMPLES_HELLO_PROGNAME)
-PRIORITY  = $(CONFIG_EXAMPLES_HELLO_PRIORITY)
-STACKSIZE = $(CONFIG_EXAMPLES_HELLO_STACKSIZE)
-MODULE    = $(CONFIG_EXAMPLES_HELLO)
-
-# Hello, World! Example
-
-MAINSRC = hello_main.c
-
-include $(APPDIR)/Application.mk
+ifneq ($(CONFIG_EXAMPLES_HELLO_WASM),)
+CONFIGURED_APPS += $(APPDIR)/examples/hello_wasm
+endif

--- a/examples/hello_wasm/Makefile
+++ b/examples/hello_wasm/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/examples/hello/Makefile
+# apps/examples/hello_wasm/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -22,13 +22,21 @@ include $(APPDIR)/Make.defs
 
 # Hello, World! built-in application info
 
-PROGNAME  = $(CONFIG_EXAMPLES_HELLO_PROGNAME)
-PRIORITY  = $(CONFIG_EXAMPLES_HELLO_PRIORITY)
-STACKSIZE = $(CONFIG_EXAMPLES_HELLO_STACKSIZE)
-MODULE    = $(CONFIG_EXAMPLES_HELLO)
+PROGNAME  = $(CONFIG_EXAMPLES_HELLO_WASM_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_HELLO_WASM_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_HELLO_WASM_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_HELLO_WASM)
 
 # Hello, World! Example
 
 MAINSRC = hello_main.c
+
+# Build with WebAssembly when CONFIG_INTERPRETERS_WAMR is enabled
+
+WASM_BUILD = y
+
+# Mode of WebAssembly Micro Runtime
+
+WAMR_MODE  = AOT
 
 include $(APPDIR)/Application.mk

--- a/examples/hello_wasm/hello_main.c
+++ b/examples/hello_wasm/hello_main.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * apps/examples/hello_wasm/hello_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * hello_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  printf("Hello, WebAssembly!!\n");
+  return 0;
+}


### PR DESCRIPTION


## Summary
Decouple the hello example into hello and hello_wasm. The hello_wasm example is a minimal example to show how to build a wasm application by using the NuttX build system, and avoid disturbing the hello (native build).
## Impact
Wasm build
## Testing
CI and local machine
