### PR TITLE
dhcp6c: Add the renew6 command for dhcp6c.

### DIFF
--- a/netutils/dhcp6c/dhcp6c.c
+++ b/netutils/dhcp6c/dhcp6c.c
@@ -359,11 +359,16 @@ static bool dhcp6c_commit_state(FAR void *handle, enum dhcpv6_state_e state,
   size_t new_len = pdhcp6c->state_len[state] - old_len;
   FAR uint8_t *old_data = pdhcp6c->state_data[state];
   FAR uint8_t *new_data = old_data + old_len;
-  bool upd = (new_len != old_len) ||
+  bool upd = false;
+
+  if (new_len != 0 || old_len != 0)
+    {
+       upd = (new_len != old_len) ||
              (memcmp(old_data, new_data, new_len) != 0);
 
-  memmove(old_data, new_data, new_len);
-  dhcp6c_resize_state(handle, state, -old_len);
+       memmove(old_data, new_data, new_len);
+       dhcp6c_resize_state(handle, state, -old_len);
+    }
 
   return upd;
 }

--- a/system/dhcp6c/CMakeLists.txt
+++ b/system/dhcp6c/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/dhcpc/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_DHCPC_RENEW6)
+  nuttx_add_application(
+    NAME
+    dhcpc6
+    SRCS
+    renew6_main.c
+    STACKSIZE
+    ${CONFIG_DHCPC_RENEW6_STACKSIZE}
+    PRIORITY
+    ${CONFIG_DHCPC_RENEW6_PRIORITY})
+endif()

--- a/system/dhcp6c/Kconfig
+++ b/system/dhcp6c/Kconfig
@@ -1,0 +1,31 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_DHCPC_RENEW6
+	tristate "DHCP IPv6 Address Renewal"
+	default n
+	select NETUTILS_DHCP6C
+	depends on NET_UDP && NET_IPv6
+	---help---
+		Enable the DHCP client 'renew6' command
+
+if SYSTEM_DHCPC_RENEW6
+
+config DHCPC_RENEW6_PROGNAME
+	string "Program dhcpv6 name"
+	default "renew6"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config DHCPC_RENEW6_PRIORITY
+	int "DHCPC6 task priority"
+	default 100
+
+config DHCPC_RENEW6_STACKSIZE
+	int "DHCPC6 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/system/dhcp6c/Make.defs
+++ b/system/dhcp6c/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/dhcpc/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_DHCPC_RENEW6),)
+CONFIGURED_APPS += $(APPDIR)/system/dhcp6c
+endif

--- a/system/dhcp6c/Makefile
+++ b/system/dhcp6c/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/system/dhcpc/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# DHCPCv6 address renewal built-in application info
+
+PROGNAME = $(CONFIG_DHCPC_RENEW6_PROGNAME)
+PRIORITY = $(CONFIG_DHCPC_RENEW6_PRIORITY)
+STACKSIZE = $(CONFIG_DHCPC_RENEW6_STACKSIZE)
+MODULE = $(CONFIG_SYSTEM_DHCPC_RENEW6)
+
+# DHCPCv6 address renewal
+
+MAINSRC = renew6_main.c
+
+include $(APPDIR)/Application.mk

--- a/system/dhcp6c/renew6_main.c
+++ b/system/dhcp6c/renew6_main.c
@@ -1,0 +1,142 @@
+/****************************************************************************
+ * apps/system/dhcp6c/renew6_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <debug.h>
+
+#include <net/if.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <nuttx/net/net.h>
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/dns.h>
+#include "netutils/netlib.h"
+#include "netutils/dhcp6c.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void icmpv6_linkipaddr_6(FAR const uint8_t *mac, uint16_t *ipaddr)
+{
+  ipaddr[0]  = HTONS(0xfe80);
+  ipaddr[1]  = 0;
+  ipaddr[2]  = 0;
+  ipaddr[3]  = 0;
+  ipaddr[4]  = HTONS(mac[0] << 8 | mac[1]);
+  ipaddr[5]  = HTONS(mac[2] << 8 | 0x00ff);
+  ipaddr[6]  = HTONS(0x00fe << 8 | mac[3]);
+  ipaddr[7]  = HTONS(mac[4] << 8 | mac[5]);
+  ipaddr[4] ^= HTONS(0x0200);
+}
+
+static void dhcp6c_set_lladdr(FAR const char *ifname)
+{
+  struct in6_addr addr6;
+  uint8_t mac[IFHWADDRLEN];
+
+  /* Get the MAC address of the NIC */
+
+  netlib_getmacaddr(ifname, mac);
+
+  /* Set the Link Local Address of the NIC */
+
+  icmpv6_linkipaddr_6(mac, (uint16_t *)&addr6);
+  netlib_set_ipv6addr(ifname, &addr6);
+  netlib_prefix2ipv6netmask(64, &addr6);
+}
+
+static int setup_result(FAR const char *ifname,
+                        FAR struct dhcp6c_state *presult)
+{
+  int ret;
+
+  ret = netlib_set_ipv6addr(ifname, &presult->addr);
+  if (ret != OK)
+    {
+      nerr("netlib_set_ipv6addr fail\n");
+      return ret;
+    }
+
+  ret = netlib_set_ipv6netmask(ifname, &presult->netmask);
+  if (ret != OK)
+    {
+      nerr("netlib_set_ipv6netmask fail\n");
+      return ret;
+    }
+
+  ret = netlib_set_ipv6dnsaddr(&presult->dns);
+  if (ret != OK)
+    {
+      nerr("netlib_set_ipv6dnsaddr fail\n");
+      return ret;
+    }
+
+  return ret;
+}
+
+int main(int argc, FAR char * const argv[])
+{
+  char ifname[IFNAMSIZ];
+  void *handle = NULL;
+  struct dhcp6c_state result;
+  int ret = -EINVAL;
+
+  memset(ifname, 0, sizeof(ifname));
+  memset(&result, 0, sizeof(result));
+  if (argc < 2)
+    {
+      nerr("Input parameters are invalid!\n");
+      return ret;
+    }
+
+  strlcpy(ifname, argv[1], sizeof(ifname));
+
+  if (argc == 2)
+    {
+      ret = netlib_icmpv6_autoconfiguration(ifname);
+      if (ret)
+        {
+          nerr("netlib_icmpv6_autoconfiguration fail\n");
+          return ret;
+        }
+    }
+  else
+    {
+      dhcp6c_set_lladdr(ifname);
+      handle = dhcp6c_open(ifname);
+      ret = dhcp6c_request(handle, &result);
+      if (ret != OK)
+        {
+          nerr("dhcp6c_request fail\n");
+        }
+
+      setup_result(ifname, &result);
+      dhcp6c_close(handle);
+    }
+
+  return ret;
+}


### PR DESCRIPTION
## Summary
Add the renew6 command for dhcp6c. The command can supports two mode Stateless and Stateful.
 The renew6 is used as follows:
 - Stateless: renew6 eth0
 - Stateful: renew6 eth0 1

## Impact
The renew6 comand can obtain an IPv6 address for a specify interface using the dhcpv6 protocol.

## Testing
Use the following steps to verify the renew6 command function.
- Open the configuration option `SYSTEM_DHCPC_RENEW6`
- Up interface, for example `ifup eth0`
- Obtain IPv6 address, `renew6 eth0 1`
- Check the obtained IPv6 address, `ifconfig eth0`
