### PR TITLE
industry/foc/fixed16/foc_ang_onfo.c: use b16abs operation

### DIFF
--- a/industry/foc/fixed16/foc_ang_onfo.c
+++ b/industry/foc/fixed16/foc_ang_onfo.c
@@ -41,10 +41,6 @@
   (b16divb16(b16mulb16((x - in_min), (out_max - out_min)),  \
              (in_max - in_min)) + out_min)
 
-#ifndef ABS
-#  define ABS(a)   (a < 0 ? -a : a)
-#endif
-
 /****************************************************************************
  * Private Data Types
  ****************************************************************************/
@@ -299,7 +295,7 @@ static int foc_angle_onfo_run_b16(FAR foc_angle_b16_t *h,
 
   /* Update and the observer gain. */
 
-  dyn_gain = b16mulb16(LINEAR_MAP(ABS(duty_now),
+  dyn_gain = b16mulb16(LINEAR_MAP(b16abs(duty_now),
                                   0,
                                   b16ONE,
                                   b16mulb16(ob->cfg.gain, ob->cfg.gain_slow),


### PR DESCRIPTION
## Summary
industry/foc/fixed16/foc_ang_onfo.c: use b16abs operation
we get rid of custom ABS() macro

## Impact
cosmetics

## Testing
CI
