### PR TITLE
foc/openloop: don't use direction argument, instead use signed velocity

### DIFF
--- a/industry/foc/fixed16/foc_ang_openloop.c
+++ b/industry/foc/fixed16/foc_ang_openloop.c
@@ -258,9 +258,11 @@ static int foc_angle_ol_run_b16(FAR foc_angle_b16_t *h,
   DEBUGASSERT(h->data);
   ol = h->data;
 
-  /* Update open-loop */
+  /* Update open-loop.
+   * NOTE: we don't use dir argument here, instead we use signed velocity.
+   */
 
-  motor_openloop_b16(&ol->data, in->vel, in->dir);
+  motor_openloop_b16(&ol->data, in->vel, 1);
 
   tmp = motor_openloop_angle_get_b16(&ol->data);
 

--- a/industry/foc/float/foc_ang_openloop.c
+++ b/industry/foc/float/foc_ang_openloop.c
@@ -259,9 +259,11 @@ static int foc_angle_ol_run_f32(FAR foc_angle_f32_t *h,
   DEBUGASSERT(h->data);
   ol = h->data;
 
-  /* Update open-loop */
+  /* Update open-loop.
+   * NOTE: we don't use dir argument here, instead we use signed velocity.
+   */
 
-  motor_openloop(&ol->data, in->vel, in->dir);
+  motor_openloop(&ol->data, in->vel, 1.0f);
 
   /* Get open-loop angle */
 


### PR DESCRIPTION
## Summary
industry/foc/openloop: don't use direction argument, instead use signed velocity

otherwise, when dir=-1 and the velocity value is negative, the output from velocity is in the opposite direction than the intended one

## Impact

## Testing
ESC based on b-g431b-esc
