### PR TITLE
industry/foc: force angle observers output to zero if motor stopped

### DIFF
--- a/industry/foc/fixed16/foc_ang_onfo.c
+++ b/industry/foc/fixed16/foc_ang_onfo.c
@@ -285,6 +285,15 @@ static int foc_angle_onfo_run_b16(FAR foc_angle_b16_t *h,
   DEBUGASSERT(h->data);
   ob = h->data;
 
+  if (in->vel == 0)
+    {
+      /* Do nothing if motor stopped */
+
+      out->type  = FOC_ANGLE_TYPE_ELE;
+      out->angle = 0;
+      return OK;
+    }
+
   /* Normalize the d-q voltage to get the d-q modulation
    * voltage
    */

--- a/industry/foc/fixed16/foc_ang_osmo.c
+++ b/industry/foc/fixed16/foc_ang_osmo.c
@@ -268,6 +268,15 @@ static int foc_angle_osmo_run_b16(FAR foc_angle_b16_t *h,
   DEBUGASSERT(h->data);
   ob = h->data;
 
+  if (in->vel == 0)
+    {
+      /* Do nothing if motor stopped */
+
+      out->type  = FOC_ANGLE_TYPE_ELE;
+      out->angle = 0;
+      return OK;
+    }
+
   /* Update observer */
 
   motor_aobserver_smo_b16(&ob->o, &in->state->iab, &in->state->vab,

--- a/industry/foc/float/foc_ang_onfo.c
+++ b/industry/foc/float/foc_ang_onfo.c
@@ -280,6 +280,15 @@ static int foc_angle_onfo_run_f32(FAR foc_angle_f32_t *h,
   DEBUGASSERT(h->data);
   ob = h->data;
 
+  if (in->vel == 0.0f)
+    {
+      /* Do nothing if motor stopped */
+
+      out->type  = FOC_ANGLE_TYPE_ELE;
+      out->angle = 0.0f;
+      return OK;
+    }
+
   /* Normalize the d-q voltage to get the d-q modulation voltage */
 
   v_dq_mod.d = in->state->vdq.d * in->state->mod_scale;

--- a/industry/foc/float/foc_ang_osmo.c
+++ b/industry/foc/float/foc_ang_osmo.c
@@ -268,6 +268,15 @@ static int foc_angle_osmo_run_f32(FAR foc_angle_f32_t *h,
   DEBUGASSERT(h->data);
   ob = h->data;
 
+  if (in->vel == 0.0f)
+    {
+      /* Do nothing if motor stopped */
+
+      out->type  = FOC_ANGLE_TYPE_ELE;
+      out->angle = 0.0f;
+      return OK;
+    }
+
   /* Update observer */
 
   motor_aobserver_smo(&ob->o, &in->state->iab, &in->state->vab,


### PR DESCRIPTION
## Summary
industry/foc: force angle observers output to zero if motor stopped
this prevents junk data from the observer when the motor is stopped

## Impact

## Testing
ESC based on b-g431b-esc
