### PR TITLE
industry/foc: improvements for align

### DIFF
--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -118,7 +118,9 @@ static int foc_motor_align(FAR struct foc_motor_b16_s *motor, FAR bool *done)
         }
 
       PRINTF("Aling results:\n");
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
       PRINTF("  dir    = %.2f\n", b16tof(final.dir));
+#endif
       PRINTF("  offset = %.2f\n", b16tof(final.offset));
 
       *done = true;

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -118,7 +118,9 @@ static int foc_motor_align(FAR struct foc_motor_f32_s *motor, FAR bool *done)
         }
 
       PRINTF("Aling results:\n");
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
       PRINTF("  dir    = %.2f\n", final.dir);
+#endif
       PRINTF("  offset = %.2f\n", final.offset);
 
       *done = true;

--- a/industry/foc/Kconfig
+++ b/industry/foc/Kconfig
@@ -135,6 +135,12 @@ config INDUSTRY_FOC_ALIGN
 
 if INDUSTRY_FOC_ALIGN
 
+config INDUSTRY_FOC_ALIGN_DIR
+	bool "FOC alignment direction support"
+	default n
+	---help---
+		Enable support for sensor direction alignment
+
 config INDUSTRY_FOC_ALIGN_INDEX
 	bool "FOC alignment index search support"
 	default n

--- a/industry/foc/fixed16/foc_align.c
+++ b/industry/foc/fixed16/foc_align.c
@@ -1005,5 +1005,12 @@ int foc_routine_align_final_b16(FAR foc_routine_b16_t *r, FAR void *data)
 
   memcpy(data, &a->final, sizeof(struct foc_routine_aling_final_b16_s));
 
+  /* Reset data but leave configuration */
+
+  memset(&a->final,
+         0,
+         (sizeof(struct foc_align_b16_s) -
+          sizeof(struct foc_routine_align_cfg_b16_s)));
+
   return OK;
 }

--- a/industry/foc/fixed16/foc_align.c
+++ b/industry/foc/fixed16/foc_align.c
@@ -75,7 +75,9 @@ enum foc_align_run_stage_e
   FOC_ALIGN_RUN_INDEX,
 #endif
   FOC_ALIGN_RUN_OFFSET,
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
   FOC_ALIGN_RUN_DIR,
+#endif
   FOC_ALIGN_RUN_IDLE,
   FOC_ALIGN_RUN_DONE
 };
@@ -347,6 +349,7 @@ errout:
   return ret;
 }
 
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
 /****************************************************************************
  * Name: foc_align_dir_move_b16
  ****************************************************************************/
@@ -663,6 +666,7 @@ errout:
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: foc_align_idle_run_b16
@@ -910,6 +914,7 @@ int foc_routine_align_run_b16(FAR foc_routine_b16_t *r,
         break;
       }
 
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
       case FOC_ALIGN_RUN_DIR:
         {
           /* Align direction procedure */
@@ -930,6 +935,7 @@ int foc_routine_align_run_b16(FAR foc_routine_b16_t *r,
 
           break;
         }
+#endif
 
       case FOC_ALIGN_RUN_IDLE:
         {

--- a/industry/foc/float/foc_align.c
+++ b/industry/foc/float/foc_align.c
@@ -1005,5 +1005,12 @@ int foc_routine_align_final_f32(FAR foc_routine_f32_t *r, FAR void *data)
 
   memcpy(data, &a->final, sizeof(struct foc_routine_aling_final_f32_s));
 
+  /* Reset data but leave configuration */
+
+  memset(&a->final,
+         0,
+         (sizeof(struct foc_align_f32_s) -
+          sizeof(struct foc_routine_align_cfg_f32_s)));
+
   return OK;
 }

--- a/industry/foc/float/foc_align.c
+++ b/industry/foc/float/foc_align.c
@@ -75,8 +75,10 @@ enum foc_align_run_stage_e
   FOC_ALIGN_RUN_INDEX,
 #endif
   FOC_ALIGN_RUN_OFFSET,
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
   FOC_ALIGN_RUN_DIR,
   FOC_ALIGN_RUN_IDLE,
+#endif
   FOC_ALIGN_RUN_DONE
 };
 
@@ -347,6 +349,7 @@ errout:
   return ret;
 }
 
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
 /****************************************************************************
  * Name: foc_align_dir_move_f32
  ****************************************************************************/
@@ -709,6 +712,7 @@ static int foc_align_idle_run_f32(FAR struct foc_align_f32_s *align,
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: foc_routine_align_init_f32
@@ -910,6 +914,7 @@ int foc_routine_align_run_f32(FAR foc_routine_f32_t *r,
         break;
       }
 
+#ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
       case FOC_ALIGN_RUN_DIR:
         {
           /* Align direction procedure */
@@ -951,6 +956,7 @@ int foc_routine_align_run_f32(FAR foc_routine_f32_t *r,
 
           break;
         }
+#endif
 
       case FOC_ALIGN_RUN_DONE:
         {


### PR DESCRIPTION
## Summary

- industry/foc: make direction alignment configurable
    
    for sensorless velocity controller (ESC) we don't need to align the direction,
    but we have to align the initial motor phase each time the motor start

- industry/foc: reset align data when align is finished
    
    this allows the align procedure to be run multiple times


## Impact

## Testing
ESC based on b-g431b-esc
