### PR TITLE
industry/foc: reset observer data when foc_velocity_zero is called

### DIFF
--- a/industry/foc/fixed16/foc_vel_odiv.c
+++ b/industry/foc/fixed16/foc_vel_odiv.c
@@ -214,6 +214,8 @@ static int foc_velocity_div_zero_b16(FAR foc_velocity_b16_t *h)
                                div->cfg.filter,
                                div->cfg.per);
 
+  div->o.speed = 0;
+
   return ret;
 }
 

--- a/industry/foc/fixed16/foc_vel_opll.c
+++ b/industry/foc/fixed16/foc_vel_opll.c
@@ -212,6 +212,8 @@ static int foc_velocity_pll_zero_b16(FAR foc_velocity_b16_t *h)
                                pll->cfg.kp,
                                pll->cfg.ki);
 
+  pll->o.speed = 0;
+
   return ret;
 }
 

--- a/industry/foc/float/foc_vel_odiv.c
+++ b/industry/foc/float/foc_vel_odiv.c
@@ -214,6 +214,8 @@ static int foc_velocity_div_zero_f32(FAR foc_velocity_f32_t *h)
                            div->cfg.filter,
                            div->cfg.per);
 
+  div->o.speed = 0.0f;
+
   return ret;
 }
 

--- a/industry/foc/float/foc_vel_opll.c
+++ b/industry/foc/float/foc_vel_opll.c
@@ -212,6 +212,8 @@ static int foc_velocity_pll_zero_f32(FAR foc_velocity_f32_t *h)
                            pll->cfg.kp,
                            pll->cfg.ki);
 
+  pll->o.speed = 0.0f;
+
   return ret;
 }
 


### PR DESCRIPTION
## Summary
industry/foc: reset velocity observer output foc_velocity_zero_xx() is called

## Impact

## Testing
ESC based on b-g431b-esc
