### PR TITLE
examples/foc: configure active breake current

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -321,6 +321,13 @@ config EXAMPLES_FOC_MMODE
 		4 - align only
 		5 - ident only
 
+config EXAMPLES_FOC_STOP_CURRENT
+	int "FOC stop state Q voltage/current [x1000]"
+	default 0
+	---help---
+		This current or voltage will be forced on the motor Q axis when
+		the application is in active break state.
+
 config EXAMPLES_FOC_OPENLOOP_Q
 	int "FOC open-loop Vq/Iq setting [x1000]"
 	default 200

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -605,6 +605,10 @@ static int foc_motor_state(FAR struct foc_motor_b16_s *motor, int state)
 
           /* DQ vector not zero - active brake */
 
+          motor->dq_ref.q = ftob16(CONFIG_EXAMPLES_FOC_STOP_CURRENT /
+                                   1000.0f);
+          motor->dq_ref.d = 0;
+
           break;
         }
 

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -583,6 +583,9 @@ static int foc_motor_state(FAR struct foc_motor_f32_s *motor, int state)
 
           /* DQ vector not zero - active brake */
 
+          motor->dq_ref.q = CONFIG_EXAMPLES_FOC_STOP_CURRENT / 1000.0f;
+          motor->dq_ref.d = 0.0f;
+
           break;
         }
 


### PR DESCRIPTION
## Summary
examples/foc: configure active breake current
## Impact

## Testing
ESC based on b-g431b-esc
