### PR TITLE
examples/foc: add support for feedforward compensation

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -326,6 +326,16 @@ config EXAMPLES_FOC_OPENLOOP_Q
 	default 200
 	depends on EXAMPLES_FOC_HAVE_OPENLOOP
 
+config EXAMPLES_FOC_FEEDFORWARD
+	bool "FOC use feedforward compensation for current controller"
+	select INDUSTRY_FOC_FEEDFORWARD
+	default n
+	---help---
+		This option enables feed-forward compensation for PI current controller
+		which can help achieve better performace of FOC. This option is not 
+		recomended for sensorless operations and for current controllers that 
+		already has high update frequency.
+
 if EXAMPLES_FOC_CONTROL_PI
 
 config EXAMPLES_FOC_IDQ_KP

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -30,6 +30,9 @@
 #include "foc_cfg.h"
 #include "foc_debug.h"
 #include "foc_motor_b16.h"
+#ifdef CONFIG_EXAMPLES_FOC_FEEDFORWARD
+#  include "industry/foc/float/foc_feedforward.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -795,8 +798,13 @@ static int foc_motor_run(FAR struct foc_motor_b16_s *motor)
 
   /* DQ compensation */
 
+#ifdef CONFIG_EXAMPLES_FOC_FEEDFORWARD
+  foc_feedforward_pmsm_b16(&motor->phy, &motor->foc_state.idq,
+                           motor->vel.now, &motor->vdq_comp);
+#else
   motor->vdq_comp.q = 0;
   motor->vdq_comp.d = 0;
+#endif
 
 errout:
   return ret;

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -30,6 +30,9 @@
 #include "foc_cfg.h"
 #include "foc_debug.h"
 #include "foc_motor_f32.h"
+#ifdef CONFIG_EXAMPLES_FOC_FEEDFORWARD
+#  include "industry/foc/float/foc_feedforward.h"
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -780,8 +783,13 @@ static int foc_motor_run(FAR struct foc_motor_f32_s *motor)
 
   /* DQ compensation */
 
+#ifdef CONFIG_EXAMPLES_FOC_FEEDFORWARD
+  foc_feedforward_pmsm_f32(&motor->phy, &motor->foc_state.idq,
+                           motor->vel.now, &motor->vdq_comp);
+#else
   motor->vdq_comp.q = 0.0f;
   motor->vdq_comp.d = 0.0f;
+#endif
 
 errout:
   return ret;


### PR DESCRIPTION
## Summary
examples/foc: add support for feedforward compensation
needs https://github.com/apache/nuttx-apps/pull/2125
## Impact

## Testing
ESC based on b-g431b-esc
