### PR TITLE
examples/foc: rename SETPOINT_ADC_SCALE to SETPOINT_INTF_SCALE

### DIFF
--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -154,13 +154,13 @@
 /* Setpoint ADC scale factor */
 
 #ifdef CONFIG_EXAMPLES_FOC_SETPOINT_ADC
-#  define SETPOINT_ADC_SCALE (1.0f / CONFIG_EXAMPLES_FOC_ADC_MAX)
+#  define SETPOINT_INTF_SCALE (1.0f / CONFIG_EXAMPLES_FOC_ADC_MAX)
 #endif
 
 /* If constant setpoint is selected, setpoint value must be provided */
 
 #ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
-#  define SETPOINT_ADC_SCALE   (1)
+#  define SETPOINT_INTF_SCALE   (1)
 #  if CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE == 0
 #    error
 #  endif
@@ -169,7 +169,7 @@
 /* CHARCTRL setpoint control */
 
 #ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CHAR
-#  define SETPOINT_ADC_SCALE  (1.0f / (CONFIG_EXAMPLES_FOC_SETPOINT_MAX / 1000.0f))
+#  define SETPOINT_INTF_SCALE  (1.0f / (CONFIG_EXAMPLES_FOC_SETPOINT_MAX / 1000.0f))
 #endif
 
 /* VBUS source must be specified */

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -439,7 +439,7 @@ static int foc_motor_torq(FAR struct foc_motor_b16_s *motor, uint32_t torq)
    */
 
   tmp1 = itob16(motor->envp->cfg->torqmax / 1000);
-  tmp2 = b16mulb16(ftob16(SETPOINT_ADC_SCALE), tmp1);
+  tmp2 = b16mulb16(ftob16(SETPOINT_INTF_SCALE), tmp1);
 
   motor->torq.des = b16muli(tmp2, torq);
 
@@ -464,7 +464,7 @@ static int foc_motor_vel(FAR struct foc_motor_b16_s *motor, uint32_t vel)
    */
 
   tmp1 = itob16(motor->envp->cfg->velmax / 1000);
-  tmp2 = b16mulb16(ftob16(SETPOINT_ADC_SCALE), tmp1);
+  tmp2 = b16mulb16(ftob16(SETPOINT_INTF_SCALE), tmp1);
 
   motor->vel.des = b16muli(tmp2, vel);
 
@@ -489,7 +489,7 @@ static int foc_motor_pos(FAR struct foc_motor_b16_s *motor, uint32_t pos)
    */
 
   tmp1 = itob16(motor->envp->cfg->posmax / 1000);
-  tmp2 = b16mulb16(ftob16(SETPOINT_ADC_SCALE), tmp1);
+  tmp2 = b16mulb16(ftob16(SETPOINT_INTF_SCALE), tmp1);
 
   motor->pos.des = b16muli(tmp2, pos);
 

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -431,7 +431,7 @@ static int foc_motor_torq(FAR struct foc_motor_f32_s *motor, uint32_t torq)
 
   /* Update motor torque destination */
 
-  motor->torq.des = (torq * SETPOINT_ADC_SCALE *
+  motor->torq.des = (torq * SETPOINT_INTF_SCALE *
                      motor->envp->cfg->torqmax / 1000.0f);
 
   return OK;
@@ -449,7 +449,7 @@ static int foc_motor_vel(FAR struct foc_motor_f32_s *motor, uint32_t vel)
 
   /* Update motor velocity destination */
 
-  motor->vel.des = (vel * SETPOINT_ADC_SCALE *
+  motor->vel.des = (vel * SETPOINT_INTF_SCALE *
                     motor->envp->cfg->velmax / 1000.0f);
 
   return OK;
@@ -467,7 +467,7 @@ static int foc_motor_pos(FAR struct foc_motor_f32_s *motor, uint32_t pos)
 
   /* Update motor position destination */
 
-  motor->pos.des = (pos * SETPOINT_ADC_SCALE *
+  motor->pos.des = (pos * SETPOINT_INTF_SCALE *
                     motor->envp->cfg->posmax / 1000.0f);
 
   return OK;


### PR DESCRIPTION
## Summary

- examples/foc: rename SETPOINT_ADC_SCALE to SETPOINT_INTF_SCALE
SETPOINT_INTF_SCALE is more appropriate name because this definition is not only used for ADC scale

## Impact
cosmetics
## Testing
CI
