### PR TITLE
Application.mk:resolve file conflicts with the same name when batching archives

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -205,9 +205,10 @@ $(ZIGOBJS): %$(ZIGEXT)$(SUFFIX)$(OBJEXT): %$(ZIGEXT)
 	$(if $(and $(CONFIG_BUILD_LOADABLE), $(CELFFLAGS)), \
 		$(call ELFCOMPILEZIG, $<, $@), $(call COMPILEZIG, $<, $@))
 
-AROBJS := 
+AROBJS :=
 ifneq ($(OBJS),)
-$(eval $(call SPLITVARIABLE,OBJS_SPILT,$(OBJS),100))
+SORTOBJS := $(sort $(OBJS))
+$(eval $(call SPLITVARIABLE,OBJS_SPILT,$(SORTOBJS),100))
 $(foreach BATCH, $(OBJS_SPILT_TOTAL), \
 	$(foreach obj, $(OBJS_SPILT_$(BATCH)), \
 		$(eval substitute := $(patsubst %$(OBJEXT),%_$(BATCH)$(OBJEXT),$(obj))) \
@@ -298,7 +299,7 @@ endif
 	  $(shell $(MKDEP) $(DEPPATH) --obj-suffix .c$(SUFFIX)$(OBJEXT) "$(CC)" -- $(CFLAGS) -- $(filter %.c,$(ALL_DEP_OBJS_$(BATCH))) >Make.dep) \
 	  $(shell $(MKDEP) $(DEPPATH) --obj-suffix .S$(SUFFIX)$(OBJEXT) "$(CC)" -- $(CFLAGS) -- $(filter %.S,$(ALL_DEP_OBJS_$(BATCH))) >>Make.dep) \
 	  $(shell $(MKDEP) $(DEPPATH) --obj-suffix $(CXXEXT)$(SUFFIX)$(OBJEXT) "$(CXX)" -- $(CXXFLAGS) -- $(filter %$(CXXEXT),$(ALL_DEP_OBJS_$(BATCH))) >>Make.dep) \
-	) 
+	)
 	$(Q) touch $@
 
 depend:: .depend
@@ -306,8 +307,8 @@ depend:: .depend
 
 clean::
 	$(call DELFILE, .built)
+	$(call CLEANAROBJS)
 	$(call CLEAN)
-
 distclean:: clean
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/Application.mk
+++ b/Application.mk
@@ -205,8 +205,20 @@ $(ZIGOBJS): %$(ZIGEXT)$(SUFFIX)$(OBJEXT): %$(ZIGEXT)
 	$(if $(and $(CONFIG_BUILD_LOADABLE), $(CELFFLAGS)), \
 		$(call ELFCOMPILEZIG, $<, $@), $(call COMPILEZIG, $<, $@))
 
-.built: $(OBJS)
-	$(call SPLITVARIABLE,ALL_OBJS,$(OBJS),100)
+AROBJS := 
+ifneq ($(OBJS),)
+$(eval $(call SPLITVARIABLE,OBJS_SPILT,$(OBJS),100))
+$(foreach BATCH, $(OBJS_SPILT_TOTAL), \
+	$(foreach obj, $(OBJS_SPILT_$(BATCH)), \
+		$(eval substitute := $(patsubst %$(OBJEXT),%_$(BATCH)$(OBJEXT),$(obj))) \
+		$(eval AROBJS += $(substitute)) \
+		$(eval $(call AROBJSRULES, $(substitute),$(obj))) \
+	) \
+)
+endif
+
+.built: $(AROBJS)
+	$(call SPLITVARIABLE,ALL_OBJS,$(AROBJS),100)
 	$(foreach BATCH, $(ALL_OBJS_TOTAL), \
 		$(shell $(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH)))) \
 	)

--- a/Make.defs
+++ b/Make.defs
@@ -156,3 +156,8 @@ endef
 define ARLOCK
 	flock $1.lock $(call ARCHIVE, $1, $(2))
 endef
+
+define AROBJSRULES
+$(1) : $(2)
+	cp $(2) $(1)
+endef

--- a/Make.defs
+++ b/Make.defs
@@ -157,7 +157,21 @@ define ARLOCK
 	flock $1.lock $(call ARCHIVE, $1, $(2))
 endef
 
+# dynamic AR target
+
 define AROBJSRULES
 $(1) : $(2)
 	cp $(2) $(1)
 endef
+
+# CLEANAROBJS - del AR target files exclusively
+
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+define CLEANAROBJS
+	$(call DELFILE,$(subst /,\,$(AROBJS)))
+endef
+else
+define CLEANAROBJS
+	$(Q) rm -f $(AROBJS)
+endef
+endif


### PR DESCRIPTION
## Summary

This is a workaround to solve the problem of not being able to use `ar rcsP`

when there are too many target files in archive and need to be processed in batches,
in order to avoid file replacement due to duplicate names,
we dynamically rename the target files here.

```makefile
OBJS := SAME_NAME.foo.bar.o ...... SAME_NAME.foo.bar.o

# After call SPLIT splitting the variable, the .o file with the same name will be replaced in the archive
# therefore, new AROBJS rules are added and dynamically generated

AROBJS := SAME_NAME.foo.bar_1.o ...... SAME_NAME.foo.bar_2.o

#  For instance: 
#  $(AROBJS) : $(OBJS)
#        cp $< $@


.built : $(AROBJS)
``` 

## Impact
relate to (merge before):  https://github.com/apache/nuttx/pull/10973

## Testing
CI build
