### PR TITLE
testing: add verbose output of correct/incorrect tests

### DIFF
--- a/testing/fstest/fstest_main.c
+++ b/testing/fstest/fstest_main.c
@@ -89,6 +89,10 @@ struct fstest_ctx_s
   struct mallinfo mmprevious;
   struct mallinfo mmafter;
 };
+
+static int tests_ok = 0;
+static int tests_err = 0;
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -968,6 +972,8 @@ int main(int argc, FAR char *argv[])
   int loop_num;
   int option;
 
+  tests_ok = tests_err = 0;
+
   ctx = malloc(sizeof(struct fstest_ctx_s));
   if (ctx == NULL)
     {
@@ -1101,6 +1107,7 @@ int main(int argc, FAR char *argv[])
       ret = fstest_delfiles(ctx);
       if (ret < 0)
         {
+          tests_err += 1;
           printf("ERROR: Failed to delete files\n");
           printf("  Number of files: %d\n", ctx->nfiles);
           printf("  Number deleted:  %d\n", ctx->ndeleted);
@@ -1109,6 +1116,7 @@ int main(int argc, FAR char *argv[])
         }
       else
         {
+          tests_ok += 1;
           printf("Deleted some files\n");
           printf("  Number of files: %d\n", ctx->nfiles);
           printf("  Number deleted:  %d\n", ctx->ndeleted);
@@ -1128,6 +1136,7 @@ int main(int argc, FAR char *argv[])
       ret = fstest_verifyfs(ctx);
       if (ret < 0)
         {
+          tests_err += 1;
           printf("ERROR: Failed to verify files\n");
           printf("  Number of files: %d\n", ctx->nfiles);
           printf("  Number deleted:  %d\n", ctx->ndeleted);
@@ -1136,6 +1145,7 @@ int main(int argc, FAR char *argv[])
         }
       else
         {
+          tests_ok += 1;
 #if CONFIG_TESTING_FSTEST_VERBOSE != 0
           printf("Verified!\n");
           printf("  Number of files: %d\n", ctx->nfiles);
@@ -1148,19 +1158,19 @@ int main(int argc, FAR char *argv[])
       ret = statfs(ctx->mountdir, &buf);
       if (ret < 0)
         {
-           printf("ERROR: statfs failed: %d\n", errno);
-           free(ctx);
-           exit(ret);
+          printf("ERROR: statfs failed: %d\n", errno);
+          free(ctx);
+          exit(ret);
         }
       else
         {
-           printf("File System:\n");
-           printf("  Block Size:      %lu\n", (unsigned long)buf.f_bsize);
-           printf("  No. Blocks:      %lu\n", (unsigned long)buf.f_blocks);
-           printf("  Free Blocks:     %ld\n", (long)buf.f_bfree);
-           printf("  Avail. Blocks:   %ld\n", (long)buf.f_bavail);
-           printf("  No. File Nodes:  %ld\n", (long)buf.f_files);
-           printf("  Free File Nodes: %ld\n", (long)buf.f_ffree);
+          printf("File System:\n");
+          printf("  Block Size:      %lu\n", (unsigned long)buf.f_bsize);
+          printf("  No. Blocks:      %lu\n", (unsigned long)buf.f_blocks);
+          printf("  Free Blocks:     %ld\n", (long)buf.f_bfree);
+          printf("  Avail. Blocks:   %ld\n", (long)buf.f_bavail);
+          printf("  No. File Nodes:  %ld\n", (long)buf.f_files);
+          printf("  Free File Nodes: %ld\n", (long)buf.f_ffree);
         }
 
       /* Perform garbage collection, integrity checks */
@@ -1182,6 +1192,9 @@ int main(int argc, FAR char *argv[])
   free(ctx->fileimage);
   free(ctx->files);
   free(ctx);
+
+  printf("File system tests done... OK: %d, FAILED: %d\n", tests_ok,
+                                                           tests_err);
 
 #ifdef CONFIG_TESTING_FSTEST_POWEROFF
   /* Power down. This is useful when used with the simulator and gcov,

--- a/testing/scanftest/Kconfig
+++ b/testing/scanftest/Kconfig
@@ -30,4 +30,10 @@ config TESTING_SCANFTEST_STACKSIZE
 	int "Scanftest stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config TESTING_SCANFTEST_FNAME
+	string "Scanftest file name"
+	default "/mnt/fs/test.txt"
+	---help---
+		Path to the file for test writes/reads.
+
 endif

--- a/testing/scanftest/scanftest_main.c
+++ b/testing/scanftest/scanftest_main.c
@@ -1083,8 +1083,11 @@ int main(int argc, FAR char *argv[])
   double d2;
   FAR FILE *fp;
 
+  int tests_ok = 0;
+  int tests_err = 0;
+
   FAR const char *teststring = "teststring a";
-  FAR const char *fname = "/mnt/fs/test.txt";
+  FAR const char *fname = CONFIG_TESTING_SCANFTEST_FNAME;
 
   /* Test that scanf() can recognize percent-signs in the input. ** Test that
    * integer converters skip white-space. ** Test that "%i" can scan a single
@@ -1129,20 +1132,24 @@ int main(int argc, FAR char *argv[])
 
                   if (strcmp(s1, teststring) != 0)
                     {
+                      tests_err += 1;
                       printf("Error %s != %s.\n", teststring, s1);
                     }
                   else
                     {
+                      tests_ok += 1;
                       printf("Test PASSED.\n");
                     }
                 }
               else
                 {
+                  tests_err += 1;
                   printf("Error opening %s for read.\n", fname);
                 }
             }
           else
             {
+              tests_err += 1;
               printf("Error opening %s for write.\n", fname);
             }
         }
@@ -1171,6 +1178,7 @@ int main(int argc, FAR char *argv[])
                 }
               else
                 {
+                  tests_err += 1;
                   printf("Error opening %s for write.\n", fname);
                   break;
                 }
@@ -1320,7 +1328,12 @@ int main(int argc, FAR char *argv[])
 
           if (ok)
             {
+              tests_ok += 1;
               printf("Test #%u PASSED.\n", t + 1);
+            }
+          else
+            {
+              tests_err += 1;
             }
         }
     }
@@ -1457,9 +1470,16 @@ int main(int argc, FAR char *argv[])
 
       if (ok)
         {
+          tests_ok += 1;
           printf("Test #%u PASSED.\n", t + 1);
         }
+      else
+        {
+          tests_err += 1;
+        }
     }
+
+  printf("Scanf tests done... OK: %d, FAILED: %d\n", tests_ok, tests_err);
 
   return OK;
 }


### PR DESCRIPTION
## Summary
This adds counting of correct/incorrect tests to scanftest and fstest and thus allow to check whether the tests are really
successful. Current CI tests only check whether the test program does on end with hard fault but do not check whether
the results are correct (and they are not). This will allow to check if new patches break some OS functions.

## Impact
Better CI.

## Testing
CI test pass
