### PR TITLE
examples/foc: add an option to call nxscope work from control thread

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -620,11 +620,39 @@ config EXAMPLES_FOC_NXSCOPE_START
 		frame from a NxScope master device. This allows us to capture
 		controller data from the very beginning of its operation.
 
+choice
+	prompt "FOC nxscope work caller"
+	default EXAMPLES_FOC_NXSCOPE_MAIN
+
+config EXAMPLES_FOC_NXSCOPE_MAIN
+	bool "FOC nxscope uses foc_main()"
+	---help---
+		Use foc_main() for NxScope communication.
+
+config EXAMPLES_FOC_NXSCOPE_CONTROL
+	bool "FOC nxscope uses control thread"
+	---help---
+		Use control thread for NxScope communication.
+		With this option enabled you should limit the number of nxscope channels.
+		Otherwise, handling incoming nxscope data may significantly delay the control
+		loop, and consequently, the control cycle may be missed.
+
 config EXAMPLES_FOC_NXSCOPE_THREAD
 	bool "FOC nxscope uses separate thread"
-	default n
 	---help---
 		Use a separate thread for NxScope communication.
+
+endchoice # FOC nxscope work caller
+
+if EXAMPLES_FOC_NXSCOPE_CONTROL
+
+config EXAMPLES_FOC_NXSCOPE_WORK_PRESCALER
+	int "FOC nxscope work prescaler"
+	default 10
+	---help---
+		This option allows you to reduce the frequency of calling nxscope worker.
+
+endif #EXAMPLES_FOC_NXSCOPE_CONTROL
 
 if EXAMPLES_FOC_NXSCOPE_THREAD
 

--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -471,6 +471,15 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
             }
 #endif
 
+#ifdef CONFIG_EXAMPLES_FOC_NXSCOPE_CONTROL
+          /* Handle nxscope work */
+
+          if (motor.time % CONFIG_EXAMPLES_FOC_NXSCOPE_WORK_PRESCALER == 0)
+            {
+              foc_nxscope_work(envp->nxs);
+            }
+#endif
+
           /* Terminate control thread */
 
           if (motor.ctrl_state == FOC_CTRL_STATE_TERMINATE)

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -194,7 +194,9 @@ static void foc_float_nxscope(FAR struct foc_nxscope_s *nxs,
   int        i = nxs->ch_per_inst * motor->envp->id;
 #endif
 
+#ifndef CONFIG_EXAMPLES_FOC_NXSCOPE_CONTROL
   nxscope_lock(&nxs->nxs);
+#endif
 
 #if (CONFIG_EXAMPLES_FOC_NXSCOPE_CFG & FOC_NXSCOPE_IABC)
   ptr = (FAR float *)&motor->foc_state.curr;
@@ -283,7 +285,9 @@ static void foc_float_nxscope(FAR struct foc_nxscope_s *nxs,
   nxscope_put_vfloat(&nxs->nxs, i++, ptr, 1);
 #endif
 
+#ifndef CONFIG_EXAMPLES_FOC_NXSCOPE_CONTROL
   nxscope_unlock(&nxs->nxs);
+#endif
 }
 #endif
 
@@ -450,15 +454,6 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
             }
 #endif
 
-#ifdef CONFIG_EXAMPLES_FOC_NXSCOPE
-          /* Capture nxscope samples */
-
-          if (motor.time % CONFIG_EXAMPLES_FOC_NXSCOPE_PRESCALER == 0)
-            {
-              foc_float_nxscope(envp->nxs, &motor, &dev);
-            }
-#endif
-
 #ifdef CONFIG_EXAMPLES_FOC_STATE_USE_MODEL_PMSM
           /* Feed FOC model with data */
 
@@ -475,6 +470,24 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
               PRINTF("ERROR: foc_dev_prams_set failed %d!\n", ret);
               goto errout;
             }
+
+#ifdef CONFIG_EXAMPLES_FOC_NXSCOPE
+          /* Capture nxscope samples */
+
+          if (motor.time % CONFIG_EXAMPLES_FOC_NXSCOPE_PRESCALER == 0)
+            {
+              foc_float_nxscope(envp->nxs, &motor, &dev);
+            }
+#endif
+
+#ifdef CONFIG_EXAMPLES_FOC_NXSCOPE_CONTROL
+          /* Handle nxscope work */
+
+          if (motor.time % CONFIG_EXAMPLES_FOC_NXSCOPE_WORK_PRESCALER == 0)
+            {
+              foc_nxscope_work(envp->nxs);
+            }
+#endif
 
           /* Terminate control thread */
 

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -383,8 +383,7 @@ int main(int argc, char *argv[])
     {
       PRINTFV("foc_main loop %d\n", time);
 
-#if defined(CONFIG_EXAMPLES_FOC_NXSCOPE) &&       \
-    !defined(CONFIG_EXAMPLES_FOC_NXSCOPE_THREAD)
+#ifdef CONFIG_EXAMPLES_FOC_NXSCOPE_MAIN
       foc_nxscope_work(&nxs);
 #endif
 


### PR DESCRIPTION
## Summary

- examples/foc: add an option to call nxscope work from control thread

    This alows nxscope data to be sent with every cycle of the control loop,
    which increases the execution time of the control loop, but allows data
    to be sent at a highier frequency using the small nxscope buffer.
    
    Useful when tuning and debuging using RTT transfer.

## Impact

## Testing
ESC based on b-g431b-esc

