### PR TITLE
apps/games: Rename Shift game to Brickmatch

### DIFF
--- a/games/brickmatch/Kconfig
+++ b/games/brickmatch/Kconfig
@@ -3,11 +3,11 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config GAMES_SHIFT
-	bool "Shift Game"
+config GAMES_BRICKMATCH
+	bool "Brickmatch Game"
 	default n
 	---help---
-		Enable Shift games. Shift is a brick game, like a mix
+		Enable Brickmatch games. Brickmatch is like a mix
 		between Tetris and Crush Candy. The inspiration came
 		from a Shift game that was available for Android in the
 		F-Droid store. The original game source code still here:
@@ -16,21 +16,21 @@ config GAMES_SHIFT
 		NOTE: The source code here is not based on that code from
 		above github.
 
-if GAMES_SHIFT
+if GAMES_BRICKMATCH
 
-config GAMES_SHIFT_PROGNAME
+config GAMES_BRICKMATCH_PROGNAME
 	string "Program name"
-	default "shift"
+	default "brick"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.
 
-config GAMES_SHIFT_PRIORITY
-	int "Shift Game task priority"
+config GAMES_BRICKMATCH_PRIORITY
+	int "Brickmatch Game task priority"
 	default 100
 
-config GAMES_SHIFT_STACKSIZE
-	int "Shift Game stack size"
+config GAMES_BRICKMATCH_STACKSIZE
+	int "Brickmatch Game stack size"
 	default DEFAULT_TASK_STACKSIZE
 
 #
@@ -39,17 +39,17 @@ config GAMES_SHIFT_STACKSIZE
 
 choice
 	prompt "Input Device (Joystick, Gesture Sensor, etc)"
-	default GAMES_SHIFT_USE_CONSOLEKEY
+	default GAMES_BRICKMATCH_USE_CONSOLEKEY
 
-config GAMES_SHIFT_USE_CONSOLEKEY
+config GAMES_BRICKMATCH_USE_CONSOLEKEY
 	bool "Serial Console as Input"
 	depends on !INPUT_DJOYSTICK && !SENSORS_APDS9960
 
-config GAMES_SHIFT_USE_DJOYSTICK
+config GAMES_BRICKMATCH_USE_DJOYSTICK
 	bool "Discrete Joystick as Input"
 	depends on INPUT_DJOYSTICK
 
-config GAMES_SHIFT_USE_GESTURE
+config GAMES_BRICKMATCH_USE_GESTURE
 	bool "Gesture Sensor APDS-9960 as Input"
 	depends on SENSORS_APDS9960
 

--- a/games/brickmatch/Make.defs
+++ b/games/brickmatch/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/games/shift/Make.defs
+# apps/games/brickmatch/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +18,6 @@
 #
 ############################################################################
 
-ifneq ($(CONFIG_GAMES_SHIFT),)
-CONFIGURED_APPS += $(APPDIR)/games/shift
+ifneq ($(CONFIG_GAMES_BRICKMATCH),)
+CONFIGURED_APPS += $(APPDIR)/games/brickmatch
 endif

--- a/games/brickmatch/Makefile
+++ b/games/brickmatch/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/games/shift/Makefile
+# apps/games/brickmatch/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -20,15 +20,15 @@
 
 include $(APPDIR)/Make.defs
 
-# Shift game info
+# Brickmatch game info
 
-PROGNAME = $(CONFIG_GAMES_SHIFT_PROGNAME)
-PRIORITY = $(CONFIG_GAMES_SHIFT_PRIORITY)
-STACKSIZE = $(CONFIG_GAMES_SHIFT_STACKSIZE)
-MODULE = $(CONFIG_GAMES_SHIFT)
+PROGNAME = $(CONFIG_GAMES_BRICKMATCH_PROGNAME)
+PRIORITY = $(CONFIG_GAMES_BRICKMATCH_PRIORITY)
+STACKSIZE = $(CONFIG_GAMES_BRICKMATCH_STACKSIZE)
+MODULE = $(CONFIG_GAMES_BRICKMATCH)
 
-# Shift game application
+# Brickmatch game application
 
-MAINSRC = shift_main.c
+MAINSRC = bm_main.c
 
 include $(APPDIR)/Application.mk

--- a/games/brickmatch/bm_input_console.h
+++ b/games/brickmatch/bm_input_console.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/games/shift/shift_input_console.h
+ * apps/games/brickmatch/bm_input_console.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,7 +25,7 @@
 #include <nuttx/config.h>
 #include <termios.h>
 
-#include "shift_inputs.h"
+#include "bm_inputs.h"
 
 /****************************************************************************
  * Preprocessor Definitions

--- a/games/brickmatch/bm_input_joystick.h
+++ b/games/brickmatch/bm_input_joystick.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/games/shift/shift_input_joystick.h
+ * apps/games/brickmatch/bm_input_joystick.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -26,7 +26,7 @@
 
 #include <nuttx/input/djoystick.h>
 
-#include "shift_inputs.h"
+#include "bm_inputs.h"
 
 /****************************************************************************
  * Preprocessor Definitions

--- a/games/brickmatch/bm_inputs.h
+++ b/games/brickmatch/bm_inputs.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/games/shift/shift_input_gesture.h
+ * apps/games/brickmatch/bm_inputs.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,55 +24,41 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/sensors/apds9960.h>
-
-#include "shift_inputs.h"
-
 /****************************************************************************
  * Preprocessor Definitions
  ****************************************************************************/
 
-#define APDS9960_DEVNAME "/dev/gest0"
+#ifndef DIR_NONE
+#  define DIR_NONE    0
+#endif
 
-/****************************************************************************
- * dev_input_init
- ****************************************************************************/
+#ifndef DIR_LEFT
+#  define DIR_LEFT    1
+#endif
 
-int dev_input_init(FAR struct input_state_s *dev)
+#ifndef DIR_RIGHT
+#  define DIR_RIGHT   2
+#endif
+
+#ifndef DIR_UP
+#  define DIR_UP      3
+#endif
+
+#ifndef DIR_DOWN
+#  define DIR_DOWN    4
+#endif
+
+struct input_state_s
 {
-  /* Open the gesture sensor APDS9960 */
-
-  dev->fd_gest = open(APDS9960_DEVNAME, O_RDONLY | O_NONBLOCK);
-  if (dev->fd_gest < 0)
-    {
-      int errcode = errno;
-      printf("ERROR: Failed to open %s: %d\n", APDS9960_DEVNAME, errcode);
-      return -ENODEV;
-    }
-
-  return OK;
-}
-
-/****************************************************************************
- * dev_read_input
- ****************************************************************************/
-
-int dev_read_input(FAR struct input_state_s *dev)
-{
-  int nbytes;
-  uint8_t gest;
-
-  nbytes = read(dev->fd_gest, &gest, sizeof(gest));
-  if (nbytes == sizeof(gest))
-    {
-      dev->dir = gest;
-    }
-  else
-    {
-      dev->dir = DIR_NONE;
-      return -EINVAL;
-    }
-
-  return OK;
-}
+#ifdef CONFIG_GAMES_BRICKMATCH_USE_CONSOLEKEY
+  int fd_con;
+#endif
+#ifdef CONFIG_GAMES_BRICKMATCH_USE_DJOYSTICK
+  int fd_joy;
+#endif
+#ifdef CONFIG_GAMES_BRICKMATCH_USE_GESTURE
+  int fd_gest;
+#endif
+  int dir;      /* Direction to move the blocks */
+};
 

--- a/games/brickmatch/bm_main.c
+++ b/games/brickmatch/bm_main.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/games/shift/shift_main.c
+ * apps/games/brickmatch/bm_main.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -36,16 +36,16 @@
 #include <nuttx/video/fb.h>
 #include <nuttx/video/rgbcolors.h>
 
-#ifdef CONFIG_GAMES_SHIFT_USE_CONSOLEKEY
-#include "shift_input_console.h"
+#ifdef CONFIG_GAMES_BRICKMATCH_USE_CONSOLEKEY
+#include "bm_input_console.h"
 #endif
 
-#ifdef CONFIG_GAMES_SHIFT_USE_DJOYSTICK
-#include "shift_input_joystick.h"
+#ifdef CONFIG_GAMES_BRICKMATCH_USE_DJOYSTICK
+#include "bm_input_joystick.h"
 #endif
 
-#ifdef CONFIG_GAMES_SHIFT_USE_GESTURE
-#include "shift_input_gesture.h"
+#ifdef CONFIG_GAMES_BRICKMATCH_USE_GESTURE
+#include "bm_input_gesture.h"
 #endif
 
 /****************************************************************************
@@ -302,7 +302,7 @@ void draw_board(FAR struct screen_state_s *state,
  *   Draw the board including the user non-visible border for debugging.
  ****************************************************************************/
 
-#ifdef DEBUG_SHIFT_GAME
+#ifdef DEBUG_BRICKMATCH_GAME
 void print_board(void)
 {
   int row;
@@ -750,7 +750,7 @@ int check_board(void)
  ****************************************************************************/
 
 /****************************************************************************
- * shift_main
+ * brick_main
  ****************************************************************************/
 
 int main(int argc, FAR char *argv[])
@@ -854,7 +854,7 @@ int main(int argc, FAR char *argv[])
 
       screen.dir = input.dir;
 
-#ifdef DEBUG_SHIFT_GAME
+#ifdef DEBUG_BRICKMATCH_GAME
       printf("Before moving:\n");
       print_board();
       usleep(2000000);
@@ -868,7 +868,7 @@ int main(int argc, FAR char *argv[])
 
       draw_board(&state, &area, &screen);
 
-#ifdef DEBUG_SHIFT_GAME
+#ifdef DEBUG_BRICKMATCH_GAME
       printf("After moving:\n");
       print_board();
       usleep(1000000);
@@ -907,7 +907,7 @@ int main(int argc, FAR char *argv[])
           usleep(500000);
         }
 
-#ifdef DEBUG_SHIFT_GAME
+#ifdef DEBUG_BRICKMATCH_GAME
       printf("After checking:\n");
       print_board();
       usleep(1000000);


### PR DESCRIPTION
## Summary
Rename Shift game to Brickmatch
## Impact
Better name of the game
## Testing
esp32-devkitc:brickgame (see https://github.com/apache/nuttx/pull/10996)
