### PR TITLE
ramspeed:Fix the problem that the "-i" option doesn't work.

### DIFF
--- a/system/ramspeed/ramspeed_main.c
+++ b/system/ramspeed/ramspeed_main.c
@@ -128,7 +128,7 @@ static void parse_commandline(int argc, FAR char **argv,
       show_usage(argv[0], EXIT_FAILURE);
     }
 
-  while ((ch = getopt(argc, argv, "r:w:s:v:n:i:a")) != ERROR)
+  while ((ch = getopt(argc, argv, "r:w:s:v:n:ia")) != ERROR)
     {
       switch (ch)
         {


### PR DESCRIPTION
## Summary
Fixed a bug that caused misrecognition when using the -i parameter.

## Impact
None

## Testing
Local test passed