### PR TITLE
import/mk: Use libm from the export package when defined.

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -70,12 +70,14 @@ ifeq ($(CONFIG_BUILD_KERNEL),y)
   ifeq ($(CONFIG_HAVE_CXX),y)
     LDLIBS += -lxx
   endif
-ifneq ($(CONFIG_LIBM),y)
+ifeq ($(CONFIG_LIBM_TOOLCHAIN),y)
   LIBM = ${shell "$(CC)" $(ARCHCPUFLAGS) --print-file-name=libm.a}
 ifneq ($(LIBM),".")
   LDLIBPATH += -L "${shell dirname $(LIBM)}"
   LDLIBS += -lm
 endif
+else ifneq($(CONFIG_LIBM_NONE),)
+  LDLIBS += -lm
 endif
 endif
 


### PR DESCRIPTION
## Summary

Nuttx exports libm.a when `CONFIG_LIBM` is enabled. Adjust the application import makefile to pick this up when linking.

## Impact

Applications using `CONFIG_BUILD_KERNEL` and `CONIFG_LIBM` can link correctly when needed.

## Testing

Before this change, when trying to add  `CONFIG_EXAMPLES_CALIB_UDELAY`
```
nuttx/apps/examples/calib_udelay/calib_udelay_main.c:282: undefined reference to `ceil'
```

With this change, the `calib_udelay` application links as expected.