### PR TITLE
examples/calib_udelay: Allow the number of delay loop iterations to be specified by kconfig.

### DIFF
--- a/examples/calib_udelay/Kconfig
+++ b/examples/calib_udelay/Kconfig
@@ -22,4 +22,10 @@ config EXAMPLES_CALIB_UDELAY_NUM_RESULTS
 	int "Number of results to generate for calibration slope"
 	default 20
 
+config EXAMPLES_CALIB_UDELAY_DELAY_TEST_ITERATIONS
+	int "Delay loop interrations per test."
+	default 100000
+	---help---
+		Lower numbers decrease the time taken for the test to complete,
+		but may reduce the accuracy of the results.
 endif

--- a/examples/calib_udelay/calib_udelay_main.c
+++ b/examples/calib_udelay/calib_udelay_main.c
@@ -43,7 +43,7 @@
 #  define CONFIG_EXAMPLES_CALIB_UDELAY_NUM_RESULTS 20
 #endif
 
-#define DELAY_TEST_ITERS 100000
+#define DELAY_TEST_ITERS CONFIG_EXAMPLES_CALIB_UDELAY_DELAY_TEST_ITERATIONS
 
 /****************************************************************************
  * Private Types


### PR DESCRIPTION
## Summary

The calibration test can take a long time on platforms with less processing power. Allow the default value to be changed with kconfig.

## Impact

The calibration test completes in a more reasonable time.

## Testing

Before this change, with the default 100000 iterations:

```
nsh> calib_udelay

Calibrating timer for main calibration...
Performing main calibration for udelay. This will take approx. 220.677 seconds.
```

With this change, and `CONFIG_EXAMPLES_CALIB_UDELAY_DELAY_TEST_ITERATIONS=5000`
```
nsh> calib_udelay

Calibrating timer for main calibration...
Performing main calibration for udelay.This will take approx. 12.739 seconds.
Calibration slope for udelay:
  Y = m*X + b, where
    X is loop iterations,
    Y is time in nanoseconds,
    b is base overhead,
    m is nanoseconds per loop iteration.

  m = 127.01355925 nsec/iter
  b = 103458.24360897 nsec

  Correlation coefficient, R² = 1.0000

Without overhead, 0.00787317 iterations per nanosecond and 7873.18 iterations per millisecond.

Recommended setting for CONFIG_BOARD_LOOPSPERMSEC:
   CONFIG_BOARD_LOOPSPERMSEC=7874

```

