### PR TITLE
netutils/netinit: Reduce net monitor delay on platforms without 64 bit time type.

### DIFF
--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -207,8 +207,13 @@
  * signal indicating a change in network status.
  */
 
-#define LONG_TIME_SEC    (60*60) /* One hour in seconds */
-#define SHORT_TIME_SEC   (2)     /* 2 seconds */
+#ifdef CONFIG_SYSTEM_TIME64
+#  define LONG_TIME_SEC    (60*60)   /* One hour in seconds */
+#else
+#  define LONG_TIME_SEC    (5*60)    /* Five minutes in seconds */
+#endif
+
+#define SHORT_TIME_SEC     (2)       /* 2 seconds */
 
 /****************************************************************************
  * Private Data


### PR DESCRIPTION
## Summary

Waiting for an hour can cause the calculated tick count in `nxsem_clockwait` to overflow due to the default width of  `sclock_t`. Reduce the long wait period on platforms not using 64-bit time.

## Impact

Timed wait in the network monitor thread now operates as intended.

## Testing

Custom hardware, based on litex:arty_a7