### PR TITLE
netutils/netinit: Perform icmpv6 autoconfiguration when link transitions from down to up.

### DIFF
--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -873,6 +873,11 @@ static int netinit_monitor(void)
                   goto errout_with_notification;
                 }
 
+#ifdef CONFIG_NET_ICMPv6_AUTOCONF
+              /* Perform ICMPv6 auto-configuration */
+
+              netlib_icmpv6_autoconfiguration(ifr.ifr_name);
+#endif
               /* And wait for a short delay.  We will want to recheck the
                * link status again soon.
                */


### PR DESCRIPTION
## Summary

Without this addition, icmpv6 is never configured in the case that the device is powered on without an ethernet cable connected.

## Impact

IPv6 is configured in the case that a network cable is connected after the device has already initialised.  

## Testing

IPv6 stack on `eth0`, using custom hardware based on the litex:arty_a7.
