### PR TITLE
nshlib/nsh_fileapps.c: Remove sched_lock() from nsh_fileapp()

### DIFF
--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -159,12 +159,6 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
     }
 #endif
 
-  /* Lock the scheduler in an attempt to prevent the application from
-   * running until waitpid() has been called.
-   */
-
-  sched_lock();
-
   /* Execute the program. posix_spawnp returns a positive errno value on
    * failure.
    */
@@ -295,8 +289,6 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
         }
 #endif /* !CONFIG_SCHED_WAITPID || !CONFIG_NSH_DISABLEBG */
     }
-
-  sched_unlock();
 
   /* Free attributes and file actions.  Ignoring return values in the case
    * of an error.


### PR DESCRIPTION
## Summary
Locking the scheduler prior to calling posix_spawn() might lock the scheduler for a relatively long time, if the file to be loaded is large.

posix_spawn() loads the process into memory, possibly linking it as well if the binary format is linkable (elf). This can take tens / hundreds of milliseconds, which basically destroys the OS's real time performance.

Missing the death-of-child signal is a very trivial penalty considering the alternative.
## Impact
Remove a potentially very long scheduler lock from task spawning.
## Testing
rv-virt:knsh64 and MPFS target with >100 processes
