### PR TITLE
import/Make.defs: Fix erroneous formatting of make condition

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -76,7 +76,7 @@ ifneq ($(LIBM),".")
   LDLIBPATH += -L "${shell dirname $(LIBM)}"
   LDLIBS += -lm
 endif
-else ifneq($(CONFIG_LIBM_NONE),)
+else ifneq ($(CONFIG_LIBM_NONE),)
   LDLIBS += -lm
 endif
 endif


### PR DESCRIPTION
## Summary
Fixes:

/apps/import/Make.defs:79: extraneous text after 'else' directive
## Impact
Fix makefile condition
## Testing
make import
