### PR TITLE
nshlib: correct `ls -l` command output format

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -290,20 +290,20 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
             {
               if (buf.st_size >= GB)
                 {
-                  nsh_output(vtbl, "%7.1fG", (float)buf.st_size / GB);
+                  nsh_output(vtbl, "%11.1fG", (float)buf.st_size / GB);
                 }
               else if (buf.st_size >= MB)
                 {
-                  nsh_output(vtbl, "%7.1fM", (float)buf.st_size / MB);
+                  nsh_output(vtbl, "%11.1fM", (float)buf.st_size / MB);
                 }
               else
                 {
-                  nsh_output(vtbl, "%7.1fK", (float)buf.st_size / KB);
+                  nsh_output(vtbl, "%11.1fK", (float)buf.st_size / KB);
                 }
             }
           else
             {
-              nsh_output(vtbl, "%8" PRIdOFF, buf.st_size);
+              nsh_output(vtbl, "%12" PRIdOFF, buf.st_size);
             }
         }
     }


### PR DESCRIPTION
## Summary

Since the output format will be messed up with a size of GB.

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact

## Testing
correct before
```
ap> ls -l
/dev:
 brw-rw-rw-       0       0314572800 app
 dr--r--r--       0       0       0 audio/
 crw-rw-rw-       0       0       0 buttons
 crw-rw-rw-       0       0       0 console
 brw-rw-rw-       0       0104857600 coredump
 crw-rw-rw-       0       0       0 crypto
 brw-rw-rw-       0       02214592512 data
```

correct after
```
ap> ls -l
/dev:
 brw-rw-rw-       0       0   314572800 app
 dr--r--r--       0       0           0 audio/
 crw-rw-rw-       0       0           0 buttons
 crw-rw-rw-       0       0           0 console
 brw-rw-rw-       0       0   104857600 coredump
 crw-rw-rw-       0       0           0 crypto
 brw-rw-rw-       0       0  2214592512 data
```
