### PR TITLE
nshlib/ifconfig: Add support for add/del a single IPv6 address

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -239,7 +239,21 @@ int netlib_get_ipv4netmask(FAR const char *ifname, FAR struct in_addr *addr);
 int netlib_ipv4adaptor(in_addr_t destipaddr, FAR in_addr_t *srcipaddr);
 #endif
 
+/* We support multiple IPv6 addresses on a single interface.
+ * Recommend to use netlib_add/del_ipv6addr to manage them, by which you
+ * don't need to care about the slot it stored.
+ *
+ * Previous interfaces can still work, the ifname can be <eth>:<num>,
+ * e.g. eth0:0 stands for managing the secondary address on eth0
+ */
+
 #ifdef CONFIG_NET_IPv6
+#  ifdef CONFIG_NETDEV_MULTIPLE_IPv6
+int netlib_add_ipv6addr(FAR const char *ifname,
+                        FAR const struct in6_addr *addr, uint8_t preflen);
+int netlib_del_ipv6addr(FAR const char *ifname,
+                        FAR const struct in6_addr *addr, uint8_t preflen);
+#  endif
 int netlib_get_ipv6addr(FAR const char *ifname, FAR struct in6_addr *addr);
 int netlib_set_ipv6addr(FAR const char *ifname,
                         FAR const struct in6_addr *addr);

--- a/netutils/netlib/CMakeLists.txt
+++ b/netutils/netlib/CMakeLists.txt
@@ -56,6 +56,7 @@ if(CONFIG_NETUTILS_NETLIB)
   endif()
 
   if(CONFIG_NET_IPv6)
+    list(APPEND SRCS netlib_addipv6addr.c netlib_delipv6addr.c)
     list(APPEND SRCS netlib_setipv6addr.c netlib_getipv6addr.c)
     list(APPEND SRCS netlib_setdripv6addr.c netlib_setipv6netmask.c)
     list(APPEND SRCS netlib_prefix2ipv6netmask.c netlib_ipv6netmask2prefix.c)

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -56,6 +56,7 @@ endif
 endif
 
 ifeq ($(CONFIG_NET_IPv6),y)
+CSRCS += netlib_addipv6addr.c netlib_delipv6addr.c
 CSRCS += netlib_setipv6addr.c netlib_getipv6addr.c
 CSRCS += netlib_setdripv6addr.c netlib_setipv6netmask.c
 CSRCS += netlib_prefix2ipv6netmask.c netlib_ipv6netmask2prefix.c

--- a/netutils/netlib/netlib_addipv6addr.c
+++ b/netutils/netlib/netlib_addipv6addr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/netutils/netlib/netlib_setipv4addr.c
+ * apps/netutils/netlib/netlib_addipv6addr.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -23,7 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#ifdef CONFIG_NET_IPv4
+#ifdef CONFIG_NETDEV_MULTIPLE_IPv6
 
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -42,45 +42,54 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: netlib_set_ipv4addr
+ * Name: netlib_add_ipv6addr
  *
  * Description:
- *   Set the network driver IPv4 address
+ *   Add an IPv6 address to the network driver
  *
  * Parameters:
  *   ifname   The name of the interface to use
- *   ipaddr   The address to set
+ *   ipaddr   The address to add
+ *   preflen  The prefix length of the address
  *
  * Return:
  *   0 on success; -1 on failure
  *
  ****************************************************************************/
 
-int netlib_set_ipv4addr(FAR const char *ifname,
-                        FAR const struct in_addr *addr)
+int netlib_add_ipv6addr(FAR const char *ifname,
+                        FAR const struct in6_addr *addr, uint8_t preflen)
 {
   int ret = ERROR;
 
   if (ifname && addr)
     {
-      int sockfd = socket(AF_INET, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+      int sockfd = socket(AF_INET6, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
       if (sockfd >= 0)
         {
-          FAR struct sockaddr_in *inaddr;
           struct ifreq req;
+          struct in6_ifreq ifr6;
 
           /* Add the device name to the request */
 
           strlcpy(req.ifr_name, ifname, IFNAMSIZ);
 
-          /* Add the INET address to the request */
+          /* Get interface index */
 
-          inaddr             = (FAR struct sockaddr_in *)&req.ifr_addr;
-          inaddr->sin_family = AF_INET;
-          inaddr->sin_port   = 0;
-          memcpy(&inaddr->sin_addr, addr, sizeof(struct in_addr));
+          ret = ioctl(sockfd, SIOCGIFINDEX,
+                     ((unsigned long)(uintptr_t)&req));
+          if (ret == OK)
+            {
+              /* Add address to the interface. */
 
-          ret = ioctl(sockfd, SIOCSIFADDR, (unsigned long)&req);
+              ifr6.ifr6_ifindex = req.ifr_ifindex;
+              ifr6.ifr6_prefixlen = preflen;
+              memcpy(&ifr6.ifr6_addr, addr, sizeof(struct in6_addr));
+
+              ret = ioctl(sockfd, SIOCSIFADDR,
+                          ((unsigned long)(uintptr_t)&ifr6));
+            }
+
           close(sockfd);
         }
     }
@@ -88,4 +97,4 @@ int netlib_set_ipv4addr(FAR const char *ifname,
   return ret;
 }
 
-#endif /* CONFIG_NET_IPv4 */
+#endif /* CONFIG_NETDEV_MULTIPLE_IPv6 */

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -278,7 +278,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #ifdef CONFIG_NET
 #  ifndef CONFIG_NSH_DISABLE_IFCONFIG
   CMD_MAP("ifconfig", cmd_ifconfig, 1, 12,
-    "[interface [address_family] [mtu <len>] | [<ip-address>|dhcp]]"
+    "[interface [mtu <len>]|[address_family] [[add|del] <ip-address>|dhcp]]"
     "[dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] "
     "[dns <dns-address>] [hw <hw-mac>]"),
 #  endif


### PR DESCRIPTION
## Summary
Depends on https://github.com/apache/nuttx/pull/11054

Patches included:
- netutils/netlib: Add support for add/del a single IPv6 address
- nshlib/ifconfig: Add support for add/del a single IPv6 address

We're using similar syntaxes and error codes as Linux:
```
linux> sudo ifconfig eth0 inet6 add fc00::2/64
linux> sudo ifconfig eth0 inet6 del fc00::2/112
SIOCDIFADDR: Cannot assign requested address
linux> sudo ifconfig eth0 inet6 del fc00::3/64
SIOCDIFADDR: Cannot assign requested address
linux> sudo ifconfig eth0 inet6 add fc00::2/64
SIOCSIFADDR: File exists

nuttx> ifconfig eth0 inet6 add fc00::2/64
nuttx> ifconfig eth0 inet6 del fc00::2/112
Failed to manage IPv6 address: Cannot assign requested address
nuttx> ifconfig eth0 inet6 del fc00::3/112
Failed to manage IPv6 address: Cannot assign requested address
nuttx> ifconfig eth0 inet6 add fc00::2/64
Failed to manage IPv6 address: File exists
```

## Impact
Add support for add/del a single IPv6 address when we have multiple.

## Testing
Manually, CI

