### PR TITLE
examples/foc: configure acceleration and deceleration from command line

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -568,15 +568,15 @@ config EXAMPLES_FOC_IDQ_KI
 endif #EXAMPLES_FOC_CONTROL_PI
 
 config EXAMPLES_FOC_RAMP_THR
-	int "FOC velocity ramp threshold [x1000]"
+	int "FOC velocity ramp threshold [x1]"
 	default 0
 
 config EXAMPLES_FOC_RAMP_ACC
-	int "FOC velocity ramp acc [x1000]"
+	int "FOC velocity ramp acc [x1]"
 	default 0
 
 config EXAMPLES_FOC_RAMP_DEC
-	int "FOC velocity ramp dec [x1000]"
+	int "FOC velocity ramp dec [x1]"
 	default 0
 
 config EXAMPLES_FOC_HAVE_ALIGN

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -117,8 +117,6 @@
 /* Velocity ramp configuration */
 
 #define RAMP_CFG_THR (CONFIG_EXAMPLES_FOC_RAMP_THR / 1000.0f)
-#define RAMP_CFG_ACC (CONFIG_EXAMPLES_FOC_RAMP_ACC / 1000.0f)
-#define RAMP_CFG_DEC (CONFIG_EXAMPLES_FOC_RAMP_DEC / 1000.0f)
 
 #ifdef CONFIG_EXAMPLES_FOC_STATE_USE_MODEL_PMSM
 
@@ -239,6 +237,8 @@ struct foc_thr_cfg_s
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
   uint32_t velmax;              /* Velocity max (x1000) */
+  uint32_t acc;                 /* Acceleration (x1000) */
+  uint32_t dec;                 /* Deceleration (x1000) */
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
   uint32_t posmax;              /* Position max (x1000) */

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -116,7 +116,7 @@
 
 /* Velocity ramp configuration */
 
-#define RAMP_CFG_THR (CONFIG_EXAMPLES_FOC_RAMP_THR / 1000.0f)
+#define RAMP_CFG_THR (CONFIG_EXAMPLES_FOC_RAMP_THR / 1.0f)
 
 #ifdef CONFIG_EXAMPLES_FOC_STATE_USE_MODEL_PMSM
 
@@ -237,8 +237,8 @@ struct foc_thr_cfg_s
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
   uint32_t velmax;              /* Velocity max (x1000) */
-  uint32_t acc;                 /* Acceleration (x1000) */
-  uint32_t dec;                 /* Deceleration (x1000) */
+  uint32_t acc;                 /* Acceleration (x1) */
+  uint32_t dec;                 /* Deceleration (x1) */
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
   uint32_t posmax;              /* Position max (x1000) */

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -107,6 +107,10 @@ struct args_s g_args =
     .posmax = CONFIG_EXAMPLES_FOC_SETPOINT_MAX,
 #  endif
 #endif
+#ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
+    .acc = CONFIG_EXAMPLES_FOC_RAMP_ACC,
+    .dec = CONFIG_EXAMPLES_FOC_RAMP_DEC,
+#endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
     .ident_res_ki = CONFIG_EXAMPLES_FOC_IDENT_RES_KI,
     .ident_res_curr = CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT,

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -307,8 +307,8 @@ static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
   ret = foc_ramp_init_b16(&motor->ramp,
                           motor->per,
                           ftob16(RAMP_CFG_THR),
-                          ftob16((motor->envp->cfg->acc / 1000.0f)),
-                          ftob16((motor->envp->cfg->dec / 1000.0f)));
+                          ftob16((motor->envp->cfg->acc / 1.0f)),
+                          ftob16((motor->envp->cfg->dec / 1.0f)));
   if (ret < 0)
     {
       PRINTF("ERROR: foc_ramp_init failed %d\n", ret);

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -307,8 +307,8 @@ static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
   ret = foc_ramp_init_b16(&motor->ramp,
                           motor->per,
                           ftob16(RAMP_CFG_THR),
-                          ftob16(RAMP_CFG_ACC),
-                          ftob16(RAMP_CFG_ACC));
+                          ftob16((motor->envp->cfg->acc / 1000.0f)),
+                          ftob16((motor->envp->cfg->dec / 1000.0f)));
   if (ret < 0)
     {
       PRINTF("ERROR: foc_ramp_init failed %d\n", ret);

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -307,8 +307,8 @@ static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
   ret = foc_ramp_init_f32(&motor->ramp,
                           motor->per,
                           RAMP_CFG_THR,
-                          (motor->envp->cfg->acc / 1000.0f),
-                          (motor->envp->cfg->dec / 1000.0f));
+                          (motor->envp->cfg->acc / 1.0f),
+                          (motor->envp->cfg->dec / 1.0f));
   if (ret < 0)
     {
       PRINTF("ERROR: foc_ramp_init failed %d\n", ret);

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -307,8 +307,8 @@ static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
   ret = foc_ramp_init_f32(&motor->ramp,
                           motor->per,
                           RAMP_CFG_THR,
-                          RAMP_CFG_ACC,
-                          RAMP_CFG_ACC);
+                          (motor->envp->cfg->acc / 1000.0f),
+                          (motor->envp->cfg->dec / 1000.0f));
   if (ret < 0)
     {
       PRINTF("ERROR: foc_ramp_init failed %d\n", ret);

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -75,6 +75,8 @@ static struct option g_long_options[] =
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
     { "vel", required_argument, 0, 'v' },
+    { "acc", required_argument, 0, 'a' },
+    { "dec", required_argument, 0, 'd' },
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
     { "pos", required_argument, 0, 'x' },
@@ -156,6 +158,10 @@ static void foc_help(void)
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
   PRINTF("  [-v] velocity [x1000]\n");
+  PRINTF("  [-a] acceleration [x1000] (default: %" PRId32 ")\n",
+         args->cfg.acc);
+  PRINTF("  [-d] deceleration [x1000] (default: %" PRId32 ")\n",
+         args->cfg.dec);
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_POS
   PRINTF("  [-x] position [x1000]\n");
@@ -237,7 +243,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
 
   while (1)
     {
-      c = getopt_long(argc, argv, "ht:f:m:o:r:v:x:s:j:", g_long_options,
+      c = getopt_long(argc, argv, "ht:f:m:o:r:v:a:d:x:s:j:", g_long_options,
                       &option_index);
 
       if (c == -1)
@@ -385,6 +391,18 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
           case 'v':
             {
               args->cfg.velmax = atoi(optarg);
+              break;
+            }
+
+          case 'a':
+            {
+              args->cfg.acc = atoi(optarg);
+              break;
+            }
+
+          case 'd':
+            {
+              args->cfg.dec = atoi(optarg);
               break;
             }
 #endif


### PR DESCRIPTION
## Summary

- examples/foc: configure acceleration and deceleration from command line
- examples/foc: change the velocity ramp parameters scale to x1  
    controlling the ramp with greater accuracy makes no practical sense

## Impact

## Testing
ESC based on b-g431b-esc

