### PR TITLE
nsh: explicitly select the cpuload clock source configuration

### DIFF
--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -491,7 +491,7 @@
 
 #define NSH_HAVE_CPULOAD  1
 #if !defined(CONFIG_FS_PROCFS) || defined(CONFIG_FS_PROCFS_EXCLUDE_CPULOAD) || \
-    !defined(CONFIG_SCHED_CPULOAD) || defined(CONFIG_NSH_DISABLE_PS)
+    defined(CONFIG_SCHED_CPULOAD_NONE) || defined(CONFIG_NSH_DISABLE_PS)
 #  undef NSH_HAVE_CPULOAD
 #endif
 


### PR DESCRIPTION
## Summary
rename CONFIG_SCHED_CPULOAD to CONFIG_SCHED_CPULOAD_NONE

Modify cpuload configuration name, see this PR for details：https://github.com/apache/nuttx/pull/11102

## Impact
None

## Testing
sim/mm
