### PR TITLE
industrial/foc: add options to configure foclib logs

### DIFF
--- a/include/industry/foc/foc_log.h
+++ b/include/industry/foc/foc_log.h
@@ -35,8 +35,22 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define FOCLIBLOG(format, ...)  printf(format, ##__VA_ARGS__)
-#define FOCLIBERR(format, ...)  printf(format, ##__VA_ARGS__)
-#define FOCLIBWARN(format, ...) printf(format, ##__VA_ARGS__)
+#ifdef CONFIG_INDUSTRY_FOC_DEBUG
+#  define FOCLIBLOG(format, ...)  printf(format, ##__VA_ARGS__)
+#else
+#  define FOCLIBLOG(format, ...)
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_ERROR
+#  define FOCLIBERR(format, ...)  printf(format, ##__VA_ARGS__)
+#else
+#  define FOCLIBERR(format, ...)
+#endif
+
+#ifdef CONFIG_INDUSTRY_FOC_WARN
+#  define FOCLIBWARN(format, ...) printf(format, ##__VA_ARGS__)
+#else
+#  define FOCLIBWARN(format, ...)
+#endif
 
 #endif /* __APPS_INCLUDE_INDUSTRY_FOC_FOC_LOG_H */

--- a/industry/foc/Kconfig
+++ b/industry/foc/Kconfig
@@ -12,6 +12,18 @@ config INDUSTRY_FOC
 
 if INDUSTRY_FOC
 
+config INDUSTRY_FOC_DEBUG
+	bool "Enable FOCLIB debug log"
+	default n
+
+config INDUSTRY_FOC_ERROR
+	bool "Enable FOCLIB error log"
+	default n
+
+config INDUSTRY_FOC_WARN
+	bool "Enable FOCLIB warn log"
+	default n
+
 config INDUSTRY_FOC_CORDIC
 	bool "Enable CORDIC support"
 	default n


### PR DESCRIPTION
## Summary
industrial/foc: add options to configure foclib logs
## Impact

## Testing
ci
