### PR TITLE
examples/foc: add support for control loop performance measurements

### DIFF
--- a/examples/foc/CMakeLists.txt
+++ b/examples/foc/CMakeLists.txt
@@ -1,22 +1,22 @@
-############################################################################
+# ##############################################################################
 # apps/examples/foc/CMakeLists.txt
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_EXAMPLES_FOC)
   nuttx_add_application(
@@ -29,34 +29,36 @@ if(CONFIG_EXAMPLES_FOC)
     PRIORITY
     ${CONFIG_EXAMPLES_FOC_PRIORITY})
 
-set(CSRCS
-  foc_device.c
-  foc_mq.c
-  foc_thr.c
-  foc_intf.c)
+  set(CSRCS foc_device.c foc_mq.c foc_thr.c foc_intf.c)
 
-if(CONFIG_BUILTIN)
-  list(APPEND CSRCS foc_parseargs.c)
-endif()
+  if(CONFIG_BUILTIN)
+    list(APPEND CSRCS foc_parseargs.c)
+  endif()
 
-# fixed16 support
+  # fixed16 support
 
-if(CONFIG_INDUSTRY_FOC_FIXED16)
-  list(APPEND CSRCS foc_fixed16_thr.c foc_motor_b16.c)
-endif()
+  if(CONFIG_INDUSTRY_FOC_FIXED16)
+    list(APPEND CSRCS foc_fixed16_thr.c foc_motor_b16.c)
+  endif()
 
-# float32 support
+  # float32 support
 
-if(CONFIG_INDUSTRY_FOC_FLOAT)
-  list(APPEND CSRCS foc_float_thr.c foc_motor_f32.c)
-endif()
+  if(CONFIG_INDUSTRY_FOC_FLOAT)
+    list(APPEND CSRCS foc_float_thr.c foc_motor_f32.c)
+  endif()
 
-# NxScope support
+  # NxScope support
 
-if(CONFIG_EXAMPLES_FOC_NXSCOPE)
-  list(APPEND CSRCS foc_nxscope.c)
-endif()
+  if(CONFIG_EXAMPLES_FOC_NXSCOPE)
+    list(APPEND CSRCS foc_nxscope.c)
+  endif()
 
-target_sources(apps PRIVATE ${CSRCS})
+  # perf support
+
+  if(CONFIG_EXAMPLES_FOC_PERF)
+    list(APPEND CSRCS foc_perf.c)
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
 
 endif()

--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -43,6 +43,10 @@ config EXAMPLES_FOC_VERBOSE
 	default 1
 	range 0 2
 
+config EXAMPLES_FOC_PERF
+	bool "Enable performance meassurements"
+	default n
+
 choice
 	prompt "FOC current controller selection"
 	default EXAMPLES_FOC_CONTROL_PI

--- a/examples/foc/Makefile
+++ b/examples/foc/Makefile
@@ -56,4 +56,10 @@ ifeq ($(CONFIG_EXAMPLES_FOC_NXSCOPE),y)
   CSRCS += foc_nxscope.c
 endif
 
+# perf support
+
+ifeq ($(CONFIG_EXAMPLES_FOC_PERF),y)
+CSRCS += foc_perf.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/examples/foc/foc_device.c
+++ b/examples/foc/foc_device.c
@@ -90,6 +90,12 @@ int foc_device_init(FAR struct foc_device_s *dev, int id)
       goto errout;
     }
 
+#ifdef CONFIG_EXAMPLES_FOC_PERF
+  /* Initialize perf */
+
+  foc_perf_init(&dev->perf);
+#endif
+
 errout:
   return ret;
 }
@@ -138,6 +144,15 @@ int foc_device_start(FAR struct foc_device_s *dev, bool state)
           PRINTFV("ERROR: foc_dev_start failed %d!\n", ret);
           goto errout;
         }
+
+#ifdef CONFIG_EXAMPLES_FOC_PERF
+      /* Skip this cycle in stats. When the dev is started, many components
+       * are initialized, which significantly increases the cycle time and
+       * disturbs the statistics.
+       */
+
+      foc_perf_skip(&dev->perf);
+#endif
     }
   else
     {
@@ -172,6 +187,10 @@ int foc_dev_state_get(FAR struct foc_device_s *dev)
       goto errout;
     }
 
+#ifdef CONFIG_EXAMPLES_FOC_PERF
+  foc_perf_start(&dev->perf);
+#endif
+
 errout:
   return ret;
 }
@@ -194,6 +213,10 @@ int foc_dev_params_set(FAR struct foc_device_s *dev)
       PRINTFV("ERROR: foc_dev_setparams failed %d!\n", ret);
       goto errout;
     }
+
+#ifdef CONFIG_EXAMPLES_FOC_PERF
+  foc_perf_end(&dev->perf);
+#endif
 
 errout:
   return ret;

--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -498,6 +498,13 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
       /* Increase counter */
 
       motor.time += 1;
+
+#ifdef CONFIG_EXAMPLES_FOC_PERF
+      if (dev.perf.max_changed)
+        {
+          PRINTF_PERF("max=%" PRId32 "\n", dev.perf.max);
+        }
+#endif
     }
 
 errout:

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -511,6 +511,13 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
       /* Increase counter */
 
       motor.time += 1;
+
+#ifdef CONFIG_EXAMPLES_FOC_PERF
+      if (dev.perf.max_changed)
+        {
+          PRINTF_PERF("max=%" PRId32 "\n", dev.perf.max);
+        }
+#endif
     }
 
 errout:

--- a/examples/foc/foc_perf.c
+++ b/examples/foc/foc_perf.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/foc/foc_device.h
+ * apps/examples/foc/foc_perf.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,49 +18,73 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_EXAMPLES_FOC_FOC_DEVICE_H
-#define __APPS_EXAMPLES_FOC_FOC_DEVICE_H
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <nuttx/clock.h>
+
 #include "foc_perf.h"
 
-#include "industry/foc/foc_utils.h"
-
 /****************************************************************************
- * Public Type Definition
+ * Public Functions
  ****************************************************************************/
 
-/* FOC device data */
+/****************************************************************************
+ * Name: foc_perf_init
+ ****************************************************************************/
 
-struct foc_device_s
+int foc_perf_init(struct foc_perf_s *p)
 {
-  int                 fd;      /* FOC device */
-  struct foc_info_s   info;    /* FOC dev info */
-  struct foc_state_s  state;   /* FOC dev state */
-  struct foc_params_s params;  /* FOC dev params */
-#ifdef CONFIG_EXAMPLES_FOC_PERF
-  struct foc_perf_s   perf;    /* FOC dev perf */
-#endif
-};
+  memset(p, 0, sizeof(struct foc_perf_s));
+
+  return OK;
+}
 
 /****************************************************************************
- * Public Data
+ * Name: foc_perf_start
  ****************************************************************************/
+
+void foc_perf_start(struct foc_perf_s *p)
+{
+  p->now = perf_gettime();
+}
 
 /****************************************************************************
- * Public Function Prototypes
+ * Name: foc_perf_skip
  ****************************************************************************/
 
-int foc_device_init(FAR struct foc_device_s *dev, int id);
-int foc_device_deinit(FAR struct foc_device_s *dev);
-int foc_device_start(FAR struct foc_device_s *dev, bool state);
-int foc_dev_state_get(FAR struct foc_device_s *dev);
-int foc_dev_params_set(FAR struct foc_device_s *dev);
-int foc_dev_state_handle(FAR struct foc_device_s *dev, FAR bool *flag);
+void foc_perf_skip(struct foc_perf_s *p)
+{
+  p->skip = true;
+}
 
-#endif /* __APPS_EXAMPLES_FOC_FOC_DEVICE_H */
+/****************************************************************************
+ * Name: foc_perf_end
+ ****************************************************************************/
+
+void foc_perf_end(struct foc_perf_s *p)
+{
+  p->now = perf_gettime() - p->now;
+
+  p->max_changed = false;
+
+  if (p->skip == false)
+    {
+      if (p->now > p->max)
+        {
+          p->max = p->now;
+          p->max_changed = true;
+        }
+    }
+
+  /* Reset skip flag */
+
+  p->skip = false;
+}

--- a/examples/foc/foc_perf.h
+++ b/examples/foc/foc_perf.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/foc/foc_device.h
+ * apps/examples/foc/foc_perf.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __APPS_EXAMPLES_FOC_FOC_DEVICE_H
-#define __APPS_EXAMPLES_FOC_FOC_DEVICE_H
+#ifndef __APPS_EXAMPLES_FOC_FOC_PERF_H
+#define __APPS_EXAMPLES_FOC_FOC_PERF_H
 
 /****************************************************************************
  * Included Files
@@ -27,40 +27,31 @@
 
 #include <nuttx/config.h>
 
-#include "foc_perf.h"
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
 
-#include "industry/foc/foc_utils.h"
+#define PRINTF_PERF(format, ...) printf(format, ##__VA_ARGS__)
 
 /****************************************************************************
  * Public Type Definition
  ****************************************************************************/
 
-/* FOC device data */
-
-struct foc_device_s
+struct foc_perf_s
 {
-  int                 fd;      /* FOC device */
-  struct foc_info_s   info;    /* FOC dev info */
-  struct foc_state_s  state;   /* FOC dev state */
-  struct foc_params_s params;  /* FOC dev params */
-#ifdef CONFIG_EXAMPLES_FOC_PERF
-  struct foc_perf_s   perf;    /* FOC dev perf */
-#endif
+  bool     max_changed;
+  bool     skip;
+  uint32_t max;
+  uint32_t now;
 };
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-int foc_device_init(FAR struct foc_device_s *dev, int id);
-int foc_device_deinit(FAR struct foc_device_s *dev);
-int foc_device_start(FAR struct foc_device_s *dev, bool state);
-int foc_dev_state_get(FAR struct foc_device_s *dev);
-int foc_dev_params_set(FAR struct foc_device_s *dev);
-int foc_dev_state_handle(FAR struct foc_device_s *dev, FAR bool *flag);
+int foc_perf_init(struct foc_perf_s *p);
+void foc_perf_start(struct foc_perf_s *p);
+void foc_perf_skip(struct foc_perf_s *p);
+void foc_perf_end(struct foc_perf_s *p);
 
-#endif /* __APPS_EXAMPLES_FOC_FOC_DEVICE_H */
+#endif /* __APPS_EXAMPLES_FOC_FOC_PERF_H */


### PR DESCRIPTION
## Summary
examples/foc: add support for control loop performance measurements

## Impact

## Testing
b-g431b-esc1
