### PR TITLE
lte/alt1250: Fix some bugs in alt1250 daemon

### DIFF
--- a/lte/alt1250/alt1250_netdev.c
+++ b/lte/alt1250/alt1250_netdev.c
@@ -30,6 +30,8 @@
 
 #include "alt1250_netdev.h"
 
+#define ALT1250_SUBNET_MASK 0xFFFFFF00 /* 255.255.255.0 this is dummy */
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -61,6 +63,8 @@ void alt1250_netdev_ifdown(FAR struct alt1250_s *dev)
   dev->net_dev.d_flags = IFF_DOWN;
 #ifdef CONFIG_NET_IPv4
   memset(&dev->net_dev.d_ipaddr, 0, sizeof(dev->net_dev.d_ipaddr));
+  memset(&dev->net_dev.d_draddr, 0, sizeof(dev->net_dev.d_draddr));
+  memset(&dev->net_dev.d_netmask, 0, sizeof(dev->net_dev.d_netmask));
 #endif
 #ifdef CONFIG_NET_IPv6
   memset(&dev->net_dev.d_ipv6addr, 0, sizeof(dev->net_dev.d_ipv6addr));
@@ -85,6 +89,17 @@ void alt1250_netdev_ifup(FAR struct alt1250_s *dev, FAR lte_pdn_t *pdn)
           inet_pton(AF_INET,
                     (FAR const char *)pdn->address[i].address,
                     (FAR void *)&dev->net_dev.d_ipaddr);
+          inet_pton(AF_INET,
+                    (FAR const char *)pdn->address[i].address,
+                    (FAR void *)&dev->net_dev.d_draddr);
+
+          /* The following parameters are dummy values because
+           * they cannot be obtained from alt1250.
+           */
+
+          dev->net_dev.d_draddr = htonl((ntohl(dev->net_dev.d_draddr) &
+                                         ALT1250_SUBNET_MASK) | 1);
+          dev->net_dev.d_netmask = htonl(ALT1250_SUBNET_MASK);
         }
 #endif
 

--- a/lte/alt1250/alt1250_usockif.c
+++ b/lte/alt1250/alt1250_usockif.c
@@ -281,7 +281,7 @@ int usockif_readreqioctl(int fd, FAR struct usrsock_request_buff_s *buf)
         break;
       default:
         dbg_alt1250("Unsupported command:0x%08lx\n", req->cmd);
-        return -EINVAL;
+        return -ENOTTY;
         break;
     }
 

--- a/lte/alt1250/usock_handlers/alt1250_ioctl_ifreq.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctl_ifreq.c
@@ -391,7 +391,11 @@ int usockreq_ioctl_ifreq(FAR struct alt1250_s *dev,
   *usock_result = OK;
   *usock_xid = request->head.xid;
 
-  if (if_req->ifr_flags & IFF_UP)
+  if (!dev->usock_enable)
+    {
+      *usock_result = -ENOTTY;
+    }
+  else if (if_req->ifr_flags & IFF_UP)
     {
       ret = do_ifup(dev, req, usock_result, usock_xid, ackinfo);
     }

--- a/lte/alt1250/usock_handlers/alt1250_sockethdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_sockethdlr.c
@@ -393,11 +393,11 @@ int usockreq_socket(FAR struct alt1250_s *dev,
            request->type != SOCK_CTRL)
     {
       /* If domain is AF_INET while usock_enable is false,
-       * set usockid to -EPROTONOSUPPORT to fallback kernel
+       * set usockid to -ENOTSUP to fallback kernel
        * network stack.
        */
 
-      *usock_result = -EPROTONOSUPPORT;
+      *usock_result = -ENOTSUP;
       return REP_SEND_ACK_WOFREE;
     }
 


### PR DESCRIPTION
## Summary
Fix alt1250 daemon to return -ENOTTY when receiving ioctl request and in the state of using kernel's network stack.
Fix alt1250 daemon to return -ENOTSUP when receiving socket request and in the state of using kernel's network stack.
Fix alt1250 daemon to set dummy subnet mask in network devices. This allows the correct network device to be selected when two network devices exist.

## Impact
Only alt1250 daemon

## Testing
Test with Spresense LTE board.
