### PR TITLE
examples/foc: various fixes foc_cfg.h

### DIFF
--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -33,14 +33,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* For now only torque mode supported for sensored */
-
-#ifdef CONFIG_EXAMPLES_FOC_SENSORED
-#  ifndef CONFIG_EXAMPLES_FOC_HAVE_TORQ
-#    error
-#  endif
-#endif
-
 /* For now only sensorless velocity control supported */
 
 #ifdef CONFIG_EXAMPLES_FOC_SENSORLESS

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -33,6 +33,11 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if defined(CONFIG_EXAMPLES_FOC_SENSORLESS) && \
+  defined(CONFIG_EXAMPLES_FOC_SENSORED)
+#  error Simultaneous support for sensorless and sensored mode not supported
+#endif
+
 /* For now only sensorless velocity control supported */
 
 #ifdef CONFIG_EXAMPLES_FOC_SENSORLESS

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -45,10 +45,10 @@
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
 #  ifndef CONFIG_EXAMPLES_FOC_HAVE_VEL
-#    error
+#    error open-loop needs CONFIG_EXAMPLES_FOC_HAVE_VEL set
 #  endif
 #  ifndef CONFIG_INDUSTRY_FOC_ANGLE_OPENLOOP
-#    error
+#    error open-loop needs CONFIG_INDUSTRY_FOC_ANGLE_OPENLOOP
 #  endif
 #endif
 
@@ -61,13 +61,13 @@
 /* Velocity ramp must be configured */
 
 #if (CONFIG_EXAMPLES_FOC_RAMP_THR == 0)
-#  error
+#  error CONFIG_EXAMPLES_FOC_RAMP_THR not configured
 #endif
 #if (CONFIG_EXAMPLES_FOC_RAMP_ACC == 0)
-#  error
+#  error CONFIG_EXAMPLES_FOC_RAMP_ACC not configured
 #endif
 #if (CONFIG_EXAMPLES_FOC_RAMP_DEC == 0)
-#  error
+#  error CONFIG_EXAMPLES_FOC_RAMP_DEC not configured
 #endif
 
 /* ADC Iphase ratio must be provided */
@@ -80,19 +80,19 @@
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT
 #  if (CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT == 0)
-#    error
+#    error CONFIG_EXAMPLES_FOC_IDENT_RES_CURRENT not configured
 #  endif
 #  if (CONFIG_EXAMPLES_FOC_IDENT_RES_KI == 0)
-#    error
+#    error CONFIG_EXAMPLES_FOC_IDENT_RES_KI not configured
 #  endif
 #  if (CONFIG_EXAMPLES_FOC_IDENT_IND_VOLTAGE == 0)
-#    error
+#    error CONFIG_EXAMPLES_FOC_IDENT_IND_VOLTAGE not configured
 #  endif
 #  if (CONFIG_EXAMPLES_FOC_IDENT_RES_SEC == 0)
-#    error
+#    error CONFIG_EXAMPLES_FOC_IDENT_RES_SEC not configured
 #  endif
 #  if (CONFIG_EXAMPLES_FOC_IDENT_IND_SEC == 0)
-#    error
+#    error CONFIG_EXAMPLES_FOC_IDENT_IND_SEC not configured
 #  endif
 #endif
 
@@ -128,10 +128,10 @@
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_QENCO
 #  if CONFIG_EXAMPLES_FOC_MOTOR_POLES == 0
-#    error
+#    error CONFIG_EXAMPLES_FOC_MOTOR_POLES must be defined
 #  endif
 #  if CONFIG_EXAMPLES_FOC_QENCO_POSMAX == 0
-#    error
+#    error CONFIG_EXAMPLES_FOC_QENCO_POSMAX must be defined
 #  endif
 #endif
 
@@ -140,7 +140,7 @@
 #if !defined(CONFIG_EXAMPLES_FOC_SETPOINT_CONST) &&  \
     !defined(CONFIG_EXAMPLES_FOC_SETPOINT_ADC) && \
     !defined(CONFIG_EXAMPLES_FOC_SETPOINT_CHAR)
-#  error
+#  error setpoint source not selected
 #endif
 
 /* Setpoint ADC scale factor */
@@ -154,7 +154,7 @@
 #ifdef CONFIG_EXAMPLES_FOC_SETPOINT_CONST
 #  define SETPOINT_INTF_SCALE   (1)
 #  if CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE == 0
-#    error
+#    error CONFIG_EXAMPLES_FOC_SETPOINT_CONST_VALUE not configured
 #  endif
 #endif
 
@@ -168,7 +168,7 @@
 
 #if !defined(CONFIG_EXAMPLES_FOC_VBUS_CONST) &&  \
     !defined(CONFIG_EXAMPLES_FOC_VBUS_ADC)
-#  error
+#  error no VBUS source selected !
 #endif
 
 /* VBUS ADC scale factor */
@@ -187,7 +187,7 @@
 #  define VBUS_ADC_SCALE   (1)
 #  define VBUS_CONST_VALUE (CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE / 1000.0f)
 #  if CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE == 0
-#    error
+#    error CONFIG_EXAMPLES_FOC_VBUS_CONST_VALUE not configured
 #  endif
 #endif
 

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -203,8 +203,10 @@
 
 /* Open-loop to observer angle merge factor */
 
-#if CONFIG_EXAMPLES_FOC_ANGOBS_MERGE_RATIO > 0
-#  define ANGLE_MERGE_FACTOR (CONFIG_EXAMPLES_FOC_ANGOBS_MERGE_RATIO / 100.0f)
+#ifdef CONFIG_EXAMPLES_FOC_SENSORLESS
+#  if CONFIG_EXAMPLES_FOC_ANGOBS_MERGE_RATIO > 0
+#    define ANGLE_MERGE_FACTOR (CONFIG_EXAMPLES_FOC_ANGOBS_MERGE_RATIO / 100.0f)
+#  endif
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
- examples/foc: allow sensored velocity mode
- examples/foc: add #error messages
- examples/foc: raise error if both sensorless and sensored modes enabled
- examples/foc: fix warning for sensored configurations

## Impact

## Testing
CI
