### PR TITLE
examples/foc: fixes for sensored operation mode

### DIFF
--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -1228,7 +1228,7 @@ static int foc_motor_vel_get(FAR struct foc_motor_b16_s *motor)
   UNUSED(vout);
 
   motor->vel_el = motor->vel.set;
-#elif defined(CONFIG_EXAMPLES_FOC_VELOBS)
+#elif defined(CONFIG_EXAMPLES_FOC_VELOBS) && defined(CONFIG_EXAMPLES_FOC_SENSORLESS)
   if (motor->openloop_now == FOC_OPENLOOP_DISABLED)
     {
       /* Get electrical velocity from observer if we are in closed-loop */
@@ -1241,6 +1241,10 @@ static int foc_motor_vel_get(FAR struct foc_motor_b16_s *motor)
 
       motor->vel_el = motor->vel.set;
     }
+#elif defined(CONFIG_EXAMPLES_FOC_VELOBS) && defined(CONFIG_EXAMPLES_FOC_SENSORED)
+  /* Get electrical velocity from observer in sensored mode */
+
+  motor->vel_el = motor->vel_obs;
 #else
   /* Need electrical velocity source here - raise assertion */
 

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -602,7 +602,7 @@ static int foc_motor_state(FAR struct foc_motor_f32_s *motor, int state)
 
   DEBUGASSERT(motor);
 
-  /* Update motor state */
+  /* Update motor state - this function is called every controller cycle */
 
   switch (state)
     {
@@ -620,12 +620,24 @@ static int foc_motor_state(FAR struct foc_motor_f32_s *motor, int state)
 
       case FOC_EXAMPLE_STATE_STOP:
         {
+#ifdef CONFIG_EXAMPLES_FOC_SENSORLESS
+          /* For sensorless we can just set Q reference to lock the motor */
+
           motor->dir = DIR_NONE;
 
           /* DQ vector not zero - active brake */
 
           motor->dq_ref.q = CONFIG_EXAMPLES_FOC_STOP_CURRENT / 1000.0f;
           motor->dq_ref.d = 0.0f;
+#else
+          /* For sensored mode we set requested velocity to 0 */
+
+#  ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
+          motor->vel.des = 0.0f;
+#  else
+#    error STOP state for sensored mode requires velocity support
+#  endif
+#endif
 
           break;
         }
@@ -882,10 +894,15 @@ static int foc_motor_run(FAR struct foc_motor_f32_s *motor)
   q_ref = motor->dq_ref.q;
   d_ref = motor->dq_ref.d;
 
-  /* Ignore controller if motor is free or stopped */
+  /* Ignore controller if motor is free (sensorless and sensored mode)
+   * or stopped (only sensorless mode)
+   */
 
-  if (motor->mq.app_state == FOC_EXAMPLE_STATE_FREE ||
-      motor->mq.app_state == FOC_EXAMPLE_STATE_STOP)
+  if (motor->mq.app_state == FOC_EXAMPLE_STATE_FREE
+#ifdef CONFIG_EXAMPLES_FOC_SENSORLESS
+      || motor->mq.app_state == FOC_EXAMPLE_STATE_STOP
+#endif
+    )
     {
       goto no_controller;
     }

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -1215,7 +1215,7 @@ static int foc_motor_vel_get(FAR struct foc_motor_f32_s *motor)
   UNUSED(vout);
 
   motor->vel_el = motor->vel.set;
-#elif defined(CONFIG_EXAMPLES_FOC_VELOBS)
+#elif defined(CONFIG_EXAMPLES_FOC_VELOBS) && defined(CONFIG_EXAMPLES_FOC_SENSORLESS)
   if (motor->openloop_now == FOC_OPENLOOP_DISABLED)
     {
       /* Get electrical velocity from observer if we are in closed-loop */
@@ -1228,6 +1228,10 @@ static int foc_motor_vel_get(FAR struct foc_motor_f32_s *motor)
 
       motor->vel_el = motor->vel.set;
     }
+#elif defined(CONFIG_EXAMPLES_FOC_VELOBS) && defined(CONFIG_EXAMPLES_FOC_SENSORED)
+  /* Get electrical velocity from observer in sensored mode */
+
+  motor->vel_el = motor->vel_obs;
 #else
   /* Need electrical velocity source here - raise assertion */
 

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -441,6 +441,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
               break;
             }
 
+#  ifdef CONFIG_EXAMPLES_FOC_ANGOBS
           case OPT_OLTHR:
             {
               args->cfg.ol_thr = atoi(optarg);
@@ -452,6 +453,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
               args->cfg.ol_hys = atoi(optarg);
               break;
             }
+#  endif
 #endif
 
           case '?':


### PR DESCRIPTION
## Summary
- examples/foc: get velocity from observer if sensored mode
- examples/foc: fix active brake for sensored mode
- examples/foc: fix compilation for open-loop without angle observer

## Impact

## Testing
velocity control and position control with qencoder
