### PR TITLE
examples/foc: don't raise error when EXAMPLES_FOC_IPHASE_ADC isn't set

### DIFF
--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -75,12 +75,6 @@
 #  error CONFIG_EXAMPLES_FOC_RAMP_DEC not configured
 #endif
 
-/* ADC Iphase ratio must be provided */
-
-#if (CONFIG_EXAMPLES_FOC_IPHASE_ADC == 0)
-#  error
-#endif
-
 /* Motor identification support */
 
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_IDENT


### PR DESCRIPTION
## Summary
- examples/foc: don't raise error when EXAMPLES_FOC_IPHASE_ADC isn't set   
    This is the first step towards getting rid of CONFIG_EXAMPLES_FOC_IPHASE_ADC completely
    
## Impact

## Testing
CI
