### PR TITLE
examples/foc: get iphase scale from the FOC device interface

### DIFF
--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -323,9 +323,10 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
       goto errout;
     }
 
-  /* Get PWM max duty */
+  /* Store data from device */
 
   motor.pwm_duty_max = FOCDUTY_TO_FIXED16(dev.info.hw_cfg.pwm_max);
+  motor.iphase_adc = b16idiv(dev.info.hw_cfg.iphase_scale, 100000);
 
   /* Start with motor free */
 

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -336,9 +336,10 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
       goto errout;
     }
 
-  /* Get PWM max duty */
+  /* Store data from device */
 
   motor.pwm_duty_max = FOCDUTY_TO_FLOAT(dev.info.hw_cfg.pwm_max);
+  motor.iphase_adc = dev.info.hw_cfg.iphase_scale / 100000.0f;
 
   /* Start with motor free */
 

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -1346,7 +1346,6 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
   /* Initialize motor data */
 
   motor->per        = b16divi(b16ONE, CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ);
-  motor->iphase_adc = ftob16((CONFIG_EXAMPLES_FOC_IPHASE_ADC) / 100000.0f);
 #ifdef CONFIG_EXAMPLES_FOC_ANGOBS
   motor->ol_thr     = ftob16(motor->envp->cfg->ol_thr / 1.0f);
   motor->ol_hys     = ftob16(motor->envp->cfg->ol_hys / 1.0f);

--- a/examples/foc/foc_motor_b16.h
+++ b/examples/foc/foc_motor_b16.h
@@ -90,13 +90,16 @@ struct foc_motor_b16_s
   int                           time;         /* Helper counter */
   b16_t                         vbus;         /* Power bus voltage */
   b16_t                         per;          /* Controller period in seconds */
-  b16_t                         iphase_adc;   /* Iphase ADC scaling factor */
-  b16_t                         pwm_duty_max; /* PWM duty max */
 #ifdef CONFIG_EXAMPLES_FOC_ANGOBS
   b16_t                         ol_thr;       /* Angle observer threshold velocity */
   b16_t                         ol_hys;       /* Angle observer hysteresis */
   b16_t                         angle_step;   /* Open-loop transition step */
 #endif
+
+  /* Data from FOC device ***************************************************/
+
+  b16_t                         iphase_adc;   /* Iphase ADC scaling factor */
+  b16_t                         pwm_duty_max; /* PWM duty max */
 
   /* Velocity controller data ***********************************************/
 

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -1334,7 +1334,6 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
   /* Initialize motor data */
 
   motor->per        = (float)(1.0f / CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ);
-  motor->iphase_adc = ((CONFIG_EXAMPLES_FOC_IPHASE_ADC) / 100000.0f);
 #ifdef CONFIG_EXAMPLES_FOC_ANGOBS
   motor->ol_thr     = (motor->envp->cfg->ol_thr / 1.0f);
   motor->ol_hys     = (motor->envp->cfg->ol_hys / 1.0f);

--- a/examples/foc/foc_motor_f32.h
+++ b/examples/foc/foc_motor_f32.h
@@ -90,12 +90,15 @@ struct foc_motor_f32_s
   int                           time;         /* Helper counter */
   float                         vbus;         /* Power bus voltage */
   float                         per;          /* Controller period in seconds */
-  float                         iphase_adc;   /* Iphase ADC scaling factor */
-  float                         pwm_duty_max; /* PWM duty max */
 #ifdef CONFIG_EXAMPLES_FOC_ANGOBS
   float                         ol_thr;       /* Angle observer threshold velocity */
   float                         ol_hys;       /* Angle observer hysteresis */
 #endif
+
+  /* Data from FOC device ***************************************************/
+
+  float                         iphase_adc;   /* Iphase ADC scaling factor */
+  float                         pwm_duty_max; /* PWM duty max */
 
   /* Velocity controller data ***********************************************/
 


### PR DESCRIPTION
## Summary
examples/foc: get iphase scale from the FOC device interface

## Impact

## Testing
CI
