### PR TITLE
examples/foc: remove obsolete CONFIG_EXAMPLES_FOC_IPHASE_ADC option

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -69,12 +69,6 @@ config EXAMPLES_FOC_NOTIFIER_FREQ
 	---help---
 		Select the FOC notifier frequency
 
-config EXAMPLES_FOC_IPHASE_ADC
-	int "FOC phase current scale [x100000]"
-	default 0
-	---help---
-		This parameter is used to get real currents from ADC RAW values
-
 config EXAMPLES_FOC_STATE_PRINT_FREQ
 	int "FOC example data printer frequency"
 	default 0


### PR DESCRIPTION
## Summary
examples/foc: remove obsolete CONFIG_EXAMPLES_FOC_IPHASE_ADC option

needs https://github.com/apache/nuttx/pull/11192 to pass CI
## Impact

## Testing
CI
