### PR TITLE
examples/foc: replace CONFIG_INDUSTRY_FOC_* with CONFIG_EXAMPLES_FOC_*

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -48,6 +48,16 @@ config EXAMPLES_FOC_PERF
 	default n
 
 choice
+	prompt "FOC modulation selection"
+	default EXAMPLES_FOC_MODULATION_SVM3
+
+config EXAMPLES_FOC_MODULATION_SVM3
+	bool "FOC use SVM3"
+	select INDUSTRY_FOC_MODULATION_SVM3
+
+endchoice # FOC modulation selection
+
+choice
 	prompt "FOC current controller selection"
 	default EXAMPLES_FOC_CONTROL_PI
 

--- a/examples/foc/foc_cfg.h
+++ b/examples/foc/foc_cfg.h
@@ -66,8 +66,8 @@
 #  ifndef CONFIG_EXAMPLES_FOC_HAVE_VEL
 #    error open-loop needs CONFIG_EXAMPLES_FOC_HAVE_VEL set
 #  endif
-#  ifndef CONFIG_INDUSTRY_FOC_ANGLE_OPENLOOP
-#    error open-loop needs CONFIG_INDUSTRY_FOC_ANGLE_OPENLOOP
+#  ifndef CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
+#    error open-loop needs CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP
 #  endif
 #endif
 
@@ -276,7 +276,7 @@ struct foc_thr_cfg_s
   uint32_t vel_pi_ki;           /* Vel controller PI Ki (x1000000) */
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+#ifdef CONFIG_EXAMPLES_FOC_ANGOBS_NFO
   uint32_t ang_nfo_slow;        /* Ang NFO slow gain (x1) */
   uint32_t ang_nfo_gain;        /* Ang NFO gain (x1) */
 #endif

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -133,7 +133,7 @@ struct args_s g_args =
     .vel_pi_kp = CONFIG_EXAMPLES_FOC_VELCTRL_PI_KP,
     .vel_pi_ki = CONFIG_EXAMPLES_FOC_VELCTRL_PI_KI,
 #endif
-#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+#ifdef CONFIG_EXAMPLES_FOC_ANGOBS_NFO
     .ang_nfo_slow = CONFIG_EXAMPLES_FOC_ANGOBS_NFO_GAINSLOW,
     .ang_nfo_gain = CONFIG_EXAMPLES_FOC_ANGOBS_NFO_GAIN,
 #endif

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -292,7 +292,7 @@ static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   struct foc_initdata_b16_s ctrl_cfg;
 #endif
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   struct foc_mod_cfg_b16_s mod_cfg;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_STATE_USE_MODEL_PMSM
@@ -327,7 +327,7 @@ static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
 
   /* Get FOC modulation */
 
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   foc_mod = &g_foc_mod_svm3_b16;
 #else
 #  error FOC modulation not selected
@@ -358,7 +358,7 @@ static int foc_motor_configure(FAR struct foc_motor_b16_s *motor)
   ctrl_cfg.iq_ki = ftob16(motor->envp->cfg->foc_pi_ki / 1000.0f);
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   /* Get SVM3 modulation configuration */
 
   mod_cfg.pwm_duty_max = motor->pwm_duty_max;

--- a/examples/foc/foc_motor_b16.h
+++ b/examples/foc/foc_motor_b16.h
@@ -80,7 +80,7 @@ struct foc_motor_b16_s
   /* FOC data ***************************************************************/
 
   struct foc_state_b16_s        foc_state;    /* FOC controller sate */
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   struct svm3_state_b16_s       mod_state;    /* Modulation state */
 #endif
   foc_handler_b16_t             handler;      /* FOC controller */

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -292,7 +292,7 @@ static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
 #ifdef CONFIG_EXAMPLES_FOC_CONTROL_PI
   struct foc_initdata_f32_s ctrl_cfg;
 #endif
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   struct foc_mod_cfg_f32_s mod_cfg;
 #endif
 #ifdef CONFIG_EXAMPLES_FOC_STATE_USE_MODEL_PMSM
@@ -327,7 +327,7 @@ static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
 
   /* Get FOC modulation */
 
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   foc_mod = &g_foc_mod_svm3_f32;
 #else
 #  error FOC modulation not selected
@@ -356,7 +356,7 @@ static int foc_motor_configure(FAR struct foc_motor_f32_s *motor)
   ctrl_cfg.iq_ki = (motor->envp->cfg->foc_pi_ki / 1000.0f);
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   /* Get SVM3 modulation configuration */
 
   mod_cfg.pwm_duty_max = motor->pwm_duty_max;

--- a/examples/foc/foc_motor_f32.h
+++ b/examples/foc/foc_motor_f32.h
@@ -80,7 +80,7 @@ struct foc_motor_f32_s
   /* FOC data ***************************************************************/
 
   struct foc_state_f32_s        foc_state;    /* FOC controller sate */
-#ifdef CONFIG_INDUSTRY_FOC_MODULATION_SVM3
+#ifdef CONFIG_EXAMPLES_FOC_MODULATION_SVM3
   struct svm3_state_f32_s       mod_state;    /* Modulation state */
 #endif
   foc_handler_f32_t             handler;      /* FOC controller */

--- a/examples/foc/foc_nxscope.c
+++ b/examples/foc/foc_nxscope.c
@@ -158,7 +158,7 @@ int foc_nxscope_init(FAR struct foc_nxscope_s *nxs)
 
       switch (foc_thread_type(j))
         {
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+#if CONFIG_EXAMPLES_FOC_FLOAT_INST > 0
           case FOC_NUMBER_TYPE_FLOAT:
             {
               u.s.dtype = NXSCOPE_TYPE_FLOAT;
@@ -166,7 +166,7 @@ int foc_nxscope_init(FAR struct foc_nxscope_s *nxs)
             }
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+#if CONFIG_EXAMPLES_FOC_FIXED16_INST > 0
           case FOC_NUMBER_TYPE_FIXED16:
             {
               u.s.dtype = NXSCOPE_TYPE_B16;

--- a/examples/foc/foc_parseargs.c
+++ b/examples/foc/foc_parseargs.c
@@ -115,7 +115,7 @@ static struct option g_long_options[] =
     { "vcpikp", required_argument, 0, OPT_VCPIKP },
     { "vcpiki", required_argument, 0, OPT_VCPIKI },
 #endif
-#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+#ifdef CONFIG_EXAMPLES_FOC_ANGOBS_NFO
     { "anfos", required_argument, 0, OPT_ANFOS },
     { "anfog", required_argument, 0, OPT_ANFOG },
 #endif
@@ -221,7 +221,7 @@ static void foc_help(FAR struct args_s *args)
   PRINTF("  [--vcpiki] velctrl PI Ki [x1000000] (default: %" PRId32 ")\n",
          args->cfg.vel_pi_ki);
 #endif
-#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+#ifdef CONFIG_EXAMPLES_FOC_ANGOBS_NFO
   PRINTF("  [--anfos] angobs NFO Slow [x1] (default: %" PRId32 ")\n",
          args->cfg.ang_nfo_slow);
   PRINTF("  [--anfog] angobs NFO Gain [x1] (default: %" PRId32 ")\n",
@@ -342,7 +342,7 @@ void parse_args(FAR struct args_s *args, int argc, FAR char **argv)
             }
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_ANGLE_ONFO
+#ifdef CONFIG_EXAMPLES_FOC_ANGOBS_NFO
           case OPT_ANFOS:
             {
               args->cfg.ang_nfo_slow = atoi(optarg);

--- a/examples/foc/foc_thr.c
+++ b/examples/foc/foc_thr.c
@@ -54,11 +54,11 @@
  * Extern Functions Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+#if CONFIG_EXAMPLES_FOC_FLOAT_INST > 0
 extern int foc_float_thr(FAR struct foc_ctrl_env_s *envp);
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+#if CONFIG_EXAMPLES_FOC_FIXED16_INST > 0
 extern int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp);
 #endif
 
@@ -69,10 +69,10 @@ extern int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp);
 pthread_mutex_t g_cntr_lock;
 
 static uint32_t g_foc_thr = 0;
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+#if CONFIG_EXAMPLES_FOC_FLOAT_INST > 0
 static int g_float_thr_cntr = 0;
 #endif
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+#if CONFIG_EXAMPLES_FOC_FIXED16_INST > 0
 static int g_fixed16_thr_cntr = 0;
 #endif
 
@@ -142,7 +142,7 @@ static FAR void *foc_control_thr(FAR void *arg)
 
   switch (envp->type)
     {
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+#if CONFIG_EXAMPLES_FOC_FLOAT_INST > 0
       case FOC_NUMBER_TYPE_FLOAT:
         {
           pthread_mutex_lock(&g_cntr_lock);
@@ -164,7 +164,7 @@ static FAR void *foc_control_thr(FAR void *arg)
         }
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+#if CONFIG_EXAMPLES_FOC_FIXED16_INST > 0
       case FOC_NUMBER_TYPE_FIXED16:
         {
           pthread_mutex_lock(&g_cntr_lock);
@@ -290,14 +290,14 @@ int foc_thread_type(int id)
 {
   int ret = -1;
 
-#ifdef CONFIG_INDUSTRY_FOC_FLOAT
+#if CONFIG_EXAMPLES_FOC_FLOAT_INST > 0
   if (id < CONFIG_EXAMPLES_FOC_FLOAT_INST)
     {
       ret = FOC_NUMBER_TYPE_FLOAT;
     }
 #endif
 
-#ifdef CONFIG_INDUSTRY_FOC_FIXED16
+#if CONFIG_EXAMPLES_FOC_FIXED16_INST > 0
   if (id < CONFIG_EXAMPLES_FOC_FLOAT_INST + CONFIG_EXAMPLES_FOC_FIXED16_INST)
     {
       ret = FOC_NUMBER_TYPE_FIXED16;


### PR DESCRIPTION
## Summary
- examples/foc: replace CONFIG_INDUSTRY_FOC_* with CONFIG_EXAMPLES_FOC_*
  Decouple the FOC example configuration from the FOC lib configuration. 
  
## Impact
Purely cosmetic change, without affecting functionality.

## Testing
CI
