### PR TITLE
industry/foc: fix direction alignment

### DIFF
--- a/industry/foc/fixed16/foc_align.c
+++ b/industry/foc/fixed16/foc_align.c
@@ -402,6 +402,8 @@ static void foc_align_dir_move_b16(FAR struct foc_align_b16_s *align,
 static void foc_align_dir_hold_b16(FAR struct foc_align_b16_s *align,
                                    b16_t dir, bool last, bool diff)
 {
+  b16_t tmp = 0;
+
   DEBUGASSERT(align);
 
   /* Lock angle */
@@ -422,13 +424,16 @@ static void foc_align_dir_hold_b16(FAR struct foc_align_b16_s *align,
 
       if (diff == true)
         {
+          tmp = align->angle_now - align->angle_last;
+          angle_norm_2pi_b16(&tmp, -b16PI, b16PI);
+
           if (dir == DIR_CW_B16)
             {
-              align->diff_cw += (align->angle_now - align->angle_last);
+              align->diff_cw += tmp;
             }
           else if (dir == DIR_CCW_B16)
             {
-              align->diff_ccw += (align->angle_now - align->angle_last);
+              align->diff_ccw += tmp;
             }
           else
             {

--- a/industry/foc/float/foc_align.c
+++ b/industry/foc/float/foc_align.c
@@ -402,6 +402,8 @@ static void foc_align_dir_move_f32(FAR struct foc_align_f32_s *align,
 static void foc_align_dir_hold_f32(FAR struct foc_align_f32_s *align,
                                    float dir, bool last, bool diff)
 {
+  float tmp = 0.0f;
+
   DEBUGASSERT(align);
 
   /* Lock angle */
@@ -422,13 +424,16 @@ static void foc_align_dir_hold_f32(FAR struct foc_align_f32_s *align,
 
       if (diff == true)
         {
+          tmp = align->angle_now - align->angle_last;
+          angle_norm_2pi(&tmp, -M_PI_F, M_PI_F);
+
           if (dir == DIR_CW)
             {
-              align->diff_cw += (align->angle_now - align->angle_last);
+              align->diff_cw += tmp;
             }
           else if (dir == DIR_CCW)
             {
-              align->diff_ccw += (align->angle_now - align->angle_last);
+              align->diff_ccw += tmp;
             }
           else
             {


### PR DESCRIPTION
## Summary
- industry/foc: fix direction alignment
  CCW direction wasn't properly detected when we start alignment from near zero position

## Impact

## Testing
odrive3.6
