### PR TITLE
ostest: Add initial support for CONFIG_BUILD_KERNEL

### DIFF
--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -115,7 +115,9 @@ void aio_test(void);
 
 /* restart.c ****************************************************************/
 
+#ifndef CONFIG_BUILD_KERNEL
 void restart_test(void);
+#endif
 
 /* waitpid.c ****************************************************************/
 

--- a/testing/ostest/restart.c
+++ b/testing/ostest/restart.c
@@ -36,6 +36,8 @@
 
 #include "ostest.h"
 
+#ifndef CONFIG_BUILD_KERNEL
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -225,3 +227,5 @@ void restart_test(void)
 
   printf("restart_main: Exiting\n");
 }
+
+#endif /* !CONFIG_BUILD_KERNEL */

--- a/testing/ostest/suspend.c
+++ b/testing/ostest/suspend.c
@@ -37,6 +37,12 @@
 
 #include "ostest.h"
 
+/* REVISIT: This could be implemented for CONFIG_BUILD_KERNEL as well, by
+ * starting a new process instead of using task_create()
+ */
+
+#ifndef CONFIG_BUILD_KERNEL
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -136,3 +142,4 @@ void suspend_test(void)
   printf("suspend_test: done\n");
   FFLUSH();
 }
+#endif /* !CONFIG_BUILD_KERNEL */

--- a/testing/ostest/waitpid.c
+++ b/testing/ostest/waitpid.c
@@ -35,7 +35,11 @@
 
 #include "ostest.h"
 
-#ifdef CONFIG_SCHED_WAITPID
+/* REVISIT: This could be implemented for CONFIG_BUILD_KERNEL as well, by
+ * starting a new process instead of using task_create()
+ */
+
+#if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_BUILD_KERNEL)
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -392,4 +396,4 @@ int waitpid_test(void)
   return 0;
 }
 
-#endif /* CONFIG_SCHED_WAITPID */
+#endif /* defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_BUILD_KERNEL) */


### PR DESCRIPTION
## Summary

This is the continuation of the pull https://github.com/apache/nuttx-apps/pull/1500

task_* APIs are unavailable in kernel build mode, replacing with posix_spawn or pthread_* API to pass the case. But posix_spawn require some dependency, for example CONFIG_BUILTIN and CONFIG_LIBC_EXECFUNCS, so pthread_* APIs are used in most scenarios. Some tests should be re-visited because the intent is to user another task (in this case another process) to e.g. receive signals. That will require quite a bit of extra work.

Tests that had to be disabled:
- restart: task_restart() does not work at all with kernel mode so it is disabled entirely
- fpu: make sure the FPU test is not even attempted, because it will cause ASSERT() and stop the test
- vfork: vfork() does not work for some reason in CONFIG_BUILD_KERNEL, there is something missing on the kernel side, so just disable the test for now

Tests that should be re-visited:
- The signal tests, now they signal the process itself while before the signal was sent to another task. This will require building the part that receives the signal as a separate process
- waitpid: Like stated above, waitpid does not work for pthreads
- suspend: kill to send signal does not work for pthreads

## Impact
Adds basic support for ostest with CONFIG_BUILD_KERNEL=y

## Testing
sabre-6quad:knsh
