### PR TITLE
libtest: add PRIVATE to CMakeLists.txt

### DIFF
--- a/examples/libtest/CMakeLists.txt
+++ b/examples/libtest/CMakeLists.txt
@@ -35,6 +35,6 @@ if(CONFIG_EXAMPLES_LIBTEST)
   endif()
 
   nuttx_add_library(libtest STATIC)
-  target_sources(libtest libtest.c)
+  target_sources(libtest PRIVATE libtest.c)
 
 endif()


### PR DESCRIPTION
## Summary

It looks like this word is needed for this build to work with cmake

## Impact

Fixes cmake build when `libtest` is enabled

## Testing

