### PR TITLE
cmake: add compilation support for matter

### DIFF
--- a/netutils/connectedhomeip/.gitignore
+++ b/netutils/connectedhomeip/.gitignore
@@ -2,3 +2,5 @@
 /inipp
 /nlassert
 /nlio
+/nlunit-test
+/pigweed

--- a/netutils/connectedhomeip/.gitignore
+++ b/netutils/connectedhomeip/.gitignore
@@ -1,0 +1,4 @@
+/connectedhomeip
+/inipp
+/nlassert
+/nlio

--- a/netutils/connectedhomeip/0001-chip-add-compile-support-for-NuttX.patch
+++ b/netutils/connectedhomeip/0001-chip-add-compile-support-for-NuttX.patch
@@ -1,0 +1,514 @@
+From faaac5060c5e5f9ab23344d776b44440ca3f1706 Mon Sep 17 00:00:00 2001
+From: zhanghongyu <zhanghongyu@xiaomi.com>
+Date: Tue, 31 Oct 2023 11:01:50 +0800
+Subject: [PATCH] chip: add compile support for NuttX
+
+VELAPLATFO-11575
+
+config/nuttx/chip-gn/BUILD.gn is the most important script, will output libchipnuttx.a file,
+this file include all chip symbol we need.
+
+The reference documentation for matter compilation
+https://xiaomi.f.mioffice.cn/docx/doxk4GkrddACeNZokDg618UjZZb
+
+Change-Id: Icbf140eb348dfa2ad769f76deac0abdc32618025
+Signed-off-by: zhanghongyu <zhanghongyu@xiaomi.com>
+---
+ build/config/compiler/BUILD.gn                |  9 +++
+ config/nuttx/README.md                        |  8 +++
+ config/nuttx/chip-gn/.gn                      | 29 ++++++++++
+ config/nuttx/chip-gn/BUILD.gn                 | 57 +++++++++++++++++++
+ config/nuttx/chip-gn/args.gni                 | 32 +++++++++++
+ config/nuttx/chip-gn/toolchain/BUILD.gn       | 33 +++++++++++
+ examples/lighting-app/linux/main.cpp          |  2 +-
+ scripts/codegen.py                            |  1 +
+ src/inet/BUILD.gn                             |  5 ++
+ src/lib/core/CHIPError.h                      |  8 +--
+ src/platform/BUILD.gn                         |  8 +++
+ src/platform/Linux/BUILD.gn                   |  2 +-
+ src/platform/Linux/CHIPLinuxStorage.cpp       |  2 +-
+ src/platform/Linux/ConnectivityUtils.cpp      |  7 ++-
+ src/platform/Linux/ConnectivityUtils.h        |  4 ++
+ .../Linux/DiagnosticDataProviderImpl.cpp      |  4 ++
+ src/platform/Linux/Logging.cpp                |  4 ++
+ src/platform/Linux/PlatformManagerImpl.cpp    |  4 ++
+ src/platform/device.gni                       | 12 +++-
+ 19 files changed, 220 insertions(+), 11 deletions(-)
+ create mode 100644 config/nuttx/README.md
+ create mode 100644 config/nuttx/chip-gn/.gn
+ create mode 100644 config/nuttx/chip-gn/BUILD.gn
+ create mode 100644 config/nuttx/chip-gn/args.gni
+ create mode 100644 config/nuttx/chip-gn/toolchain/BUILD.gn
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index b6ad67a649..1a590984a5 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -271,6 +271,15 @@ config("strict_warnings") {
+ 
+   cflags_cc = [ "-Wnon-virtual-dtor" ]
+ 
++  if (current_os == "nuttx") {
++    cflags -= [
++      "-Wshadow",
++    ]
++    cflags_cc -= [
++      "-Wnon-virtual-dtor",
++    ]
++  }
++
+   configs = []
+   ldflags = []
+ 
+diff --git a/config/nuttx/README.md b/config/nuttx/README.md
+new file mode 100644
+index 0000000000..3cbdfc264e
+--- /dev/null
++++ b/config/nuttx/README.md
+@@ -0,0 +1,8 @@
++# Nuttx build and configuration files
++
++This directory contains build scripts and common configuration files used by
++CHIP Nuttx applications. It is structured as follows:
++
++| File/Folder | Contents                                                                                                                            |
++| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
++| chip-gn     | GN project used to build selected CHIP libraries with the _nuttx_ platform integration layer                                        |
+diff --git a/config/nuttx/chip-gn/.gn b/config/nuttx/chip-gn/.gn
+new file mode 100644
+index 0000000000..7233a3062b
+--- /dev/null
++++ b/config/nuttx/chip-gn/.gn
+@@ -0,0 +1,29 @@
++# Copyright (c) 2020 Project CHIP Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import("//build_overrides/build.gni")
++import("//build_overrides/chip.gni")
++
++# The location of the build configuration file.
++buildconfig = "${build_root}/config/BUILDCONFIG.gn"
++
++# CHIP uses angle bracket includes.
++check_system_includes = true
++
++default_args = {
++  target_cpu = ""
++  target_os = "nuttx"
++
++  import("${chip_root}/config/nuttx/chip-gn/args.gni")
++}
+diff --git a/config/nuttx/chip-gn/BUILD.gn b/config/nuttx/chip-gn/BUILD.gn
+new file mode 100644
+index 0000000000..c4b94ab171
+--- /dev/null
++++ b/config/nuttx/chip-gn/BUILD.gn
+@@ -0,0 +1,57 @@
++# Copyright (c) 2020 Project CHIP Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import("//build_overrides/build.gni")
++import("//build_overrides/chip.gni")
++
++import("${chip_root}/build/chip/tests.gni")
++
++assert(current_os == "nuttx")
++
++declare_args() {
++  chip_build_example_providers = false
++  chip_example_lighting = false
++}
++
++static_library("nuttx") {
++  output_name = "libchipnuttx"
++
++  public_deps = [
++    "${chip_root}/examples/platform/linux:app-main",
++    "${chip_root}/src/lib",
++  ]
++
++  if (chip_build_tests) {
++    public_deps += [ "${chip_root}/src:tests" ]
++  }
++
++  if (chip_build_example_providers) {
++    public_deps += [ "${chip_root}/examples/providers:device_info_provider" ]
++  }
++
++  if (chip_example_lighting) {
++    public_deps += [
++      "${chip_root}/examples/lighting-app/lighting-common",
++      "${chip_root}/examples/lighting-app/lighting-common:lighting-manager",
++    ]
++  }
++
++  output_dir = "${root_out_dir}/lib"
++
++  complete_static_lib = true
++}
++
++group("default") {
++  deps = [ ":nuttx" ]
++}
+diff --git a/config/nuttx/chip-gn/args.gni b/config/nuttx/chip-gn/args.gni
+new file mode 100644
+index 0000000000..480dc26e9f
+--- /dev/null
++++ b/config/nuttx/chip-gn/args.gni
+@@ -0,0 +1,32 @@
++# Copyright (c) 2020 Project CHIP Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import("//build_overrides/chip.gni")
++
++import("${chip_root}/src/crypto/crypto.gni")
++
++chip_device_platform = "nuttx"
++
++chip_build_tests = false
++
++chip_project_config_include = ""
++chip_system_project_config_include = ""
++chip_ble_project_config_include = ""
++
++chip_crypto = "mbedtls"
++chip_external_mbedtls = true
++
++custom_toolchain = "${chip_root}/config/nuttx/chip-gn/toolchain:nuttx"
++
++pw_build_PIP_CONSTRAINTS = [ "${chip_root}/scripts/setup/constraints.txt" ]
+diff --git a/config/nuttx/chip-gn/toolchain/BUILD.gn b/config/nuttx/chip-gn/toolchain/BUILD.gn
+new file mode 100644
+index 0000000000..576d96f607
+--- /dev/null
++++ b/config/nuttx/chip-gn/toolchain/BUILD.gn
+@@ -0,0 +1,33 @@
++# Copyright (c) 2020 Project CHIP Authors
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import("//build/toolchain/gcc_toolchain.gni")
++import("//build_overrides/build.gni")
++
++declare_args() {
++  nuttx_ar = ""
++  nuttx_cc = ""
++  nuttx_cxx = ""
++}
++
++gcc_toolchain("nuttx") {
++  ar = nuttx_ar
++  cc = nuttx_cc
++  cxx = nuttx_cxx
++
++  toolchain_args = {
++    current_os = "nuttx"
++    is_clang = false
++  }
++}
+diff --git a/examples/lighting-app/linux/main.cpp b/examples/lighting-app/linux/main.cpp
+index 3bd27fddc0..21535c3bcd 100644
+--- a/examples/lighting-app/linux/main.cpp
++++ b/examples/lighting-app/linux/main.cpp
+@@ -93,7 +93,7 @@ void ApplicationShutdown()
+     }
+ }
+ 
+-int main(int argc, char * argv[])
++extern "C" int main(int argc, char * argv[])
+ {
+     if (ChipLinuxAppInit(argc, argv) != 0)
+     {
+diff --git a/scripts/codegen.py b/scripts/codegen.py
+index 1f679ea614..1c6a1b1883 100755
+--- a/scripts/codegen.py
++++ b/scripts/codegen.py
+@@ -15,6 +15,7 @@
+ 
+ import logging
+ import sys
++sys.path.append('py_matter_idl')
+ 
+ import click
+ 
+diff --git a/src/inet/BUILD.gn b/src/inet/BUILD.gn
+index 3f81be8964..966aff5c08 100644
+--- a/src/inet/BUILD.gn
++++ b/src/inet/BUILD.gn
+@@ -148,4 +148,9 @@ static_library("inet") {
+   }
+ 
+   cflags = [ "-Wconversion" ]
++  if (current_os == "nuttx") {
++    cflags -= [
++      "-Wconversion",
++    ]
++  }
+ }
+diff --git a/src/lib/core/CHIPError.h b/src/lib/core/CHIPError.h
+index 1b621a694f..e67ce24eb9 100644
+--- a/src/lib/core/CHIPError.h
++++ b/src/lib/core/CHIPError.h
+@@ -374,13 +374,13 @@ public:
+      *
+      * This template ensures that the numeric value is constant and well-formed.
+      */
+-    template <SdkPart PART, StorageType CODE>
++    template <SdkPart PART, StorageType SCODE>
+     struct SdkErrorConstant
+     {
+         static_assert(FitsInField(kSdkPartLength, to_underlying(PART)), "part is too large");
+-        static_assert(FitsInField(kSdkCodeLength, CODE), "code is too large");
+-        static_assert(MakeInteger(PART, CODE) != 0, "value is zero");
+-        static constexpr StorageType value = MakeInteger(PART, CODE);
++        static_assert(FitsInField(kSdkCodeLength, SCODE), "code is too large");
++        static_assert(MakeInteger(PART, SCODE) != 0, "value is zero");
++        static constexpr StorageType value = MakeInteger(PART, SCODE);
+     };
+ };
+ 
+diff --git a/src/platform/BUILD.gn b/src/platform/BUILD.gn
+index 7a7b6a81e6..4c3e2b2e30 100644
+--- a/src/platform/BUILD.gn
++++ b/src/platform/BUILD.gn
+@@ -297,6 +297,12 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
+     } else if (chip_device_platform == "stm32") {
+       device_layer_target_define = "STM32"
+       defines += [ "CHIP_DEVICE_LAYER_TARGET=stm32" ]
++    } else if (chip_device_platform == "nuttx") {
++      device_layer_target_define = "LINUX"
++      defines += [
++        "CHIP_DEVICE_LAYER_TARGET=Linux",
++        "CHIP_DEVICE_CONFIG_ENABLE_WIFI=${chip_enable_wifi}",
++      ]
+     } else {
+       device_layer_target_define = ""
+     }
+@@ -559,6 +565,8 @@ if (chip_device_platform != "none") {
+       _platform_target = "ASR"
+     } else if (chip_device_platform == "stm32") {
+       _platform_target = "stm32"
++    } else if (chip_device_platform == "nuttx") {
++      _platform_target = "Linux"
+     } else {
+       assert(false, "Unknown chip_device_platform: ${chip_device_platform}")
+     }
+diff --git a/src/platform/Linux/BUILD.gn b/src/platform/Linux/BUILD.gn
+index a2cfa6b39c..f746a999a8 100644
+--- a/src/platform/Linux/BUILD.gn
++++ b/src/platform/Linux/BUILD.gn
+@@ -20,7 +20,7 @@ import("${build_root}/config/linux/pkg_config.gni")
+ import("${chip_root}/src/lib/core/core.gni")
+ import("${chip_root}/src/platform/device.gni")
+ 
+-assert(chip_device_platform == "linux")
++assert(chip_device_platform == "linux" || chip_device_platform == "nuttx")
+ 
+ if (chip_use_pw_logging) {
+   import("//build_overrides/pigweed.gni")
+diff --git a/src/platform/Linux/CHIPLinuxStorage.cpp b/src/platform/Linux/CHIPLinuxStorage.cpp
+index 9a8afb59d7..52a8b778ce 100644
+--- a/src/platform/Linux/CHIPLinuxStorage.cpp
++++ b/src/platform/Linux/CHIPLinuxStorage.cpp
+@@ -198,7 +198,7 @@ CHIP_ERROR ChipLinuxStorage::WriteValue(const char * key, uint32_t val)
+ {
+     char buf[32];
+ 
+-    snprintf(buf, sizeof(buf), "%d", val);
++    snprintf(buf, sizeof(buf), "%" PRIu32, val);
+ 
+     return WriteValueStr(key, buf);
+ }
+diff --git a/src/platform/Linux/ConnectivityUtils.cpp b/src/platform/Linux/ConnectivityUtils.cpp
+index 2924d48612..7d5ce7e163 100644
+--- a/src/platform/Linux/ConnectivityUtils.cpp
++++ b/src/platform/Linux/ConnectivityUtils.cpp
+@@ -27,10 +27,15 @@
+ 
+ #include <arpa/inet.h>
+ #include <ifaddrs.h>
++#ifdef __NuttX__
++#include <nuttx/wireless/wireless.h>
++#include <nuttx/ethtool.h>
++#else
+ #include <linux/ethtool.h>
+ #include <linux/if_link.h>
+ #include <linux/sockios.h>
+ #include <linux/wireless.h>
++#endif
+ #include <netdb.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -688,7 +693,7 @@ CHIP_ERROR ConnectivityUtils::GetEthPHYRate(const char * ifname, app::Clusters::
+         pHYRate = EmberAfPHYRateEnum::EMBER_ZCL_PHY_RATE_ENUM_RATE400_G;
+         break;
+     default:
+-        ChipLogError(DeviceLayer, "Undefined speed! (%d)\n", speed);
++        ChipLogError(DeviceLayer, "Undefined speed! (%" PRIu32 ")\n", speed);
+         err = CHIP_ERROR_READ_FAILED;
+         break;
+     };
+diff --git a/src/platform/Linux/ConnectivityUtils.h b/src/platform/Linux/ConnectivityUtils.h
+index e4884e935b..bd79ba44a3 100644
+--- a/src/platform/Linux/ConnectivityUtils.h
++++ b/src/platform/Linux/ConnectivityUtils.h
+@@ -26,8 +26,12 @@
+ #include <platform/DiagnosticDataProvider.h>
+ #include <platform/internal/CHIPDeviceLayerInternal.h>
+ 
++#ifdef __NuttX__
++#include <nuttx/wireless/wireless.h>
++#else
+ #include <linux/types.h> /* for "caddr_t" et al      */
+ #include <linux/wireless.h>
++#endif
+ 
+ namespace chip {
+ namespace DeviceLayer {
+diff --git a/src/platform/Linux/DiagnosticDataProviderImpl.cpp b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+index f102b47b65..22bf514a47 100644
+--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
++++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+@@ -35,10 +35,14 @@
+ #include <arpa/inet.h>
+ #include <dirent.h>
+ #include <ifaddrs.h>
++#ifdef __NuttX__
++#include <netpacket/netlink.h>
++#else
+ #include <linux/ethtool.h>
+ #include <linux/if_link.h>
+ #include <linux/netlink.h>
+ #include <linux/rtnetlink.h>
++#endif
+ #include <malloc.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+diff --git a/src/platform/Linux/Logging.cpp b/src/platform/Linux/Logging.cpp
+index 28a19a6a30..6617afd54e 100644
+--- a/src/platform/Linux/Logging.cpp
++++ b/src/platform/Linux/Logging.cpp
+@@ -49,7 +49,11 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
+     flockfile(stdout);
+ 
+     printf("[%" PRIu64 ".%06" PRIu64 "][%lld:%lld] CHIP:%s: ", static_cast<uint64_t>(tv.tv_sec), static_cast<uint64_t>(tv.tv_usec),
++#ifdef __NuttX__
++           static_cast<long long>(getpid()), static_cast<long long>(gettid()), module);
++#else
+            static_cast<long long>(syscall(SYS_getpid)), static_cast<long long>(syscall(SYS_gettid)), module);
++#endif
+     vprintf(msg, v);
+     printf("\n");
+     fflush(stdout);
+diff --git a/src/platform/Linux/PlatformManagerImpl.cpp b/src/platform/Linux/PlatformManagerImpl.cpp
+index a1c83faf29..5a9afb1204 100644
+--- a/src/platform/Linux/PlatformManagerImpl.cpp
++++ b/src/platform/Linux/PlatformManagerImpl.cpp
+@@ -27,8 +27,12 @@
+ #include <arpa/inet.h>
+ #include <dirent.h>
+ #include <errno.h>
++#ifdef __NuttX__
++#include <netpacket/netlink.h>
++#else
+ #include <linux/netlink.h>
+ #include <linux/rtnetlink.h>
++#endif
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <unistd.h>
+diff --git a/src/platform/device.gni b/src/platform/device.gni
+index cf1dc07325..a9fc1b02d6 100644
+--- a/src/platform/device.gni
++++ b/src/platform/device.gni
+@@ -40,6 +40,8 @@ if (chip_device_platform == "auto") {
+     chip_device_platform = "webos"
+   } else if (current_os == "zephyr") {
+     chip_device_platform = "zephyr"
++  } else if (current_os == "nuttx") {
++    chip_device_platform = "nuttx"
+   } else {
+     chip_device_platform = "none"
+   }
+@@ -89,7 +91,8 @@ declare_args() {
+       chip_device_platform == "ameba" || chip_device_platform == "webos" ||
+       chip_device_platform == "cc32xx" || chip_device_platform == "mw320" ||
+       chip_device_platform == "beken" || chip_device_platform == "mt793x" ||
+-      chip_device_platform == "asr" || chip_device_platform == "openiotsdk") {
++      chip_device_platform == "asr" || chip_device_platform == "openiotsdk" ||
++      chip_device_platform == "nuttx") {
+     chip_mdns = "minimal"
+   } else if (chip_device_platform == "darwin" ||
+              chip_device_platform == "cc13x2_26x2" ||
+@@ -104,7 +107,8 @@ declare_args() {
+   # Enable Subscription persistence / resumption for CI and supported platforms
+   if (chip_device_platform == "darwin" || chip_device_platform == "linux" ||
+       chip_device_platform == "esp32" || chip_device_platform == "fake" ||
+-      chip_device_platform == "efr32" || chip_device_platform == "SiWx917") {
++      chip_device_platform == "efr32" || chip_device_platform == "SiWx917" ||
++      chip_device_platform == "nuttx") {
+     chip_persist_subscriptions = true
+   } else {
+     chip_persist_subscriptions = false
+@@ -185,6 +189,8 @@ if (chip_device_platform == "cc13x2_26x2") {
+   _chip_device_layer = "openiotsdk"
+ } else if (chip_device_platform == "asr") {
+   _chip_device_layer = "ASR"
++} else if (chip_device_platform == "nuttx") {
++  _chip_device_layer = "Linux"
+ } else if (chip_device_platform == "stm32") {
+   _chip_device_layer = "stm32"
+ }
+@@ -257,5 +263,5 @@ assert(
+         chip_device_platform == "bl702" || chip_device_platform == "bl702l" ||
+         chip_device_platform == "mt793x" || chip_device_platform == "SiWx917" ||
+         chip_device_platform == "openiotsdk" || chip_device_platform == "asr" ||
+-        chip_device_platform == "stm32",
++        chip_device_platform == "stm32" || chip_device_platform == "nuttx",
+     "Please select a valid value for chip_device_platform")
+-- 
+2.25.1
+

--- a/netutils/connectedhomeip/CMakeLists.txt
+++ b/netutils/connectedhomeip/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# external/connectedhomeip/CMakeLists.txt
+# apps/netutils/connectedhomeip/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -22,9 +22,126 @@ if(CONFIG_MATTER)
 
   include(ExternalProject)
 
+  function(chip_download_and_patch)
+
+    # parse arguments into variables
+
+    nuttx_parse_function_args(
+      FUNC
+      chip_download_and_patch
+      ONE_VALUE
+      NAME
+      URL
+      SOURCE_DIR
+      BINARY_DIR
+      TIMEOUT
+      MULTI_VALUE
+      PATCH_LIST
+      ARGN
+      ${ARGN})
+
+    if(NOT EXISTS ${SOURCE_DIR})
+      FetchContent_Declare(
+        ${NAME}_fetch
+        URL ${URL} SOURCE_DIR ${SOURCE_DIR} BINARY_DIR ${BINARY_DIR}
+        DOWNLOAD_NO_PROGRESS true
+        TIMEOUT ${TIMEOUT})
+
+      FetchContent_GetProperties(${NAME}_fetch)
+
+      if(NOT ${NAME}_fetch_POPULATED)
+        FetchContent_Populate(${NAME}_fetch)
+      endif()
+
+      if(PATCH_LIST)
+        foreach(PATCH ${PATCH_LIST})
+          execute_process(COMMAND sh -c "patch -p1 < ${PATCH}"
+                          WORKING_DIRECTORY ${SOURCE_DIR})
+        endforeach()
+      endif()
+
+    endif()
+
+  endfunction()
+
   get_filename_component(
     CHIP_ROOT ${NUTTX_APPS_DIR}/netutils/connectedhomeip/connectedhomeip
     REALPATH)
+
+  chip_download_and_patch(
+    NAME
+    chip
+    URL
+    https://github.com/project-chip/connectedhomeip/archive/refs/tags/v1.2.0.1.zip
+    SOURCE_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/connectedhomeip
+    BINARY_DIR
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    TIMEOUT
+    90
+    PATCH_LIST
+    ${CMAKE_CURRENT_SOURCE_DIR}/0001-chip-add-compile-support-for-NuttX.patch)
+
+  chip_download_and_patch(
+    NAME
+    pigweed
+    URL
+    https://github.com/google/pigweed/archive/refs/heads/main.zip
+    SOURCE_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/pigweed
+    BINARY_DIR
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    TIMEOUT
+    90)
+
+  chip_download_and_patch(
+    NAME
+    nlio
+    URL
+    https://github.com/nestlabs/nlio/archive/refs/tags/1.1.8.zip
+    SOURCE_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/nlio
+    BINARY_DIR
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    TIMEOUT
+    30)
+
+  chip_download_and_patch(
+    NAME
+    nlassert
+    URL
+    https://github.com/nestlabs/nlassert/archive/refs/tags/1.1.8.zip
+    SOURCE_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/nlassert
+    BINARY_DIR
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    TIMEOUT
+    30)
+
+  chip_download_and_patch(
+    NAME
+    nlunit-test
+    URL
+    https://github.com/nestlabs/nlunit-test/archive/refs/tags/1.0.9.zip
+    SOURCE_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/nlunit-test
+    BINARY_DIR
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    TIMEOUT
+    30)
+
+  chip_download_and_patch(
+    NAME
+    inipp
+    URL
+    https://github.com/mcmtroffaes/inipp/archive/refs/tags/1.0.12.zip
+    SOURCE_DIR
+    ${CMAKE_CURRENT_LIST_DIR}/inipp
+    BINARY_DIR
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    TIMEOUT
+    30)
+
   get_filename_component(GN_ROOT_TARGET ${CHIP_ROOT}/config/nuttx/chip-gn
                          REALPATH)
   get_filename_component(COMMON_CMAKE_SOURCE_DIR
@@ -33,13 +150,18 @@ if(CONFIG_MATTER)
   include(${COMMON_CMAKE_SOURCE_DIR}/chip_gn_args.cmake)
   include(${COMMON_CMAKE_SOURCE_DIR}/chip_gn.cmake)
 
+  set(nuttx_include_dirs)
+  get_target_property(include_dirs nuttx NUTTX_INCLUDE_DIRECTORIES)
+  list(APPEND nuttx_include_dirs ${include_dirs})
+  get_target_property(include_dirs nuttx INCLUDE_DIRECTORIES)
+  list(APPEND nuttx_include_dirs ${include_dirs})
+  get_target_property(include_dirs mbedtls INCLUDE_DIRECTORIES)
+  list(APPEND nuttx_include_dirs ${include_dirs})
+
   set(MATTER_INCDIR
-      ${CMAKE_BINARY_DIR}/include
-      ${CMAKE_BINARY_DIR}/include_arch
+      ${nuttx_include_dirs}
       ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/gen/include
-      ${NUTTX_DIR}/include/libcxx
-      ${NUTTX_DIR}/libs/libxx/libcxx/include
-      ${NUTTX_DIR}/include
+      ${NUTTX_APPS_DIR}/netutils/jsoncpp/jsoncpp/include
       inipp
       nlio/include
       nlassert/include
@@ -52,20 +174,12 @@ if(CONFIG_MATTER)
       connectedhomeip/zzz_generated/app-common
       connectedhomeip/src/platform/Linux
       connectedhomeip/examples/platform/linux
-      connectedhomeip/third_party/jsoncpp/repo/include
-      connectedhomeip/examples/lighting-app/lighting-common/include
-      ${NUTTX_APPS_DIR}/external/zblue/zblue/port/include
-      ${NUTTX_APPS_DIR}/external/zblue/zblue/include
-      ${NUTTX_APPS_DIR}/external/zblue/zblue/subsys/testsuite/ztest/include/
-      ${NUTTX_APPS_DIR}/crypto/mbedtls/mbedtls/include)
+      connectedhomeip/examples/lighting-app/lighting-common/include)
 
   set(MATTER_FLAGS
       -DCHIP_HAVE_CONFIG_H
-      -fexceptions
-      -fpermissive
       -std=c++17
       -Wno-undef
-      -Wno-format
       -DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>
   )
 
@@ -127,6 +241,7 @@ if(CONFIG_MATTER)
   matter_add_gn_arg_bool("chip_example_lighting" true)
   matter_add_gn_arg_bool("chip_config_network_layer_ble")
 
+  matter_get_compiler_flags_from_targets(nuttx)
   matter_common_gn_args(PROJECT_CONFIG_INC_DIR ${EXTERNAL_MATTER_INCDIR})
 
   matter_generate_args_tmp_file()
@@ -139,14 +254,15 @@ if(CONFIG_MATTER)
     ${CONFIG_CHIP_PW_RPC}
     LIB_TESTS
     ${CONFIG_CHIP_BUILD_TESTS}
-    LIB_MBEDTLS)
+    LIB_MBEDTLS
+    GN_DEPENDENCIES
+    mbedtls)
 
   add_custom_command(
     OUTPUT connectedhomeip/third_party/pigweed/repo
-    COMMAND
-      test -e ${CHIP_ROOT}/third_party/pigweed/repo/.git || git clone
-      https://github.com/google/pigweed.git -b main
-      ${CHIP_ROOT}/third_party/pigweed/repo)
+    COMMAND rm ${CHIP_ROOT}/third_party/pigweed/repo -rf
+    COMMAND ln -s ${NUTTX_APPS_DIR}/netutils/connectedhomeip/pigweed
+            ${CHIP_ROOT}/third_party/pigweed/repo)
 
   add_custom_target(chippigweed ALL
                     DEPENDS connectedhomeip/third_party/pigweed/repo)
@@ -164,10 +280,9 @@ if(CONFIG_MATTER)
 
   add_custom_command(
     OUTPUT connectedhomeip/third_party/nlassert/repo
-    COMMAND
-      test -e ${CHIP_ROOT}/third_party/nlassert/repo/.git || git clone
-      https://github.com/nestlabs/nlassert.git -b master
-      ${CHIP_ROOT}/third_party/nlassert/repo)
+    COMMAND rm ${CHIP_ROOT}/third_party/nlassert/repo -rf
+    COMMAND ln -s ${NUTTX_APPS_DIR}/netutils/connectedhomeip/nlassert
+            ${CHIP_ROOT}/third_party/nlassert/repo)
 
   add_custom_target(chipnlassert ALL
                     DEPENDS connectedhomeip/third_party/nlassert/repo)
@@ -175,38 +290,28 @@ if(CONFIG_MATTER)
 
   add_custom_command(
     OUTPUT connectedhomeip/third_party/nlio/repo
-    COMMAND
-      test -e ${CHIP_ROOT}/third_party/nlio/repo/.git || git clone
-      https://github.com/nestlabs/nlio.git -b master
-      ${CHIP_ROOT}/third_party/nlio/repo)
+    COMMAND rm ${CHIP_ROOT}/third_party/nlio/repo -rf
+    COMMAND ln -s ${NUTTX_APPS_DIR}/netutils/connectedhomeip/nlio
+            ${CHIP_ROOT}/third_party/nlio/repo)
 
   add_custom_target(chipnlio ALL DEPENDS connectedhomeip/third_party/nlio/repo)
   ExternalProject_Add_StepDependencies(chip-gn configure chipnlio)
 
   add_custom_command(
     OUTPUT connectedhomeip/third_party/nlunit-test/repo
-    COMMAND
-      test -e ${CHIP_ROOT}/third_party/nlunit-test/repo/.git || git clone
-      https://github.com/nestlabs/nlunit-test.git -b master
-      ${CHIP_ROOT}/third_party/nlunit-test/repo)
+    COMMAND rm ${CHIP_ROOT}/third_party/nlunit-test/repo -rf
+    COMMAND ln -s ${NUTTX_APPS_DIR}/netutils/connectedhomeip/nlunit-test
+            ${CHIP_ROOT}/third_party/nlunit-test/repo)
 
   add_custom_target(chipnlunit-test ALL
                     DEPENDS connectedhomeip/third_party/nlunit-test/repo)
   ExternalProject_Add_StepDependencies(chip-gn configure chipnlunit-test)
 
-  set(JSONSRC
-      ${CHIP_ROOT}/third_party/jsoncpp/repo/src/lib_json/json_writer.cpp
-      ${CHIP_ROOT}/third_party/jsoncpp/repo/src/lib_json/json_value.cpp
-      ${CHIP_ROOT}/third_party/jsoncpp/repo/src/lib_json/json_reader.cpp)
-
   add_custom_command(
-    OUTPUT connectedhomeip/third_party/jsoncpp/repo ${JSONSRC}
-    COMMAND
-      test -e ${CHIP_ROOT}/third_party/jsoncpp/repo/.git || rm -r
-      ${CHIP_ROOT}/third_party/jsoncpp/repo/src && test -e
-      ${CHIP_ROOT}/third_party/jsoncpp/repo/.git || git clone
-      https://github.com/open-source-parsers/jsoncpp.git
-      ${CHIP_ROOT}/third_party/jsoncpp/repo)
+    OUTPUT connectedhomeip/third_party/jsoncpp/repo
+    COMMAND rm -rf ${CHIP_ROOT}/third_party/jsoncpp/repo
+    COMMAND ln -s ${NUTTX_APPS_DIR}/netutils/jsoncpp/jsoncpp
+            ${CHIP_ROOT}/third_party/jsoncpp/repo)
 
   add_custom_target(chipjsoncpp ALL
                     DEPENDS connectedhomeip/third_party/jsoncpp/repo)
@@ -214,8 +319,7 @@ if(CONFIG_MATTER)
 
   set(DEMOSRC
       ${CHIP_ROOT}/examples/lighting-app/linux/main.cpp
-      ${CHIP_ROOT}/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
-      ${JSONSRC})
+      ${CHIP_ROOT}/examples/lighting-app/linux/LightingAppCommandDelegate.cpp)
 
   nuttx_add_application(
     NAME
@@ -228,6 +332,7 @@ if(CONFIG_MATTER)
     ${MATTER_FLAGS}
     DEPENDS
     chip-gn
+    mbedtls
     STACKSIZE
     16384
     PRIORITY

--- a/netutils/connectedhomeip/CMakeLists.txt
+++ b/netutils/connectedhomeip/CMakeLists.txt
@@ -1,0 +1,248 @@
+# ##############################################################################
+# external/connectedhomeip/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_MATTER)
+
+  include(ExternalProject)
+
+  get_filename_component(
+    CHIP_ROOT ${NUTTX_APPS_DIR}/netutils/connectedhomeip/connectedhomeip
+    REALPATH)
+  get_filename_component(GN_ROOT_TARGET ${CHIP_ROOT}/config/nuttx/chip-gn
+                         REALPATH)
+  get_filename_component(COMMON_CMAKE_SOURCE_DIR
+                         ${CHIP_ROOT}/config/common/cmake REALPATH)
+
+  include(${COMMON_CMAKE_SOURCE_DIR}/chip_gn_args.cmake)
+  include(${COMMON_CMAKE_SOURCE_DIR}/chip_gn.cmake)
+
+  set(MATTER_INCDIR
+      ${CMAKE_BINARY_DIR}/include
+      ${CMAKE_BINARY_DIR}/include_arch
+      ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/gen/include
+      ${NUTTX_DIR}/include/libcxx
+      ${NUTTX_DIR}/libs/libxx/libcxx/include
+      ${NUTTX_DIR}/include
+      inipp
+      nlio/include
+      nlassert/include
+      connectedhomeip/src
+      connectedhomeip/src/include
+      connectedhomeip/src/lib/dnssd
+      connectedhomeip/src/app/util/mock/include
+      connectedhomeip/zzz_generated
+      connectedhomeip/zzz_generated/lighting-app
+      connectedhomeip/zzz_generated/app-common
+      connectedhomeip/src/platform/Linux
+      connectedhomeip/examples/platform/linux
+      connectedhomeip/third_party/jsoncpp/repo/include
+      connectedhomeip/examples/lighting-app/lighting-common/include
+      ${NUTTX_APPS_DIR}/external/zblue/zblue/port/include
+      ${NUTTX_APPS_DIR}/external/zblue/zblue/include
+      ${NUTTX_APPS_DIR}/external/zblue/zblue/subsys/testsuite/ztest/include/
+      ${NUTTX_APPS_DIR}/crypto/mbedtls/mbedtls/include)
+
+  set(MATTER_FLAGS
+      -DCHIP_HAVE_CONFIG_H
+      -fexceptions
+      -fpermissive
+      -std=c++17
+      -Wno-undef
+      -Wno-format
+      -DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>
+  )
+
+  set(EXTERNAL_MATTER_INCDIR)
+
+  foreach(estring ${MATTER_INCDIR})
+    list(APPEND EXTERNAL_MATTER_INCDIR "\"${estring}\"")
+  endforeach()
+
+  matter_add_gn_arg_string("nuttx_ar" ${CMAKE_AR})
+  matter_add_gn_arg_string("nuttx_cc" ${CMAKE_C_COMPILER})
+  matter_add_gn_arg_string("nuttx_cxx" ${CMAKE_CXX_COMPILER})
+  matter_add_flags("-D__NuttX__ ")
+
+  if(CONFIG_ARCH_SIM)
+    if(CONFIG_SIM_M32)
+      matter_add_gn_arg_string("target_cpu" "x86")
+    else()
+      matter_add_gn_arg_string("target_cpu" "x86_64")
+    endif()
+
+  elseif(CONFIG_ARCH_ARM)
+    matter_add_gn_arg_string("target_cpu" "arm")
+  elseif(CONFIG_ARCH_RISCV)
+    matter_add_gn_arg_string("target_cpu" "riscv")
+    matter_add_gn_arg_string("riscv_arch" "${ARCHTYPE}${ARCHCPUEXTFLAGS}")
+
+    if(CONFIG_ARCH_DPFPU)
+      matter_add_gn_arg_string("riscv_abi" "${ARCHABITYPE}d")
+    elseif(CONFIG_ARCH_FPU)
+      matter_add_gn_arg_string("riscv_abi" "${ARCHABITYPE}f")
+    else()
+      matter_add_gn_arg_string("riscv_abi" "${ARCHABITYPE}")
+    endif()
+
+    if(CONFIG_ARCH_RV32)
+      if(${ARCHCPUEXTFLAGS} STREQUAL imc)
+        matter_add_gn_arg_string("riscv_cpu" "sifive-e20")
+      elseif(${ARCHCPUEXTFLAGS} STREQUAL imac)
+        matter_add_gn_arg_string("riscv_cpu" "sifive-e31")
+      elseif(${ARCHCPUEXTFLAGS} STREQUAL imafc)
+        matter_add_gn_arg_string("riscv_cpu" "sifive-e76")
+      endif()
+    else()
+      if(${ARCHCPUEXTFLAGS} STREQUAL imac)
+        matter_add_gn_arg_string("riscv_cpu" "sifive-s51")
+      elseif(${ARCHCPUEXTFLAGS} STREQUAL imafdc)
+        matter_add_gn_arg_string("riscv_cpu" "sifive-u54")
+      endif()
+    endif()
+
+    if(CONFIG_ARCH_RV64)
+      matter_add_flags("-mcmodel=medany")
+    endif()
+  endif()
+
+  matter_add_gn_arg_bool("chip_inet_config_enable_ipv4" CONFIG_NET_IPv4)
+  matter_add_gn_arg_bool("chip_enable_ble")
+  matter_add_gn_arg_bool("chip_example_lighting" true)
+  matter_add_gn_arg_bool("chip_config_network_layer_ble")
+
+  matter_common_gn_args(PROJECT_CONFIG_INC_DIR ${EXTERNAL_MATTER_INCDIR})
+
+  matter_generate_args_tmp_file()
+
+  matter_build(
+    chip
+    LIB_SHELL
+    ${CONFIG_CHIP_LIB_SHELL}
+    LIB_PW_RPC
+    ${CONFIG_CHIP_PW_RPC}
+    LIB_TESTS
+    ${CONFIG_CHIP_BUILD_TESTS}
+    LIB_MBEDTLS)
+
+  add_custom_command(
+    OUTPUT connectedhomeip/third_party/pigweed/repo
+    COMMAND
+      test -e ${CHIP_ROOT}/third_party/pigweed/repo/.git || git clone
+      https://github.com/google/pigweed.git -b main
+      ${CHIP_ROOT}/third_party/pigweed/repo)
+
+  add_custom_target(chippigweed ALL
+                    DEPENDS connectedhomeip/third_party/pigweed/repo)
+  ExternalProject_Add_StepDependencies(chip-gn configure chippigweed)
+
+  add_custom_command(
+    OUTPUT ${CHIP_ROOT}/build_overrides/pigweed_environment.gni
+    COMMAND touch ${CHIP_ROOT}/build_overrides/pigweed_environment.gni)
+
+  add_custom_target(
+    chipnpigweedenv ALL
+    DEPENDS ${CHIP_ROOT}/build_overrides/pigweed_environment.gni)
+  ExternalProject_Add_StepDependencies(chip-gn configure chipnpigweedenv)
+  add_dependencies(chippigweed chipnpigweedenv)
+
+  add_custom_command(
+    OUTPUT connectedhomeip/third_party/nlassert/repo
+    COMMAND
+      test -e ${CHIP_ROOT}/third_party/nlassert/repo/.git || git clone
+      https://github.com/nestlabs/nlassert.git -b master
+      ${CHIP_ROOT}/third_party/nlassert/repo)
+
+  add_custom_target(chipnlassert ALL
+                    DEPENDS connectedhomeip/third_party/nlassert/repo)
+  ExternalProject_Add_StepDependencies(chip-gn configure chipnlassert)
+
+  add_custom_command(
+    OUTPUT connectedhomeip/third_party/nlio/repo
+    COMMAND
+      test -e ${CHIP_ROOT}/third_party/nlio/repo/.git || git clone
+      https://github.com/nestlabs/nlio.git -b master
+      ${CHIP_ROOT}/third_party/nlio/repo)
+
+  add_custom_target(chipnlio ALL DEPENDS connectedhomeip/third_party/nlio/repo)
+  ExternalProject_Add_StepDependencies(chip-gn configure chipnlio)
+
+  add_custom_command(
+    OUTPUT connectedhomeip/third_party/nlunit-test/repo
+    COMMAND
+      test -e ${CHIP_ROOT}/third_party/nlunit-test/repo/.git || git clone
+      https://github.com/nestlabs/nlunit-test.git -b master
+      ${CHIP_ROOT}/third_party/nlunit-test/repo)
+
+  add_custom_target(chipnlunit-test ALL
+                    DEPENDS connectedhomeip/third_party/nlunit-test/repo)
+  ExternalProject_Add_StepDependencies(chip-gn configure chipnlunit-test)
+
+  set(JSONSRC
+      ${CHIP_ROOT}/third_party/jsoncpp/repo/src/lib_json/json_writer.cpp
+      ${CHIP_ROOT}/third_party/jsoncpp/repo/src/lib_json/json_value.cpp
+      ${CHIP_ROOT}/third_party/jsoncpp/repo/src/lib_json/json_reader.cpp)
+
+  add_custom_command(
+    OUTPUT connectedhomeip/third_party/jsoncpp/repo ${JSONSRC}
+    COMMAND
+      test -e ${CHIP_ROOT}/third_party/jsoncpp/repo/.git || rm -r
+      ${CHIP_ROOT}/third_party/jsoncpp/repo/src && test -e
+      ${CHIP_ROOT}/third_party/jsoncpp/repo/.git || git clone
+      https://github.com/open-source-parsers/jsoncpp.git
+      ${CHIP_ROOT}/third_party/jsoncpp/repo)
+
+  add_custom_target(chipjsoncpp ALL
+                    DEPENDS connectedhomeip/third_party/jsoncpp/repo)
+  ExternalProject_Add_StepDependencies(chip-gn configure chipjsoncpp)
+
+  set(DEMOSRC
+      ${CHIP_ROOT}/examples/lighting-app/linux/main.cpp
+      ${CHIP_ROOT}/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
+      ${JSONSRC})
+
+  nuttx_add_application(
+    NAME
+    matter
+    SRCS
+    ${DEMOSRC}
+    INCLUDE_DIRECTORIES
+    ${MATTER_INCDIR}
+    COMPILE_FLAGS
+    ${MATTER_FLAGS}
+    DEPENDS
+    chip-gn
+    STACKSIZE
+    16384
+    PRIORITY
+    100)
+
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a
+    COMMAND echo generate libchipnuttx.a)
+  add_custom_target(
+    libchipnuttx ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a
+  )
+  add_dependencies(libchipnuttx chip-gn)
+
+  nuttx_add_extra_library(
+    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a)
+
+endif()

--- a/netutils/connectedhomeip/Kconfig
+++ b/netutils/connectedhomeip/Kconfig
@@ -1,0 +1,10 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config MATTER
+	bool "Connected Home over IP (CHIP)"
+	default n
+	---help---
+		Enable the Connected Home over IP (CHIP)

--- a/netutils/jsoncpp/.gitignore
+++ b/netutils/jsoncpp/.gitignore
@@ -1,0 +1,1 @@
+/jsoncpp

--- a/netutils/jsoncpp/CMakeLists.txt
+++ b/netutils/jsoncpp/CMakeLists.txt
@@ -1,0 +1,49 @@
+# ##############################################################################
+# apps/netutils/jsoncpp/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_JSONCPP)
+  set(JSONCPP_DIR ${CMAKE_CURRENT_LIST_DIR}/jsoncpp)
+
+  if(NOT EXISTS ${JSONCPP_DIR})
+    set(JSONCPP_URL
+        https://github.com/open-source-parsers/jsoncpp/archive/refs/tags)
+    set(JSONCPP_VERSION ${CONFIG_JSONCPP_VERSION})
+    FetchContent_Declare(
+      jsoncpp_fetch
+      URL ${JSONCPP_URL}/${JSONCPP_VERSION}.zip SOURCE_DIR ${JSONCPP_DIR}
+          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/netutils/jsoncpp
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(jsoncpp_fetch)
+
+    if(NOT jsoncpp_fetch_POPULATED)
+      FetchContent_Populate(jsoncpp_fetch)
+    endif()
+  endif()
+
+  target_include_directories(apps PUBLIC jsoncpp/include)
+  target_compile_options(apps PRIVATE -DJSON_USE_EXCEPTION=0)
+  target_sources(
+    apps
+    PRIVATE jsoncpp/src/lib_json/json_writer.cpp
+            jsoncpp/src/lib_json/json_value.cpp
+            jsoncpp/src/lib_json/json_reader.cpp)
+endif()

--- a/netutils/jsoncpp/Kconfig
+++ b/netutils/jsoncpp/Kconfig
@@ -1,0 +1,22 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NETUTILS_JSONCPP
+	bool "JSONCPP"
+	default n
+	---help---
+		JsonCpp is a C++ library that allows manipulating JSON values,
+		including serialization and deserialization to and from strings.
+		It can also preserve existing comment in unserialization/
+		serialization steps, making it a convenient format to store user
+		input files.
+
+if NETUTILS_JSONCPP
+
+config JSONCPP_VERSION
+	string "Jsoncpp Version"
+	default "1.9.5"
+
+endif # NETUTILS_JSONCPP

--- a/netutils/jsoncpp/Make.defs
+++ b/netutils/jsoncpp/Make.defs
@@ -1,0 +1,24 @@
+############################################################################
+# apps/netutils/jsoncpp/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_NETUTILS_JSONCPP),)
+CONFIGURED_APPS += $(APPDIR)/netutils/jsoncpp
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)$(DELIM)netutils$(DELIM)jsoncpp$(DELIM)jsoncpp$(DELIM)include
+endif

--- a/netutils/jsoncpp/Makefile
+++ b/netutils/jsoncpp/Makefile
@@ -1,0 +1,58 @@
+############################################################################
+# apps/netutils/jsoncpp/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+JSONCPP_URL ?= "https://github.com/open-source-parsers/jsoncpp/archive/refs/tags"
+
+JSONCPP_VERSION = $(patsubst "%",%,$(strip $(CONFIG_JSONCPP_VERSION)))
+JSONCPP_ZIP = $(CONFIG_JSONCPP_VERSION).zip
+
+JSONCPP_UNPACKNAME = jsoncpp
+UNPACK ?= unzip -q -o
+
+$(JSONCPP_ZIP):
+	@echo "Downloading: $(JSONCPP_URL)/$(JSONCPP_ZIP)"
+	$(Q) curl -O -L $(JSONCPP_URL)/$(JSONCPP_ZIP)
+
+$(JSONCPP_UNPACKNAME): $(JSONCPP_ZIP)
+	@echo "Unpacking: $(JSONCPP_ZIP) -> $(JSONCPP_UNPACKNAME)"
+	$(Q) $(UNPACK) $(JSONCPP_ZIP)
+	$(Q) mv jsoncpp-$(JSONCPP_VERSION) $(JSONCPP_UNPACKNAME)
+	$(Q) touch $(JSONCPP_UNPACKNAME)
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(JSONCPP_UNPACKNAME)),)
+context:: $(JSONCPP_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(JSONCPP_UNPACKNAME))
+	$(call DELFILE, $(JSONCPP_ZIP))
+endif
+
+CXXEXT = .cpp
+
+CXXFLAGS += -DJSON_USE_EXCEPTION=0
+
+CXXSRCS += jsoncpp/src/lib_json/json_writer.cpp
+CXXSRCS += jsoncpp/src/lib_json/json_value.cpp
+CXXSRCS += jsoncpp/src/lib_json/json_reader.cpp
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
A nuttx with the matter command can be compiled using cmake and enable CONFIG_MATTER option.
The matter compiled by the current script is just a lighting example of
a limited number of commands that can be tested by chip-tool.

After nuttx is connected to the LAN and the matter command is executed, other devices in the LAN, such as linux PCS, can run the following commands to scan, connect, turn on and off, adjust brightness and contrast, and so on.

chip-tool pairing onnetwork 1 20202021
chip-tool onoff on 1 1
chip-tool levelcontrol move-to-level 128 10 0 0 1 1
chip-tool colorcontrol move-to-hue-and-saturation 240 100 0 0 0 1 1

Depends on the following configuration options:
CONFIG_CRYPTO_MBEDTLS=y
CONFIG_DEV_URANDOM=y
CONFIG_LIBCXX=y
CONFIG_LIBM=y
CONFIG_NET_IPv6=y
CONFIG_NET_ICMPv6=y
CONFIG_NET_ICMPv6_AUTOCONF=y
CONFIG_NET_ICMPv6_NEIGHBOR=y
CONFIG_NET_ICMPv6_ROUTER=y
CONFIG_NET_ICMPv6_SOCKET=y
CONFIG_NET_IGMP=y
CONFIG_NET_MLD=y
CONFIG_NET_MLD_ROUTER=y

This initial version does not yet have Bluetooth and OTA support.

The community version needs to dynamically fetch the matter source code at compile time and apply the required nuttx adaptation patch.

## Impact

## Testing
sim:local and risc-v32 board
