### PR TITLE
Wasm build system improvements

### DIFF
--- a/interpreters/wamr/Toolchain.defs
+++ b/interpreters/wamr/Toolchain.defs
@@ -37,16 +37,35 @@ else ifeq ($(CONFIG_ARCH_SIM),y)
   else
     WTARGET = x86_64
   endif
-else
+else ifeq ($(findstring thumb,$(LLVM_ARCHTYPE)),thumb)
 
-  # Flags for other architectures (arm or riscv)
+  # target triple of thumb may very complex, such as thumbv8m.main+dsp+mve.fp+fp.dp
+  # so we just use the target name before the first plus sign
 
-  WTARGET = $(LLVM_ARCHTYPE)
-  WCPU    = $(LLVM_CPUTYPE)
-
+  WTARGET = $(shell echo $(LLVM_ARCHTYPE) | cut -d'+' -f1)
 endif
 
-RCFLAGS += --target=$(WTARGET) --target-abi=$(LLVM_ABITYPE) --cpu=$(WCPU)
+# If WTARGET is not defined, then use the same as LLVM_ARCHTYPE
+
+ifeq ($(WTARGET),)
+  WTARGET = $(LLVM_ARCHTYPE)
+endif
+
+# If WCPU is not defined, then use the same as LLVM_CPU
+
+ifeq ($(WCPU),)
+  WCPU = $(LLVM_CPUTYPE)
+endif
+
+# If LLVM_ABITYPE is eabihf, then convert it to gnueabihf which is used by wamrc
+
+ifeq ($(LLVM_ABITYPE),eabihf)
+  WABITYPE = gnueabihf
+else
+  WABITYPE = $(LLVM_ABITYPE)
+endif
+
+RCFLAGS += --target=$(WTARGET) --target-abi=$(WABITYPE) --cpu=$(WCPU)
 
 define WAMR_AOT_COMPILE
 	$(if $(wildcard $(APPDIR)$(DELIM)wasm$(DELIM)*.wo), \

--- a/interpreters/wamr/Toolchain.defs
+++ b/interpreters/wamr/Toolchain.defs
@@ -74,14 +74,14 @@ define WAMR_AOT_COMPILE
 	    $(eval WAMRMODE=$(shell echo $(notdir $(bin)) | cut -d'#' -f5)) \
 	    $(if $(CONFIG_INTERPRETERS_WAMR_AOT), \
 	      $(if $(filter AOT,$(WAMRMODE)), \
-	        $(info Wamrc Generate AoT: $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).aot) \
-	        $(shell $(WRC) $(RCFLAGS) -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).aot \
-	                          $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm > /dev/null), \
+	        $(info Wamrc Generate AoT: $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).aot) \
+	        $(shell $(WRC) $(RCFLAGS) -o $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).aot \
+	                          $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm > /dev/null), \
 	        $(if $(filter XIP,$(WAMRMODE)), \
-	          $(info Wamrc Generate XiP: $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).xip) \
+	          $(info Wamrc Generate XiP: $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).xip) \
 	          $(shell $(WRC) $(RCFLAGS) --enable-indirect-mode --disable-llvm-intrinsics \
-	                         -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).xip \
-	                            $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm > /dev/null) \
+	                         -o $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).xip \
+	                            $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm > /dev/null) \
 	         ) \
 	       ) \
 	     ) \

--- a/tools/WASI-SDK.defs
+++ b/tools/WASI-SDK.defs
@@ -1,0 +1,86 @@
+
+############################################################################
+# apps/tools/WASI-SDK.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# wasi-sdk toolchain
+
+WCC ?= $(WASI_SDK_PATH)/bin/clang
+WAR ?= $(WASI_SDK_PATH)/bin/llvm-ar rcs
+
+# Sysroot for building wasm module, default is NuttX
+
+WSYSROOT ?= $(TOPDIR)
+
+# Force disable wasm build when WCC is not exist
+
+ifeq ($(wildcard $(WCC)),)
+  WASM_BUILD = n
+else
+  WASM_BUILD ?= n
+endif
+
+# Force disable wasm build when WASM_SYSROOT is not defined and on specific
+# targets that do not support wasm build.
+# Since some architecture level inline assembly instructions can not be
+# recognized by wasm-clang. For example:
+# Error: /github/workspace/sources/nuttx/include/arch/chip/irq.h:220:27: error: invalid output constraint '=a' in asm
+# asm volatile("rdtscp" : "=a" (lo), "=d" (hi)::"memory");
+
+ifeq ($(CONFIG_ARCH_INTEL64)$(CONFIG_ARCH_SPARC_V8)$(CONFIG_ARCH_AVR)$(CONFIG_ARCH_XTENSA),y)
+  WASM_BUILD = n
+endif
+
+# Build optimization flags from scratch
+
+ifeq ($(CONFIG_DEBUG_FULLOPT),y)
+  WCFLAGS += -Oz
+else ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
+  WCFLAGS += $(CONFIG_DEBUG_OPTLEVEL)
+endif
+
+ifneq ($(CONFIG_LTO_FULL)$(CONFIG_LTO_THIN),)
+  WCFLAGS += -flto
+  WLDFLAGS += -flto
+endif
+
+# Build other compiler flags from native compiler
+
+CFLAGS_STRIP = -fsanitize=kernel-address -fsanitize=address -fsanitize=undefined
+CFLAGS_STRIP += $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(ARCHOPTIMIZATION) $(EXTRAFLAGS)
+
+WCFLAGS += $(filter-out $(CFLAGS_STRIP),$(CFLAGS))
+WCFLAGS += --sysroot=$(WSYSROOT) -nostdlib -D__NuttX__
+
+# If CONFIG_LIBM not defined, then define it to 1
+ifeq ($(CONFIG_LIBM),)
+WCFLAGS += -DCONFIG_LIBM=1 -I$(APPDIR)$(DELIM)include$(DELIM)wasm
+endif
+
+WLDFLAGS += -z stack-size=$(STACKSIZE) -Wl,--initial-memory=$(INITIAL_MEMORY)
+WLDFLAGS += -Wl,--export=main -Wl,--export=__main_argc_argv
+WLDFLAGS += -Wl,--export=__heap_base -Wl,--export=__data_end
+WLDFLAGS += -Wl,--no-entry -Wl,--strip-all -Wl,--allow-undefined
+
+WCC_COMPILER_RT_LIB = $(shell $(WCC) --print-libgcc-file-name)
+ifeq ($(wildcard $(WCC_COMPILER_RT_LIB)),)
+  # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
+  # then go ahead and try "--print-file-name"
+  WCC_COMPILER_RT_LIB := $(wildcard $(shell $(WCC) --print-file-name $(notdir $(WCC_COMPILER_RT_LIB))))
+endif

--- a/tools/WASI-SDK.defs
+++ b/tools/WASI-SDK.defs
@@ -73,7 +73,7 @@ ifeq ($(CONFIG_LIBM),)
 WCFLAGS += -DCONFIG_LIBM=1 -I$(APPDIR)$(DELIM)include$(DELIM)wasm
 endif
 
-WLDFLAGS += -z stack-size=$(STACKSIZE) -Wl,--initial-memory=$(INITIAL_MEMORY)
+WLDFLAGS += -z stack-size=$(STACKSIZE) -Wl,--initial-memory=$(WASM_INITIAL_MEMORY)
 WLDFLAGS += -Wl,--export=main -Wl,--export=__main_argc_argv
 WLDFLAGS += -Wl,--export=__heap_base -Wl,--export=__data_end
 WLDFLAGS += -Wl,--no-entry -Wl,--strip-all -Wl,--allow-undefined

--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -87,6 +87,7 @@ define LINK_WASM
 	    $(eval STACKSIZE=$(shell echo $(notdir $(bin)) | cut -d'#' -f3)) \
 	    $(eval PROGNAME=$(shell echo $(notdir $(bin)) | cut -d'#' -f1)) \
 	    $(eval RETVAL=$(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) $(COMPILER_RT_LIB) \
+	        -Wl,--Map=$(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).map \
 	        -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm || echo 1;)) \
 	    $(if $(RETVAL), \
 	        $(error wasm build failed for $(PROGNAME).wasm) \

--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -36,6 +36,7 @@ define LINK_WASM
 	    $(eval INITIAL_MEMORY=$(shell echo $(notdir $(bin)) | cut -d'#' -f2)) \
 	    $(eval STACKSIZE=$(shell echo $(notdir $(bin)) | cut -d'#' -f3)) \
 	    $(eval PROGNAME=$(shell echo $(notdir $(bin)) | cut -d'#' -f1)) \
+	    $(eval WLDFLAGS=$(shell cat $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).ldflags)) \
 	    $(eval RETVAL=$(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) $(WCC_COMPILER_RT_LIB) \
 	        -Wl,--Map=$(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).map \
 	        -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm || echo 1;)) \
@@ -99,6 +100,7 @@ $(WBIN): $(WOBJS)
 	  $(shell cp -rf $(strip $(main:=$(SUFFIX).wo)) \
 	    $(strip $(APPDIR)/wasm/$(progname)#$(WASM_INITIAL_MEMORY)#$(STACKSIZE)#$(PRIORITY)#$(WAMR_MODE)#$(dstname)) \
 	   ) \
+	  $(shell echo $(WLDFLAGS) > $(APPDIR)/wasm/$(progname).ldflags) \
 	 )
 
 clean::

--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -22,63 +22,13 @@
 # Only build wasm if one of the following runtime is enabled
 
 ifneq ($(CONFIG_INTERPRETERS_WAMR)$(CONFIG_INTERPRETERS_WASM)$(CONFIG_INTERPRETERS_TOYWASM),)
+include $(APPDIR)$(DELIM)tools$(DELIM)WASI-SDK.defs
 include $(APPDIR)$(DELIM)interpreters$(DELIM)wamr$(DELIM)Toolchain.defs
 
-# wasi-sdk toolchain setting
-
-WCC ?= $(WASI_SDK_PATH)/bin/clang
-WAR ?= $(WASI_SDK_PATH)/bin/llvm-ar rcs
-
-# sysroot for building wasm, default is NuttX
-
-ifeq ($(WSYSROOT),)
-	WSYSROOT := $(TOPDIR)
-	
-	# Force disable wasm build when WASM_SYSROOT is not defined and on specific
-	# targets that do not support wasm build.
-	# Since some architecture level inline assembly instructions can not be
-	# recognized by wasm-clang. For example:
-	# Error: /github/workspace/sources/nuttx/include/arch/chip/irq.h:220:27: error: invalid output constraint '=a' in asm
-    # asm volatile("rdtscp" : "=a" (lo), "=d" (hi)::"memory");
-
-	ifeq ($(CONFIG_ARCH_INTEL64)$(CONFIG_ARCH_SPARC_V8)$(CONFIG_ARCH_AVR)$(CONFIG_ARCH_XTENSA),y)
-		WASM_BUILD = n
-	endif
-
-endif
-
-# Only build wasm when WCC is exist
-
-ifneq ($(wildcard $(WCC)),)
-
-CFLAGS_STRIP = -fsanitize=kernel-address -fsanitize=address -fsanitize=undefined
-CFLAGS_STRIP += $(ARCHCPUFLAGS) $(ARCHCFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(ARCHOPTIMIZATION) $(EXTRAFLAGS)
-
-WCFLAGS += $(filter-out $(CFLAGS_STRIP),$(CFLAGS))
-WCFLAGS += --sysroot=$(WSYSROOT) -nostdlib -D__NuttX__
-
-# If CONFIG_LIBM not defined, then define it to 1
-ifeq ($(CONFIG_LIBM),)
-WCFLAGS += -DCONFIG_LIBM=1 -I$(APPDIR)$(DELIM)include$(DELIM)wasm
-endif
-
-WLDFLAGS += -z stack-size=$(STACKSIZE) -Wl,--initial-memory=$(INITIAL_MEMORY)
-WLDFLAGS += -Wl,--export=main -Wl,--export=__main_argc_argv
-WLDFLAGS += -Wl,--export=__heap_base -Wl,--export=__data_end
-WLDFLAGS += -Wl,--no-entry -Wl,--strip-all -Wl,--allow-undefined
-
-COMPILER_RT_LIB = $(shell $(WCC) --print-libgcc-file-name)
-ifeq ($(wildcard $(COMPILER_RT_LIB)),)
-  # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
-  # then go ahead and try "--print-file-name"
-  COMPILER_RT_LIB := $(wildcard $(shell $(WCC) --print-file-name $(notdir $(COMPILER_RT_LIB))))
-endif
-
-# If called from $(APPDIR)/Make.defs, WASM_BUILD is not defined
+# If called from $(APPDIR)/Makefile,
 # Provide LINK_WASM, but only execute it when file wasm/*.wo exists
 
-ifeq ($(WASM_BUILD),)
-
+ifeq ($(CURDIR),$(APPDIR))
 
 define LINK_WASM
 	$(if $(wildcard $(APPDIR)$(DELIM)wasm$(DELIM)*), \
@@ -86,7 +36,7 @@ define LINK_WASM
 	    $(eval INITIAL_MEMORY=$(shell echo $(notdir $(bin)) | cut -d'#' -f2)) \
 	    $(eval STACKSIZE=$(shell echo $(notdir $(bin)) | cut -d'#' -f3)) \
 	    $(eval PROGNAME=$(shell echo $(notdir $(bin)) | cut -d'#' -f1)) \
-	    $(eval RETVAL=$(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) $(COMPILER_RT_LIB) \
+	    $(eval RETVAL=$(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) $(WCC_COMPILER_RT_LIB) \
 	        -Wl,--Map=$(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).map \
 	        -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm || echo 1;)) \
 	    $(if $(RETVAL), \
@@ -97,14 +47,12 @@ define LINK_WASM
 	 )
 endef
 
-endif # WASM_BUILD
+endif # CURDIR
 
 # Default values for WASM_BUILD, it's a three state variable:
 #   y - build wasm module only
-#   n - don't build wasm module
+#   n - don't build wasm module, default
 #   both - build wasm module and native module
-
-WASM_BUILD ?= n
 
 ifneq ($(WASM_BUILD),n)
 
@@ -160,5 +108,4 @@ clean::
 
 endif # WASM_BUILD
 
-endif # WCC
-endif
+endif # CONFIG_INTERPRETERS_WAMR || CONFIG_INTERPRETERS_WASM || CONFIG_INTERPRETERS_TOYWASM

--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -39,7 +39,7 @@ define LINK_WASM
 	    $(eval WLDFLAGS=$(shell cat $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).ldflags)) \
 	    $(eval RETVAL=$(shell $(WCC) $(bin) $(WBIN) $(WCFLAGS) $(WLDFLAGS) $(WCC_COMPILER_RT_LIB) \
 	        -Wl,--Map=$(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).map \
-	        -o $(APPDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm || echo 1;)) \
+	        -o $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm || echo 1;)) \
 	    $(if $(RETVAL), \
 	        $(error wasm build failed for $(PROGNAME).wasm) \
 	    ) \
@@ -86,7 +86,10 @@ endif
 
 all:: $(WBIN)
 
-depend:: $(APPDIR)$(DELIM)include$(DELIM)wasm$(DELIM)math.h
+$(BINDIR)/wasm:
+	$(Q) mkdir -p $(BINDIR)/wasm
+
+depend:: $(APPDIR)$(DELIM)include$(DELIM)wasm$(DELIM)math.h $(BINDIR)/wasm
 
 $(WOBJS): %.c$(SUFFIX).wo : %.c
 	$(Q) $(WCC) $(WCFLAGS) -c $^ -o $@


### PR DESCRIPTION
## Summary

* Emit map file like NuttX's `System.map` for more debug information.
* Before WAMR 1.3.0, eabihf in wamrc is `gnueabihf`, so without this patch call wamrc will failed with target abi was `eabihf`, we should convert the standard llvm target to wamrc required. Both `eabihf` and `gnueabihf` supported after WAMR 1.3.0.
* Split origin Wasm.mk into Wasm.mk and WASI-SDK.defs
* Allow customize ld flags for each wasm module
* Move final wasm module to bin/wasm, and leave all intermediate file in apps/wasm, such as .map file, entry object etc used in wasm module build.

## Impact
Makefile for wasm build system
## Testing
Vela and CI
