### PR TITLE
lvgl/makefile: workaround for lvgl.v8

### DIFF
--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -29,6 +29,14 @@ LVGL_DIR_NAME = lvgl
 
 CFLAGS += -Wno-format -Wno-format-security -Wno-unused-variable
 
+# Since this change is only merged into the lvgl.v9, let us workaround for v8
+# ./lvgl/src/core/lv_obj.c:363:25: warning: variable 'x' set but not used [-Wunused-but-set-variable]
+#   363 |         static uint32_t x = 0;
+#       |                         ^
+# 1 warning generated.
+
+CFLAGS += -Wno-unused-but-set-variable
+
 -include ./lvgl/lvgl.mk
 
 CSRCS += port/lv_port.c


### PR DESCRIPTION

## Summary

lvgl/makefile: workaround for lvgl.v8

 Since this change is only merged into the lvgl.v9, let us workaround for v8:
 https://github.com/hubbell2019/LVGL/commit/37835260ca30a5b191d8b55d0d2b49892aad7a21

 ./lvgl/src/core/lv_obj.c:363:25: warning: variable 'x' set but not used [-Wunused-but-set-variable]
   363 |         static uint32_t x = 0;
       |                         ^
 1 warning generated.

CFLAGS += -Wno-unused-but-set-variable


## Impact

N/A

## Testing

ci-check