### PR TITLE
nshlib/ifconfig: Generate default IPv4 gateway with netmask

### DIFF
--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -855,54 +855,6 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     }
 #endif /* CONFIG_NET_IPv4 */
 
-  /* Set gateway */
-
-#ifdef CONFIG_NET_IPv6
-#ifdef CONFIG_NET_IPv4
-  if (inet6)
-#endif
-    {
-      /* Only set the gateway address if it was explicitly provided. */
-
-      if (gwip != NULL)
-        {
-          ninfo("Gateway: %s\n", gwip);
-          inet_pton(AF_INET6, gwip, &addr6);
-
-          netlib_set_dripv6addr(ifname, &addr6);
-          gip6 = addr6;
-        }
-    }
-#endif /* CONFIG_NET_IPv6 */
-
-#ifdef CONFIG_NET_IPv4
-#ifdef CONFIG_NET_IPv6
-  else
-#endif
-    {
-      if (gwip != NULL)
-        {
-          ninfo("Gateway: %s\n", gwip);
-          gip = addr.s_addr = inet_addr(gwip);
-        }
-      else
-        {
-          if (gip != 0)
-            {
-              ninfo("Gateway: default\n");
-              gip  = NTOHL(gip);
-              gip &= ~0x000000ff;
-              gip |= 0x00000001;
-              gip  = HTONL(gip);
-            }
-
-          addr.s_addr = gip;
-        }
-
-      netlib_set_dripv4addr(ifname, &addr);
-    }
-#endif /* CONFIG_NET_IPv4 */
-
   /* Set network mask */
 
 #ifdef CONFIG_NET_IPv6
@@ -972,6 +924,54 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         }
 
       netlib_set_ipv4netmask(ifname, &addr);
+    }
+#endif /* CONFIG_NET_IPv4 */
+
+  /* Set gateway */
+
+#ifdef CONFIG_NET_IPv6
+#ifdef CONFIG_NET_IPv4
+  if (inet6)
+#endif
+    {
+      /* Only set the gateway address if it was explicitly provided. */
+
+      if (gwip != NULL)
+        {
+          ninfo("Gateway: %s\n", gwip);
+          inet_pton(AF_INET6, gwip, &addr6);
+
+          netlib_set_dripv6addr(ifname, &addr6);
+          gip6 = addr6;
+        }
+    }
+#endif /* CONFIG_NET_IPv6 */
+
+#ifdef CONFIG_NET_IPv4
+#ifdef CONFIG_NET_IPv6
+  else
+#endif
+    {
+      if (gwip != NULL)
+        {
+          ninfo("Gateway: %s\n", gwip);
+          gip = addr.s_addr = inet_addr(gwip);
+        }
+      else
+        {
+          if (gip != 0)
+            {
+              ninfo("Gateway: default\n");
+              gip  = NTOHL(gip);
+              gip &= ~0x000000ff;
+              gip |= 0x00000001;
+              gip  = HTONL(gip);
+            }
+
+          addr.s_addr = gip;
+        }
+
+      netlib_set_dripv4addr(ifname, &addr);
     }
 #endif /* CONFIG_NET_IPv4 */
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -550,6 +550,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv4
   struct in_addr addr;
   in_addr_t gip = INADDR_ANY;
+  in_addr_t mip;
 #endif
 #ifdef CONFIG_NET_IPv6
   struct in6_addr addr6;
@@ -923,6 +924,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
           addr.s_addr = inet_addr("255.255.255.0");
         }
 
+      mip = addr.s_addr;
       netlib_set_ipv4netmask(ifname, &addr);
     }
 #endif /* CONFIG_NET_IPv4 */
@@ -959,13 +961,13 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         }
       else
         {
-          if (gip != 0)
+          if (gip != INADDR_ANY)
             {
               ninfo("Gateway: default\n");
-              gip  = NTOHL(gip);
-              gip &= ~0x000000ff;
+              gip  = ntohl(gip);
+              gip &= ntohl(mip);
               gip |= 0x00000001;
-              gip  = HTONL(gip);
+              gip  = htonl(gip);
             }
 
           addr.s_addr = gip;


### PR DESCRIPTION
## Summary
Patches included:
- nshlib/ifconfig: Set network mask before setting gateway
  - Switch the order of setting network mask and gateway, re-order only, no logic change.
- nshlib/ifconfig: Generate default IPv4 gateway with netmask
  - Generate default gateway using configured netmask instead of fixed 255.255.255.0, which may be more flexible under certain situations. e.g. A subnet like 10.0.23.16/28 may not contain the .1 address.

Before:

ifconfig eth0 10.0.23.22 netmask 255.255.255.252 => DRaddr:10.0.23.1
ifconfig eth0 10.0.23.22 netmask 255.255.255.240 => DRaddr:10.0.23.1
ifconfig eth0 10.0.23.22 netmask 255.255.255.0   => DRaddr:10.0.23.1
ifconfig eth0 10.0.23.22 netmask 255.255.0.0     => DRaddr:10.0.23.1
ifconfig eth0 10.0.23.22 => Mask:255.255.255.0      DRaddr:10.0.23.1

After:

ifconfig eth0 10.0.23.22 netmask 255.255.255.252 => DRaddr:10.0.23.21
ifconfig eth0 10.0.23.22 netmask 255.255.255.240 => DRaddr:10.0.23.17
ifconfig eth0 10.0.23.22 netmask 255.255.255.0   => DRaddr:10.0.23.1
ifconfig eth0 10.0.23.22 netmask 255.255.0.0     => DRaddr:10.0.0.1
ifconfig eth0 10.0.23.22 => Mask:255.255.255.0      DRaddr:10.0.23.1

## Impact
ifconfig command

## Testing
Manually
