### PR TITLE
interpreters/bas: Fix compiler warning after gcc upgrade to version 12

### DIFF
--- a/interpreters/bas/bas_token.h
+++ b/interpreters/bas/bas_token.h
@@ -100,7 +100,7 @@ struct Identifier
 {
   struct Symbol *sym;
   enum ValueType defaultType;
-  char name[2/* ... */];
+  char name[0];
 };
 
 struct Next


### PR DESCRIPTION
## Summary

````
bas_token.l: In function 'yylex':
Error: bas_token.l:1210:31: error: 'strcpy' writing 1 or more bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
 1210 |                             }
      |                               ^
In file included from bas_auto.h:77,
                 from bas_token.l:16:
bas_token.h:103:8: note: at offset 2 into destination object 'name' of size 2
  103 |   char name[2/* ... */];
      |        ^~~~
```

## Impact

fix ci break report here: https://github.com/apache/nuttx/actions/runs/7144096261/job/19457106837?pr=11301

## Testing

ci