### PR TITLE
Fix nuttx/porttimer.c:71:24: error: a function declaration without a prototype is deprecated

### DIFF
--- a/modbus/nuttx/porttimer.c
+++ b/modbus/nuttx/porttimer.c
@@ -68,12 +68,12 @@ bool xMBPortTimersInit(uint16_t usTim1Timerout50us)
   return xMBPortSerialSetTimeout(ulTimeOut);
 }
 
-void xMBPortTimersClose()
+void xMBPortTimersClose(void)
 {
   /* Does not use any hardware resources. */
 }
 
-void vMBPortTimerPoll()
+void vMBPortTimerPoll(void)
 {
   uint32_t       ulDeltaMS;
   struct timeval xTimeCur;
@@ -101,7 +101,7 @@ void vMBPortTimerPoll()
     }
 }
 
-void vMBPortTimersEnable()
+void vMBPortTimersEnable(void)
 {
   int res = gettimeofday(&xTimeLast, NULL);
 
@@ -109,7 +109,7 @@ void vMBPortTimersEnable()
   bTimeoutEnable = true;
 }
 
-void vMBPortTimersDisable()
+void vMBPortTimersDisable(void)
 {
   bTimeoutEnable = false;
 }


### PR DESCRIPTION
## Summary

Please ignore the "Mixed case identifier found" from the 3rd party library:
```
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/modbus/nuttx/porttimer.c:51:9: error: Mixed case identifier found
```

## Impact

fix ci break reported here: https://github.com/apache/nuttx/actions/runs/7161008130/job/19496039910?pr=11365

## Testing

ci