### PR TITLE
nshlib:dmesg add '-c|-C' opt

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -201,7 +201,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #if defined(CONFIG_SYSLOG_DEVPATH) && !defined(CONFIG_NSH_DISABLE_DMESG)
-  CMD_MAP("dmesg",    cmd_dmesg,    1, 1, NULL),
+  CMD_MAP("dmesg",    cmd_dmesg,    1, 2, "[-c,--clear |-C,--read-clear]"),
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_ECHO


### PR DESCRIPTION
## Summary
dmesg add '-c|-C' opt
## Impact
No impact on previous usage, while supporting "dmesg - c/-C"
## Testing
os test
