### PR TITLE
examples/rmtchar: Implement RX and/or TX using the RMT char driver

### DIFF
--- a/examples/rmtchar/CMakeLists.txt
+++ b/examples/rmtchar/CMakeLists.txt
@@ -1,0 +1,38 @@
+# ##############################################################################
+# apps/examples/rmtchar/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RMTCHAR)
+  nuttx_add_application(
+    NAME
+    rmtchar
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RMTCHAR}
+    SRCS
+    rmtchar_common.c
+    rmtchar_main.c)
+  if(CONFIG_EXAMPLES_RMTCHAR_TX)
+    target_sources(apps PRIVATE rmtchar_transmitter.c)
+  endif()
+  if(CONFIG_EXAMPLES_RMTCHAR_RX)
+    target_sources(apps PRIVATE rmtchar_receiver.c)
+  endif()
+endif()

--- a/examples/rmtchar/Kconfig
+++ b/examples/rmtchar/Kconfig
@@ -1,0 +1,68 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_RMTCHAR
+	tristate "RMT character driver test"
+	default n
+	depends on RMT
+	---help---
+		Enable the RMT character driver test
+
+if EXAMPLES_RMTCHAR
+
+config EXAMPLES_RMTCHAR_TX
+	bool "Use RMT transmitter"
+	default n
+	---help---
+		This should be set if the RMT device supports a transmitter.
+
+if EXAMPLES_RMTCHAR_TX
+
+config EXAMPLES_RMTCHAR_TX_DEVPATH
+	string "RMT transmitter character device path"
+	default "/dev/rmt0"
+	---help---
+		The default path to the RMT transmitter character device.
+		Default: /dev/rmt0
+
+config EXAMPLES_RMTCHAR_TXSTACKSIZE
+	int "Transmitter thread stack size"
+	default DEFAULT_TASK_STACKSIZE
+	---help---
+		This is the stack size to use when starting the transmitter thread.
+
+endif # EXAMPLES_RMTCHAR_TX
+
+config EXAMPLES_RMTCHAR_RX
+	bool "Use RMT receiver"
+	default n
+	---help---
+		This should be set if the RMT device supports a receiver.
+
+if EXAMPLES_RMTCHAR_RX
+
+config EXAMPLES_RMTCHAR_RX_DEVPATH
+		string "RMT receiver character device path"
+		default "/dev/rmt1"
+		---help---
+			The default path to the RMT receiver character device.
+			Default: /dev/rmt1
+
+config EXAMPLES_RMTCHAR_RXSTACKSIZE
+	int "Receiver thread stack size"
+	default DEFAULT_TASK_STACKSIZE
+	---help---
+		This is the stack size to use when starting the receiver thread.
+
+endif # EXAMPLES_RMTCHAR_RX
+
+config EXAMPLES_RMTCHAR_ITEMS
+	int "Number of words to transmit or receive"
+	default 64
+	---help---
+		This is the total amount of words to be transmitted or
+		received by the RMT RX device.
+
+endif

--- a/examples/rmtchar/Make.defs
+++ b/examples/rmtchar/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/rmtchar/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_RMTCHAR),)
+CONFIGURED_APPS += $(APPDIR)/examples/rmtchar
+endif

--- a/examples/rmtchar/Makefile
+++ b/examples/rmtchar/Makefile
@@ -1,0 +1,41 @@
+############################################################################
+# apps/examples/rmtchar/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# rmt character driver test
+
+ifeq ($(CONFIG_EXAMPLES_RMTCHAR_TX),y)
+CSRCS += rmtchar_transmitter.c
+endif
+ifeq ($(CONFIG_EXAMPLES_RMTCHAR_RX),y)
+CSRCS += rmtchar_receiver.c
+endif
+CSRCS += rmtchar_common.c
+MAINSRC = rmtchar_main.c
+
+# Touchscreen built-in application info
+
+PROGNAME = rmtchar
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_RMTCHAR)
+
+include $(APPDIR)/Application.mk

--- a/examples/rmtchar/rmtchar.h
+++ b/examples/rmtchar/rmtchar.h
@@ -1,0 +1,127 @@
+/****************************************************************************
+ * apps/examples/rmtchar/rmtchar.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_EXAMPLES_RMTCHAR_RMTCHAR_H
+#define __APPS_EXAMPLES_RMTCHAR_RMTCHAR_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <pthread.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Configuration */
+
+#ifndef CONFIG_EXAMPLES_RMTCHAR_TX_DEVPATH
+#  define CONFIG_EXAMPLES_RMTCHAR_TX_DEVPATH "/dev/rmt0"
+#endif
+
+#ifndef CONFIG_EXAMPLES_RMTCHAR_RX_DEVPATH
+#  define CONFIG_EXAMPLES_RMTCHAR_RX_DEVPATH "/dev/rmt1"
+#endif
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct rmtchar_state_s
+{
+  bool initialized;
+  int rmtchar_items;
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+  FAR char *txdevpath;
+#endif
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+  FAR char *rxdevpath;
+#endif
+};
+
+struct rmt_item32_s
+{
+  union
+    {
+      struct
+        {
+          uint32_t duration0 : 15; /* Duration of level0 */
+          uint32_t level0 : 1;     /* Level of the first part */
+          uint32_t duration1 : 15; /* Duration of level1 */
+          uint32_t level1 : 1;     /* Level of the second part */
+        };
+      uint32_t val; /* Equivalent unsigned value for the RMT item */
+    };
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rmtchar_transmitter()
+ *
+ * Description:
+ *   This is the entry point for the transmitter thread.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+pthread_addr_t rmtchar_transmitter(pthread_addr_t arg);
+#endif
+
+/****************************************************************************
+ * Name: rmtchar_receiver()
+ *
+ * Description:
+ *   This is the entry point for the receiver thread.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+pthread_addr_t rmtchar_receiver(pthread_addr_t arg);
+#endif
+
+/****************************************************************************
+ * Name: print_items
+ *
+ * Description:
+ *   This function prints the level and duration of RMT items stored in a
+ *   buffer. It iterates over the buffer, printing the level and duration of
+ *   each item in a formatted manner.
+ *
+ * Input Parameters:
+ *   buf  - Pointer to the buffer containing the RMT items.
+ *   len  - The number of RMT items in the buffer.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void print_items(struct rmt_item32_s *buf, int len);
+
+#endif /* __APPS_EXAMPLES_RMTCHAR_RMTCHAR_H */

--- a/examples/rmtchar/rmtchar_common.c
+++ b/examples/rmtchar/rmtchar_common.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * apps/examples/rmtchar/rmtchar_common.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+
+#include "rmtchar.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: print_items
+ *
+ * Description:
+ *   This function prints the level and duration of RMT items stored in a
+ *   buffer. It iterates over the buffer, printing the level and duration of
+ *   each item in a formatted manner.
+ *
+ * Input Parameters:
+ *   buf  - Pointer to the buffer containing the RMT items.
+ *   len  - The number of RMT items in the buffer.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void print_items(struct rmt_item32_s *buf, int len)
+{
+  int i;
+
+  for (i = 0; i < len; i++, buf++)
+    {
+      printf("\t[%d]:\tL %d\tD %d\t", i, buf->level0, buf->duration0);
+      printf("L %d\t D %d\n", buf->level1, buf->duration1);
+    }
+}

--- a/examples/rmtchar/rmtchar_main.c
+++ b/examples/rmtchar/rmtchar_main.c
@@ -1,0 +1,360 @@
+/****************************************************************************
+ * apps/examples/rmtchar/rmtchar_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <errno.h>
+#include <debug.h>
+
+#include "rmtchar.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if !defined(CONFIG_EXAMPLES_RMTCHAR_RX) && \
+    !defined(CONFIG_EXAMPLES_RMTCHAR_TX)
+#  error "At least one of CONFIG_EXAMPLES_RMTCHAR_RX or \
+          CONFIG_EXAMPLES_RMTCHAR_TX must be defined"
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct rmtchar_state_s g_rmtchar;
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rmtchar_devpath
+ ****************************************************************************/
+
+static void rmtchar_devpath(FAR struct rmtchar_state_s *rmtchar,
+                            FAR const char *devpath,
+                            bool is_tx)
+{
+  /* Get rid of any old device path */
+
+  if (is_tx)
+    {
+      if (rmtchar->txdevpath)
+        {
+          free(rmtchar->txdevpath);
+        }
+
+      /* Then set-up the new device path by copying the string */
+
+      rmtchar->txdevpath = strdup(devpath);
+    }
+  else
+    {
+      if (rmtchar->rxdevpath)
+        {
+          free(rmtchar->rxdevpath);
+        }
+
+      /* Then set-up the new device path by copying the string */
+
+      rmtchar->rxdevpath = strdup(devpath);
+    }
+}
+
+/****************************************************************************
+ * Name: rmtchar_help
+ ****************************************************************************/
+
+static void rmtchar_help(FAR struct rmtchar_state_s *rmtchar)
+{
+  printf("Usage: rmtchar [OPTIONS]\n");
+  printf("\nArguments are \"sticky\".\n");
+  printf("For example, once the RMT character device is\n");
+  printf("specified, that device will be re-used until it is changed.\n");
+  printf("\n\"sticky\" OPTIONS include:\n");
+  printf("  [-i items] selects the number of words (items) to be transmitted"
+         " or received by the RMT character device. "
+         "Default: %d Current: %d\n",
+         CONFIG_EXAMPLES_RMTCHAR_ITEMS,
+         rmtchar->rmtchar_items ? rmtchar->rmtchar_items :
+         CONFIG_EXAMPLES_RMTCHAR_ITEMS);
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+  printf("  [-t devpath] selects the RMT transmitter character device path. "
+         "Default: %s Current: %s\n",
+         CONFIG_EXAMPLES_RMTCHAR_TX_DEVPATH,
+         rmtchar->txdevpath ? rmtchar->txdevpath : "NONE");
+#endif
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+  printf("  [-r devpath] selects the RMT receiver character device path. "
+         "Default: %s Current: %s\n",
+         CONFIG_EXAMPLES_RMTCHAR_RX_DEVPATH,
+         rmtchar->rxdevpath ? rmtchar->rxdevpath : "NONE");
+#endif
+  printf("  [-h] shows this message and exits\n");
+}
+
+/****************************************************************************
+ * Name: arg_string
+ ****************************************************************************/
+
+static int arg_string(FAR char **arg, FAR char **value)
+{
+  FAR char *ptr = *arg;
+
+  if (ptr[2] == '\0')
+    {
+      *value = arg[1];
+      return 2;
+    }
+  else
+    {
+      *value = &ptr[2];
+      return 1;
+    }
+}
+
+/****************************************************************************
+ * Name: arg_decimal
+ ****************************************************************************/
+
+static int arg_decimal(FAR char **arg, FAR int *value)
+{
+  FAR char *string;
+  int ret;
+
+  ret = arg_string(arg, &string);
+  *value = strtol(string, NULL, 10);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: parse_args
+ ****************************************************************************/
+
+static void parse_args(FAR struct rmtchar_state_s *rmtchar,
+                       int argc,
+                       FAR char **argv)
+{
+  FAR char *ptr;
+  FAR char *str;
+  int value;
+  int index;
+  int nargs;
+
+  for (index = 1; index < argc; )
+    {
+      ptr = argv[index];
+      if (ptr[0] != '-')
+        {
+          printf("Invalid options format: %s\n", ptr);
+          exit(0);
+        }
+
+      switch (ptr[1])
+        {
+          case 'i':
+            nargs = arg_decimal(&argv[index], &value);
+            if (value < 0)
+              {
+                printf("Count must be non-negative: %d\n", value);
+                exit(1);
+              }
+
+            rmtchar->rmtchar_items = value;
+            index += nargs;
+            break;
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+          case 't':
+            nargs = arg_string(&argv[index], &str);
+            rmtchar_devpath(rmtchar, str, true);
+            index += nargs;
+            break;
+#endif
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+          case 'r':
+            nargs = arg_string(&argv[index], &str);
+            rmtchar_devpath(rmtchar, str, false);
+            index += nargs;
+            break;
+#endif
+          case 'h':
+            rmtchar_help(rmtchar);
+            exit(0);
+
+          default:
+            printf("Unsupported option: %s\n", ptr);
+            rmtchar_help(rmtchar);
+            exit(1);
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rmtchar_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  pthread_attr_t attr;
+  pthread_addr_t result;
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+  pthread_t transmitter;
+#endif
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+  pthread_t receiver;
+#endif
+#if defined(CONFIG_EXAMPLES_RMTCHAR_RX) && defined(CONFIG_EXAMPLES_RMTCHAR_TX)
+  struct sched_param param;
+#endif
+  int ret;
+
+  UNUSED(ret);
+
+  /* Check if we have initialized */
+
+  if (!g_rmtchar.initialized)
+    {
+      /* Set the default values */
+
+      g_rmtchar.rmtchar_items = CONFIG_EXAMPLES_RMTCHAR_ITEMS;
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+      rmtchar_devpath(&g_rmtchar, CONFIG_EXAMPLES_RMTCHAR_TX_DEVPATH, true);
+#endif
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+      rmtchar_devpath(&g_rmtchar, CONFIG_EXAMPLES_RMTCHAR_RX_DEVPATH, false);
+#endif
+
+      g_rmtchar.initialized = true;
+    }
+
+  /* Parse the command line */
+
+  parse_args(&g_rmtchar, argc, argv);
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+  /* Start the receiver thread */
+
+  printf("rmtchar_main: Start receiver thread\n");
+  pthread_attr_init(&attr);
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+  /* Bump the receiver priority from the default so that it will be above
+   * the priority of transmitter.  This is important if a loopback test is
+   * being performed.
+   */
+
+  pthread_attr_getschedparam(&attr, &param);
+  param.sched_priority++;
+  pthread_attr_setschedparam(&attr, &param);
+#endif
+
+  /* Set the receiver stack size */
+
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_RMTCHAR_RXSTACKSIZE);
+
+  /* Start the receiver */
+
+  ret = pthread_create(&receiver, &attr, rmtchar_receiver, &g_rmtchar);
+  if (ret != OK)
+    {
+      printf("rmtchar_main: ERROR: failed to Start receiver thread: %d\n",
+             ret);
+      return EXIT_FAILURE;
+    }
+
+  pthread_setname_np(receiver, "receiver");
+#endif
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+  /* Start the transmitter thread */
+
+  printf("rmtchar_main: Start transmitter thread\n");
+  pthread_attr_init(&attr);
+
+  /* Set the transmitter stack size */
+
+  pthread_attr_setstacksize(&attr, CONFIG_EXAMPLES_RMTCHAR_TXSTACKSIZE);
+
+  /* Start the transmitter */
+
+  ret = pthread_create(&transmitter, &attr, rmtchar_transmitter, &g_rmtchar);
+  if (ret != OK)
+    {
+      printf("rmtchar_main: ERROR: failed to Start transmitter thread: %d\n",
+             ret);
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+      printf("rmtchar_main: Waiting for the receiver thread\n");
+      pthread_join(receiver, &result);
+#endif
+      return EXIT_FAILURE;
+    }
+
+  pthread_setname_np(transmitter, "transmitter");
+#endif
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+  printf("rmtchar_main: Waiting for the transmitter thread\n");
+  ret = pthread_join(transmitter, &result);
+  if (ret != OK)
+    {
+      printf("rmtchar_main: ERROR: pthread_join failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+  printf("rmtchar_main: Waiting for the receiver thread\n");
+  ret = pthread_join(receiver, &result);
+  if (ret != OK)
+    {
+      printf("rmtchar_main: ERROR: pthread_join failed: %d\n", ret);
+    }
+#endif
+
+  return EXIT_SUCCESS;
+}

--- a/examples/rmtchar/rmtchar_receiver.c
+++ b/examples/rmtchar/rmtchar_receiver.c
@@ -1,0 +1,138 @@
+/****************************************************************************
+ * apps/examples/rmtchar/rmtchar_receiver.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+
+#include "rmtchar.h"
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_RX
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rmtchar_receiver()
+ *
+ * Description:
+ *   This is the entry point for the receiver thread.
+ *
+ ****************************************************************************/
+
+pthread_addr_t rmtchar_receiver(pthread_addr_t arg)
+{
+  FAR struct rmtchar_state_s *rmtchar = (FAR struct rmtchar_state_s *)arg;
+  struct rmt_item32_s buf[rmtchar->rmtchar_items];
+  int nread;
+  int fd;
+
+  /* Open the RMT character device */
+
+  fd = open(rmtchar->rxdevpath, O_RDONLY);
+  if (fd < 0)
+    {
+      int errcode = errno;
+      printf("rmtchar_receiver: ERROR: failed to open %s: %d\n",
+              rmtchar->rxdevpath, errcode);
+      pthread_exit(NULL);
+    }
+
+  /* Flush any output before reading */
+
+  fflush(stdout);
+
+  /* Read the buffer to the RMT character driver */
+
+  nread = read(fd, (char *)buf, rmtchar->rmtchar_items *
+               sizeof(struct rmt_item32_s));
+  if (nread < 0)
+    {
+      int errcode = errno;
+      if (errcode != EINTR)
+        {
+          printf("rmtchar_receiver: ERROR: read failed: %d\n",
+                  errcode);
+          close(fd);
+          pthread_exit(NULL);
+        }
+    }
+  else
+    {
+      if (nread != (rmtchar->rmtchar_items * sizeof(struct rmt_item32_s)))
+        {
+          printf("rmtchar_receiver: ERROR: partial read: %d\n",
+                  nread);
+          printf("rmtchar_receiver: Received buffer:\n");
+          print_items(buf, nread / sizeof(struct rmt_item32_s));
+          close(fd);
+          pthread_exit(NULL);
+        }
+      else
+        {
+          printf("rmtchar_receiver: Received buffer:\n");
+          print_items(buf, nread / sizeof(struct rmt_item32_s));
+        }
+    }
+
+  /* Make sure that the transmitter thread has a chance to run */
+
+  pthread_yield();
+
+  close(fd);
+  return NULL;
+}
+
+#endif /* CONFIG_EXAMPLES_RMTCHAR_RX */

--- a/examples/rmtchar/rmtchar_transmitter.c
+++ b/examples/rmtchar/rmtchar_transmitter.c
@@ -1,0 +1,156 @@
+/****************************************************************************
+ * apps/examples/rmtchar/rmtchar_transmitter.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <errno.h>
+#include <debug.h>
+#include <unistd.h>
+
+#include <nuttx/audio/audio.h>
+
+#include "rmtchar.h"
+
+#ifdef CONFIG_EXAMPLES_RMTCHAR_TX
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rmtchar_transmitter()
+ *
+ * Description:
+ *   This is the entry point for the transmitter thread.
+ *
+ ****************************************************************************/
+
+pthread_addr_t rmtchar_transmitter(pthread_addr_t arg)
+{
+  FAR struct rmtchar_state_s *rmtchar = (FAR struct rmtchar_state_s *)arg;
+  struct rmt_item32_s buf[rmtchar->rmtchar_items];
+  int duration = 100;
+  int nwritten;
+  int fd;
+  int i;
+
+  /* Open the RMT character device */
+
+  fd = open(rmtchar->txdevpath, O_WRONLY);
+  if (fd < 0)
+    {
+      int errcode = errno;
+      printf("rmtchar_transmitter: ERROR: failed to open %s: %d\n",
+              rmtchar->txdevpath, errcode);
+      pthread_exit(NULL);
+    }
+
+  /* Fill the transmitter buffer with known items */
+
+  for (i = 0; i < rmtchar->rmtchar_items; i++)
+    {
+      buf[i].level0 = 1;
+      buf[i].duration0 = duration;
+      buf[i].level1 = 0;
+      buf[i].duration1 = duration;
+
+      duration += 10;
+    }
+
+  /* Flush any output before writing */
+
+  fflush(stdout);
+
+  /* Print the buffer to be sent */
+
+  print_items(buf, rmtchar->rmtchar_items);
+
+  /* Then send the buffer */
+
+  /* Write the buffer to the RMT character driver */
+
+  nwritten = write(fd, (char *)buf, rmtchar->rmtchar_items *
+                   sizeof(struct rmt_item32_s));
+  if (nwritten < 0)
+    {
+      int errcode = errno;
+      if (errcode != EINTR)
+        {
+          printf("rmtchar_transmitter: ERROR: write failed: %d\n",
+                  errcode);
+          close(fd);
+          pthread_exit(NULL);
+        }
+    }
+  else if (nwritten != (rmtchar->rmtchar_items *
+                        sizeof(struct rmt_item32_s)))
+    {
+      printf("rmtchar_transmitter: ERROR: partial write: %d\n",
+              nwritten);
+      close(fd);
+      pthread_exit(NULL);
+    }
+  else
+    {
+      printf("rmtchar_transmitter: Send buffer with %d bytes\n",
+             rmtchar->rmtchar_items * sizeof(struct rmt_item32_s));
+    }
+
+  /* Make sure that the receiver thread has a chance to run */
+
+  pthread_yield();
+
+  close(fd);
+  return NULL;
+}
+
+#endif /* CONFIG_EXAMPLES_RMTCHAR_TX */


### PR DESCRIPTION
## Summary

* examples/rmtchar: Implement RX and/or TX using the RMT char driver

The RMT (remote control) character driver is used to send and/or receive data packets. Eventually, this app can be used to perform a loopback test to validate the RMT driver implementation.

## Impact

Enable testing the RMT character driver.

## Testing

Internal CI testing + ESP32-S2-Saola-1 and ESP32-S3-DevKitC-1 with the new RMT driver (to be sent upstream).
