### PR TITLE
fsutils: passwd: Fix wrong macro

### DIFF
--- a/include/fsutils/passwd.h
+++ b/include/fsutils/passwd.h
@@ -59,7 +59,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_FSUTILS_PASSWD_READONLY)
+#if !defined(CONFIG_FSUTILS_PASSWD_READONLY)
 int passwd_adduser(FAR const char *username, FAR const char *password);
 
 /****************************************************************************


### PR DESCRIPTION
```passwd_update/adduser/deluser```  should be enabled
if ```CONFIG_FSUTILS_PASSWD_READONLY``` is not defined.
