### PR TITLE
apps: Select PIPES when enabling system popen

### DIFF
--- a/system/popen/Kconfig
+++ b/system/popen/Kconfig
@@ -7,7 +7,8 @@ config SYSTEM_POPEN
 	bool "popen()/pclose() Functions"
 	default n
 	select SCHED_WAITPID
-	depends on NSH_LIBRARY && PIPES
+	select PIPES
+	depends on NSH_LIBRARY
 	---help---
 		Enable support for the popen() and pclose() interfaces.
 		This will support execution of NSH commands from C code with


### PR DESCRIPTION
## Summary
Select PIPES when enabling system popen we explained here: https://github.com/apache/nuttx/issues/11435
## Impact
Users will be able to get popen working correctly
## Testing
Build
