### PR TITLE
interpreters/wamr: add INTERPRETERS_WAMR_DEBUG_AOT option

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -51,6 +51,11 @@ config INTERPRETERS_NONE
 
 endchoice # Enable interpreter
 
+config INTERPRETERS_WAMR_DEBUG_AOT
+	bool "Enable debugger support for AOT modules"
+	default n
+	depends on INTERPRETERS_WAMR_AOT
+
 config INTERPRETERS_WAMR_DEBUG_INTERP
 	bool "Enable debugger support in the interpreter"
 	default n


### PR DESCRIPTION
## Summary

At least it's sometimes useful for nuttx sim.

eg. (modified a bit to avoid github autolinks)
```
spacetanuki% lldb ./nuttx
(lldb) target create "./nuttx"
Current executable set to '/Users/yamamoto/git/nuttx/nuttx/nuttx' (x86_64).
(lldb) settings set plugin.jit-loader.gdb.enable on
(lldb) b foo
Breakpoint 1: no locations (pending).
WARNING:  Unable to resolve breakpoint to any actual locations.
(lldb) r
Process 37011 launched: '/Users/yamamoto/git/nuttx/nuttx/nuttx' (x86_64)

NuttShell (NSH) NuttX-10.4.0
nsh> mount -t hostfs -o fs=/tmp/wasm /mnt
nsh> iwasm /mnt/test.aot
1 location added to breakpoint 1
Process 37011 stopped
* thread #_1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #_0: 0x0000000105800673 JIT(0x1058002d4)`foo(exenv=0x0000000101284280) at test.c:5
   2
   3    __attribute__((noinline))
   4    void foo()
-> 5    {
   6        printf("hello from %s\n", __func__);
   7    }
   8
Target 0: (nuttx) stopped.
(lldb) bt
* thread #_1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #_0: 0x0000000105800673 JIT(0x1058002d4)`foo(exenv=0x0000000101284280) at test.c:5
    frame #_1: 0x000000010580077a JIT(0x1058002d4)`bar(exenv=0x0000000101284280) at test.c:12:2
    frame #_2: 0x000000010580086a JIT(0x1058002d4)`baz(exenv=0x0000000101284280) at test.c:19:2
    frame #_3: 0x0000000105800972 JIT(0x1058002d4)`__main_argc_argv(exenv=<unavailable>, argc=<unavailable>, argv=<unavailable>) at test.c:26:3
    frame #_4: 0x00000001058061aa JIT(0x1058002d4)`aot_func#14 + 278
    frame #_5: 0x00000001058005cd JIT(0x1058002d4)`aot_func#2 + 153
    frame #_6: 0x00000001000e250f nuttx`push_args_end at invokeNative_em64.s:61
    frame #_7: 0x000000010013851a nuttx`wasm_runtime_invoke_native(exec_env=0x0000000101284280, func_ptr=0x0000000105800534, func_type=0x00000001011e2e20, signature=0x0000000000000000, attachment=0x0000000000000000, argv=0x0000000000000000, argc=0, argv_ret=0x0000000000000000) at wasm_runtime_common.c:4631:9
    frame #_8: 0x00000001000da1ae nuttx`aot_call_function(exec_env=0x0000000101284280, function=0x00000001011e1fb0, argc=0, argv=0x0000000000000000) at aot_runtime.c:1654:15
    frame #_9: 0x0000000100134b56 nuttx`wasm_runtime_call_wasm(exec_env=0x0000000101284280, function=0x00000001011e1fb0, argc=0, argv=0x0000000000000000) at wasm_runtime_common.c:2048:15
    frame #_10: 0x00000001000fbad4 nuttx`execute_main(module_inst=0x00000001011e3890, argc=1, argv=0x00000001011b63f8) at wasm_application.c:112:15
    frame #_11: 0x00000001000fb995 nuttx`wasm_application_execute_main(module_inst=0x00000001011e3890, argc=1, argv=0x00000001011b63f8) at wasm_application.c:238:11
    frame #_12: 0x00000001000ea1a0 nuttx`app_instance_main(module_inst=0x00000001011e3890) at main.c:113:5
    frame #_13: 0x00000001000e9d60 nuttx`iwasm_main(argc=1, argv=0x00000001011b63f8) at main.c:947:21
    frame #_14: 0x0000000100023275 nuttx`nxtask_startup(entrypt=(nuttx`iwasm_main at main.c:545), argc=2, argv=0x00000001011b63f0) at task_startup.c:70:8
    frame #_15: 0x000000010001065a nuttx`nxtask_start at task_start.c:134:7
    frame #_16: 0x000000010003a15f nuttx`pre_start at sim_initialstate.c:52:3
(lldb)

```

## Impact

## Testing
tested on sim/macos.
