### PR TITLE
optional argument for generated ROMFS file path.

### DIFF
--- a/tools/mkromfsimg.sh
+++ b/tools/mkromfsimg.sh
@@ -36,6 +36,12 @@ fsdir=${topdir}/bin
 romfsimg=romfs.img
 headerfile=boot_romfsimg.h
 
+if [ -n "$1" ]; then            # output file path
+  _path=$(dirname "$1")
+  # ensure output path exists
+  mkdir -p $_path 2>/dev/null && headerfile=$1
+fi
+
 # Sanity checks
 
 if [ ! -d "${fsdir}" ]; then


### PR DESCRIPTION

## Summary

This adds one optional position argument for generated ROMFS file path.
The existing headerfile path is used when the argument is missing, falling back to existing behavior.

## Impact

No impacts to exsiting users.

## Testing

checked on Ubuntu Jammy host.