### PR TITLE
examples/hello_nim: Fix nimcache location

### DIFF
--- a/examples/hello_nim/Makefile
+++ b/examples/hello_nim/Makefile
@@ -30,8 +30,8 @@ MODULE    = $(CONFIG_EXAMPLES_HELLO_NIM)
 # Hello, World! Example
 
 NIMPATH = $(shell choosenim show path)
-CFLAGS += -I $(NIMPATH)/lib -I ./.nimcache
-CSRCS += $(wildcard .nimcache/*.c)
+CFLAGS += -I $(NIMPATH)/lib -I ../../.nimcache
+CSRCS += $(wildcard ../../.nimcache/*.c)
 
 MAINSRC = hello_nim_main.c
 


### PR DESCRIPTION
## Summary

The Nim Example App fails to build because the `.nimcache` is located 2 folders up. This PR fixes the location of `.nimcache` in the `Makefile` of the Nim Example App.

`.nimcache` is explained in [this article](https://lupyuen.github.io/articles/nim#inside-nim-on-nuttx).

## Impact

Nim Example App builds and runs correctly after fixing the `.nimcache` location.

No impact on other apps, since the `Makefile` is used only by the Nim Example App.

## Testing

We tested on QEMU Arm64:

```bash
$ tools/configure.sh -l qemu-armv8a:nsh
## TODO: Init networking: https://github.com/lupyuen2/wip-pinephone-nuttx/commit/77b8295eb761954370481ed113254b7e930f65c0
## TODO: Suppress warnings: https://github.com/lupyuen2/wip-pinephone-nuttx/commit/e82be7d1f9f662ef369a3c4adc8290a4035f9857

$ make menuconfig
## Enable "Application Configuration > Examples > Hello World Example (Nim)"
## Networking support: Enable "Networking support"
## Networking Support → SocketCAN Support:
##   Enable "SocketCAN Support"
##   Enable "sockopt support"
## RTOS Features → Tasks and Scheduling:
##   Enable "Support parent/child task relationships"
##   Enable "Retain child exit status"

$ make
```

### Before Fixing

NuttX Build fails because `.nimcache/hello_nim_async.h` could not be found:

```text
./hello_nim_main.c:26:10: fatal error: hello_nim_async.h: No such file or directory
   26 | #include "hello_nim_async.h"
```

[(See the Build Log)](https://gist.github.com/lupyuen/b13a7b36a404c94180aaa501d5a88700)

### After Fixing

NuttX Build succeeds and Nim Example App runs correctly. Note that we need to [suppress the warnings](https://github.com/lupyuen2/wip-pinephone-nuttx/commit/e82be7d1f9f662ef369a3c4adc8290a4035f9857) and [initialise the network](https://github.com/lupyuen2/wip-pinephone-nuttx/commit/77b8295eb761954370481ed113254b7e930f65c0). We might need to fix these in a future PR.

```text
$ qemu-system-aarch64 \
  -cpu cortex-a53 \
  -nographic \
  -machine virt,virtualization=on,gic-version=3 \
  -net none \
  -chardev stdio,id=con,mux=on \
  -serial chardev:con \
  -mon chardev=con,mode=readline \
  -kernel nuttx

NuttShell (NSH) NuttX-12.0.3
nsh> uname -a
NuttX  12.0.3 77b8295eb76 Jan  2 2024 04:53:17 arm64 qemu-armv8a

nsh> hello_nim
task_spawn: name=hello_nim entry=0x402a4f4c file_actions=0x403ede48 attr=0x403ede50 argv=0x403edf90
spawn_execattrs: Setting policy=2 priority=100 for pid=3
pthread_mutex_init: mutex=0x403e4918 attr=0
pthread_mutex_init: Returning 0
Hello from task 1! loops: 0
pthread_mutex_timedlock: mutex=0x403e4918
pthread_mutex_timedlock: Returning 0
pthread_mutex_unlock: mutex=0x403e4918
pthread_mutex_unlock: Returning 0
Hello from task 2! loops: 0
Hello from task 3! loops: 0
Hello from task 1! loops: 1
Hello from task 2! loops: 1
Hello from task 3! loops: 1
Hello from task 1! loops: 2
Hello from task 2! loops: 2
Hello from task 3! loops: 2
nxsig_tcbdispatch: TCB=0x403ebd40 pid=2 signo=17 code=5 value=0 masked=NO
nsh> 
```

[(See the NuttX Log)](https://gist.github.com/lupyuen/dc10bbb329a33020cef789fa9a20c4c8)
