### PR TITLE
add const for romfs_img_len

### DIFF
--- a/tools/mkromfsimg.sh
+++ b/tools/mkromfsimg.sh
@@ -57,11 +57,13 @@ genromfs -h 1>/dev/null 2>&1 || { \
 
 # Now we are ready to make the ROMFS image
 
-genromfs -f ${romfsimg} -d ${fsdir} -V "NuttXBootVol" || { echo "genromfs failed" ; exit 1 ; }
+genromfs -f ${romfsimg} -d ${fsdir} -V "NuttXBootVol" || \
+  { echo "genromfs failed" ; exit 1 ; }
 
 # And, finally, create the header file
 
 echo '#include <nuttx/compiler.h>' >${headerfile}
-xxd -i ${romfsimg} | sed 's/^unsigned char/const unsigned char aligned_data(4)/g' >>${headerfile} || \
+xxd -i ${romfsimg} | sed -e 's/^unsigned /const unsigned /' \
+  -e 's/char /char aligned_data(4) /' >>${headerfile} || \
   { echo "ERROR: xxd of $< failed" ; rm -f ${romfsimg}; exit 1 ; }
 rm -f ${romfsimg}


### PR DESCRIPTION
## Summary

currently `romfs_img_len` is not defined with `const`, but `romfs_img` is.
this PR adds `const` to back `romfs_img_len` so that both are read-only as they are corelated. 
they both were read-only before commit# 2498be1f4083c199d33755f24758d76cd95f9d0f

## Impact

ROMFS usages

## Testing

checked with canmv230/knsh


