### PR TITLE
libcoap: add makefile, Kconfig and CMakeLists.txt

### DIFF
--- a/netutils/libcoap/.gitignore
+++ b/netutils/libcoap/.gitignore
@@ -1,0 +1,1 @@
+/libcoap*

--- a/netutils/libcoap/CMakeLists.txt
+++ b/netutils/libcoap/CMakeLists.txt
@@ -1,0 +1,130 @@
+# ##############################################################################
+# apps/netutils/libcoap/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_LIBCOAP)
+  set(LIBCOAP_DIR ${CMAKE_CURRENT_LIST_DIR}/libcoap)
+
+  if(NOT EXISTS ${LIBCOAP_DIR})
+    set(LIBCOAP_URL https://codeload.github.com/obgm/libcoap/zip/refs/tags)
+    set(LIBCOAP_VERSION ${CONFIG_LIBCOAP_VERSION})
+    FetchContent_Declare(
+      libcoap_fetch
+      URL ${LIBCOAP_URL}/v${LIBCOAP_VERSION} SOURCE_DIR ${LIBCOAP_DIR}
+          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/netutils/libcoap
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(libcoap_fetch)
+
+    if(NOT libcoap_fetch_POPULATED)
+      FetchContent_Populate(libcoap_fetch)
+    endif()
+  endif()
+
+  set(LIBCOAP_FLAGS -Wno-undef)
+  set(LIBCOAP_INCDIR ${CMAKE_CURRENT_LIST_DIR} ${LIBCOAP_DIR}/include
+                     ${NUTTX_APPS_DIR}/crypto/mbedtls/mbedtls/include)
+
+  target_include_directories(apps PUBLIC ${LIBCOAP_INCDIR})
+  target_compile_options(apps PRIVATE ${LIBCOAP_FLAGS})
+  target_sources(
+    apps
+    PRIVATE libcoap/src/coap_address.c
+            libcoap/src/coap_asn1.c
+            libcoap/src/coap_async.c
+            libcoap/src/coap_block.c
+            libcoap/src/coap_cache.c
+            libcoap/src/coap_debug.c
+            libcoap/src/coap_dtls.c
+            libcoap/src/coap_encode.c
+            libcoap/src/coap_event.c
+            libcoap/src/coap_hashkey.c
+            libcoap/src/coap_gnutls.c
+            libcoap/src/coap_io.c
+            libcoap/src/coap_layers.c
+            libcoap/src/coap_mbedtls.c
+            libcoap/src/coap_mem.c
+            libcoap/src/coap_net.c
+            libcoap/src/coap_netif.c
+            libcoap/src/coap_notls.c
+            libcoap/src/coap_openssl.c
+            libcoap/src/coap_option.c
+            libcoap/src/coap_oscore.c
+            libcoap/src/coap_pdu.c
+            libcoap/src/coap_prng.c
+            libcoap/src/coap_resource.c
+            libcoap/src/coap_session.c
+            libcoap/src/coap_str.c
+            libcoap/src/coap_subscribe.c
+            libcoap/src/coap_tcp.c
+            libcoap/src/coap_time.c
+            libcoap/src/coap_tinydtls.c
+            libcoap/src/coap_uri.c
+            libcoap/src/coap_ws.c
+            libcoap/src/oscore/oscore.c
+            libcoap/src/oscore/oscore_cbor.c
+            libcoap/src/oscore/oscore_context.c
+            libcoap/src/oscore/oscore_cose.c
+            libcoap/src/oscore/oscore_crypto.c)
+
+  set(LIBCOAP_API_VERSION 3)
+  set(LIBCOAP_PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net")
+  set(LIBCOAP_PACKAGE_NAME "libcoap")
+  set(LIBCOAP_PACKAGE_VERSION "${CONFIG_LIBCOAP_VERSION}")
+  set(LIBCOAP_PACKAGE_STRING
+      "${LIBCOAP_PACKAGE_NAME} ${LIBCOAP_PACKAGE_VERSION}")
+  set(LIBCOAP_PACKAGE_URL "https://libcoap.net/")
+  configure_file(${LIBCOAP_DIR}/include/coap3/coap.h.in
+                 ${LIBCOAP_DIR}/include/coap3/coap.h)
+
+  if(CONFIG_NETUTILS_LIBCOAP_EXAMPLE)
+    nuttx_add_application(
+      NAME
+      coap_server
+      SRCS
+      libcoap/examples/coap-server.c
+      INCLUDE_DIRECTORIES
+      ${LIBCOAP_INCDIR}
+      COMPILE_FLAGS
+      ${LIBCOAP_FLAGS}
+      DEPENDS
+      mbedtls
+      STACKSIZE
+      ${CONFIG_NETUTILS_LIBCOAP_EXAMPLE_STACKSIZE}
+      PRIORITY
+      ${CONFIG_NETUTILS_LIBCOAP_EXAMPLE_PRIORITY})
+
+    nuttx_add_application(
+      NAME
+      coap_client
+      SRCS
+      libcoap/examples/coap-client.c
+      INCLUDE_DIRECTORIES
+      ${LIBCOAP_INCDIR}
+      COMPILE_FLAGS
+      ${LIBCOAP_FLAGS}
+      DEPENDS
+      mbedtls
+      STACKSIZE
+      ${CONFIG_NETUTILS_LIBCOAP_EXAMPLE_STACKSIZE}
+      PRIORITY
+      ${CONFIG_NETUTILS_LIBCOAP_EXAMPLE_PRIORITY})
+  endif()
+endif()

--- a/netutils/libcoap/Kconfig
+++ b/netutils/libcoap/Kconfig
@@ -1,0 +1,37 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NETUTILS_LIBCOAP
+	bool "LIBCOAP"
+	default n
+	---help---
+		libcoap is a C implementation of a lightweight application-protocol
+		for devices that are constrained their resources such as computing
+		power, RF range, memory, bandwidth, or network packet sizes. This
+		protocol, CoAP, is standardized by the IETF as RFC 7252.
+
+if NETUTILS_LIBCOAP
+
+config LIBCOAP_VERSION
+	string "libcoap version"
+	default "4.3.4"
+
+config NETUTILS_LIBCOAP_EXAMPLE
+	tristate "Example coap-server and coap-client"
+	default n
+
+if NETUTILS_LIBCOAP_EXAMPLE
+
+config NETUTILS_LIBCOAP_EXAMPLE_PRIORITY
+	int "libcoap example priority"
+	default 100
+
+config NETUTILS_LIBCOAP_EXAMPLE_STACKSIZE
+	int "libcoap example stacksize"
+	default 2048
+
+endif # NETUTILS_LIBCOAP_EXAMPLE
+
+endif # NETUTILS_LIBCOAP

--- a/netutils/libcoap/Make.defs
+++ b/netutils/libcoap/Make.defs
@@ -1,0 +1,24 @@
+############################################################################
+# apps/netutils/libcoap/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_NETUTILS_LIBCOAP),)
+CONFIGURED_APPS += $(APPDIR)/netutils/libcoap
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)$(DELIM)netutils$(DELIM)libcoap$(DELIM)libcoap$(DELIM)include
+endif

--- a/netutils/libcoap/Makefile
+++ b/netutils/libcoap/Makefile
@@ -1,0 +1,105 @@
+############################################################################
+# apps/netutils/libcoap/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+COAP_URL ?= "https://codeload.github.com/obgm/libcoap/zip/refs/tags"
+
+COAP_ZIP = libcoap-$(CONFIG_LIBCOAP_VERSION).zip
+
+COAP_UNPACKNAME = libcoap
+UNPACK ?= unzip -q -o
+
+$(COAP_ZIP):
+	@echo "Downloading: $(COAP_URL)/v$(CONFIG_LIBCOAP_VERSION)"
+	$(Q) curl -o $(COAP_ZIP) -L $(COAP_URL)/v$(CONFIG_LIBCOAP_VERSION)
+
+$(COAP_UNPACKNAME): $(COAP_ZIP)
+	@echo "Unpacking: $(COAP_ZIP) -> $(COAP_UNPACKNAME)"
+	$(Q) $(UNPACK) $(COAP_ZIP)
+	@echo "Unpacking: $(COAP_ZIP) -> $(COAP_UNPACKNAME)"
+	$(Q) mv libcoap-$(CONFIG_LIBCOAP_VERSION) $(COAP_UNPACKNAME)
+	$(Q) touch $(COAP_UNPACKNAME)
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(COAP_UNPACKNAME)/.git),)
+context:: $(COAP_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(COAP_UNPACKNAME))
+	$(call DELFILE, $(COAP_ZIP))
+endif
+
+context:: $(COAP_UNPACKNAME)/include/coap3/coap.h
+
+$(COAP_UNPACKNAME)/include/coap3/coap.h:: $(COAP_UNPACKNAME)
+	cd $(COAP_UNPACKNAME) && ./autogen.sh && \
+	./configure --disable-doxygen --disable-manpages
+
+CSRCS  += libcoap/src/coap_address.c
+CSRCS  += libcoap/src/coap_asn1.c
+CSRCS  += libcoap/src/coap_async.c
+CSRCS  += libcoap/src/coap_block.c
+CSRCS  += libcoap/src/coap_cache.c
+CSRCS  += libcoap/src/coap_debug.c
+CSRCS  += libcoap/src/coap_dtls.c
+CSRCS  += libcoap/src/coap_encode.c
+CSRCS  += libcoap/src/coap_event.c
+CSRCS  += libcoap/src/coap_hashkey.c
+CSRCS  += libcoap/src/coap_gnutls.c
+CSRCS  += libcoap/src/coap_io.c
+CSRCS  += libcoap/src/coap_layers.c
+CSRCS  += libcoap/src/coap_mbedtls.c
+CSRCS  += libcoap/src/coap_mem.c
+CSRCS  += libcoap/src/coap_net.c
+CSRCS  += libcoap/src/coap_netif.c
+CSRCS  += libcoap/src/coap_notls.c
+CSRCS  += libcoap/src/coap_openssl.c
+CSRCS  += libcoap/src/coap_option.c
+CSRCS  += libcoap/src/coap_oscore.c
+CSRCS  += libcoap/src/coap_pdu.c
+CSRCS  += libcoap/src/coap_prng.c
+CSRCS  += libcoap/src/coap_resource.c
+CSRCS  += libcoap/src/coap_session.c
+CSRCS  += libcoap/src/coap_str.c
+CSRCS  += libcoap/src/coap_subscribe.c
+CSRCS  += libcoap/src/coap_tcp.c
+CSRCS  += libcoap/src/coap_time.c
+CSRCS  += libcoap/src/coap_tinydtls.c
+CSRCS  += libcoap/src/coap_uri.c
+CSRCS  += libcoap/src/coap_ws.c
+CSRCS  += libcoap/src/oscore/oscore.c
+CSRCS  += libcoap/src/oscore/oscore_cbor.c
+CSRCS  += libcoap/src/oscore/oscore_context.c
+CSRCS  += libcoap/src/oscore/oscore_cose.c
+CSRCS  += libcoap/src/oscore/oscore_crypto.c
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)$(DELIM)netutils$(DELIM)libcoap
+CFLAGS += -Wno-undef
+
+ifneq ($(CONFIG_NETUTILS_LIBCOAP_EXAMPLE),)
+PROGNAME += coap_server coap_client
+PRIORITY  = $(CONFIG_NETUTILS_LIBCOAP_EXAMPLE_PRIORITY)
+STACKSIZE = $(CONFIG_NETUTILS_LIBCOAP_EXAMPLE_STACKSIZE)
+MODULE    = $(CONFIG_NETUTILS_LIBCOAP_EXAMPLE)
+MAINSRC   = libcoap/examples/coap-server.c libcoap/examples/coap-client.c
+endif
+
+include $(APPDIR)/Application.mk

--- a/netutils/libcoap/coap_config.h
+++ b/netutils/libcoap/coap_config.h
@@ -1,0 +1,227 @@
+/****************************************************************************
+ * apps/netutils/libcoap/coap_config.h
+ *
+ * Copyright (C) 2020 Carlos Gomes Martinho
+ *                    <carlos.gomes_martinho@siemens.com>
+ * Copyright (C) 2021-2023 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ ****************************************************************************/
+
+#ifndef COAP_CONFIG_H_
+#define COAP_CONFIG_H_
+
+#if ! defined(_WIN32)
+#define _GNU_SOURCE
+#endif
+
+/* Define to 1 if you have <ws2tcpip.h> header file. */
+
+/* #undef HAVE_WS2TCPIP_H */
+
+/* Define to 1 if the system has small stack size. */
+
+/* #undef COAP_CONSTRAINED_STACK */
+
+/* Define to 1 if you have <winsock2.h> header file. */
+
+/* #undef HAVE_WINSOCK2_H */
+
+#ifdef CONFIG_LIBCOAP_EXAMPLE_CLIENT
+/* Define to 1 if the library has client support. */
+#define COAP_CLIENT_SUPPORT 1
+
+/* Define to 1 if the library has server support. */
+#define COAP_SERVER_SUPPORT 1
+#endif
+
+/* Define to 1 if the library is to have observe persistence. */
+#define COAP_WITH_OBSERVE_PERSIST 1
+
+/* Define to 1 if the system has epoll support. */
+
+/* #undef COAP_EPOLL_SUPPORT */
+
+/* Define to 1 if the library has OSCORE support. */
+#define COAP_OSCORE_SUPPORT 1
+
+/* Define to 1 if the library has WebSockets support. */
+
+/* #undef COAP_WS_SUPPORT */
+
+/* Define to 1 if the library has async separate response support. */
+#define COAP_ASYNC_SUPPORT 1
+
+/* Define to 0-8 for maximum logging level. */
+
+/* #undef COAP_MAX_LOGGING_LEVEL */
+
+/* Define to 1 to build without TCP support. */
+#define COAP_DISABLE_TCP 0
+
+#ifdef CONFIG_NET_IPv4
+/* Define to 1 to build with IPv4 support. */
+#define COAP_IPV4_SUPPORT 1
+#endif
+
+#ifdef CONFIG_NET_IPv6
+/* Define to 1 to build with IPv6 support. */
+#define COAP_IPV6_SUPPORT 1
+#endif
+
+/* Define to 1 to build with Unix socket support. */
+#define COAP_AF_UNIX_SUPPORT 1
+
+/* Define to 1 to build with Q-Block (RFC 9177) support. */
+#define COAP_Q_BLOCK_SUPPORT 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <assert.h> header file. */
+#define HAVE_ASSERT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#define HAVE_GETADDRINFO 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <erno.h> header file. */
+#define HAVE_ERRNO_H 1
+
+/* Define to 1 if the system has openssl */
+
+/* #undef COAP_WITH_LIBOPENSSL */
+
+/* Define to 1 if the system has libgnutls28 */
+
+/* #undef COAP_WITH_LIBGNUTLS */
+
+/* Define to 1 if the system has libtinydtls */
+
+/* #undef COAP_WITH_LIBTINYDTLS */
+
+/* Define to 1 if the system has libmbedtls */
+#define COAP_WITH_LIBMBEDTLS 1
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if you have the `malloc' function. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to 1 if you have the `if_nametoindex' function. */
+#define HAVE_IF_NAMETOINDEX 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#define HAVE_NETDB_H 1
+
+/* Define to 1 if you have the <net/if.h> header file. */
+#define HAVE_NET_IF_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#define HAVE_PTHREAD_H 1
+
+/* Define to 1 if you have the `pthread_mutex_lock' function. */
+#define HAVE_PTHREAD_MUTEX_LOCK 1
+
+/* Define to 1 if you have the `select' function. */
+#define HAVE_SELECT 1
+
+/* Define to 1 if you have the `socket' function. */
+#define HAVE_SOCKET 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strcasecmp' function. */
+#define HAVE_STRCASECMP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strnlen' function. */
+#define HAVE_STRNLEN 1
+
+/* Define to 1 if you have the `strrchr' function. */
+#define HAVE_STRRCHR 1
+
+/* Define to 1 if you have the `getrandom' function. */
+#define HAVE_GETRANDOM 1
+
+/* Define to 1 if you have the `randon' function. */
+#define HAVE_RANDOM 1
+
+/* Define to 1 if the system has the type `struct cmsghdr'. */
+#define HAVE_STRUCT_CMSGHDR 1
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <sys/unistd.h> header file. */
+#define HAVE_SYS_UNISTD_H 1
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libcoap"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libcoap 4.3.4"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libcoap"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://libcoap.net/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "4.3.4"
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900) && !defined(snprintf)
+#define snprintf _snprintf
+#endif
+
+#endif /* COAP_CONFIG_H_ */


### PR DESCRIPTION
## Summary
added support for coap and testing tools.

server:
when ipv6 is enable:
ap> coap_server
only ipv4 is enable, we need to specify the ip address of the network card:
ap> coap_server -A [ipv4 address]

client:
ap> coap_client -m get coap://[ipv4/6 address]/time
Dec 26 06:41:12

Other Examples:
        coap_client -m get coap://[::1]/
        coap_client -m get coap://[::1]/.well-known/core
        coap_client -m get coap+tcp://[::1]/.well-known/core
        coap_client -m get coap://%2Funix%2Fdomain%2Fpath%2Fdgram/.well-known/core
        coap_client -m get coap+tcp://%2Funix%2Fdomain%2Fpath%2Fstream/.well-known/core
        coap_client -m get coaps://[::1]/.well-known/core
        coap_client -m get coaps+tcp://[::1]/.well-known/core
        coap_client -m get coaps://%2Funix%2Fdomain%2Fpath%2Fdtls/.well-known/core
        coap_client -m get coaps+tcp://%2Funix%2Fdomain%2Fpath%2Ftls/.well-known/core
        coap_client -m get -T cafe coap://[::1]/time
        echo -n 1000 | coap-client -m put -T cafe coap://[::1]/time -f -

## Impact

## Testing
sim:local
