### PR TITLE
nsh cmd rptun: add rptun ping useage description

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -514,7 +514,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
-  CMD_MAP("rptun",    cmd_rptun,    3, 7,
+  CMD_MAP("rptun",    cmd_rptun,    2, 7,
     "<start|stop|reset|panic|dump|ping> <path|all>"
     " [value|times length ack sleep]"),
 #endif

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -605,6 +605,27 @@ static int cmd_rptun_recursive(FAR struct nsh_vtbl_s *vtbl,
 
 int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
+  if (argc >= 2 && strcmp(argv[1], "-h") == 0)
+    {
+      nsh_output(vtbl, "usage:\n");
+      nsh_output(vtbl, "  rptun <start|stop|reset|panic|dump> <path> "
+                "<value>\n");
+      nsh_output(vtbl, "  rptun <reset> <path> <resetvalue>\n");
+      nsh_output(vtbl, "  rptun ping <path> <times> <length> <ack> "
+                "<period(ms)>\n\n");
+      nsh_output(vtbl, "  <path>         Rptun device path.\n");
+      nsh_output(vtbl, "  <times>        Times of rptun ping.\n");
+      nsh_output(vtbl, "  <length>       The length of each ping packet.\n");
+      nsh_output(vtbl, "  <ack>          Whether the peer acknowlege or "
+                "check data.\n");
+      nsh_output(vtbl, "                 0 - No acknowledge and check.\n");
+      nsh_output(vtbl, "                 1 - Acknowledge, no data check.\n");
+      nsh_output(vtbl, "                 2 - Acknowledge and data check.\n");
+      nsh_output(vtbl, "  <period(ms)>   ping period (ms) \n\n");
+
+      return OK;
+    }
+
   if (argc < 3)
     {
       nsh_output(vtbl, g_fmtargrequired, argv[0]);


### PR DESCRIPTION
## Summary
nsh cmd rptun: add rptun ping useage description

## Impact
when rptun -h is entered, the usage of rptun will be displayed.

## Testing
tested in sim vela.