### PR TITLE
rpsock_client.c: fix printf format warning

### DIFF
--- a/examples/rpmsgsocket/rpsock_client.c
+++ b/examples/rpmsgsocket/rpsock_client.c
@@ -201,7 +201,7 @@ static int rpsock_unsync_test(struct rpsock_arg_s *args)
                   if (intp[i] != ALIGN_UP(total) / sizeof(uint32_t) + i)
                     {
                       printf("client check fail total %d, \
-                              i %d, %08" PRIx32 ", %08x\n",
+                              i %d, %08" PRIx32 ", %08zx\n",
                               ALIGN_UP(total), i, intp[i],
                               ALIGN_UP(total) / sizeof(uint32_t) + i);
                     }


### PR DESCRIPTION
## Summary
rpsock_client.c: fix printf format warning as flows
rpsock_client.c:203:30: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 5 has type ‘long unsigned int’ [-Wformat=]
  203 |                       printf("client check fail total %d, \
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  204 |                               i %d, %08" PRIx32 ", %08x\n",
      |                               ~~~~~~~~~~
  205 |                               ALIGN_UP(total), i, intp[i],
  206 |                               (ALIGN_UP(total) / sizeof(uint32_t) + i));
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                   |
      |                                                                   long unsigned int

## Impact
Reduce warnings and reduce the possibility of inaccurate data on other platforms
## Testing
Tested in sim vela and 86panel
