### PR TITLE
nsh syscmds: add CONFIG_RPTUN_PING when use rptun_ping

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -517,7 +517,9 @@ int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
                           FAR const char *path, FAR char **argv)
 {
+#ifdef CONFIG_RPTUN_PING
   struct rptun_ping_s ping;
+#endif
   unsigned long val = 0;
   int cmd;
   int fd;
@@ -543,6 +545,7 @@ static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
     {
       cmd = RPTUNIOC_DUMP;
     }
+#ifdef CONFIG_RPTUN_PING
   else if (strcmp(argv[1], "ping") == 0)
     {
       if (argv[3] == 0 || argv[4] == 0 ||
@@ -560,6 +563,7 @@ static int cmd_rptun_once(FAR struct nsh_vtbl_s *vtbl,
       cmd = RPTUNIOC_PING;
       val = (unsigned long)&ping;
     }
+#endif
   else
     {
       nsh_output(vtbl, g_fmtarginvalid, argv[1]);


### PR DESCRIPTION
## Summary
nsh syscmds: add CONFIG_RPTUN_PING when use rptun_ping.
## Impact
rptun_ping can only be used when CONFIG_RPTUN_PING = y.
## Testing
Tested in sim vela and 86panel.
