### PR TITLE
Zig apps: add kernel mode build support

### DIFF
--- a/examples/hello_zig/Makefile
+++ b/examples/hello_zig/Makefile
@@ -22,7 +22,7 @@ include $(APPDIR)/Make.defs
 
 # Hello, Zig! Example
 
-MAINSRC = hello_zig_main.zig
+MAINSRC = hello_zig.zig
 
 # Hello, Zig! built-in application info
 

--- a/examples/hello_zig/hello_zig.zig
+++ b/examples/hello_zig/hello_zig.zig
@@ -1,0 +1,40 @@
+//***************************************************************************
+// examples/hello_zig/hello_zig.zig
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+//***************************************************************************
+
+//***************************************************************************
+// Included Files
+//***************************************************************************
+const std = @import("std");
+
+//****************************************************************************
+//* Externs
+//****************************************************************************
+
+pub extern fn printf(_format: [*:0]const u8) c_int;
+
+//****************************************************************************
+//* hello_zig_main
+//****************************************************************************
+pub export fn main(_argc: c_int, _argv: [*]const [*]const u8) u8 {
+    _ = _argc;
+    _ = _argv;
+    _ = printf("Hello, Zig!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

This patch adds support of building hello-zig app for kernel mode NuttX.
 works with `nuttx-export` containing Zig macros which is available in https://github.com/apache/nuttx/pull/11548

## Impact

hello_zig elf can build and run in kernel mode NuttX

## Testing

with `rv-virt/knsh32` on Linux host
