### PR TITLE
config.nims: fix NimSuggest crash.

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -127,6 +127,7 @@ proc setup_cfg(cfg: DotConfig) =
       switch("define", "nimMemAlignTiny")
 
 
-let topdir = getEnv("TOPDIR")
+const key = "TOPDIR"
+let topdir = if existsEnv(key): getEnv(key) else: thisDir() & "/../nuttx"
 let cfg = read_config(topdir & "/.config")
 cfg.setup_cfg()


### PR DESCRIPTION
## Summary

When editing in VSCode, NimSuggest refers to config.nims and tries to find the NuttX .config.
Fixed a problem that .config cannot be read because the environment variable "TOPDIR" is not defined.

## Impact

## Testing

Confirmation that completion works with VSCode, etc.
