### PR TITLE
lte/alt1250: Notice instance information

### DIFF
--- a/include/lte/lte_lwm2m.h
+++ b/include/lte/lte_lwm2m.h
@@ -250,7 +250,8 @@ typedef CODE void (*lwm2mstub_ovstart_cb_t)(int seq_no, int srv_id,
 typedef CODE void (*lwm2mstub_ovstop_cb_t)(int seq_no, int srv_id,
               FAR struct lwm2mstub_instance_s *inst, FAR char *token);
 
-typedef CODE void (*lwm2mstub_operation_cb_t)(int event);
+typedef CODE void (*lwm2mstub_operation_cb_t)(int event, int srv_id,
+                   FAR struct lwm2mstub_instance_s *inst);
 
 typedef CODE void (*lwm2mstub_fwupstate_cb_t)(int event);
 

--- a/lte/alt1250/callback_handlers/alt1250_evt.c
+++ b/lte/alt1250/callback_handlers/alt1250_evt.c
@@ -638,9 +638,10 @@ static FAR void *g_lwm2movstopargs[] =
 
 /* event argument for LTE_CMDID_LWM2M_SERVEROP_EVT */
 
+static struct lwm2mstub_instance_s g_lwm2msrvop_inst;
 static FAR void *g_lwm2moperationargs[] =
 {
-  NULL
+  NULL, NULL, &g_lwm2msrvop_inst
 };
 
 /* event argument for LTE_CMDID_LWM2M_FWUP_EVT */
@@ -1445,7 +1446,8 @@ static uint64_t lwm2m_operation_evt_cb(FAR void *cb, FAR void **cbarg,
 
   if (callback)
     {
-      callback((int)cbarg[0]);
+      callback((int)cbarg[0], (int)cbarg[1],
+               (FAR struct lwm2mstub_instance_s *)cbarg[2]);
     }
 
   return 0ULL;


### PR DESCRIPTION
## Summary

Notice instance information of LwM2M server operation to application.

## Impact

Alt1250 Daemon only

## Testing

Test if Alt1250 daemon works fine on Spresense environment.