### PR TITLE
nshlib: add `expr` command support

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -359,6 +359,10 @@ config NSH_DISABLE_EXIT
 	bool "Disable exit"
 	default DEFAULT_SMALL && !NSH_TELNET
 
+config NSH_DISABLE_EXPR
+	bool "Disable expr"
+	default DEFAULT_SMALL
+
 config NSH_DISABLE_EXPORT
 	bool "Disable export"
 	default DEFAULT_SMALL


### PR DESCRIPTION
## Summary

nshlib: add `expr` command support
    
It is a mini version for the `expr` command, which implements the features of addition, subtraction, multiplication, division and mod.
    
Reference: https://www.geeksforgeeks.org/expr-command-in-linux-with-examples/

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact

## Testing

    bl2> expr 5 - 2
    3
    bl2> set hello 10
    bl2> expr $hello - 2
    8
    bl2> expr 8 a 9
    Unknown operator
    bl2> expr 20 / 5
    4
    bl2> expr 10 % 4
    2
    bl2> expr 10 / 0
    operand2 invalid
    bl2>
    bl2> expr 100 + 0
    100
    

