### PR TITLE
nshcmd/rptun: align help mesg with command handler

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -615,6 +615,7 @@ int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       nsh_output(vtbl, "  rptun <start|stop|reset|panic|dump> <path> "
                 "<value>\n");
       nsh_output(vtbl, "  rptun <reset> <path> <resetvalue>\n");
+#ifdef CONFIG_RPTUN_PING
       nsh_output(vtbl, "  rptun ping <path> <times> <length> <ack> "
                 "<period(ms)>\n\n");
       nsh_output(vtbl, "  <path>         Rptun device path.\n");
@@ -626,6 +627,7 @@ int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       nsh_output(vtbl, "                 1 - Acknowledge, no data check.\n");
       nsh_output(vtbl, "                 2 - Acknowledge and data check.\n");
       nsh_output(vtbl, "  <period(ms)>   ping period (ms) \n\n");
+#endif
 
       return OK;
     }


### PR DESCRIPTION


## Summary

The ping subcommand of rptun command is guarded with RPTUN_PING in handler. its help mesg should also have same guard to avoid confusing user.

## Impact

rptun command 

## Testing

checked with `sim/rpserver`

