### PR TITLE
nsh_syscmds: update rptun_ping to rpmsg_ping, add cmd_rpmsg.

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -569,6 +569,11 @@ config NSH_DISABLE_ROUTE
 	depends on FS_PROCFS && NET_ROUTE && !FS_PROCFS_EXCLUDE_NET && !FS_PROCFS_EXCLUDE_ROUTE
 	default DEFAULT_SMALL
 
+config NSH_DISABLE_RPMSG
+	bool "Disable rpmsg"
+	default DEFAULT_SMALL
+	depends on RPMSG
+
 config NSH_DISABLE_RPTUN
 	bool "Disable rptun"
 	default DEFAULT_SMALL

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1141,6 +1141,10 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
                       FAR char **argv);
 #endif
 
+#if defined(CONFIG_RPMSG) && !defined(CONFIG_NSH_DISABLE_RPMSG)
+  int cmd_rpmsg(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
+
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
   int cmd_rptun(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -523,6 +523,12 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 #endif
 
+#if defined(CONFIG_RPMSG) && !defined(CONFIG_NSH_DISABLE_RPMSG)
+  CMD_MAP("rpmsg",    cmd_rpmsg,    2, 7,
+    "<panic|dump|ping> <path|all>"
+    " [value|times length ack sleep]"),
+#endif
+
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
   CMD_MAP("rptun",    cmd_rptun,    2, 7,
     "<start|stop|reset|panic|dump|ping> <path|all>"


### PR DESCRIPTION
## Summary

To support rpmsg ioctl, add cmd_rpmsg function, and update rptun ping to rpmsg ping.
depends on https://github.com/apache/nuttx/pull/11618

## Impact

Able to use rpmsg ioctl cmd.

## Testing

Tested in sim vela and 86 panel.
