### PR TITLE
nsh_timcmds: show RTC time in timedatectl command only if CONFIG_RTC_DRIVER is set

### DIFF
--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -501,6 +501,7 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
       nsh_output(vtbl, "Universal time: %s %s\n", timbuf, tm.tm_zone);
 
+#ifdef CONFIG_RTC_DRIVER
       ret = open("/dev/rtc0", O_RDONLY);
       if (ret > 0)
         {
@@ -522,6 +523,7 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
           nsh_output(vtbl, "      RTC time: %s\n", timbuf);
         }
+#endif /* CONFIG_RTC_DRIVER */
     }
 
   return ret;


### PR DESCRIPTION
## Summary
NuttX build fails otherwise as required structures are not included.

## Impact
Build fix.

## Testing
Build pass, app works.
