### PR TITLE
testing/getprime: add cmake support

### DIFF
--- a/testing/getprime/CMakeLists.txt
+++ b/testing/getprime/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/testing/getprime/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_GETPRIME)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_TESTING_GETPRIME_PROGNAME}
+    SRCS
+    getprime_main.c
+    STACKSIZE
+    ${CONFIG_TESTING_GETPRIME_STACKSIZE}
+    PRIORITY
+    ${CONFIG_TESTING_GETPRIME_PRIORITY})
+endif()


### PR DESCRIPTION

## Summary

add CMakeLists.txt to support building with CMake

## Impact

None

## Testing

checked with CanMV230

