### PR TITLE
nsh_fscmds.c: Fix CONFIG_FS_SHM -> CONFIG_FS_SHMFS

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -182,7 +182,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
               details[0] = 'f';
             }
 #endif
-#ifdef CONFIG_FS_SHM
+#ifdef CONFIG_FS_SHMFS
           else if (S_ISSHM(buf.st_mode))
             {
               details[0] = 'h';


### PR DESCRIPTION
## Summary
The define macro was wrong
## Impact
fscmds works for shm objects
## Testing
CI pass
