### PR TITLE
toywasm: update to v38

### DIFF
--- a/interpreters/toywasm/Makefile
+++ b/interpreters/toywasm/Makefile
@@ -90,7 +90,7 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/lib
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libwasi
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libdyld
 
-TOYWASM_VERSION  = 15e6585cecd8049a03a901a4ed8a6b2dd3c18e48
+TOYWASM_VERSION  = b3e060f308db23e21aaa3004484bf9335e4d3fcc
 TOYWASM_UNPACK   = toywasm
 TOYWASM_TARBALL  = $(TOYWASM_VERSION).zip
 TOYWASM_URL_BASE = https://github.com/yamt/toywasm/archive/

--- a/interpreters/toywasm/include/toywasm_version.h
+++ b/interpreters/toywasm/include/toywasm_version.h
@@ -21,6 +21,6 @@
 #if !defined(_TOYWASM_VERSION_H)
 #define _TOYWASM_VERSION_H
 
-#define TOYWASM_VERSION "v36.0.0"
+#define TOYWASM_VERSION "v38.0.0"
 
 #endif /* !defined(_TOYWASM_VERSION_H) */


### PR DESCRIPTION
## Summary
toywasm: update to v38

## Impact

## Testing
Tested with sim/macOS/x86-64
