### PR TITLE
port more tools to cmake

### DIFF
--- a/benchmarks/spinlock_bench/CMakeLists.txt
+++ b/benchmarks/spinlock_bench/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CONFIG_BENCHMARK_SPINLOCK)
   # Config and Fetch Coremark application
   # ############################################################################
 
-  set(SPINLOCKAPP_DIR ${CMAKE_CURRENT_LIST_DIR}/spinlock_bench)
+  set(SPINLOCKAPP_DIR ${CMAKE_CURRENT_LIST_DIR})
 
   # ############################################################################
   # Sources

--- a/testing/cachespeed/CMakeLists.txt
+++ b/testing/cachespeed/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/testing/cachespeed/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_CACHESPEED)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_TESTING_CACHESPEED_PROGNAME}
+    SRCS
+    cachespeed_main.c
+    STACKSIZE
+    ${CONFIG_TESTING_CACHESPEED_STACKSIZE}
+    PRIORITY
+    ${CONFIG_TESTING_CACHESPEED_PRIORITY})
+endif()

--- a/testing/smp/CMakeLists.txt
+++ b/testing/smp/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/testing/smp/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_SMP)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_TESTING_SMP_PROGNAME}
+    SRCS
+    smp_main.c
+    STACKSIZE
+    ${CONFIG_TESTING_SMP_STACKSIZE}
+    PRIORITY
+    ${CONFIG_TESTING_SMP_PRIORITY})
+endif()

--- a/wireless/ieee802154/CMakeLists.txt
+++ b/wireless/ieee802154/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/wireless/ieee802154/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "IEEE 802.15.4 applications")

--- a/wireless/ieee802154/i8sak/CMakeLists.txt
+++ b/wireless/ieee802154/i8sak/CMakeLists.txt
@@ -1,0 +1,54 @@
+# ##############################################################################
+# apps/wireless/ieee802154/i8sak/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_IEEE802154_I8SAK)
+
+  # Application info
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_IEEE802154_I8SAK_PROGNAME}
+    SRCS
+    i8sak_main.c
+    STACKSIZE
+    ${CONFIG_IEEE802154_I8SAK_STACKSIZE}
+    PRIORITY
+    ${CONFIG_IEEE802154_I8SAK_PRIORITY})
+
+  # IEEE 802.15.4 SAK (swiss army knife)
+
+  set(CSRCS
+      i8sak_acceptassoc.c
+      i8sak_assoc.c
+      i8sak_scan.c
+      i8sak_blaster.c
+      i8sak_poll.c
+      i8sak_sniffer.c
+      i8sak_startpan.c
+      i8sak_tx.c
+      i8sak_get.c
+      i8sak_set.c
+      i8sak_reset.c
+      i8sak_regdump.c
+      i8sak_events.c)
+
+  target_sources(apps PRIVATE ${CSRCS})
+
+endif()

--- a/wireless/ieee802154/i8shark/CMakeLists.txt
+++ b/wireless/ieee802154/i8shark/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/wireless/bluetooth/i8shark/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_IEEE802154_I8SHARK)
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_IEEE802154_I8SHARK_PROGNAME}
+    SRCS
+    i8shark_main.c
+    STACKSIZE
+    ${CONFIG_IEEE802154_I8SHARK_STACKSIZE}
+    PRIORITY
+    ${CONFIG_IEEE802154_I8SHARK_PRIORITY})
+
+endif()

--- a/wireless/ieee802154/libmac/CMakeLists.txt
+++ b/wireless/ieee802154/libmac/CMakeLists.txt
@@ -1,0 +1,58 @@
+# ##############################################################################
+# apps/wireless/bluetooth/libmac/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_IEEE802154_LIBMAC)
+
+  set(CSRCS
+      ieee802154_assocreq.c
+      ieee802154_assocresp.c
+      ieee802154_disassocreq.c
+      ieee802154_getreq.c
+      ieee802154_gtsreq.c
+      ieee802154_orphanresp.c
+      ieee802154_resetreq.c
+      ieee802154_rxenabreq.c
+      ieee802154_scanreq.c
+      ieee802154_setreq.c
+      ieee802154_startreq.c
+      ieee802154_syncreq.c
+      ieee802154_pollreq.c)
+
+  if(CONFIG_NET_6LOWPAN)
+    list(
+      APPEND
+      CSRCS
+      sixlowpan_assocreq.c
+      sixlowpan_assocresp.c
+      sixlowpan_disassocreq.c
+      sixlowpan_getreq.c
+      sixlowpan_gtsreq.c
+      sixlowpan_orphanresp.c
+      sixlowpan_resetreq.c
+      sixlowpan_rxenabreq.c
+      sixlowpan_scanreq.c
+      sixlowpan_setreq.c
+      sixlowpan_startreq.c
+      sixlowpan_syncreq.c
+      sixlowpan_pollreq.c)
+  endif()
+
+  target_sources(apps PRIVATE ${CSRCS})
+endif()

--- a/wireless/ieee802154/libutils/CMakeLists.txt
+++ b/wireless/ieee802154/libutils/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ##############################################################################
+# apps/wireless/bluetooth/libutils/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_IEEE802154_LIBUTILS)
+
+  set(CSRCS ieee802154_addrtostr.c)
+
+  target_sources(apps PRIVATE ${CSRCS})
+endif()


### PR DESCRIPTION
## Summary
- cmake: fix spinlock_bench compilation
- cmake: add cachespeed
- cmake: add smp test
- cmake: add ieee802154 tools

## Impact

## Testing

