### PR TITLE
lte/alt1250: Correspond to ALT1250_EVTBIT_RESTARTAPI event

### DIFF
--- a/lte/alt1250/alt1250_devevent.c
+++ b/lte/alt1250/alt1250_devevent.c
@@ -299,6 +299,19 @@ exit:
 }
 
 /****************************************************************************
+ * Name: perform_alt1250_restartevt
+ ****************************************************************************/
+
+static void perform_alt1250_restartevt(FAR struct alt1250_s *dev)
+{
+  /* All LTE API/Socket requests must be available. */
+
+  alt1250_set_api_enable(dev, true);
+
+  altdevice_powerresponse(dev->altfd, LTE_CMDID_RESTARTAPI, OK);
+}
+
+/****************************************************************************
  * Name: perform_alt1250_suspendevt
  ****************************************************************************/
 
@@ -397,6 +410,12 @@ int perform_alt1250events(FAR struct alt1250_s *dev)
       /* Handling API stop request */
 
       perform_alt1250_apistopevt(dev);
+    }
+  else if (bitmap & ALT1250_EVTBIT_RESTARTAPI)
+    {
+      /* Handling API restart request */
+
+      perform_alt1250_restartevt(dev);
     }
   else if (bitmap & ALT1250_EVTBIT_SUSPEND)
     {


### PR DESCRIPTION
## Summary
If the ALT1250_EVTBIT_RESTARTAPI event is received, the ALT1250 daemon changes its state to handle LAPI normally.

## Impact
Only ALT1250 daemon.

## Testing
Test with Spresense LTE board.
