### PR TITLE
lte/alt1250: Fix bug that caused stack when executing the socket API

### DIFF
--- a/lte/alt1250/alt1250_atcmd.c
+++ b/lte/alt1250/alt1250_atcmd.c
@@ -245,7 +245,7 @@ static int send_internal_at_command(FAR struct alt1250_s *dev,
 
   err_alt1250("Internal ATCMD : %s\n", dev->tx_buff);
 
-  ret = altdevice_send_command(dev->altfd, container, usock_result);
+  ret = altdevice_send_command(dev, dev->altfd, container, usock_result);
   if (ret == REP_NO_ACK)
     {
       /* In case of no error */

--- a/lte/alt1250/alt1250_devif.c
+++ b/lte/alt1250/alt1250_devif.c
@@ -92,10 +92,20 @@ FAR struct alt_container_s *altdevice_exchange_selcontainer(int fd,
  * name: altdevice_send_command
  ****************************************************************************/
 
-int altdevice_send_command(int fd, FAR struct alt_container_s *container,
+int altdevice_send_command(FAR struct alt1250_s *dev, int fd,
+                           FAR struct alt_container_s *container,
                            FAR int32_t *usock_res)
 {
   int ret;
+
+#ifdef CONFIG_LTE_ALT1250_ENABLE_HIBERNATION_MODE
+  if (dev->is_resuming)
+    {
+      *usock_res = -EOPNOTSUPP;
+      return REP_SEND_ACK;
+    }
+#endif
+
   ret = ioctl_wrapper(fd, ALT1250_IOC_SEND, (unsigned long)container);
   if (ret < 0)
     {

--- a/lte/alt1250/alt1250_devif.h
+++ b/lte/alt1250/alt1250_devif.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 #include <nuttx/modem/alt1250.h>
+#include "alt1250_daemon.h"
 
 #define DEV_ALT1250  "/dev/alt1250"
 
@@ -39,7 +40,8 @@ int init_alt1250_device(void);
 void finalize_alt1250_device(int fd);
 FAR struct alt_container_s *altdevice_exchange_selcontainer(int fd,
     FAR struct alt_container_s *container);
-int altdevice_send_command(int fd, FAR struct alt_container_s *container,
+int altdevice_send_command(FAR struct alt1250_s *dev, int fd,
+                           FAR struct alt_container_s *container,
                            FAR int32_t *usock_res);
 int altdevice_powercontrol(int fd, uint32_t cmd);
 int altdevice_seteventbuff(int fd, FAR struct alt_evtbuffer_s *buffers);

--- a/lte/alt1250/alt1250_reset_seq.c
+++ b/lte/alt1250/alt1250_reset_seq.c
@@ -116,7 +116,7 @@ static int send_getversion_onreset(FAR struct alt1250_s *dev,
   set_container_postproc(container, postproc_ponresetseq,
                          (unsigned long)&reset_arg);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/alt1250_select.c
+++ b/lte/alt1250/alt1250_select.c
@@ -119,7 +119,7 @@ static int send_select_command(FAR struct alt1250_s *dev,
   set_container_ids(&container, 0, LTE_CMDID_SELECT);
   set_container_argument(&container, in, nitems(in));
 
-  return altdevice_send_command(dev->altfd, &container, &usock_result);
+  return altdevice_send_command(dev, dev->altfd, &container, &usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_accepthdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_accepthdlr.c
@@ -90,7 +90,7 @@ static int send_close_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_accepterr, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -188,7 +188,7 @@ static int send_accept_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_accept, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_bindhdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_bindhdlr.c
@@ -65,7 +65,7 @@ static int send_bind_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_sockcommon, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_closehdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_closehdlr.c
@@ -63,7 +63,7 @@ static int send_close_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_sockcommon, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_connecthdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_connecthdlr.c
@@ -175,7 +175,7 @@ static int send_connect_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_connect, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_getsocknamehdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_getsocknamehdlr.c
@@ -114,7 +114,7 @@ static int send_getsockname_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_getsockname, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_getsockopthdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_getsockopthdlr.c
@@ -146,7 +146,7 @@ int send_getsockopt_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, func, priv);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_ioctl_event.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctl_event.c
@@ -53,7 +53,7 @@ static int send_eventnotice_command(FAR struct alt1250_s *dev,
   set_container_response(container, ltecmd->outparam, ltecmd->outparamlen);
   set_container_postproc(container, NULL, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_ioctl_fwupdate.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctl_fwupdate.c
@@ -445,7 +445,7 @@ int usockreq_ioctl_fwupdate(FAR struct alt1250_s *dev,
                              ltecmd->outparamlen);
       set_container_postproc(container, postproc_hdlr, postproc_priv);
 
-      ret = altdevice_send_command(dev->altfd, container, usock_result);
+      ret = altdevice_send_command(dev, dev->altfd, container, usock_result);
 
       if (IS_NEED_CONTAINER_FREE(ret))
         {

--- a/lte/alt1250/usock_handlers/alt1250_ioctl_ifreq.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctl_ifreq.c
@@ -101,7 +101,7 @@ static int send_actpdn_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_actpdn, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -124,7 +124,7 @@ static int send_radio_command(FAR struct alt1250_s *dev,
   set_container_postproc(container,
                     on ? postproc_radioon : postproc_radiooff, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -369,7 +369,7 @@ int send_reportnet_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, func, priv);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_listenhdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_listenhdlr.c
@@ -65,7 +65,7 @@ static int send_listen_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_sockcommon, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_recvfromhdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_recvfromhdlr.c
@@ -142,7 +142,7 @@ static int send_recvfrom_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx++);
   set_container_postproc(container, postproc_recvfrom, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_sendtohdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_sendtohdlr.c
@@ -71,7 +71,7 @@ static int send_sendto_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_sockcommon, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_setsockopthdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_setsockopthdlr.c
@@ -67,7 +67,7 @@ static int send_setsockopt_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_sockcommon, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_shutdownhdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_shutdownhdlr.c
@@ -64,7 +64,7 @@ static int send_shutdown_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_sockcommon, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_sms.c
+++ b/lte/alt1250/usock_handlers/alt1250_sms.c
@@ -172,7 +172,7 @@ static int send_smsinit_command(FAR struct alt1250_s *dev,
   set_container_response(container, &dummy_output, 1);
   set_container_postproc(container, func, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -197,7 +197,7 @@ static int send_smsfin_command(FAR struct alt1250_s *dev,
   set_container_response(container, &dummy_output, 1);
   set_container_postproc(container, func, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -239,7 +239,7 @@ static int send_smssend_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_smssend, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -270,7 +270,7 @@ static int send_smsdelete_command(FAR struct alt1250_s *dev,
   set_container_response(container, &dummy_output, 1);
   set_container_postproc(container, postproc_smsdelete, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -286,7 +286,7 @@ static int send_smsreportrecv_command(FAR struct alt1250_s *dev,
 
   set_container_ids(&container, 0, LTE_CMDID_SMS_REPORT_RECV);
 
-  return altdevice_send_command(dev->altfd, &container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, &container, usock_result);
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_sockethdlr.c
+++ b/lte/alt1250/usock_handlers/alt1250_sockethdlr.c
@@ -94,7 +94,7 @@ static int send_fctl_command(FAR struct alt1250_s *dev,
   set_container_postproc(container, cmd == ALTCOM_SETFL ? postproc_setfl :
                           cmd == ALTCOM_GETFL ? postproc_getfl : NULL, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************
@@ -331,7 +331,7 @@ static int send_socket_command(FAR struct alt1250_s *dev,
   set_container_response(container, USOCKET_REP_RESPONSE(usock), idx);
   set_container_postproc(container, postproc_socket, 0);
 
-  return altdevice_send_command(dev->altfd, container, usock_result);
+  return altdevice_send_command(dev, dev->altfd, container, usock_result);
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary
Fix a bug that caused the application to get stuck when executing the socket API after waking up from hibernation and before executing lte_hibernation_resume().

## Impact
Only ALT1250 daemon

## Testing
Test with Spresense LTE board.
