### PR TITLE
examples/rmtchar: Increase initial duration time

### DIFF
--- a/examples/rmtchar/rmtchar_transmitter.c
+++ b/examples/rmtchar/rmtchar_transmitter.c
@@ -78,7 +78,7 @@ pthread_addr_t rmtchar_transmitter(pthread_addr_t arg)
 {
   FAR struct rmtchar_state_s *rmtchar = (FAR struct rmtchar_state_s *)arg;
   struct rmt_item32_s buf[rmtchar->rmtchar_items];
-  int duration = 100;
+  int duration = 1000;
   int nwritten;
   int fd;
   int i;


### PR DESCRIPTION
## Summary

* examples/rmtchar: Increase initial duration time

With higher RMT source clocks, small durations are hard to be
detected. Increasing it makes it easier to enable automated tests.

## Impact

Makes it easier to enable automated testing

## Testing

Internal CI testing