### PR TITLE
elf/tests/helloxx: fix build break with elf cpp exceptions example

### DIFF
--- a/examples/elf/tests/helloxx/hello++5.cxx
+++ b/examples/elf/tests/helloxx/hello++5.cxx
@@ -154,7 +154,7 @@ void CThingSayer::ThrowThing(void)
 void CThingSayer::ThrowMyThing(const char *czSayThis = NULL)
 {
   cout << "CThingSayer::ThrowMyThing: I am now throwing an MyException (with reason)." << endl;
-  throw MyException(tring(czSayThis));
+  throw MyException(string(czSayThis));
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
fix the below build error by correcting the typo (tring -> string)

hello++5.cxx: In member function 'virtual void CThingSayer::ThrowMyThing(const char*)': hello++5.cxx:157:21: error: 'tring' was not declared in this scope
  157 |   throw MyException(tring(czSayThis));
      |                     ^~~~~

## Impact

## Testing

