### PR TITLE
lte/alt1250: Force change modem parameter

### DIFF
--- a/lte/alt1250/alt1250_atcmd.c
+++ b/lte/alt1250/alt1250_atcmd.c
@@ -432,6 +432,33 @@ int ltenwop_send_setnwoptp(FAR struct alt1250_s *dev,
 }
 
 /****************************************************************************
+ * name: ltesp_send_getscanplan
+ ****************************************************************************/
+
+int ltesp_send_getscanplan(FAR struct alt1250_s *dev,
+                           FAR struct alt_container_s *container)
+{
+  int32_t dummy;
+  snprintf((FAR char *)dev->tx_buff, _TX_BUFF_SIZE,
+           "AT%%GETCFG=\"SCAN_PLAN_EN\"\r");
+  return send_internal_at_command(dev, container, -1, NULL, 0, &dummy);
+}
+
+/****************************************************************************
+ * name: ltesp_send_setscanplan
+ ****************************************************************************/
+
+int ltesp_send_setscanplan(FAR struct alt1250_s *dev,
+                           FAR struct alt_container_s *container,
+                           bool enable)
+{
+  int32_t dummy;
+  snprintf((FAR char *)dev->tx_buff, _TX_BUFF_SIZE,
+           "AT%%SETCFG=\"SCAN_PLAN_EN\",\"%s\"\r", (enable ? "1" : "0"));
+  return send_internal_at_command(dev, container, -1, NULL, 0, &dummy);
+}
+
+/****************************************************************************
  * name: lwm2mstub_send_getqueuemode
  ****************************************************************************/
 

--- a/lte/alt1250/alt1250_atcmd.h
+++ b/lte/alt1250/alt1250_atcmd.h
@@ -109,6 +109,13 @@ int ltenwop_send_getnwop(FAR struct alt1250_s *dev,
 int ltenwop_send_setnwoptp(FAR struct alt1250_s *dev,
                            FAR struct alt_container_s *container);
 
+int ltesp_send_getscanplan(FAR struct alt1250_s *dev,
+                           FAR struct alt_container_s *container);
+
+int ltesp_send_setscanplan(FAR struct alt1250_s *dev,
+                           FAR struct alt_container_s *container,
+                           bool enable);
+
 int lwm2mstub_send_getqueuemode(FAR struct alt1250_s *dev,
                                 FAR struct alt_container_s *container,
                                 int16_t usockid, FAR int32_t *ures);


### PR DESCRIPTION
## Summary
In some conditions, LTE connection has issue.
To fix it, need to change a modem parameter.

## Impact
Only ALT1250 daemon.

## Testing
Test with Spresense LTE board.
