### PR TITLE
fix modbus master exemple

### DIFF
--- a/examples/modbusmaster/mbmaster_main.c
+++ b/examples/modbusmaster/mbmaster_main.c
@@ -280,7 +280,7 @@ int main(int argc, FAR char *argv[])
 
   if (ret != OK)
     {
-      fprintf(stderr, "mbmaster_main: ",
+      fprintf(stderr, "mbmaster_main: "
               "ERROR: mbmaster_initialize failed: %d\n", ret);
       goto errout;
     }
@@ -292,10 +292,14 @@ int main(int argc, FAR char *argv[])
 
   if (ret != OK)
     {
-      fprintf(stderr, "mbmaster_main: ",
+      fprintf(stderr, "mbmaster_main: "
               "ERROR: mbmaster_pollthread create failed: %d\n", ret);
       goto errout_with_initialize;
     }
+
+  /* Work around to give time to pthread_create run the modbus poller */
+
+  usleep(100000);
 
   printf("Sending %d requests to slave %d\n",
          MBMASTER_REQUESTS_COUNT, SLAVE_ID);

--- a/include/modbus/mbport.h
+++ b/include/modbus/mbport.h
@@ -126,7 +126,7 @@ bool xMBPortEventGet(eMBEventType *eEvent);
 
 bool xMBMasterPortEventInit(void);
 bool xMBMasterPortEventPost(eMBMasterEventType eEvent);
-bool xMBMasterPortEventGet(eMBMasterEventType * eEvent);
+bool xMBMasterPortEventGet(eMBMasterEventType *eEvent);
 void vMBMasterOsResInit(void);
 bool xMBMasterRunResTake(int32_t time);
 void vMBMasterRunResRelease(void);
@@ -138,7 +138,7 @@ bool xMBPortSerialInit(uint8_t ucPort, speed_t ulBaudRate,
 void vMBPortClose(void);
 void xMBPortSerialClose(void);
 void vMBPortSerialEnable(bool xRxEnable, bool xTxEnable);
-bool xMBPortSerialGetByte(int8_t * pucByte);
+bool xMBPortSerialGetByte(int8_t *pucByte);
 bool xMBPortSerialPutByte(int8_t ucByte);
 
 bool xMBMasterPortSerialInit(uint8_t ucPort, speed_t ulBaudRate,
@@ -146,7 +146,7 @@ bool xMBMasterPortSerialInit(uint8_t ucPort, speed_t ulBaudRate,
 void vMBMasterPortClose(void);
 void xMBMasterPortSerialClose(void);
 void vMBMasterPortSerialEnable(bool xRxEnable, bool xTxEnable);
-bool xMBMasterPortSerialGetByte(int8_t * pucByte);
+bool xMBMasterPortSerialGetByte(int8_t *pucByte);
 bool xMBMasterPortSerialPutByte(int8_t ucByte);
 
 /* Timers functions */

--- a/modbus/mb_m.c
+++ b/modbus/mb_m.c
@@ -429,6 +429,13 @@ eMBErrorCode eMBMasterPoll(void)
 
           vMBMasterRunResRelease();
           break;
+
+          case EV_MASTER_PROCESS_SUCCESS:
+          case EV_MASTER_ERROR_RESPOND_TIMEOUT:
+          case EV_MASTER_ERROR_RECEIVE_DATA:
+          case EV_MASTER_ERROR_EXECUTE_FUNCTION:
+          default:
+          break;
         }
     }
 

--- a/modbus/nuttx/portevent_m.c
+++ b/modbus/nuttx/portevent_m.c
@@ -94,7 +94,7 @@ bool xMBMasterPortEventPost(eMBMasterEventType eEvent)
   return true;
 }
 
-bool xMBMasterPortEventGet(eMBMasterEventType * eEvent)
+bool xMBMasterPortEventGet(eMBMasterEventType *eEvent)
 {
   bool xEventHappened = false;
 
@@ -227,7 +227,7 @@ void vMBMasterRunResRelease(void)
  */
 
 void vMBMasterErrorCBRespondTimeout(uint8_t ucDestAddress,
-                                    const uint8_t * pucPDUData,
+                                    const uint8_t *pucPDUData,
                                     uint16_t usPDULength)
 {
   xMBMasterPortEventPost(EV_MASTER_ERROR_RESPOND_TIMEOUT);
@@ -243,7 +243,7 @@ void vMBMasterErrorCBRespondTimeout(uint8_t ucDestAddress,
  */
 
 void vMBMasterErrorCBReceiveData(uint8_t ucDestAddress,
-                                 const uint8_t * pudPDUData,
+                                 const uint8_t *pudPDUData,
                                  uint16_t usPDULength)
 {
   xMBMasterPortEventPost(EV_MASTER_ERROR_RECEIVE_DATA);
@@ -259,7 +259,7 @@ void vMBMasterErrorCBReceiveData(uint8_t ucDestAddress,
  */
 
 void vMBMasterErrorCBExecuteFunction(uint8_t ucDestAddress,
-                                     const uint8_t * pucPDUData,
+                                     const uint8_t *pucPDUData,
                                      uint16_t usPDULength)
 {
   xMBMasterPortEventPost(EV_MASTER_ERROR_EXECUTE_FUNCTION);

--- a/modbus/rtu/mbrtu_m.c
+++ b/modbus/rtu/mbrtu_m.c
@@ -278,7 +278,7 @@ bool xMBMasterRTUReceiveFSM(void)
 
   /* Always read the character. */
 
-  xMBMasterPortSerialGetByte((uint8_t *) & ucByte);
+  xMBMasterPortSerialGetByte((int8_t *) & ucByte);
 
   switch (eRcvState)
     {
@@ -396,6 +396,10 @@ bool xMBMasterRTUTransmitFSM(void)
               vMBMasterPortTimersRespondTimeoutEnable();
             }
         }
+      break;
+
+      case STATE_M_TX_XFWR:
+      default:
       break;
     }
 


### PR DESCRIPTION
## Summary
 
The modbus master exemplo stop to work before the PR [#6038](https://github.com/apache/nuttx/pull/6038l)

## Impact

Fix modbus master example.

## Testing

```
# config target to use the mosbus master example
$tools/configure.sh stm32f401rc-rs485:modbus_master

# run diagslave app to start a modbus slave
$ sudo diagslave -a 10 -b 38400 /dev/ttyUSB0

# on target execute the modbus master exemple
nsh> modbusmaster
Initializing modbus master...
Creating poll thread.
Sending 100 requests to slave 10
mbmaster_main: Exiting poll thread.
Modbus master statistics:
Requests count:  100
Responses count: 100
Errors count:    0
Deinitializing modbus master...

```