### PR TITLE
i8sak: add support for tracedump command

### DIFF
--- a/wireless/ieee802154/i8sak/CMakeLists.txt
+++ b/wireless/ieee802154/i8sak/CMakeLists.txt
@@ -47,6 +47,7 @@ if(CONFIG_IEEE802154_I8SAK)
       i8sak_set.c
       i8sak_reset.c
       i8sak_regdump.c
+      i8sak_tracedump.c
       i8sak_events.c)
 
   target_sources(apps PRIVATE ${CSRCS})

--- a/wireless/ieee802154/i8sak/Makefile
+++ b/wireless/ieee802154/i8sak/Makefile
@@ -31,7 +31,7 @@ MODULE = $(CONFIG_IEEE802154_I8SAK)
 
 CSRCS = i8sak_acceptassoc.c i8sak_assoc.c i8sak_scan.c i8sak_blaster.c i8sak_poll.c
 CSRCS += i8sak_sniffer.c i8sak_startpan.c i8sak_tx.c i8sak_get.c i8sak_set.c
-CSRCS += i8sak_reset.c i8sak_regdump.c i8sak_events.c
+CSRCS += i8sak_reset.c i8sak_regdump.c i8sak_events.c i8sak_tracedump.c
 MAINSRC = i8sak_main.c
 
 include $(APPDIR)/Application.mk

--- a/wireless/ieee802154/i8sak/i8sak.h
+++ b/wireless/ieee802154/i8sak/i8sak.h
@@ -213,6 +213,8 @@ void i8sak_poll_cmd        (FAR struct i8sak_s *i8sak,
                             int argc, FAR char *argv[]);
 void i8sak_regdump_cmd     (FAR struct i8sak_s *i8sak,
                             int argc, FAR char *argv[]);
+void i8sak_tracedump_cmd   (FAR struct i8sak_s *i8sak,
+                            int argc, FAR char *argv[]);
 void i8sak_reset_cmd       (FAR struct i8sak_s *i8sak,
                             int argc, FAR char *argv[]);
 void i8sak_scan_cmd        (FAR struct i8sak_s *i8sak,

--- a/wireless/ieee802154/i8sak/i8sak_main.c
+++ b/wireless/ieee802154/i8sak/i8sak_main.c
@@ -95,6 +95,7 @@ static const struct i8sak_command_s g_i8sak_commands[] =
   {"get",         (CODE void *)i8sak_get_cmd},
   {"poll",        (CODE void *)i8sak_poll_cmd},
   {"regdump",     (CODE void *)i8sak_regdump_cmd},
+  {"tracedump",   (CODE void *)i8sak_tracedump_cmd},
   {"reset",       (CODE void *)i8sak_reset_cmd},
   {"scan",        (CODE void *)i8sak_scan_cmd},
   {"set",         (CODE void *)i8sak_set_cmd},
@@ -810,6 +811,7 @@ static int i8sak_showusage(FAR const char *progname, int exitcode)
           "    get [-h] parameter\n"
           "    poll [-h]\n"
           "    regdump [-h]\n"
+          "    tracedump [-h]\n"
           "    reset [-h]\n"
           "    scan [-h|p|a|e] minch-maxch\n"
           "    set [-h] param val\n"

--- a/wireless/ieee802154/i8sak/i8sak_tracedump.c
+++ b/wireless/ieee802154/i8sak/i8sak_tracedump.c
@@ -1,0 +1,120 @@
+/****************************************************************************
+ * apps/wireless/ieee802154/i8sak/i8sak_tracedump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <nuttx/fs/ioctl.h>
+
+#include "i8sak.h"
+
+#include <nuttx/wireless/ieee802154/ieee802154_mac.h>
+#include "wireless/ieee802154.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: i8sak_tracedump_cmd
+ *
+ * Description:
+ *   Print trace information of radio device
+ *
+ ****************************************************************************/
+
+void i8sak_tracedump_cmd(FAR struct i8sak_s *i8sak, int argc,
+                         FAR char *argv[])
+{
+  struct ieee802154_get_req_s req;
+  int option;
+  int fd = 0;
+
+  while ((option = getopt(argc, argv, ":h")) != ERROR)
+    {
+      switch (option)
+        {
+          case 'h':
+            fprintf(stderr, "Prints trace info of radio device\n"
+                    "Usage: %s [-h]\n"
+                    "    -h = this help menu\n"
+                    , argv[0]);
+
+            /* Must manually reset optind if we are going to exit early */
+
+            optind = -1;
+            return;
+
+          case ':':
+            fprintf(stderr, "ERROR: missing argument\n");
+
+            /* Must manually reset optind if we are going to exit early */
+
+            optind = -1;
+            i8sak_cmd_error(i8sak); /* This exits for us */
+          case '?':
+            fprintf(stderr, "ERROR: unknown argument\n");
+
+            /* Must manually reset optind if we are going to exit early */
+
+            optind = -1;
+            i8sak_cmd_error(i8sak); /* This exits for us */
+        }
+    }
+
+  req.attr = IEEE802154_ATTR_PHY_TRACEDUMP;
+
+  if (i8sak->mode == I8SAK_MODE_CHAR)
+    {
+      fd = open(i8sak->ifname, O_RDWR);
+      if (fd < 0)
+        {
+          fprintf(stderr, "ERROR: cannot open %s, errno=%d\n",
+                  i8sak->ifname, errno);
+          i8sak_cmd_error(i8sak);
+        }
+
+      ieee802154_get_req(fd, &req);
+    }
+#ifdef CONFIG_NET_6LOWPAN
+  else if (i8sak->mode == I8SAK_MODE_NETIF)
+    {
+      fd = socket(PF_INET6, SOCK_DGRAM, 0);
+      if (fd < 0)
+        {
+          fprintf(stderr, "ERROR: failed to open socket, errno=%d\n", errno);
+          i8sak_cmd_error(i8sak);
+        }
+
+      sixlowpan_get_req(fd, i8sak->ifname, &req);
+    }
+#endif
+
+  close(fd);
+}


### PR DESCRIPTION
## Summary

- i8sak: add support for tracedump command
used to dump trace log from radio

depends on https://github.com/apache/nuttx/pull/11701
## Impact

## Testing

