### PR TITLE
nsh/uname: alloc dynamic heap on non-GNU compilers

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -690,6 +690,7 @@ int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   FAR const char *str;
   struct lib_memoutstream_s stream;
   struct utsname info;
+  struct utsname output;
   unsigned int set;
   int option;
   bool badarg;
@@ -780,8 +781,7 @@ int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   /* Process each option */
 
   first = true;
-  lib_memoutstream(&stream, alloca(sizeof(struct utsname)),
-                   sizeof(struct utsname));
+  lib_memoutstream(&stream, (FAR char *)&output, sizeof(output));
   for (i = 0; set != 0; i++)
     {
       unsigned int mask = (1 << i);


### PR DESCRIPTION


## Summary

nsh/uname: alloc dynamic heap on non-GNU compilers

The alloca() function is machine- and compiler-dependent.  For certain applications, its use can improve efficiency compared to the use of malloc(3) plus free(3).  In certain cases, it can also simplify memory deallocation in applications that use longjmp(3) or siglongjmp(3). Otherwise, its use is discouraged.

## Impact

N/A

## Testing

Tasking