### PR TITLE
modbus_master: fix cmake build warning

### DIFF
--- a/modbus/nuttx/portevent_m.c
+++ b/modbus/nuttx/portevent_m.c
@@ -102,7 +102,6 @@ bool xMBMasterPortEventGet(eMBMasterEventType *eEvent)
 
   if (eQueuedEvent & ~(WAITER_EVENTS))
     {
-
       /* Fetch events by priority */
 
       if (eQueuedEvent & EV_MASTER_READY)
@@ -136,9 +135,9 @@ bool xMBMasterPortEventGet(eMBMasterEventType *eEvent)
   else
     {
       /* Poll the serial device. The serial device timeouts if no characters
-       * have been received within for t3.5 during an active transmission or if
-       * nothing happens within a specified amount of time. Both timeouts are
-       * configured from the timer init functions.
+       * have been received within for t3.5 during an active transmission or
+       * if nothing happens within a specified amount of time. Both timeouts
+       * are configured from the timer init functions.
        */
 
       xMBMasterPortSerialPoll();
@@ -188,6 +187,7 @@ bool xMBMasterRunResTake(int32_t lTimeOut)
         {
           return false;
         }
+
       return true;
     }
   else
@@ -198,6 +198,7 @@ bool xMBMasterRunResTake(int32_t lTimeOut)
         {
           return false;
         }
+
       return true;
     }
 }
@@ -274,7 +275,8 @@ void vMBMasterCBRequestSuccess(void)
   xMBMasterPortEventPost(EV_MASTER_PROCESS_SUCCESS);
 }
 
-/* This function will wait for Modbus Master request finish and return result.
+/* This function will wait for Modbus Master request finish
+ * and return result.
  */
 
 eMBMasterReqErrCode eMBMasterWaitRequestFinish(void)
@@ -303,6 +305,7 @@ eMBMasterReqErrCode eMBMasterWaitRequestFinish(void)
         {
           eErrStatus = MB_MRE_EXE_FUN;
         }
+
       eQueuedEvent &= ~WAITER_EVENTS;
     }
 

--- a/modbus/nuttx/portother.c
+++ b/modbus/nuttx/portother.c
@@ -74,17 +74,21 @@ void vMBPortLogFile(FILE * fNewLogFile)
   fLogFile = fNewLogFile;
 }
 
-void vMBPortLog(eMBPortLogLevel eLevel, const char * szModule, const char * szFmt, ...)
+void vMBPortLog(eMBPortLogLevel eLevel, const char * szModule,
+                const char * szFmt, ...)
 {
   char     szBuf[512];
   int      i;
   va_list  args;
   FILE    *fOutput = fLogFile == NULL ? stderr : fLogFile;
 
-  static const char *arszLevel2Str[] = { "ERROR", "WARN", "INFO", "DEBUG" };
+  static const char *arszLevel2Str[] =
+  {
+     "ERROR", "WARN", "INFO", "DEBUG"
+   };
 
-  i = snprintf(szBuf, NELEMS(szBuf), "%s: %s: ", arszLevel2Str[eLevel], szModule);
-
+  i = snprintf(szBuf, NELEMS(szBuf), "%s: %s: ",
+               arszLevel2Str[eLevel], szModule);
   if (i != 0)
     {
       va_start(args, szFmt);
@@ -106,7 +110,8 @@ void vMBPortEnterCritical(void)
   int ret = pthread_mutex_lock(&xLock);
   if (ret != 0)
     {
-      vMBPortLog(MB_LOG_ERROR, "OTHER", "Locking primitive failed: %d\n", ret);
+      vMBPortLog(MB_LOG_ERROR, "OTHER",
+                 "Locking primitive failed: %d\n", ret);
     }
 }
 
@@ -115,6 +120,7 @@ void vMBPortExitCritical(void)
   int ret = pthread_mutex_unlock(&xLock);
   if (ret != 0)
     {
-      vMBPortLog(MB_LOG_ERROR, "OTHER", "Locking primitive failed: %d\n", ret);
+      vMBPortLog(MB_LOG_ERROR,
+                 "OTHER", "Locking primitive failed: %d\n", ret);
     }
 }

--- a/modbus/nuttx/portother_m.c
+++ b/modbus/nuttx/portother_m.c
@@ -84,7 +84,10 @@ void vMBMasterPortLog(eMBPortLogLevel eLevel, const char * szModule,
   va_list  args;
   FILE    *fOutput = fLogFile == NULL ? stderr : fLogFile;
 
-  static const char *arszLevel2Str[] = { "ERROR", "WARN", "INFO", "DEBUG" };
+  static const char *arszLevel2Str[] =
+  {
+    "ERROR", "WARN", "INFO", "DEBUG"
+  };
 
   i = snprintf(szBuf, NELEMS(szBuf),
                "%s: %s: ", arszLevel2Str[eLevel], szModule);

--- a/modbus/nuttx/porttimer_m.c
+++ b/modbus/nuttx/porttimer_m.c
@@ -75,7 +75,7 @@ bool bTimeoutEnable;               /* timeout is active */
  * Private Functions
  ****************************************************************************/
 
-void vMBMasterPortTimersEnable( void )
+void vMBMasterPortTimersEnable(void)
 {
   int res = gettimeofday(&xTimeLast, NULL);
 
@@ -114,33 +114,33 @@ bool xMBMasterPortTimersInit(uint16_t usTimeOut50us)
   return xMBMasterPortSerialSetTimeout(ulTimeOut);
 }
 
-void xMBMasterPortTimersClose()
+void xMBMasterPortTimersClose(void)
 {
   /* Does not use any hardware resources. */
 }
 
-INLINE void vMBMasterPortTimersT35Enable( void )
+INLINE void vMBMasterPortTimersT35Enable(void)
 {
   vMBMasterPortTimersEnable();
   ulTimeOut = ulTimeoutT35;
   vMBMasterSetCurTimerMode(MB_TMODE_T35);
 }
 
-INLINE void vMBMasterPortTimersConvertDelayEnable( void )
+INLINE void vMBMasterPortTimersConvertDelayEnable(void)
 {
   vMBMasterPortTimersEnable();
   ulTimeOut = ulTimeoutConvertDelay;
   vMBMasterSetCurTimerMode(MB_TMODE_CONVERT_DELAY);
 }
 
-INLINE void vMBMasterPortTimersRespondTimeoutEnable( void )
+INLINE void vMBMasterPortTimersRespondTimeoutEnable(void)
 {
   vMBMasterPortTimersEnable();
   ulTimeOut = ulTimeoutResponse;
-  vMBMasterSetCurTimerMode( MB_TMODE_RESPOND_TIMEOUT );
+  vMBMasterSetCurTimerMode(MB_TMODE_RESPOND_TIMEOUT);
 }
 
-void vMBMasterPortTimerPoll( void )
+void vMBMasterPortTimerPoll(void)
 {
   uint32_t       ulDeltaMS;
   struct timeval xTimeCur;
@@ -168,7 +168,7 @@ void vMBMasterPortTimerPoll( void )
     }
 }
 
-void vMBMasterPortTimersDisable()
+void vMBMasterPortTimersDisable(void)
 {
   bTimeoutEnable = false;
 }


### PR DESCRIPTION
## Summary
fix build warning of PR [11698](https://github.com/apache/nuttx/pull/11698).

```
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_CLANG
  Building NuttX...
Error: nuttx/porttimer_m.c:117:30: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
  117 | void xMBMasterPortTimersClose()
      |                              ^
      |                               void
Error: nuttx/porttimer_m.c:171:32: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
  171 | void vMBMasterPortTimersDisable()
      |                                ^
      |                                 void
2 errors generated.
```
## Impact
Fix build modbus master warning

## Testing

```
nuttx$  ./tools/configure.sh linum-stm32h753bi:modbus_master
nuttx$  make v=1