### PR TITLE
apps/graphics: add lcddev_obj initialization to fix crash in lcd_dev mode

### DIFF
--- a/graphics/lvgl/port/lv_port_lcddev.c
+++ b/graphics/lvgl/port/lv_port_lcddev.c
@@ -148,6 +148,8 @@ static FAR lv_disp_t *lcddev_init(int fd,
       return NULL;
     }
 
+  memset(lcddev_obj, 0, sizeof(struct lcddev_obj_s));
+
   buf1 = malloc(buf_size);
   if (buf1 == NULL)
     {


### PR DESCRIPTION

## Summary

Fix crash in lvgldemo while using lcd dev.

Reference: https://github.com/apache/nuttx/issues/11683

## Impact
CI

## Testing

ESP32 Wrover
