### PR TITLE
build/ci: fix CI blocking unused warning issues (apps repo part)

### DIFF
--- a/testing/getprime/getprime_main.c
+++ b/testing/getprime/getprime_main.c
@@ -158,6 +158,7 @@ static void get_prime_in_parallel(int n)
     }
 
   printf("Done\n");
+  UNUSED(status);
 }
 
 /****************************************************************************


### PR DESCRIPTION

## Summary

This patch attempts to fix the blocking issues encountered with build 6374 of apps/pull/2300.
It needs be used with #11739 in nuttx repo.

## Impact

CI checker

## Testing

CI checks.
