### PR TITLE
fix variable set but not used

### DIFF
--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -38,7 +38,7 @@ PRIORITY  += SCHED_PRIORITY_DEFAULT
 STACKSIZE += $(CONFIG_DEFAULT_TASK_STACKSIZE)
 endif
 
-CFLAGS += -Wno-undef
+CFLAGS += -Wno-undef -Wno-unused-but-set-variable
 
 CSRCS := $(MCUBOOT_UNPACK)/boot/bootutil/src/boot_record.c \
          $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_misc.c \

--- a/lte/alt1250/alt1250_main.c
+++ b/lte/alt1250/alt1250_main.c
@@ -96,6 +96,7 @@ static void notify_to_lapi_caller(sem_t *syncsem)
 static int initialize_daemon(FAR struct alt1250_s *dev)
 {
   int ret;
+  UNSED(ret);
 
   /* Initialize sub-system */
 

--- a/modbus/nuttx/porttimer.c
+++ b/modbus/nuttx/porttimer.c
@@ -105,6 +105,7 @@ void vMBPortTimersEnable(void)
 {
   int res = gettimeofday(&xTimeLast, NULL);
 
+  UNUSED(res);
   DEBUGASSERT(res == 0);
   bTimeoutEnable = true;
 }

--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -34,6 +34,12 @@ $(ADB_UNPACKDIR):
 	$(call DELFILE, $(ADB_VERSION).zip)
 	$(call MOVEFILE, $(ADB_UNPACKNAME)-$(ADB_VERSION), $(ADB_UNPACKDIR))
 
+# Fix warnings in microADB
+# Error: microADB/hal/hal_uv_client_usb.c:90:13: error: unused variable 'ret' [-Werror=unused-variable]
+#  90 |         int ret = uv_read_start((uv_stream_t*)&client->pipe,
+
+CFLAGS += -Wno-error=unused-variable
+
 # adb server app
 
 PROGNAME  := $(CONFIG_ADBD_PROGNAME)

--- a/system/adb/logcat_service.c
+++ b/system/adb/logcat_service.c
@@ -67,6 +67,7 @@ static void logcat_on_kick(struct adb_service_s *service)
   if (!svc->wait_ack)
     {
       int ret;
+      UNUSED(ret);
       ret = uv_poll_start(&svc->poll, UV_READABLE, logcat_on_data_available);
       assert(ret == 0);
     }
@@ -93,6 +94,7 @@ static void logcat_on_close(struct adb_service_s *service)
   int ret;
   logcat_service_t *svc = container_of(service, logcat_service_t, service);
 
+  UNUSED(ret);
   ret = uv_fileno((uv_handle_t *)&svc->poll, &fd);
   assert(ret == 0);
 

--- a/testing/getprime/getprime_main.c
+++ b/testing/getprime/getprime_main.c
@@ -119,6 +119,7 @@ static void get_prime_in_parallel(int n)
   int status;
   int i;
 
+  UNUSED(status);
   status = pthread_attr_init(&attr);
   ASSERT(status == OK);
 


### PR DESCRIPTION
## Summary
These variables will trigger variable 'ret' set but not used warnings due to different configurations.

For using variables only in assert, added UNUSED to declare
Warnings in external repositories are ignored in the makefile

## Impact
Let's ignore the following format check, which seems to have nothing to do with this change
```
apps/modbus/nuttx/porttimer.c:51:9: error: Mixed case identifier found
  return xMBPortSerialSetTimeout(ulTimeOut);
```


## Testing

