### PR TITLE
apps: Make /dev/temp0 as default to system/lm75

### DIFF
--- a/system/lm75/lm75.c
+++ b/system/lm75/lm75.c
@@ -41,7 +41,7 @@
 
 #ifndef CONFIG_SYSTEM_LM75_DEVNAME
 #  warning CONFIG_SYSTEM_LM75_DEVNAME is not defined
-#  define CONFIG_SYSTEM_LM75_DEVNAME "/dev/temp"
+#  define CONFIG_SYSTEM_LM75_DEVNAME "/dev/temp0"
 #endif
 
 #if !defined(CONFIG_SYSTEM_LM75_FAHRENHEIT) && !defined(CONFIG_SYSTEM_LM75_CELSIUS)


### PR DESCRIPTION
## Summary
The stm32 common logic board uses /dev/temp0 as
default, but system/lm75/lm75.c is trying to
open /dev/temp instead
## Impact
Make things work out of box
## Testing
stm32
