### PR TITLE
dd:support "seek"

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -188,7 +188,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #ifndef CONFIG_NSH_DISABLE_DD
   CMD_MAP("dd",       cmd_dd,       3, 7,
     "if=<infile> of=<outfile> [bs=<sectsize>] [count=<sectors>] "
-    "[skip=<sectors>] [verify]"),
+    "[skip=<sectors>] [seek=<sectors>] [verify]"),
 #endif
 
 #if defined(CONFIG_NET) && defined(CONFIG_NET_ROUTE) && !defined(CONFIG_NSH_DISABLE_DELROUTE)

--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -75,6 +75,7 @@ struct dd_s
   int          outfd;      /* File descriptor of the output device */
   uint32_t     nsectors;   /* Number of sectors to transfer */
   uint32_t     skip;       /* The number of sectors skipped on input */
+  uint32_t     seek;       /* The number of bytes skipped on output */
   bool         eof;        /* true: The end of the input or output file has been hit */
   bool         verify;     /* true: Verify infile and outfile correctness */
   size_t       sectsize;   /* Size of one sector */
@@ -332,6 +333,10 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         {
           dd.skip = atoi(&argv[i][5]);
         }
+      else if (strncmp(argv[i], "seek=", 5) == 0)
+        {
+          dd.seek = atoi(&argv[i][5]);
+        }
       else if (strncmp(argv[i], "verify", 6) == 0)
         {
           dd.verify = true;
@@ -382,7 +387,18 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       ret = lseek(dd.infd, dd.skip * dd.sectsize, SEEK_SET);
       if (ret < -1)
         {
-          nsh_error(vtbl, g_fmtcmdfailed, g_dd, "lseek", NSH_ERRNO);
+          nsh_error(vtbl, g_fmtcmdfailed, g_dd, "skip lseek", NSH_ERRNO);
+          ret = ERROR;
+          goto errout_with_outf;
+        }
+    }
+
+  if (dd.seek)
+    {
+      ret = lseek(dd.outfd, dd.seek * dd.sectsize, SEEK_SET);
+      if (ret < -1)
+        {
+          nsh_error(vtbl, g_fmtcmdfailed, g_dd, "seek lseek", NSH_ERRNO);
           ret = ERROR;
           goto errout_with_outf;
         }


### PR DESCRIPTION
## Summary
Added "seek" support to the dd command, We can use "seek" to set how many Bytes the written target should skip first.
## Impact
“dd“ supports seek parameter parsing
## Testing
local test PASS
