### PR TITLE
cp:support -r recursive copies

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -169,7 +169,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_CP
-  CMD_MAP("cp",       cmd_cp,       3, 3, "<source-path> <dest-path>"),
+  CMD_MAP("cp",       cmd_cp,       3, 4, "[-r] <source-path> <dest-path>"),
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_CMP

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -290,6 +290,7 @@ static int cp_recursive(FAR struct nsh_vtbl_s *vtbl, FAR const char *srcpath,
 
       if (S_ISDIR(buf.st_mode))
         {
+#if !defined(CONFIG_DISABLE_MOUNTPOINT) || !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS)
           ret = mkdir(allocdestpath, S_IRWXU | S_IRWXG | S_IROTH |
                       S_IXOTH);
           if (ret != OK)
@@ -297,6 +298,7 @@ static int cp_recursive(FAR struct nsh_vtbl_s *vtbl, FAR const char *srcpath,
               nsh_error(vtbl, g_fmtcmdfailed, "cp", "mkdir", NSH_ERRNO);
               goto errout_with_allocdestpath;
             }
+#endif
 
           ret = cp_recursive(vtbl, allocsrcpath, allocdestpath);
           if (ret != OK)


### PR DESCRIPTION
## Summary
The cp command supports recursive copying. Use "cp -r" to copy a folder.

## Impact
The behavior of mkdir is used during the cp -r process, and the mkdir behavior is skipped when mkdir is unavailable (this may cause unpredictable behavior of cp -r)

## Testing
local test PASS
