### PR TITLE
graphics/lvgl: remove unused code

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -101,18 +101,6 @@ if(CONFIG_GRAPHICS_LVGL)
     list(APPEND CSRCS port/lv_port_syslog.c)
   endif()
 
-  if(CONFIG_LIBUV)
-    list(APPEND CSRCS port/lv_port_libuv.c)
-  endif()
-
-  if(CONFIG_LIBUV)
-    list(APPEND CSRCS port/lv_port_libuv.c)
-  endif()
-
-  if(CONFIG_LIBUV)
-    list(APPEND CSRCS port/lv_port_libuv.c)
-  endif()
-
   if(CONFIG_LV_MEM_CUSTOM)
     if(NOT CONFIG_LV_PORT_MEM_CUSTOM_SIZE EQUAL 0)
       list(APPEND CFLAGS -DLV_MEM_CUSTOM_ALLOC=lv_port_mem_alloc)


### PR DESCRIPTION
## Summary

graphics/lvgl: remove unused code

Since it has beed used from https://github.com/apache/nuttx-apps/blob/master/graphics/lvgl/CMakeLists.txt#L72-L74

## Impact

## Testing
local build

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

