### PR TITLE
netinit: Add check mount path retry option for delayed mounts

### DIFF
--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -118,6 +118,13 @@ config NETINIT_THREAD_PRIORITY
 		PHY polling is CPU intensive and can interfere with the usability of
 		of threads competing for CPU bandwidth.
 
+config NETINIT_RETRY_MOUNTPATH
+	int "Network initialization retry mount path count"
+	default 0
+	---help---
+		This should be set if the filesystem get mounted after netinit got started.
+		The netinit thread will check for the mount path before continuing.
+
 endif # NETINIT_THREAD
 
 config NETINIT_DEBUG

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -334,6 +334,30 @@ static void netinit_set_macaddr(void)
 #  define netinit_set_macaddr()
 #endif
 
+#if defined(CONFIG_NETINIT_THREAD) && CONFIG_NETINIT_RETRY_MOUNTPATH > 0
+static inline void netinit_checkpath(void)
+{
+  int retries = CONFIG_NETINIT_RETRY_MOUNTPATH;
+  while (retries > 0)
+    {
+      DIR * dir = opendir(CONFIG_IPCFG_PATH);
+      if (dir)
+        {
+          /* Directory exists. */
+
+          closedir(dir);
+          break;
+        }
+      else
+        {
+        usleep(100000);
+        }
+
+      retries--;
+    }
+}
+#endif
+
 /****************************************************************************
  * Name: netinit_set_ipv4addrs
  *
@@ -354,6 +378,10 @@ static inline void netinit_set_ipv4addrs(void)
   /* Attempt to obtain IPv4 address configuration from the IP configuration
    * file.
    */
+
+#if defined(CONFIG_NETINIT_THREAD) && CONFIG_NETINIT_RETRY_MOUNTPATH > 0
+  netinit_checkpath();
+#endif
 
   ret = ipcfg_read(NET_DEVNAME, (FAR struct ipcfg_s *)&ipv4cfg, AF_INET);
 #ifdef CONFIG_NETUTILS_DHCPC
@@ -511,6 +539,10 @@ static inline void netinit_set_ipv6addrs(void)
   /* Attempt to obtain IPv6 address configuration from the IP configuration
    * file.
    */
+
+#if defined(CONFIG_NETINIT_THREAD) && CONFIG_NETINIT_RETRY_MOUNTPATH > 0
+  netinit_checkpath();
+#endif
 
   ret = ipcfg_read(NET_DEVNAME, (FAR struct ipcfg_s *)&ipv6cfg, AF_INET6);
   if (ret >= 0 && IPCFG_HAVE_STATIC(ipv6cfg.proto))


### PR DESCRIPTION
## Summary
Some systems the sd card gets mounted later after netinit started this causes netinit to be unable to read the config. 

This pr add a KConfig symbol to set retries to allow delayed mount

## Impact
Minimal, default behavior is the same

## Testing
Teensy
