### PR TITLE
system/libuv: fix compiler warning of "container_of" redefined

### DIFF
--- a/system/libuv/0001-libuv-port-for-nuttx.patch
+++ b/system/libuv/0001-libuv-port-for-nuttx.patch
@@ -3544,3 +3544,33 @@ index bbc0c305..4e7996f5 100644
  
    MAKE_VALGRIND_HAPPY(loop);
    return 0;
+diff --git a/src/uv-common.h b/src/uv-common.h
+index cd57e5a..f951ca8 100644
+--- a/src/uv-common.h
++++ b/src/uv-common.h
+@@ -54,8 +54,10 @@ extern int snprintf(char*, size_t, const char*, ...);
+ #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+ #define ARRAY_END(a)  ((a) + ARRAY_SIZE(a))
+ 
++#ifndef container_of
+ #define container_of(ptr, type, member) \
+   ((type *) ((char *) (ptr) - offsetof(type, member)))
++#endif
+ 
+ /* C11 defines static_assert to be a macro which calls _Static_assert. */
+ #if defined(static_assert)
+diff --git a/test/task.h b/test/task.h
+index 25af255..b451903 100644
+--- a/test/task.h
++++ b/test/task.h
+@@ -71,8 +71,10 @@
+ 
+ #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+ 
++#ifndef container_of
+ #define container_of(ptr, type, member) \
+   ((type *) ((char *) (ptr) - offsetof(type, member)))
++#endif
+ 
+ typedef enum {
+   TCP = 0,


### PR DESCRIPTION
## Summary
system/libuv: fix compiler warning of "container_of" redefined
    
```
    In file included from libuv/test/runner.c:27:
    libuv/test/task.h:74: warning: "container_of" redefined
       74 | #define container_of(ptr, type, member) \
          |
    In file included from /home/archer/code/nuttx/n2/nuttx/include/nuttx/list.h:47,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/tls.h:34,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/sched.h:48,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/arch.h:87,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/userspace.h:35,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/mm/mm.h:30,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/kmalloc.h:34,
                     from /home/archer/code/nuttx/n2/nuttx/include/nuttx/lib/lib.h:31,
                     from /home/archer/code/nuttx/n2/nuttx/include/stdio.h:35,
                     from libuv/test/runner.c:22:
    /home/archer/code/nuttx/n2/nuttx/include/nuttx/nuttx.h:48: note: this is the location of the previous definition
       48 | #define container_of(ptr, type, member) \
          |
```
    
Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check