### PR TITLE
ci: Remove the codecheck from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim-01, sim-02, xtensa, codechecker]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim-01, sim-02, xtensa]
 
     steps:
       - name: Download Source Artifact


### PR DESCRIPTION

## Summary

the check isn't really enabled and enforce before
due to a mass of false alarm, but recently it break ci frequently, so it's better to remove it now.

## Impact

ci

## Testing

ci