### PR TITLE
examples/fmsynth: Fix freaze when execute it in 2nd time

### DIFF
--- a/audioutils/nxaudio/nxaudio.c
+++ b/audioutils/nxaudio/nxaudio.c
@@ -197,7 +197,8 @@ int init_nxaudio_devname(FAR struct nxaudio_s *nxaudio,
 
       /* Create message queue to communicate with audio driver */
 
-      nxaudio->mq = create_audiomq(mqname, nxaudio->fd, buf_info.nbuffers + 8);
+      nxaudio->mq = create_audiomq(mqname, nxaudio->fd,
+                                   buf_info.nbuffers + 8);
 
       /* Create audio buffers to inject audio sample */
 

--- a/examples/fmsynth/keyboard_main.c
+++ b/examples/fmsynth/keyboard_main.c
@@ -79,7 +79,6 @@ struct key_convert_s
  * Private Function Prototypes
  ****************************************************************************/
 
-extern int board_external_amp_mute_control(bool en);
 static void app_dequeue_cb(unsigned long arg,
                            FAR struct ap_buffer_s *apb);
 static void app_complete_cb(unsigned long arg);
@@ -91,6 +90,7 @@ static void app_user_cb(unsigned long arg,
  ****************************************************************************/
 
 static struct kbd_s g_kbd;
+static bool g_running = true;
 
 static struct nxaudio_callbacks_s cbs =
 {
@@ -191,7 +191,10 @@ static void app_dequeue_cb(unsigned long arg,
                                       NULL, 0);
     }
 
-  nxaudio_enqbuffer(&kbd->nxaudio, apb);
+  if (g_running)
+    {
+      nxaudio_enqbuffer(&kbd->nxaudio, apb);
+    }
 }
 
 /****************************************************************************
@@ -373,11 +376,11 @@ int main(int argc, FAR char *argv[])
   int i;
   int ret;
   int key;
-  bool running = true;
   pthread_t pid;
   struct app_options appopt;
   int key_idx;
 
+  g_running = true;
   if (configure_option(&appopt, argc, argv) != OK)
     {
       print_help(argv[0]);
@@ -414,7 +417,7 @@ int main(int argc, FAR char *argv[])
   printf("Start %s\n", argv[0]);
   print_keyusage();
 
-  while (running)
+  while (g_running)
     {
       key = getchar();
       if (key != EOF)
@@ -422,7 +425,7 @@ int main(int argc, FAR char *argv[])
           switch (key)
             {
               case 'q':
-                running = false;
+                g_running = false;
                 break;
 
               default:
@@ -437,8 +440,6 @@ int main(int argc, FAR char *argv[])
             }
         }
     }
-
-  board_external_amp_mute_control(true);
 
   nxaudio_stop(&g_kbd.nxaudio);
   pthread_join(pid, NULL);

--- a/examples/fmsynth/mmlplayer_main.c
+++ b/examples/fmsynth/mmlplayer_main.c
@@ -98,6 +98,7 @@ static void app_user_cb(unsigned long arg,
  ****************************************************************************/
 
 static struct mmlplayer_s g_mmlplayer;
+static bool g_running = true;
 
 static struct nxaudio_callbacks_s cbs =
 {
@@ -263,7 +264,11 @@ static void app_dequeue_cb(unsigned long arg,
                                   mmlplayer->nxaudio.chnum,
                                   tick_callback,
                                   (unsigned long)(uintptr_t)mmlplayer);
-  nxaudio_enqbuffer(&mmlplayer->nxaudio, apb);
+
+  if (g_running)
+    {
+      nxaudio_enqbuffer(&mmlplayer->nxaudio, apb);
+    }
 }
 
 /****************************************************************************
@@ -503,12 +508,12 @@ int main(int argc, FAR char *argv[])
   int i;
   int ret;
   int key;
-  bool running = true;
   pthread_t pid;
   struct app_options appopt;
 
   printf("Start %s\n", argv[0]);
 
+  g_running = true;
   if (configure_option(&appopt, argc, argv) != OK)
     {
       print_help(argv[0]);
@@ -540,7 +545,7 @@ int main(int argc, FAR char *argv[])
 
   pid = create_audio_thread(&g_mmlplayer);
 
-  while (running)
+  while (g_running)
     {
       key = getchar();
       if (key != EOF)
@@ -548,7 +553,7 @@ int main(int argc, FAR char *argv[])
           switch (key)
             {
               case 'q':
-                running = false;
+                g_running = false;
                 break;
             }
         }

--- a/include/audioutils/nxaudio.h
+++ b/include/audioutils/nxaudio.h
@@ -63,6 +63,9 @@ extern "C"
 
 int init_nxaudio(FAR struct nxaudio_s *nxaudio,
                  int fs, int bps, int chnum);
+int init_nxaudio_devname(FAR struct nxaudio_s *nxaudio,
+                 int fs, int bps, int chnum,
+                 const char *devname, const char *mqname);
 void fin_nxaudio(FAR struct nxaudio_s *nxaudio);
 int nxaudio_enqbuffer(FAR struct nxaudio_s *nxaudio,
                       FAR struct ap_buffer_s *apb);


### PR DESCRIPTION
## Summary

Fix a freaze BUG when the example is executed again after 1st execution.

## Impact

examples/fmsynth

## Testing

Verify if fmsynth examples work again after finished 1st execution, on spresense board.