### PR TITLE
Ignore all *.lock in apps folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 .context
 .depend
 .kconfig
-/*.lock
+*.lock
 /bin
 /boot_romfsimg.h
 /external


### PR DESCRIPTION
## Summary

to fix the ci break reported by:
https://github.com/apache/nuttx/actions/runs/8124056482/job/22205151164?pr=11829

## Impact

fix ci break

## Testing

ci