### PR TITLE
ostest: add test for libc memmem() function

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -20,7 +20,14 @@
 
 if(CONFIG_TESTING_OSTEST)
 
-  set(SRCS getopt.c restart.c sigprocmask.c sighand.c signest.c sighelper.c)
+  set(SRCS
+      getopt.c
+      libc_memmem.c
+      restart.c
+      sigprocmask.c
+      sighand.c
+      signest.c
+      sighelper.c)
 
   if(CONFIG_DEV_NULL)
     list(APPEND SRCS dev_null.c)

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -29,8 +29,9 @@ MODULE = $(CONFIG_TESTING_OSTEST)
 
 # NuttX OS Test
 
-CSRCS   = getopt.c restart.c sigprocmask.c sighand.c signest.c
-CSRCS  += sighelper.c
+CSRCS   = getopt.c libc_memmem.c restart.c sigprocmask.c sighand.c \
+          signest.c sighelper.c
+
 MAINSRC = ostest_main.c
 
 ifeq ($(CONFIG_DEV_NULL),y)

--- a/testing/ostest/libc_memmem.c
+++ b/testing/ostest/libc_memmem.c
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * apps/testing/ostest/libc_memmem.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <assert.h>
+#include <string.h>
+
+#include "ostest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int memmem_test(void)
+{
+  char *haystack = "hello";
+  char *s;
+
+  s = memmem(haystack, 5, "hel", 3);
+  ASSERT(s == haystack);
+
+  s = memmem(haystack, 5, "lo", 2);
+  ASSERT(s == haystack + 3);
+
+  s = memmem(haystack, 5, "hello", 5);
+  ASSERT(s == haystack);
+
+  /* Compare '\0' bytes at string ends. */
+
+  s = memmem(haystack, 6, "o", 2);
+  ASSERT(s == haystack + 4);
+
+  /* Must not find needle that is right after end of haystack. */
+
+  s = memmem("helloX", 5, "X", 1);
+  ASSERT(s == NULL);
+
+  /* Too long needle should return NULL. */
+
+  s = memmem(haystack, 5, "hellohello", 10);
+  ASSERT(s == NULL);
+
+  /* Zero length needle is deemed to reside at start of haystack. */
+
+  s = memmem(haystack, 5, "", 0);
+  ASSERT(s == haystack);
+
+  return OK;
+}

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -91,6 +91,10 @@
 
 int getopt_test(void);
 
+/* libc_memmem.c ************************************************************/
+
+int memmem_test(void);
+
 /* setvbuf.c ****************************************************************/
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -260,6 +260,12 @@ static int user_main(int argc, char *argv[])
   getopt_test();
   check_test_memory_usage();
 
+  /* Test misc libc functions. */
+
+  printf("\nuser_main: libc tests\n");
+  memmem_test();
+  check_test_memory_usage();
+
   /* If retention of child status is enable, then suppress it for this task.
    * This task may produce many, many children (especially if
    * CONFIG_TESTING_OSTEST_LOOPS) and it does not harvest their exit status.


### PR DESCRIPTION
## Summary

ostest: add test for libc memmem() function

See https://github.com/apache/nuttx/pull/11889

## Impact

## Testing

