### PR TITLE
testing/ostest/cancel: joining a detached/canceled thread should return EINVAL, not ESRCH

### DIFF
--- a/testing/ostest/cancel.c
+++ b/testing/ostest/cancel.c
@@ -607,7 +607,7 @@ void cancel_test(void)
       printf("cancel_test: ERROR pthread_join succeeded\n");
       ASSERT(false);
     }
-  else if (status != ESRCH)
+  else if (status != EINVAL)
     {
       printf("cancel_test:"
              " ERROR pthread_join failed but with wrong status=%d\n",
@@ -616,7 +616,7 @@ void cancel_test(void)
     }
   else
     {
-      printf("cancel_test: PASS pthread_join failed with status=ESRCH\n");
+      printf("cancel_test: PASS pthread_join failed with status=EINVAL\n");
     }
 
   /* Test 4: Non-cancelable threads *****************************************/


### PR DESCRIPTION
## Summary

testing/ostest/cancel: joining a detached/canceled thread should return EINVAL, not ESRCH

Reference:
https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_join.html
  [EINVAL]
    The value specified by thread does not refer to a joinable thread.

https://docs.oracle.com/cd/E19120-01/open.solaris/816-5137/tlib-25/index.html

  EINVAL
    The thread corresponding to the given thread ID is a detached thread.

https://linux.die.net/man/3/pthread_join

  EINVAL
    thread is not a joinable thread.


## Impact

Depends on: https://github.com/apache/nuttx/pull/11898

N/A

## Testing

ostest