### PR TITLE
matter cmake:fix matter_generate_args_tmp_file call error

### DIFF
--- a/crypto/mbedtls/CMakeLists.txt
+++ b/crypto/mbedtls/CMakeLists.txt
@@ -74,7 +74,7 @@ if(CONFIG_CRYPTO_MBEDTLS)
   # ############################################################################
 
   nuttx_add_library(mbedtls STATIC)
-
+  nuttx_export_header(TARGET mbedtls INCLUDE_DIRECTORIES ${MBEDTLS_DIR}/include)
   target_sources(mbedtls PRIVATE ${CSRCS})
   target_include_directories(mbedtls PRIVATE ${INCDIR})
   target_compile_definitions(mbedtls PRIVATE __unix__)

--- a/netutils/connectedhomeip/CMakeLists.txt
+++ b/netutils/connectedhomeip/CMakeLists.txt
@@ -151,12 +151,13 @@ if(CONFIG_MATTER)
   include(${COMMON_CMAKE_SOURCE_DIR}/chip_gn.cmake)
 
   set(nuttx_include_dirs)
-  get_target_property(include_dirs nuttx NUTTX_INCLUDE_DIRECTORIES)
-  list(APPEND nuttx_include_dirs ${include_dirs})
-  get_target_property(include_dirs nuttx INCLUDE_DIRECTORIES)
-  list(APPEND nuttx_include_dirs ${include_dirs})
-  get_target_property(include_dirs mbedtls INCLUDE_DIRECTORIES)
-  list(APPEND nuttx_include_dirs ${include_dirs})
+  get_target_property(include_dirs nuttx NUTTX_CXX_INCLUDE_DIRECTORIES)
+  if(include_dirs)
+    list(APPEND nuttx_include_dirs ${include_dirs})
+  endif()
+  list(APPEND nuttx_include_dirs ${NUTTX_DIR}/include
+       ${CMAKE_BINARY_DIR}/include ${CMAKE_BINARY_DIR}/include_arch)
+  list(APPEND nuttx_include_dirs ${NUTTX_APPS_BINDIR}/include/mbedtls)
 
   set(MATTER_INCDIR
       ${nuttx_include_dirs}


### PR DESCRIPTION
## Summary
adapt to matter libcxx library support
this patch fix https://github.com/apache/nuttx/pull/11893 ci failed

## Impact
sim:matter

## Testing
CI build
