### PR TITLE
Derive MAC Address from board unique_id

### DIFF
--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -474,6 +474,14 @@ choice
 		address to the hardware before it brings the network up.  This
 		choice allows you select the source of that MAC address.
 
+config NETINIT_UIDMAC
+	bool "Board Unique ID"
+	depends on BOARDCTL_UNIQUEID
+	---help---
+		Assign a MAC address based on the board unique ID.
+		CONFIG_BOARDCTL_UNIQUEID_SIZE must be at least 6 bytes for
+		Ethernet, 8 bytes for 6LOWPAN.
+
 config NETINIT_SWMAC
 	bool "Fixed address"
 	---help---


### PR DESCRIPTION
## Summary

Adds an option to derive a MAC Address from the board's unique_id.  Essentially just retrieves the unique_id and performs bit manipulation to ensure it is a valid unicast, locally administered MAC address.  This is useful for Ethernet hardware that does not have a built-in MAC address.  

Requires BOARDCTL_UNIQUEID.
Adds the NETINIT_UIDMAC Kconfig option.

## Impact

Allows use of multiple boards on the same network without having to manually configure different MAC addresses for each.

## Testing

Enable NETINIT_NOMAC and NETINIT_UIDMAC.  Your Ethernet interface should initialize with a unique MAC address based on the board's ID.

Tested on a RP2040 based W5500-EVB-Pico evaluation board and a custom board.