### PR TITLE
examples/hello_rust: Add -O flag

### DIFF
--- a/examples/hello_rust/Makefile
+++ b/examples/hello_rust/Makefile
@@ -31,6 +31,6 @@ MODULE    = $(CONFIG_EXAMPLES_HELLO_RUST)
 
 MAINSRC = hello_rust_main.rs
 
-RUSTFLAGS += -C panic=abort
+RUSTFLAGS += -C panic=abort -O
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
The current issue with the "hello_rust_main.rs" file not building successfully is addressed by this pull request, which aims to enhance the build process by incorporating the "-O" flag into the rustc flags. This adjustment is crucial for optimizing the code at level 2, ensuring better performance and efficiency. The modifications are made in the Makefile located at `apps/examples/hello_rust/Makefile`

The discussion surrounding the Rust build issue can be found in the [Rust-Lang issue #245](https://github.com/rust-lang/compiler-builtins/issues/245), where various aspects of the problem and potential solutions are discussed. This issue highlights the importance of optimization flags in the Rust compiler and how they can impact the build process and the resulting application's performance.

The "-O" flag in rustc is used to specify the optimization level for the compiler. According to the Rust documentation, the optimization levels in rustc are loosely based on the ones that GCC has. The "-O" level, in particular, enables a broader range of optimizations compared to "-opt-level=1", aiming to provide a good balance between performance and compilation time. For more information: [Rust Documentation](https://doc.rust-lang.org/rustc/command-line-arguments.html#option-o-optimize)

Incorporating the "-O" flag into the rustc flags for the "hello_rust_main.rs" file is a move to ensure that the code is optimized at a higher level, potentially leading to improved performance and efficiency. This change is expected to address the build issue by enabling more aggressive optimizations during the compilation process.

## Impact
This pull request (PR) introduces a significant improvement to the build process for Rust files within the NuttX environment, ensuring successful compilation.
The impact of this PR is primarily focused on the successful build of Rust files, with no adverse effects on the NuttX kernel or the NuttX applications. This ensures that the optimization does not introduce any unintended side effects or compatibility issues within the broader NuttX ecosystem.

## Testing
- This fgets() code is used to test: [Rust fgets() Code](https://gist.github.com/rushabhvg/e7927ee8340f385279068d407c8fcab7)
```
extern "C" {
    pub fn printf(format: *const u8, ...) -> i32;
    pub fn puts(s: *const core::ffi::c_char) -> core::ffi::c_int;
    pub fn fgets(
        buf: *mut core::ffi::c_char,
        n: core::ffi::c_int,
        stream: *mut core::ffi::c_void
    ) -> *mut core::ffi::c_char;
    pub fn lib_get_stream(fd: core::ffi::c_int) -> *mut core::ffi::c_void;
}
```
```
printf(b"Please give your output:\n\0" as *const u8);
let stdin: *mut core::ffi::c_void = lib_get_stream(0);
let mut buf: [core::ffi::c_char; 256] = [0; 256];
if !fgets(
    &mut buf[0], 
    buf.len() as i32 - 1,
    stdin
).is_null() {
    printf(b"You entered...\n\0" as *const u8);
    puts(&buf[0]);
}
```

- Currently it fails to link with "undefined panic" [Failed Build Log](https://gist.github.com/rushabhvg/a8760d43e12479f3045b6b356921c04a)
```
rushabhvg@rushabhvg-laptop:~/nuttxspace/nuttx$ make
LD: nuttx
riscv64-unknown-elf-ld: warning: /home/rushabhvg/nuttxspace/nuttx/staging/libapps.a(hello_rust_main.rs.home.rushabhvg.nuttxspace.apps.examples.hello_rust_1.o): mis-matched ISA version 2.1 for 'i' extension, the output version is 2.0
...
riscv64-unknown-elf-ld: /home/rushabhvg/nuttxspace/nuttx/staging/libapps.a(hello_rust_main.rs.home.rushabhvg.nuttxspace.apps.examples.hello_rust_1.o): in function `no symbol':
/home/rushabhvg/nuttxspace/apps/examples/hello_rust/hello_rust_main.rs:127: undefined reference to `core::panicking::panic'
make[1]: *** [Makefile:179: nuttx] Error 1
make: *** [tools/Unix.mk:546: nuttx] Error 2\
```

- Adding "-O" will solve the linking problem: examples\hello_rust\Makefile
```
RUSTFLAGS += -C panic=abort -O
```

We tested with QEMU:
```
qemu-system-riscv32 \
  -semihosting \
  -M virt,aclint=on \
  -cpu rv32 \
  -smp 8 \
  -bios none \
  -kernel nuttx \
  -nographic
```
The [Rust build log](https://gist.github.com/rushabhvg/eacb3ff6658750dd37db46ac6eb4ee3d) for NuttX shows that rust apps are build successfully.