### PR TITLE
dhcpc: reset the state of the "cancel" variable when restarting the async dhcpc thread

### DIFF
--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -959,6 +959,7 @@ int dhcpc_request_async(FAR void *handle, dhcpc_callback_t callback)
     }
 
   pdhcpc->callback = callback;
+  pdhcpc->cancel   = 0;
   ret = pthread_create(&pdhcpc->thread, NULL, dhcpc_run, pdhcpc);
   if (ret != 0)
     {


### PR DESCRIPTION
## Summary
dhcpc can run in async mode with a background thread. this can be cancelled (when the link goes down)

but when the link goes up again the variable dhcpc_state->cancel is not reinitialized, so the async mode works only once

## Impact

dhcpc async thread can be started multiple times

## Testing

verified to work experimentally on a stm32f4 custom board