### PR TITLE
nsh: Include option to disable uname timestamp

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -644,6 +644,15 @@ config NSH_DISABLE_UNAME
 	bool "Disable uname"
 	default DEFAULT_SMALL
 
+config NSH_DISABLE_UNAME_TIMESTAMP
+	bool "Disable uname timestamp"
+	default n
+	---help---
+		Currently uname command will print the timestamp
+		when the binary was built, and it generates an issue
+		because two identical built binaries will have differents
+		hashes/CRC.
+
 config NSH_DISABLE_UNSET
 	bool "Disable unset"
 	default DEFAULT_SMALL


### PR DESCRIPTION
## Summary
Currently uname command will print the timestamp
when the binary was built, and it generates an issue because two identical built binaries will have differents hashes/CRC.

## Impact
It could be possible to disable this feature and generate identical binaries

## Testing
SIM
