### PR TITLE
nshlib/irqaff: add irq affinity command 

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -689,6 +689,11 @@ config NSH_DISABLE_RESET_CAUSE
 	default DEFAULT_SMALL
 	depends on BOARDCTL_RESET_CAUSE
 
+config NSH_DISABLE_IRQ_AFFINITY
+	bool "Disable command of irq affinity"
+	default DEFAULT_SMALL
+	depends on BOARDCTL_IRQ_AFFINITY
+
 endmenu
 
 if MMCSD

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1145,6 +1145,11 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
                       FAR char **argv);
 #endif
 
+#if defined(CONFIG_BOARDCTL_IRQ_AFFINITY) && !defined(CONFIG_NSH_DISABLE_IRQ_AFFINITY)
+  int cmd_irq_affinity(FAR struct nsh_vtbl_s *vtbl, int argc,
+                       FAR char **argv);
+#endif
+
 #if defined(CONFIG_RPMSG) && !defined(CONFIG_NSH_DISABLE_RPMSG)
   int cmd_rpmsg(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -497,6 +497,11 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("resetcause", cmd_reset_cause, 1, 1, NULL),
 #endif
 
+#if defined(CONFIG_BOARDCTL_IRQ_AFFINITY) && !defined(CONFIG_NSH_DISABLE_IRQ_AFFINITY)
+  CMD_MAP("irqaff", cmd_irq_affinity, 3, 3,
+    "irqaff [IRQ Number] [Core Mask]"),
+#endif
+
 #ifdef NSH_HAVE_DIROPTS
 #  ifndef CONFIG_NSH_DISABLE_RM
   CMD_MAP("rm",       cmd_rm,       2, 3, "[-r] <file-path>"),

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -519,6 +519,32 @@ int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #endif
 
 /****************************************************************************
+ * Name: cmd_irq_affinity
+ ****************************************************************************/
+
+#if defined(CONFIG_BOARDCTL_IRQ_AFFINITY) && !defined(CONFIG_NSH_DISABLE_IRQ_AFFINITY)
+int cmd_irq_affinity(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
+{
+  unsigned int affinity[2];
+
+  if (argc == 3)
+    {
+      affinity[0] = strtoul(argv[1], NULL, 0);
+      affinity[1] = strtoul(argv[2], NULL, 0);
+
+      if (affinity[1] == 0)
+        {
+          affinity[1] = 0x1;
+        }
+
+      return boardctl(BOARDIOC_IRQ_AFFINITY, (uintptr_t)affinity);
+    }
+
+  return ERROR;
+}
+#endif
+
+/****************************************************************************
  * Name: cmd_rpmsg
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

nshlib/irqaff: add irq affinity command

add support for set an IRQ affinity to CPUs by software

Signed-off-by: chao an <anchao@lixiang.com>



## Impact

N/A

Depends on: https://github.com/apache/nuttx/pull/12020

## Testing

qemu-armv7a/bmp ostest on single core

```
nuttx$ qemu-system-arm -cpu cortex-a7 -nographic      -machine virt,virtualization=off,gic-version=2 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel ./nuttx -smp 4 

NuttShell (N
NuttS
Nutt
NH) NutShellShetSutlltX- (NSH) NuttX-10.4.0
4t(NheSH) NuttX-ns0.h> 1ll (NSH) Nu0.4.0
nstX-1h> 
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK           STACK   USED  FILLED COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 004080 000536  13.1%  CPU0 IDLE
    1     1 192 RR       Kthread   - Waiting  Semaphore 0000000000000000 004032 000296   7.3%  hpwork 0x4013f51c 0x4013f530
    2     2 100 RR       Task      - Running            0000000000000000 004056 001168  28.7%  nsh_main
nsh> irqaff 33 0x2
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK           STACK   USED  FILLED COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 004080 000736  18.0%  CPU1 IDLE
    1     1 192 RR       Kthread   - Waiting  Semaphore 0000000000000000 004032 000296   7.3%  hpwork 0x4013f544 0x4013f558
    2     2 100 RR       Task      - Running            0000000000000000 004056 001288  31.7%  nsh_main
nsh> irqaff 33 0x4
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK           STACK   USED  FILLED COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 004080 000736  18.0%  CPU2 IDLE
    1     1 192 RR       Kthread   - Waiting  Semaphore 0000000000000000 004032 000296   7.3%  hpwork 0x4013f56c 0x4013f580
    2     2 100 RR       Task      - Running            0000000000000000 004056 001168  28.7%  nsh_main
nsh> irqaff 33 0x8
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK           STACK   USED  FILLED COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 004080 000736  18.0%  CPU3 IDLE
    1     1 192 RR       Kthread   - Waiting  Semaphore 0000000000000000 004032 000296   7.3%  hpwork 0x4013f594 0x4013f5a8
    2     2 100 RR       Task      - Running            0000000000000000 004056 001168  28.7%  nsh_main

```