### PR TITLE
Make.defs:make all AROBJS and OBJS batch cleaned in Application

### DIFF
--- a/Make.defs
+++ b/Make.defs
@@ -169,9 +169,17 @@ endef
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define CLEANAROBJS
 	$(call DELFILE,$(subst /,\,$(AROBJS)))
+	$(call DELFILE,$(subst /,\,$(OBJS)))
+	$(eval OBJS :=)
 endef
 else
 define CLEANAROBJS
-	$(Q) rm -f $(AROBJS)
+	$(call SPLITVARIABLE,CLEAN_AROBJS,${AROBJS},100)
+	$(foreach BATCH, $(CLEAN_AROBJS_TOTAL), \
+		$(shell rm -rf $(CLEAN_AROBJS_$(BATCH))))
+	$(call SPLITVARIABLE,CLEAN_OBJS,${OBJS},100)
+	$(foreach BATCH, $(CLEAN_OBJS_TOTAL), \
+		$(shell rm -rf $(CLEAN_OBJS_$(BATCH))))
+	$(eval OBJS :=)
 endef
 endif


### PR DESCRIPTION
## Summary
hi @xiaoxiang781216 @anchao 
I saw the issue discussed in this PR https://github.com/apache/nuttx/pull/11997 about ltp failure
we previously used batch splitting to solve the problem of `argument too long` during compilation.
but there is a problem here in `nuttx/tools/Config.mk`
application `OBJS` clean call `CLEAN` macro defined in nuttx/tools/Config.mk
variables are expand directly within the marco.

https://github.com/apache/nuttx/blob/806d783fd6dab9cb4de79da2516e9ece71b4efdc/tools/Config.mk#L597-L601

this is no problem in the nuttx call, because the obj generated by nuttx compilation definitely does not have a suffix.
however, there is uncertainty in the obj expansion of the Applications call.

---

This patch follows the previous design of batch splitting and performs batch **deletion**.
**and at the same time, reset the OBJS variables** , $(OBJS) remove in Application CLEAN before CLEANAROBJS:
```
clean::
   $(call DELFILE, .built)
   $(call CLEANAROBJS)
   $(call CLEAN)
```
I plan to keep OBJS CLEAN in non-apps build here, delete and reset OBJS in batches in apps build.

## Impact

make distclean

## Testing

CI build
