### PR TITLE
apps/nshlib: Never disable HELP and ?

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -406,7 +406,7 @@ config NSH_DISABLE_GET
 
 config NSH_DISABLE_HELP
 	bool "Disable help"
-	default DEFAULT_SMALL
+	default n
 
 config NSH_DISABLE_ERROR_PRINT
 	bool "Disable NSH Error Printing"


### PR DESCRIPTION
## Summary
Never disable HELP and ?
## Impact
Users will be able to see available commands in NSH
## Testing
stm32f103-minimum

Please ignore the CI failing, it needs https://github.com/apache/nuttx/pull/12038 because default board config changed (chichen-egg dilemma).