### PR TITLE
Minor improvement for tools/ci:  Fixed cmake build of bloaty and installation in darwin.sh script.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
           cache-name: ${{ runner.os }}-cache-tools
         with:
           path: ./sources/tools
-          key: ${{ runner.os }}-tools-${{ hashFiles('./sources/nuttx/tools/ci/cibuild.sh') }}
+          key: ${{ runner.os }}-tools-${{ hashFiles('./sources/nuttx/tools/ci/platforms/darwin.sh') }}
 
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

function bloaty() Add  -D CMAKE_INSTALL_PREFIX="${NUTTXTOOLS}"/bloaty. Improves workflow execution time because it is now cached.

Changed reference file to calculate the hash for key of actions/cache@v4. Now it is darwin.sh.

## Impact

ci

## Testing

ci