### PR TITLE
examples/pipe:removes useless data from test cases

### DIFF
--- a/examples/pipe/pipe_main.c
+++ b/examples/pipe/pipe_main.c
@@ -157,6 +157,12 @@ int main(int argc, FAR char *argv[])
       return 6;
     }
 
+  ret = remove(FIFO_PATH1);
+  if (ret != 0)
+    {
+      fprintf(stderr, "pipe_main: remove failed with errno=%d\n", errno);
+    }
+
   /* Perform the FIFO interlock test */
 
   fprintf(stderr, "\npipe_main: Performing pipe interlock test\n");


### PR DESCRIPTION
## Summary
A file was created during the test, and it was not deleted when it was used up
![image](https://github.com/apache/nuttx-apps/assets/78419332/e456d260-8946-4385-8f22-01d030ab6ad7)
