### PR TITLE
Revert "testing/ostest/cancel: joining a detached/canceled thread should return EINVAL, not ESRCH"

### DIFF
--- a/testing/ostest/cancel.c
+++ b/testing/ostest/cancel.c
@@ -607,7 +607,7 @@ void cancel_test(void)
       printf("cancel_test: ERROR pthread_join succeeded\n");
       ASSERT(false);
     }
-  else if (status != EINVAL)
+  else if (status != ESRCH)
     {
       printf("cancel_test:"
              " ERROR pthread_join failed but with wrong status=%d\n",
@@ -616,7 +616,7 @@ void cancel_test(void)
     }
   else
     {
-      printf("cancel_test: PASS pthread_join failed with status=EINVAL\n");
+      printf("cancel_test: PASS pthread_join failed with status=ESRCH\n");
     }
 
   /* Test 4: Non-cancelable threads *****************************************/


### PR DESCRIPTION


## Summary

Revert "testing/ostest/cancel: joining a detached/canceled thread should return EINVAL, not ESRCH"


This reverts commit 69e497f68127cad345fd13786c5342822c58173f.

In order to ensure the detached thread obtain the correct return value from pthread_join()/pthread_cancel(), the detached thread will create joininfo to save the detached status after thread destroyed.  If there are too many of detached threads in the process group, the joininfo will consume too much memory. This is not friendly to embedded MCU devices.
This commit keep the semantics as #11898 was introduced, will no longer save joininfo for detached threads to avoid wasting memory.

Refer PR:
https://github.com/apache/nuttx/pull/12106
## Impact
Fix issue https://github.com/apache/nuttx/issues/12096

## Testing
ostest / ci-check
