### PR TITLE
apps/nsh_commands: Use quit to poweroff

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -456,6 +456,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #if defined(CONFIG_BOARDCTL_POWEROFF) && !defined(CONFIG_NSH_DISABLE_POWEROFF)
   CMD_MAP("poweroff", cmd_poweroff, 1, 2, NULL),
+  CMD_MAP("quit", cmd_poweroff, 1, 2, NULL),
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_PRINTF


### PR DESCRIPTION
## Summary
Currently new users when try to run NuttX using the SIM get stuck into simulator, because they have no idea that poweroff command is used to leave it. Let use KISS approach and use quit as alias to poweroff command.
## Impact
Make it easier to user to leave SIM
## Testing
sim
