### PR TITLE
benchmarks: Change options from bool to tristate

### DIFF
--- a/benchmarks/cachespeed/Kconfig
+++ b/benchmarks/cachespeed/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config BENCHMARK_CACHESPEED
-	bool "CACHE Speed Test"
+	tristate "CACHE Speed Test"
 	depends on ARCH_ICACHE && ARCH_DCACHE
 	default n
 	---help---

--- a/benchmarks/coremark-pro/Kconfig
+++ b/benchmarks/coremark-pro/Kconfig
@@ -4,7 +4,7 @@
 #
 
 menuconfig BENCHMARK_COREMARK_PRO
-	bool "Coremark Pro Benchmark"
+	tristate "Coremark Pro Benchmark"
 	default n
 	depends on LIBC_FLOATINGPOINT
 

--- a/benchmarks/coremark/Kconfig
+++ b/benchmarks/coremark/Kconfig
@@ -4,7 +4,7 @@
 #
 
 menuconfig BENCHMARK_COREMARK
-	bool "CoreMark Benchmark"
+	tristate "CoreMark Benchmark"
 	select LIBC_FLOATINGPOINT
 	default n
 	---help---


### PR DESCRIPTION


## Summary
This patch changes the enable options of coremark, coremark-pro and cachespeed from bool to tristate.

This allows the user to select the benchmark to be built as a elf module, which can be loaded and executed on the target dynamically.
## Impact
None
## Testing
CI and local machine