### PR TITLE
mcuboot: add option to specify MCUboot source git repository

### DIFF
--- a/boot/mcuboot/Kconfig
+++ b/boot/mcuboot/Kconfig
@@ -12,9 +12,21 @@ menuconfig BOOT_MCUBOOT
 
 if BOOT_MCUBOOT
 
+config MCUBOOT_REPOSITORY
+	string "MCUboot GIT repository"
+	default "github.com/mcu-tools/mcuboot"
+	---help---
+		Specifies the location of MCUboot GIT repository . This
+		is by default MCUboot main GIT repository, but it can be changed
+		to user's fork if required.
+
 config MCUBOOT_VERSION
 	string "MCUboot version"
 	default "fefc398cc13ebbc527e297fe9df78cd98a359d75"
+	---help---
+		Defines MCUboot version to be downloaded. Either release tag
+		or commit hash should be specified. Using newer MCUboot version
+		may cause compatability issues.
 
 config MCUBOOT_ENABLE_LOGGING
 	bool "Enable MCUboot logging"

--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -20,10 +20,11 @@
 
 include $(APPDIR)/Make.defs
 
-MCUBOOT_VERSION := $(patsubst "%",%,$(CONFIG_MCUBOOT_VERSION))
-MCUBOOT_TARBALL  = $(MCUBOOT_VERSION).tar.gz
-MCUBOOT_UNPACK   = mcuboot
-MCUBOOT_SRCDIR   = $(MCUBOOT_UNPACK)$(DELIM)boot$(DELIM)bootutil$(DELIM)src
+MCUBOOT_VERSION    := $(patsubst "%",%,$(CONFIG_MCUBOOT_VERSION))
+MCUBOOT_REPOSITORY := $(patsubst "%",%,$(CONFIG_MCUBOOT_REPOSITORY))
+MCUBOOT_TARBALL     = $(MCUBOOT_VERSION).tar.gz
+MCUBOOT_UNPACK      = mcuboot
+MCUBOOT_SRCDIR      = $(MCUBOOT_UNPACK)$(DELIM)boot$(DELIM)bootutil$(DELIM)src
 
 DEPPATH += --dep-path $(MCUBOOT_UNPACK)$(DELIM)src
 DEPPATH += --dep-path $(MCUBOOT_SRCDIR)
@@ -75,8 +76,8 @@ CXXFLAGS += ${INCDIR_PREFIX}mcuboot/ext/tinycrypt/lib/include
 endif
 
 $(MCUBOOT_TARBALL):
-	$(Q) echo "Downloading MCUboot-$(MCUBOOT_VERSION)"
-	$(Q) curl -O -L https://github.com/mcu-tools/mcuboot/archive/$(MCUBOOT_TARBALL)
+	$(Q) echo "Downloading MCUboot-$(MCUBOOT_VERSION) from $(MCUBOOT_REPOSITORY)"
+	$(Q) curl -O -L --proto-default https $(MCUBOOT_REPOSITORY)/archive/$(MCUBOOT_TARBALL)
 
 $(MCUBOOT_UNPACK): $(MCUBOOT_TARBALL)
 	$(Q) echo "Unpacking: $(MCUBOOT_TARBALL) -> $(MCUBOOT_UNPACK)"


### PR DESCRIPTION
## Summary
Configuration option MCUBOOT_REPOSITORY adds possibility to configure MCUboot GIT repository to be downloaded (for specified hash commit or version). This allows to use different forks and personal repositories.

MCUboot main repository is kept as default option.
