### PR TITLE
build/import: matching nuttx side #12201

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -95,5 +95,5 @@ endif
 ifeq ($(CONFIG_BINFMT_ELF_RELOCATABLE),y)
   LDELFFLAGS += -r
 endif
-LDELFFLAGS += -e _start -Bstatic
+LDELFFLAGS += -e __start -Bstatic
 LDELFFLAGS += $(addprefix -T,$(call CONVERT_PATH,$(TOPDIR)/scripts/gnu-elf.ld))


### PR DESCRIPTION
## Summary
This matches the entry name change in [nuttx/pull/12201](https://github.com/apache/nuttx/pull/12201).

## Impact
kernel mode app building with `make import`

## Testing
`rv-virt/knsh64` and CI checks
