### PR TITLE
apps/lvgl: fix compile warning

### DIFF
--- a/graphics/lvgl/0001-fix-demo-fix-compile-warning.patch
+++ b/graphics/lvgl/0001-fix-demo-fix-compile-warning.patch
@@ -1,0 +1,46 @@
+From d1576c890e8a8622c95dc4a782c457ab3884e7fa Mon Sep 17 00:00:00 2001
+From: Xu Xingliang <xuxingliang@xiaomi.com>
+Date: Mon, 22 Apr 2024 12:26:35 +0800
+Subject: [PATCH] fix(demo): fix compile warning
+
+In file included from /home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/../../lvgl.h:30,
+                 from /home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/../lv_demos.h:16,
+                 from /home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/lv_demo_stress.h:16,
+                 from /home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/lv_demo_stress.c:9:
+/home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/lv_demo_stress.c: In function 'obj_test_task_cb':
+/home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/lv_demo_stress.c:81:29: warning: format '%zu' expects argument of type 'size_t', but argument 6 has type 'long unsigned int' [-Wformat=]
+   81 |                 LV_LOG_USER("mem leak since start: %zu, frag: %3d %%", mem_free_start - mon.free_size, mon.frag_pct);
+      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                                                                       |
+      |                                                                                       long unsigned int
+/home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/../../src/misc/lv_log.h:132:97: note: in definition of macro 'LV_LOG_USER'
+  132 | #    define LV_LOG_USER(...) _lv_log_add(LV_LOG_LEVEL_USER, LV_LOG_FILE, LV_LOG_LINE, __func__, __VA_ARGS__)
+      |                                                                                                 ^~~~~~~~~~~
+/home/neo/projects/nuttx/apps/graphics/lvgl/lvgl/demos/stress/lv_demo_stress.c:81:54: note: format string is defined here
+   81 |                 LV_LOG_USER("mem leak since start: %zu, frag: %3d %%", mem_free_start - mon.free_size, mon.frag_pct);
+      |                                                    ~~^
+      |                                                      |
+      |                                                      unsigned int
+      |                                                    %lu
+
+Signed-off-by: Xu Xingliang <xuxingliang@xiaomi.com>
+---
+ demos/stress/lv_demo_stress.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/demos/stress/lv_demo_stress.c b/demos/stress/lv_demo_stress.c
+index 65728519c..b76c1f655 100644
+--- a/demos/stress/lv_demo_stress.c
++++ b/demos/stress/lv_demo_stress.c
+@@ -32,7 +32,7 @@ static void obj_test_task_cb(lv_timer_t * tmr);
+  **********************/
+ static lv_obj_t * main_page;
+ static lv_obj_t * ta;
+-static uint32_t mem_free_start = 0;
++static size_t mem_free_start = 0;
+ static int16_t g_state = -1;
+ 
+ /**********************
+-- 
+2.34.1
+

--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -42,6 +42,9 @@ if(CONFIG_GRAPHICS_LVGL)
           ""
           TEST_COMMAND
           ""
+      PATCH_COMMAND
+        patch -p1 -s -d ${CMAKE_CURRENT_LIST_DIR}/lvgl <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-fix-demo-fix-compile-warning.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -37,6 +37,8 @@ WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
 CONFIG_GRAPH_LVGL_URL ?= "https://github.com/lvgl/lvgl/archive/refs/tags"
 
+LVGL_PATCHS ?= $(sort $(wildcard 000*.patch))
+
 LVGL_VERSION = 9.1.0
 LVGL_TARBALL = v$(LVGL_VERSION).zip
 
@@ -55,6 +57,7 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 	$(ECHO_BEGIN)"Unpacking: $(LVGL_TARBALL) -> $(LVGL_UNPACKNAME)"
 	$(Q) $(UNPACK) $(LVGL_TARBALL)
 	$(Q) mv	lvgl-$(LVGL_VERSION) $(LVGL_UNPACKNAME)
+	$(Q) cat $(LVGL_PATCHS) | patch -s -N -d $(LVGL_UNPACKNAME) -p1
 	$(Q) touch $(LVGL_UNPACKNAME)
 	$(ECHO_END)
 


### PR DESCRIPTION

## Summary
Add patch to fix the compile warning, which is already fixed in upstream: https://github.com/lvgl/lvgl/pull/6100

## Impact
No.

## Testing
Tested with sim:lvgl_lcd
