### PR TITLE
apps/lvgl: fix distclean warnings

### DIFF
--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -64,10 +64,12 @@ $(LVGL_UNPACKNAME): $(LVGL_TARBALL)
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 context:: $(LVGL_UNPACKNAME)
+endif
 
+include $(APPDIR)/Application.mk
+
+ifeq ($(wildcard $(LVGL_UNPACKNAME)/.git),)
 distclean::
 	$(call DELDIR, $(LVGL_UNPACKNAME))
 	$(call DELFILE, $(LVGL_TARBALL))
 endif
-
-include $(APPDIR)/Application.mk


### PR DESCRIPTION

## Summary

LVGL uses `shell find` to set CSRCS. LVGL sources have already been deleted when `Application.mk ` is included at file end, thus causing the warning.

lvgl/lvgl.mk
```makefile
LVGL_PATH ?= ${shell pwd}/lvgl

ASRCS += $(shell find $(LVGL_PATH)/src -type f -name '*.S')
CSRCS += $(shell find $(LVGL_PATH)/src -type f -name '*.c')
CSRCS += $(shell find $(LVGL_PATH)/demos -type f -name '*.c')
CSRCS += $(shell find $(LVGL_PATH)/examples -type f -name '*.c')
CXXEXT := .cpp
CXXSRCS += $(shell find $(LVGL_PATH)/src -type f -name '*${CXXEXT}')

AFLAGS += "-I$(LVGL_PATH)"
CFLAGS += "-I$(LVGL_PATH)"
CXXFLAGS += "-I$(LVGL_PATH)"

```

Cleaning...
find: '/github/workspace/sources/apps/graphics/lvgl/lvgl/src': No such file or directory find: '/github/workspace/sources/apps/graphics/lvgl/lvgl/src': No such file or directory find: '/github/workspace/sources/apps/graphics/lvgl/lvgl/src': No such file or directory find: '/github/workspace/sources/apps/graphics/lvgl/lvgl/demos': No such file or directory find: '/github/workspace/sources/apps/graphics/lvgl/lvgl/examples': No such file or directory find: '/github/workspace/sources/apps/graphics/lvgl/lvgl/src': No such file or directory

## Impact

## Testing

