### PR TITLE
system/adb: Ignore warnings for using variables

### DIFF
--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -52,6 +52,7 @@ CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv.c
 CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv_packet.c
 
 CFLAGS += -I$(ADB_UNPACKNAME)
+CFLAGS += -Wno-unused-variable -Wno-unused-but-set-variable
 
 ifeq ($(CONFIG_ADBD_TCP_SERVER),y)
 CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv_client_tcp.c


### PR DESCRIPTION
## Summary
Will cause compilation warning if NDEBUG is defined We can't modify the code of the external library, so let's ignore it

microADB/hal/hal_uv_client_usb.c:90:13: warning: unused variable 'ret' [-Wunused-variable]
   90 |         int ret = uv_read_start((uv_stream_t*)&client->pipe,

## Impact

## Testing

