### PR TITLE
testing/ramtest/CMakeLists.txt: fix the names of the config entry

### DIFF
--- a/testing/ramtest/CMakeLists.txt
+++ b/testing/ramtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/system/ramtest/CMakeLists.txt
+# apps/testing/ramtest/CMakeLists.txt
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -18,6 +18,6 @@
 #
 # ##############################################################################
 
-if(CONFIG_SYSTEM_RAMTEST)
+if(CONFIG_TESTING_RAMTEST)
   nuttx_add_application(NAME ramtest)
 endif()


### PR DESCRIPTION
## Summary
CONFIG_SYSTEM_ -> CONFIG_TESTING_
fix Relative file path does not match actual file.
## Impact
none
## Testing

