### PR TITLE
wamr: Add a few options for esp32s3

### DIFF
--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -47,6 +47,16 @@ config INTERPRETERS_WAMR_AOT_QUICK_ENTRY
 		signature.
 		Enable this option will increase the size of runtime, ~8KB.
 
+config INTERPRETERS_WAMR_AOT_WORD_ALIGN_READ
+	bool "Make WAMR AOT loader use word-aligned read"
+	default y
+	depends on INTERPRETERS_WAMR_AOT && ARCH_CHIP_ESP32S3
+
+config INTERPRETERS_WAMR_MEM_DUAL_BUS_MIRROR
+	bool "Make WAMR AOT loader aware of ESP32-S3's memory mapping"
+	default y
+	depends on INTERPRETERS_WAMR_AOT && ARCH_CHIP_ESP32S3
+
 choice
 	prompt "Enable interpreter"
 	default INTERPRETERS_NONE

--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -49,13 +49,11 @@ config INTERPRETERS_WAMR_AOT_QUICK_ENTRY
 
 config INTERPRETERS_WAMR_AOT_WORD_ALIGN_READ
 	bool "Make WAMR AOT loader use word-aligned read"
-	default y
-	depends on INTERPRETERS_WAMR_AOT && ARCH_CHIP_ESP32S3
+	default n
 
 config INTERPRETERS_WAMR_MEM_DUAL_BUS_MIRROR
-	bool "Make WAMR AOT loader aware of ESP32-S3's memory mapping"
-	default y
-	depends on INTERPRETERS_WAMR_AOT && ARCH_CHIP_ESP32S3
+	bool "Make WAMR AOT loader aware of separate instruction/data memory mapping"
+	default n
 
 choice
 	prompt "Enable interpreter"


### PR DESCRIPTION
## Summary
The corresponding WAMR change:
https://github.com/bytecodealliance/wasm-micro-runtime/pull/2348

## Impact

## Testing

