### PR TITLE
nimble: Ignore nimble compile warnings

### DIFF
--- a/wireless/bluetooth/nimble/CMakeLists.txt
+++ b/wireless/bluetooth/nimble/CMakeLists.txt
@@ -194,6 +194,6 @@ if(CONFIG_NIMBLE)
   target_include_directories(nimble PUBLIC include ${INCLUDES})
 
   target_compile_options(nimble PUBLIC -Wno-pointer-to-int-cast -Wno-undef
-                                       -Wno-format)
+                                       -Wno-format -Wno-unused-but-set-variable)
   target_sources(nimble PRIVATE ${SRCS})
 endif()

--- a/wireless/bluetooth/nimble/Makefile.nimble
+++ b/wireless/bluetooth/nimble/Makefile.nimble
@@ -66,4 +66,4 @@ CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
 
 # disable printf format checks
 
-CFLAGS += -Wno-format
+CFLAGS += -Wno-format -Wno-unused-but-set-variable


### PR DESCRIPTION
## Summary
Will cause compilation warning if NDEBUG is defined We can't modify the code of the external library, so let's ignore it

services/ans/src/ble_svc_ans.c:450:9: error: variable 'rc' set but not used [-Werror=unused-but-set-variable]
  450 |     int rc;
      |         ^~

## Impact

## Testing

