### PR TITLE
mcuboot: Ignore mcuboot compile warnings

### DIFF
--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -39,7 +39,7 @@ PRIORITY  += SCHED_PRIORITY_DEFAULT
 STACKSIZE += $(CONFIG_DEFAULT_TASK_STACKSIZE)
 endif
 
-CFLAGS += -Wno-undef
+CFLAGS += -Wno-undef -Wno-unused-but-set-variable
 
 CSRCS := $(MCUBOOT_UNPACK)/boot/bootutil/src/boot_record.c \
          $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_misc.c \


### PR DESCRIPTION
## Summary
Will cause compilation warning if NDEBUG is defined We can't modify the code of the external library, so let's ignore it
mcuboot/boot/bootutil/src/loader.c:1265:9: error: variable 'rc' set but not used [-Werror=unused-but-set-variable]
 1265 |     int rc;
      |         ^~
## Impact

## Testing

