### PR TITLE
system/spi: Set SPI delay characteristics to zero when enabled.

### DIFF
--- a/system/spi/spi_exch.c
+++ b/system/spi/spi_exch.c
@@ -154,6 +154,13 @@ int spicmd_exch(FAR struct spitool_s *spitool, int argc, FAR char **argv)
   seq.ntrans = 1;
   seq.trans = &trans;
 
+#ifdef CONFIG_SPI_DELAY_CONTROL
+  seq.a = 0;
+  seq.b = 0;
+  seq.i = 0;
+  seq.c = 0;
+#endif
+
   trans.deselect = true;
 #ifdef CONFIG_SPI_CMDDATA
   trans.cmd = spitool->command;


### PR DESCRIPTION
## Summary

Previously, when delay control was enabled, spi_transfer would pass junk values down to the underlying driver because these values where not initialized.

Setting them to zero provides a predictable result considering they are not controlled by this tool.

## Impact

SPI tool provides consistent value to the underlying driver's delay characteristics when enabled.

## Testing

SPI tool with custom SPI driver.