### PR TITLE
testing/ostest: Fix config name

### DIFF
--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -590,7 +590,7 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
-#if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)
+#if defined(CONFIG_ARCH_HAVE_FORK) && defined(CONFIG_SCHED_WAITPID)
 #ifndef CONFIG_BUILD_KERNEL
       printf("\nuser_main: vfork() test\n");
       vfork_test();


### PR DESCRIPTION
## Summary

Fix config name to execute vfork() test.
CONFIG_ARCH_HAVE_VFORK -> CONFIG_ARCH_HAVE_FORK

## Impact

## Testing

