### PR TITLE
toywasm: ignore compile warnings

### DIFF
--- a/interpreters/toywasm/Makefile
+++ b/interpreters/toywasm/Makefile
@@ -131,6 +131,11 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/lib
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libwasi
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libdyld
 
+# Keep the compilation parameters consistent with toywasm mainline
+# https://github.com/yamt/toywasm/blob/master/cmake/ToywasmConfig.cmake#L298-L302
+
+CFLAGS += -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-variable -Wno-return-type
+
 TOYWASM_VERSION  = 76b9d7088ab321e329b6f958360fb05cebd3df9f
 TOYWASM_UNPACK   = toywasm
 TOYWASM_TARBALL  = $(TOYWASM_VERSION).zip


### PR DESCRIPTION
## Summary
Will cause compilation warning if NDEBUG is defined We can't modify the code of the external library, so let's ignore it

## Impact

## Testing

