### PR TITLE
add include to handle when PM_NDOMAINS from pm.h

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/power/pm.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/streams.h>
 #include <sys/boardctl.h>


### PR DESCRIPTION
## Summary
For furthur domain usage, CONFIG_PM_NDOMAINS maybe not from .config,
possible generated from <nuttx/power/pm.h>

## Impact
None

## Testing
CI-test
