### PR TITLE
Fix compiler errors

### DIFF
--- a/system/taskset/taskset.c
+++ b/system/taskset/taskset.c
@@ -138,7 +138,8 @@ int main(int argc, FAR char *argv[])
           goto errout;
         }
 
-      printf("pid %d's current affinity mask: %x\n", pid, cpuset);
+      printf("pid %d's current affinity mask: 0x%" PRIx32 "\n", pid,
+             (uint32_t)cpuset);
     }
   else
     {


### PR DESCRIPTION


## Summary
taskset.c: In function 'taskset_main':
Error: taskset.c:141:48: error: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'cpu_set_t' {aka 'long unsigned int'} [-Werror=format=]
  141 |       printf("pid %d's current affinity mask: %x\n", pid, cpuset);
      |                                               ~^          ~~~~~~
      |                                                |          |
      |                                                |          cpu_set_t {aka long unsigned int}
      |                                                unsigned int
      |                                               %lx
cc1: all warnings being treated as errors
make[2]: *** [/github/workspace/sources/apps/Application.mk:271: taskset.c.github.workspace.sources.apps.system.taskset.o] Error 1
make[2]: Target 'all' not remade because of errors.
make[1]: *** [Makefile:51: /github/workspace/sources/apps/system/taskset_all] Error 2
make[1]: Target 'all' not remade because of errors.
make: *** [tools/LibTargets.mk:232: /github/workspace/sources/apps/libapps.a] Error 2
make: Target 'all' not remade because of errors.

## Impact
NONE
## Testing
ostest

