### PR TITLE
Fix Error: usrsocktest_basic_connect.c:112:7: error: variable 'ret' set but not used

### DIFF
--- a/examples/usrsocktest/usrsocktest_basic_connect.c
+++ b/examples/usrsocktest/usrsocktest_basic_connect.c
@@ -114,13 +114,13 @@ static void teardown(void)
   if (sd >= 0)
     {
       ret = close(sd);
-      assert(ret >= 0);
+      TEST_ASSERT_TRUE(ret >= 0);
     }
 
   if (started)
     {
       ret = usrsocktest_daemon_stop();
-      assert(ret == OK);
+      TEST_ASSERT_EQUAL(OK, ret);
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the warning reported here: https://github.com/apache/nuttx/pull/12320#issuecomment-2123613920

## Impact

minor

## Testing

ci