### PR TITLE
system/nxdiag: Remove unnecessary `--depth` parameter

### DIFF
--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -80,7 +80,7 @@ INFO_DEPS += espressif_prepare
 espressif_prepare:
 ifeq ($(HALDIR),$(ARCH_ESP_HALDIR))
 	@echo "Unshallowing Espressif HAL..."
-	(cd ${HALDIR} && git fetch --depth=10000 && git fetch --tags)
+	(cd ${HALDIR} && git fetch && git fetch --tags)
 endif
 
 ifdef ESPTOOL_BINDIR


### PR DESCRIPTION
## Summary

* system/nxdiag: Remove unnecessary `--depth` parameter
  * Espressif common headers do not require it and the parameter is not supported for some GIT operations.

## Impact

Enable using local `http`-based URL for `ESP_HAL_3RDPARTY_URL`.

## Testing

Internal CI testing