### PR TITLE
benchmark: update gitignore for superpi and dhrystone

### DIFF
--- a/benchmarks/dhrystone/.gitignore
+++ b/benchmarks/dhrystone/.gitignore
@@ -1,0 +1,2 @@
+/dhrystone
+/dhrystone.zip

--- a/benchmarks/superpi/.gitignore
+++ b/benchmarks/superpi/.gitignore
@@ -1,1 +1,2 @@
 /superpi
+/main.zip


### PR DESCRIPTION
## Summary
benchmark: update gitignore for superpi and dhrystone
ignore downloaded files for superpi and dhrystone

## Impact

## Testing
local build
