### PR TITLE
system/telnetd: add CMake

### DIFF
--- a/system/telnetd/CMakeLists.txt
+++ b/system/telnetd/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/system/telnetd/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_TELNETD)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_SYSTEM_TELNETD_PROGNAME}
+    SRCS
+    telnetd.c
+    STACKSIZE
+    ${CONFIG_SYSTEM_TELNETD_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_TELNETD_PRIORITY})
+endif()


### PR DESCRIPTION
## Summary

Adds CMake support for `system/telnetd`

## Impacts

CMake

## Testing

- local testing with `rv-virt`
- CI checks
