### PR TITLE
examples: Remove unnecessary descriptions from Makefile

### DIFF
--- a/examples/audio_rttl/CMakeLists.txt
+++ b/examples/audio_rttl/CMakeLists.txt
@@ -27,5 +27,5 @@ if(CONFIG_EXAMPLES_AUDIO_SOUND)
     STACKSIZE
     ${CONFIG_EXAMPLES_AUDIO_SOUND_STACKSIZE}
     SRCS
-    audio_rttl.c)
+    audio_rttl.cxx)
 endif()

--- a/examples/audio_rttl/Makefile
+++ b/examples/audio_rttl/Makefile
@@ -19,7 +19,6 @@
 ############################################################################
 
 include $(APPDIR)/Make.defs
--include $(SDKDIR)/Make.defs
 
 # Audio application info
 
@@ -30,14 +29,5 @@ STACKSIZE = $(CONFIG_EXAMPLES_AUDIO_SOUND_STACKSIZE)
 # Audio Example
 
 MAINSRC = audio_rttl.cxx
-
-# Audio Example paths
-
-AUDIODIR = $(SDKDIR)$(DELIM)modules$(DELIM)audio
-
-# Audio Example flags
-
-CXXFLAGS += ${INCDIR_PREFIX}"$(AUDIODIR)"
-CXXFLAGS += -D_POSIX
 
 include $(APPDIR)/Application.mk

--- a/examples/bmi160/Makefile
+++ b/examples/bmi160/Makefile
@@ -19,7 +19,6 @@
 ############################################################################
 
 include $(APPDIR)/Make.defs
--include $(SDKDIR)/Make.defs
 
 # sixaxis built-in application info
 

--- a/examples/charger/Makefile
+++ b/examples/charger/Makefile
@@ -19,7 +19,6 @@
 ############################################################################
 
 include $(APPDIR)/Make.defs
--include $(SDKDIR)/Make.defs
 
 PROGNAME = $(CONFIG_EXAMPLES_CHARGER_PROGNAME)
 PRIORITY = $(CONFIG_EXAMPLES_CHARGER_PRIORITY)

--- a/examples/fxos8700cq_test/Makefile
+++ b/examples/fxos8700cq_test/Makefile
@@ -19,7 +19,6 @@
 #############################################################################
 
 include $(APPDIR)/Make.defs
--include $(SDKDIR)/Make.defs
 
 # fxos8700cq built-in application info
 


### PR DESCRIPTION
## Summary
Remove unnecessary SDKDIR variable from some Makefiles.
And fix audio_rttl to pass cmake build.

## Impact

## Testing

