### PR TITLE
examples/stepper: Fix typo inside for() loop

### DIFF
--- a/examples/stepper/stepper.c
+++ b/examples/stepper/stepper.c
@@ -55,7 +55,7 @@ static int parse_args(int argc, FAR char *argv[],
   args->microstep = -1;
   args->speed = 200;
 
-  for (i i = 2; i < argc; ++i)
+  for (i = 2; i < argc; ++i)
     {
       if (strncmp("-m", argv[i], 2) == 0)
         {


### PR DESCRIPTION
## Summary
Fix typo inside for() loop
## Impact
Fix
## Testing
STM32F401RC-RS485