### PR TITLE
Fix Wrong Offset in Fseek from SEEK_END

### DIFF
--- a/testing/smart_test/smart_test.c
+++ b/testing/smart_test/smart_test.c
@@ -209,7 +209,7 @@ static int smart_append_test(char *filename)
 
   /* Now seek to that position and read the data back */
 
-  fseek(fd, 30, SEEK_END);
+  fseek(fd, -30, SEEK_END);
   fread(readstring, 1, 30, fd);
   readstring[30] = '\0';
   if (strcmp(readstring, "This is a test of the append.\n") != 0)


### PR DESCRIPTION
## Title

testing/smart_test: Fix Wrong Offset in Fseek from SEEK_END


## Summary

testing/smart_test/smart_test.c: To seek to the last 30 bytes of the file, offset from SEEK_END should be negative.


## Impact

Bug fixed.


## Testing

```
nsh> smart_test -c 1000 -s 1000 -w 1000 /mnt/smart
Creating file /mnt/smart for write mode
Writing test data.  2000 lines to write
1999
Done.
Performing 1000 random seek tests
1000
Append test passed
Performing 1000 random seek with write tests
999
Pass
Creating circular log with 40000 records
Performing 1000 circular log record update tests
999
Pass
```
