### PR TITLE
[sd_bench|sd_stress]: Compatible Sd Test Printing

### DIFF
--- a/testing/sd_bench/sd_bench_main.c
+++ b/testing/sd_bench/sd_bench_main.c
@@ -176,7 +176,7 @@ static void write_test(int fd, sdb_config_t *cfg, uint8_t *block,
   uint64_t elapsed;
   uint64_t total_elapsed = 0.;
   size_t total_blocks = 0;
-  size_t *blocknumber = (unsigned int *)(void *)&block[0];
+  size_t *blocknumber = (size_t *)(void *)&block[0];
 
   printf("\n");
   printf("Testing Sequential Write Speed...\n");
@@ -277,7 +277,7 @@ static int read_test(int fd, sdb_config_t *cfg, uint8_t *block,
 
   total_elapsed = 0.;
   total_blocks = 0;
-  size_t *blocknumber = (unsigned int *)(void *) &read_block[0];
+  size_t *blocknumber = (size_t *)(void *) &read_block[0];
 
   for (int run = 0; run < cfg->num_runs;  ++run)
     {
@@ -306,8 +306,8 @@ static int read_test(int fd, sdb_config_t *cfg, uint8_t *block,
 
           if (*blocknumber !=  total_blocks + num_blocks)
             {
-              printf("Read data error at block: %d wrote:0x%04x read:0x%04x",
-                     (total_blocks + num_blocks),
+              printf("Read data error at block: %zu wrote:0x%04zx "
+                     "read:0x%04zx", total_blocks + num_blocks,
                      total_blocks + num_blocks, *blocknumber);
             }
 
@@ -316,7 +316,7 @@ static int read_test(int fd, sdb_config_t *cfg, uint8_t *block,
             {
               if (block[i] != read_block[i])
                 {
-                  printf("Read data error at offset: %d wrote:0x%02x "
+                  printf("Read data error at offset: %zu wrote:0x%02x "
                          "read:0x%02x", total_blocks + num_blocks + i,
                          block[i], read_block[i]);
                 }
@@ -353,11 +353,11 @@ static void usage(void)
   printf("Test the speed of an SD card or mount point\n");
   printf(CONFIG_TESTING_SD_BENCH_PROGNAME
          ": [-b] [-r] [-d] [-k] [-s] [-a] [-v]\n");
-  printf("  -b   Block size per write (%u-%u), default %u\n",
+  printf("  -b   Block size per write (%zu-%zu), default %zu\n",
          min_block, max_block, default_block);
-  printf("  -r   Number of runs (%u-%u), default %u\n",
+  printf("  -r   Number of runs (%zu-%zu), default %zu\n",
          min_runs, max_runs, default_runs);
-  printf("  -d   Max duration of a test (ms) (%u-%u), default %u\n",
+  printf("  -d   Max duration of a test (ms) (%zu-%zu), default %zu\n",
          min_duration, max_duration, default_duration);
   printf("  -k   Keep test file when finished, default %s\n",
          print_bool(default_keep_test));
@@ -481,7 +481,7 @@ int main(int argc, char *argv[])
       block[j] = (uint8_t)j;
     }
 
-  printf("Using block size = %u bytes, sync = %s\n", block_size,
+  printf("Using block size = %zu bytes, sync = %s\n", block_size,
          print_bool(cfg.synchronized));
 
   write_test(bench_fd, &cfg, block, block_size);

--- a/testing/sd_stress/sd_stress_main.c
+++ b/testing/sd_stress/sd_stress_main.c
@@ -85,11 +85,11 @@ static void usage(void)
 {
   printf("Stress test on a mount point\n");
   printf(CONFIG_TESTING_SD_STRESS_PROGNAME ": [-r] [-b] [-f]\n");
-  printf("  -r   Number of runs (%u-%u), default %u\n",
+  printf("  -r   Number of runs (%zu-%zu), default %zu\n",
          min_runs, max_runs, default_runs);
-  printf("  -b   Number of bytes (%u-%u), default %u\n",
+  printf("  -b   Number of bytes (%zu-%zu), default %zu\n",
          min_bytes, max_bytes, default_bytes);
-  printf("  -f   Number of files (%u-%u), default %u\n",
+  printf("  -f   Number of files (%zu-%zu), default %zu\n",
          min_files, max_files, default_files);
 }
 
@@ -150,7 +150,7 @@ static bool create_files(const char *dir, const char *name,
   for (size_t i = 0; i < num_files; ++i)
     {
       char path[MAX_PATH_LEN];
-      snprintf(path, MAX_PATH_LEN, "%s/%s%03u", dir, name, i);
+      snprintf(path, MAX_PATH_LEN, "%s/%s%03zu", dir, name, i);
 
       memset(read_bytes, 0x0, num_bytes);
 
@@ -243,7 +243,7 @@ static bool remove_files(const char *dir, const char *name,
   for (size_t i = 0; i < num_files; ++i)
     {
       char path[MAX_PATH_LEN];
-      snprintf(path, MAX_PATH_LEN, "%s/%s%03u", dir, name, i);
+      snprintf(path, MAX_PATH_LEN, "%s/%s%03zu", dir, name, i);
 
       int ret = unlink(path);
 
@@ -354,7 +354,7 @@ int main(int argc, char *argv[])
       exit(EXIT_FAILURE);
     }
 
-  printf("Start stress test with %u files, %u bytes and %u iterations.\n",
+  printf("Start stress test with %zu files, %zu bytes and %zu iterations.\n",
          num_files, num_bytes, num_runs);
 
   bytes = (char *)malloc(num_bytes);
@@ -386,7 +386,7 @@ int main(int argc, char *argv[])
 
       elapsed_time = get_elapsed_time_ms(&start);
       total_time += elapsed_time;
-      printf("iteration %u took %.3f ms: %s\n", i,
+      printf("iteration %zu took %.3f ms: %s\n", i,
              elapsed_time, result ? "OK" : "FAIL");
 
       if (!result)


### PR DESCRIPTION
## Title

testing/[sd_bench|sd_stress]: Make Printing Compatible for Both 32-bit and 64-bit Environments.
<!--testing/sd_bench: Restrict User to Set Too Small Block Size.-->


## Summary

Currently, on 64-bit environment, for example, qemu-armv8a, compilation of `sd_bench` and `sd_stress` are broken due to [type errors](https://gist.github.com/Windrow14/c42b6ee36e749c3d264678a82ed2a1cc).
<!--Currently, block number is written to blocks to test. If the block is too small to held a number, read/write data error happens.-->

testing/sd_bench/sd_bench_main.c:<!-- Add a check of input block size and force it to size of `size_t` if it is too small.-->
testing/sd_stress/sd_stress_main.c: `size_t` type should be printed with `%zu` instead of `%u`.


## Impact

Bugs fixed.


## Testing

Verify compilation with:
- 32-bit environment configuration: esp32s3-devkit:smp
- 64-bit environment configuration: qemu-armv8a:netnsh

Run `sdstress` and `sdbench` test in virtual environment:
```
qemu-system-aarch64 \
-cpu cortex-a53 \
-smp 4 \
-nographic \
-machine virt,virtualization=on,gic-version=3 \
-chardev stdio,id=con,mux=on \
-serial chardev:con \
-global virtio-mmio.force-legacy=false \
-netdev user,id=u1,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23,hostfwd=tcp:127.0.0.1:15001-10.0.2.15:5001 \
-device virtio-net-device,netdev=u1,bus=virtio-mmio-bus.0 \
-drive file=/home/windrow/code/nuttx/2GB.img,format=raw,id=hd,if=none \
-device virtio-blk-device,bus=virtio-mmio-bus.1,drive=hd \
-mon chardev=con,mode=readline \
-kernel \
./nuttx

NuttShell (NSH)
nsh> 
nsh> mount -t vfat /dev/virtblk0 /mnt
nsh> sdstress
Start stress test with 64 files, 4096 bytes and 32 iterations.
iteration 0 took 190.000 ms: OK
iteration 1 took 190.000 ms: OK
iteration 2 took 180.000 ms: OK
iteration 3 took 180.000 ms: OK
iteration 4 took 170.000 ms: OK
iteration 5 took 180.000 ms: OK
iteration 6 took 190.000 ms: OK
iteration 7 took 180.000 ms: OK
iteration 8 took 180.000 ms: OK
iteration 9 took 170.000 ms: OK
iteration 10 took 170.000 ms: OK
iteration 11 took 180.000 ms: OK
iteration 12 took 180.000 ms: OK
iteration 13 took 180.000 ms: OK
iteration 14 took 170.000 ms: OK
iteration 15 took 180.000 ms: OK
iteration 16 took 180.000 ms: OK
iteration 17 took 200.000 ms: OK
iteration 18 took 180.000 ms: OK
iteration 19 took 170.000 ms: OK
iteration 20 took 180.000 ms: OK
iteration 21 took 170.000 ms: OK
iteration 22 took 180.000 ms: OK
iteration 23 took 170.000 ms: OK
iteration 24 took 170.000 ms: OK
iteration 25 took 180.000 ms: OK
iteration 26 took 170.000 ms: OK
iteration 27 took 170.000 ms: OK
iteration 28 took 180.000 ms: OK
iteration 29 took 170.000 ms: OK
iteration 30 took 170.000 ms: OK
iteration 31 took 170.000 ms: OK
Test OK: Average time: 177.500 ms
nsh> sdbench -k
Using block size = 512 bytes, sync = false

Testing Sequential Write Speed...
  Run  1:   2263.8 KB/s, max write time: 10.000 ms (50.0 KB/s), fsync: 0.000 ms
  Run  2:   2275.8 KB/s, max write time: 10.000 ms (50.0 KB/s), fsync: 0.000 ms
  Run  3:   2268.5 KB/s, max write time: 20.000 ms (25.0 KB/s), fsync: 0.000 ms
  Run  4:   2274.3 KB/s, max write time: 10.000 ms (50.0 KB/s), fsync: 0.000 ms
  Run  5:   2279.3 KB/s, max write time: 10.000 ms (50.0 KB/s), fsync: 0.000 ms
  Avg   :   2272.3 KB/s, 22.190 MB written.

Testing Sequential Read Speed...
  Run  1:  40576.8 KB/s, max read/verify time: 10.0000 ms (50.0 KB/s)
  Avg   :  40576.8 KB/s, 22.190 MB and verified
nsh> mount -t vfat /dev/virtblk0 /mnt
nsh> sdbench -b 2
Using block size = 8 bytes, sync = false

Testing Sequential Write Speed...
  Run  1:   1356.3 KB/s, max write time: 10.000 ms (0.8 KB/s), fsync: 0.000 ms
  Run  2:   1186.4 KB/s, max write time: 20.000 ms (0.4 KB/s), fsync: 0.000 ms
  Run  3:   1281.3 KB/s, max write time: 10.000 ms (0.8 KB/s), fsync: 0.000 ms
  Run  4:   1291.0 KB/s, max write time: 20.000 ms (0.4 KB/s), fsync: 0.000 ms
  Run  5:   1298.0 KB/s, max write time: 10.000 ms (0.8 KB/s), fsync: 0.000 ms
  Avg   :   1282.6 KB/s, 12.525 MB written.

Testing Sequential Read Speed...
  Run  1:  11555.0 KB/s, max read/verify time: 10.0000 ms (0.8 KB/s)
  Avg   :  11555.0 KB/s, 12.525 MB and verified
```