### PR TITLE
Fix error caused by netinit code assuming CONFIG_NETINIT_DNS was enabled

### DIFF
--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -689,10 +689,12 @@ static void netinit_net_bringup(void)
               netlib_set_dripv4addr(NET_DEVNAME, &ds.default_router);
             }
 
+#  ifdef CONFIG_NETINIT_DNS
           if (ds.dnsaddr.s_addr != 0)
             {
               netlib_set_ipv4dnsaddr(&ds.dnsaddr);
             }
+#  endif
         }
 
       dhcpc_close(handle);


### PR DESCRIPTION
## Summary
Fix error caused by netinit code assuming CONFIG_NETINIT_DNS was enabled
## Impact
It will avoid error case the user select the DHCPC but forget to enable CONFIG_NETDB_DNSCLIENT
## Testing
N/A
