### PR TITLE
lte/alt1250: Select NET_USRSOCK_ICMP if LTE_ALT1250 is enabled

### DIFF
--- a/lte/alt1250/Kconfig
+++ b/lte/alt1250/Kconfig
@@ -8,6 +8,7 @@ config LTE_ALT1250
 	default n
 	depends on NET_USRSOCK && MODEM_ALT1250
 	select NET_USRSOCK_TCP
+	select NET_USRSOCK_ICMP
 	select PIPES
 	select NET_USRSOCK_OTHER
 	---help---


### PR DESCRIPTION
## Summary
The change by https://github.com/apache/nuttx/pull/12639 to enable CONFIG_NET_ICMP as default
has made it necessary to enable CONFIG_MM_IOB which is unnecessary for usrsock.
CONFIG_NET_USRSOCK_ICMP should be enabled if usrsock is used.

## Impact
LTE ALT1250

## Testing

