### PR TITLE
`i2ctool dev` command now uses an empty write header to scan the I2C bus

### DIFF
--- a/system/i2c/i2c_common.c
+++ b/system/i2c/i2c_common.c
@@ -173,6 +173,10 @@ int i2ctool_common_args(FAR struct i2ctool_s *i2ctool, FAR char **arg)
         i2ctool->width = (uint8_t)value;
         return ret;
 
+      case 'z':
+        i2ctool->zerowrite = true;
+        return 1;
+
       default:
         goto invalid_argument;
     }

--- a/system/i2c/i2c_main.c
+++ b/system/i2c/i2c_main.c
@@ -149,6 +149,10 @@ static int i2ccmd_help(FAR struct i2ctool_s *i2ctool, int argc,
   i2ctool_printf(i2ctool,
                  "  [-r regaddr] is the I2C device register index (hex)."
                  "  Default: not used/sent\n");
+  i2ctool_printf(
+      i2ctool,
+      "  [-z] instructs the 'dev' command to scan the I2C bus by sending "
+      "zero-byte write headers (if the architecture supports it)\n");
 
   i2ctool_printf(i2ctool, "\nNOTES:\n");
 #ifndef CONFIG_DISABLE_ENVIRON
@@ -398,6 +402,7 @@ int main(int argc, FAR char *argv[])
     }
 
   g_i2ctool.hasregindx = false;
+  g_i2ctool.zerowrite = false;
 
   /* Parse and process the command line */
 

--- a/system/i2c/i2ctool.h
+++ b/system/i2c/i2ctool.h
@@ -127,6 +127,7 @@ struct i2ctool_s
   uint8_t  regaddr;    /* [-r regaddr] is the I2C device register address */
   uint8_t  width;      /* [-w width] is the data width (8 or 16) */
   bool     start;      /* [-s|n], send|don't send start between command and data */
+  bool     zerowrite;  /* [-z] uses a zero byte write request to scan the I2C bus */
   bool     autoincr;   /* [-i|j], Auto increment|don't increment regaddr on repetitions */
   bool     hasregindx; /* true with the use of -r */
   uint32_t freq;       /* [-f freq] I2C frequency */


### PR DESCRIPTION
## Summary

The `i2ctool dev` command now supports an additional command-line flag, `-z`, to the `dev` command. This flag will use a zero-byte write request over I2C as the scan instead of the default 1 byte read. This sometimes allows for discovery of more devices, such as the SHT41 temperature and humidity sensor, and the MS5611 barometric pressure sensor.

This PR closes #994.

## Impact

This should save some developers time debugging or wondering why their devices didn't show up (and trying to wrongly diagnose a hardware issue like myself :laughing:).

## Testing

Using the previous version of this command on an I2C bus with the following sensors:

- MS5611 barometric pressure sensor (2, at 0x76 and 0x77)
- SHT41 temperature and humidity sensor (0x44)
- MAXM10S GPS (0x42)
- M24C02 EEPROM (0x50)
- LSM6DSO32 IMU (0x6b)

The output of `i2c dev 00 77` was:

```console
nsh> i2c dev 00 77
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00: 00 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- 42 -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: 50 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- 6b -- -- -- -- 
70: -- -- -- -- -- -- -- --                         
```

Even providing an argument to the register flag (`i2c dev -r 0 00 77`) resulted in the saem output.

With these proposed changes, the result when using the `-z` flag is:

```console
nsh> i2c dev -z 00 77
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- 42 -- 44 -- -- -- -- -- -- -- -- -- -- -- 
50: 50 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- 6b -- -- -- -- 
70: -- -- -- -- -- -- 76 77
```

Now all devices show up in the scan. Additionally, the general call address of `00` does not appear anymore, which is good as it is not a real device.

When the `-z` flag is not passed, the user is presented with a message indicating that some devices may not appear in the scan, and they can try a zero-byte write scan instead:

```console
nsh> i2c dev 00 77
NOTE: Some devices may not appear with this scan.
You may also try a scan with the -z flag to discover more devices using a zero-byte write request.
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00: 00 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- 42 -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: 50 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- 6b -- -- -- -- 
70: -- -- -- -- -- -- -- --                         
```