### PR TITLE
build.yml: Updated the workflow to use version v4 of the actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         run: tar zcf sources.tar.gz sources
 
       - name: Archive Source Bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: source-bundle
           path: sources.tar.gz
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Download Source Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
@@ -160,24 +160,24 @@ jobs:
                 ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
             fi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: linux-builds
+          name: linux-${{matrix.boards}}-builds
           path: buildartifacts/
         continue-on-error: true
 
   macOS:
     permissions:
       contents: none
-    runs-on: macos-12
+    runs-on: macos-13
     needs: Fetch-Source
     strategy:
       matrix:
         boards: [macos, sim-01, sim-02]
     steps:
       - name: Download Source Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
@@ -209,9 +209,9 @@ jobs:
           cd sources/nuttx/tools/ci
           ./cibuild.sh -i -c -A -R testlist/${{matrix.boards}}.dat
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: macos-builds
+          name: macos-${{matrix.boards}}-builds
           path: buildartifacts/
         continue-on-error: true
 
@@ -257,7 +257,7 @@ jobs:
       - run: git config --global core.autocrlf false
 
       - name: Download Source Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: source-bundle
           path: .
@@ -277,8 +277,8 @@ jobs:
           cd sources/nuttx/tools/ci
           ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: msys2-builds
+          name: msys2-${{matrix.boards}}-builds
           path: buildartifacts/
         continue-on-error: true


### PR DESCRIPTION
## Summary

Starting November 30, 2024, GitHub Actions customers will no longer be able to use v3 of actions/upload-artifact or actions/download-artifact.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR removes the following warning annotations:

The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/download-artifact@v3, actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

see this PR https://github.com/apache/nuttx/pull/12746


Sync the version of the macOS runner with the version used in the nuttx repository.

runs-on: macos-12 -> runs-on: macos-13
**nuttx-apps**
https://github.com/apache/nuttx-apps/blob/2fce155def57d3416bec6b7741adf2770d4ad2b6/.github/workflows/build.yml#L173

**nuttx**
https://github.com/apache/nuttx/blob/17aec1328a6c993d4cb8009fb2ac1893103ba936/.github/workflows/build.yml#L178

## Impact
Improvements
Uploads are significantly faster, upwards of 90% improvement in worst case scenarios.
https://github.com/actions/upload-artifact?tab=readme-ov-file#improvements
## Testing
ci
