### PR TITLE
examples/camera: Fix wrong device file path

### DIFF
--- a/examples/camera/camera_main.c
+++ b/examples/camera/camera_main.c
@@ -60,7 +60,7 @@
 #define APP_STATE_UNDER_CAPTURE   (1)
 #define APP_STATE_AFTER_CAPTURE   (2)
 
-#define CAMERA_DEV_PATH "/dev/video10"
+#define CAMERA_DEV_PATH "/dev/video"
 
 /****************************************************************************
  * Private Types
@@ -512,7 +512,7 @@ int main(int argc, FAR char *argv[])
 
   /* Open the device file. */
 
-  v_fd = open("/dev/video", 0);
+  v_fd = open(CAMERA_DEV_PATH, 0);
   if (v_fd < 0)
     {
       printf("ERROR: Failed to open video.errno = %d\n", errno);


### PR DESCRIPTION
## Summary

In camera_main.c, the dev paths of capture_initialize() and open() are different. So open could always failed.

## Impact

Only camera example.

## Testing

Test the camera example works well with sprsense:camera config.
