### PR TITLE
examples/qencoder: obtain samples using the QEIOC_GETINDEX ioctl call

### DIFF
--- a/examples/qencoder/qe.h
+++ b/examples/qencoder/qe.h
@@ -39,6 +39,7 @@ struct qe_example_s
 {
   FAR char    *devpath;     /* Path to the QE device */
   bool         reset;       /* True: set the count back to zero */
+  bool         use_qeindex; /* True: use the QEIOC_GETINDEX call to get samples */
   unsigned int nloops;      /* Collect this number of samples */
   unsigned int delay;       /* Delay this number of seconds between samples */
 };


### PR DESCRIPTION
Normally, the qencoder position is obtained using the QEIOC_POSITION ioctl call. Adding the -i argument uses the QEIOC_GETINDEX to obtain the qe_index_s struct containing the position alongisde other fields.


## Testing
Tested locally on the SaMoCon board with commands
```
qe -i -p /dev/qe0  # successful QEIOC_GETINDEX on /dev/qe0
qe -i -p /dev/qe1  # successful QEIOC_GETINDEX on /dev/qe1
qe -i /dev/qe0     # only QEIOC_POSITION on /dev/qe0
qe -i /dev/qe1     # only QEOIC_POSITION on /dev/qe1
```


