### PR TITLE
build.yml: Added jobs to speed up CI checks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim-01, sim-02, xtensa]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
 
     steps:
       - name: Download Source Artifact


### PR DESCRIPTION
## Summary
Divided jobs risc-v and xtensa to finish workflow under 2 hours.
depends on this PR https://github.com/apache/nuttx/pull/12793
## Impact
speeds up workflow
## Testing
CI
