### PR TITLE
nsh_dd: fix lseek return check.

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -385,7 +385,7 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (dd.skip)
     {
       ret = lseek(dd.infd, dd.skip * dd.sectsize, SEEK_SET);
-      if (ret < -1)
+      if (ret < 0)
         {
           nsh_error(vtbl, g_fmtcmdfailed, g_dd, "skip lseek", NSH_ERRNO);
           ret = ERROR;
@@ -396,7 +396,7 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (dd.seek)
     {
       ret = lseek(dd.outfd, dd.seek * dd.sectsize, SEEK_SET);
-      if (ret < -1)
+      if (ret < 0)
         {
           nsh_error(vtbl, g_fmtcmdfailed, g_dd, "seek lseek", NSH_ERRNO);
           ret = ERROR;


### PR DESCRIPTION
 - As was merged in commit 1852731df87e5895e299b74aabdb1984b7e3f795 on dd_main.c: lseek returns -1 on error.

   Should be consistent in nsh_ddcmd.c and nsh_main.c.

## Summary

## Impact

## Testing

