### PR TITLE
ostest: Enable vfork test for BUILD_KERNEL

### DIFF
--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -592,16 +592,8 @@ static int user_main(int argc, char *argv[])
 
 #if defined(CONFIG_ARCH_HAVE_FORK) && defined(CONFIG_SCHED_WAITPID) && \
    !defined(CONFIG_ARCH_SIM)
-#ifndef CONFIG_BUILD_KERNEL
       printf("\nuser_main: vfork() test\n");
       vfork_test();
-#else
-      /* REVISIT: The issue with vfork() is on the kernel side, fix the issue
-       * and re-enable this test with CONFIG_BUILD_KERNEL
-       */
-
-      printf("\nuser_main: vfork() test DISABLED (CONFIG_BUILD_KERNEL)\n");
-#endif
 #endif
 
 #ifdef CONFIG_SMP_CALL


### PR DESCRIPTION
## Summary
The test was disabled because of a bug in the NuttX kernel, which is now fixed. Obviously depends on the fix.

## Impact
Enable vfork test
## Testing
rv-virt:knsh64 + ostest

Depends on https://github.com/apache/nuttx/pull/12820