### PR TITLE
ostest/fpu_test: enable for FLAT mode only

### DIFF
--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -346,7 +346,7 @@ static int user_main(int argc, char *argv[])
 #endif
 
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_TESTING_OSTEST_FPUTESTDISABLE) && \
-    !defined(CONFIG_BUILD_KERNEL)
+    defined(CONFIG_BUILD_FLAT)
       /* Check that the FPU is properly supported during context switching */
 
       printf("\nuser_main: FPU test\n");


### PR DESCRIPTION
## Summary

This enables fpu_test() calling for FLAT build only, to be in line with the `fpu.c`.

## Impacts

`ostest` doesn't fail for PROTECTED build

## Testing

- local checks with rv-virt:pnsh64
- CI checks
