### PR TITLE
nshlib/fscmds:Fix write overflow during cp -r process

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -163,8 +163,8 @@ static int cp_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *srcpath,
 
   for (; ; )
     {
-      int nbytesread;
-      int nbyteswritten;
+      ssize_t nbyteswritten;
+      ssize_t nbytesread;
       FAR char *iobuffer = vtbl->iobuffer;
 
       nbytesread = read(rdfd, iobuffer, IOBUFFERSIZE);


### PR DESCRIPTION
## Summary
      do
        {
          nbyteswritten = write(wrfd, iobuffer, nbytesread);
          if (nbyteswritten >= 0)

The write return type is ssize_t, which is different in size from the originally declared type, so the unified type is ssize_t

## Impact
  None

## Testing
  Local test pass
