### PR TITLE
testing/memstress:Initialize the pointer

### DIFF
--- a/testing/memstress/memorystress_main.c
+++ b/testing/memstress/memorystress_main.c
@@ -245,7 +245,7 @@ static bool memorystress_iter(FAR struct memorystress_context_s *context)
     {
       /* Selection of test type and test size by random number */
 
-      FAR uint8_t *ptr;
+      FAR uint8_t *ptr = NULL;
       size_t size = randnum(context->config->max_allocsize, &seed);
       int switch_func = randnum(3, &seed);
       int align = 1 << (randnum(4, &seed) + 2);


### PR DESCRIPTION

## Summary
Initialize the pointer to avoid the pointer being unknown when the memory alloc fails
```
In function 'memorystress_iter',
    inlined from 'memstress_main' at memorystress_main.c:475:10:
memorystress_main.c:289:10: error: 'ptr' may be used uninitialized [-Werror=maybe-uninitialized]
  289 |       if (ptr == NULL)
      |          ^
memorystress_main.c: In function 'memstress_main':
memorystress_main.c:248:20: note: 'ptr' was declared here
  248 |       FAR uint8_t *ptr;
      |                    ^~~
```
## Impact

## Testing

