### PR TITLE
testing/memstress:Support enabling multi-threaded stress testing

### DIFF
--- a/testing/memstress/memorystress_main.c
+++ b/testing/memstress/memorystress_main.c
@@ -97,10 +97,10 @@ struct memorystress_node_s
 
 struct memorystress_context_s
 {
-  struct memorystress_node_s *node_array;
-  struct memorystress_config_s *config;
+  FAR struct memorystress_node_s *node_array;
+  FAR struct memorystress_config_s *config;
+  FAR pthread_t *threads;
   struct memorystress_error_s error;
-  pthread_t *threads;
   uint32_t sleep_us;
   size_t nthreads;
   bool debug;
@@ -476,11 +476,11 @@ static void init(FAR struct memorystress_context_s *context, int argc,
  * Name: memorystress_thread
  ****************************************************************************/
 
-FAR void *memorystress_thread(void *arg)
+FAR void *memorystress_thread(FAR void *arg)
 {
   FAR struct memorystress_context_s *context;
 
-  context = (struct memorystress_context_s *)arg;
+  context = (FAR struct memorystress_context_s *)arg;
   while (memorystress_iter(context))
     {
       usleep(context->sleep_us);


### PR DESCRIPTION
## Summary
  Support enabling multi-thread stress testing. Added "-x" to set the number of threads, the default is 1
## Impact
  memstress support multi-thread testing.
## Testing
  Local test pass

