### PR TITLE
nsh: input redirects

### DIFF
--- a/include/builtin/builtin.h
+++ b/include/builtin/builtin.h
@@ -64,13 +64,15 @@ extern "C"
  *   New application is run in a separate task context (and thread).
  *
  * Input Parameter:
- *   filename  - Name of the linked-in binary to be started.
- *   argv      - Argument list
- *   redirfile - If output is redirected, this parameter will be non-NULL
- *               and will provide the full path to the file.
- *   oflags    - If output is redirected, this parameter will provide the
- *               open flags to use.  This will support file replacement
- *               of appending to an existing file.
+ *   filename      - Name of the linked-in binary to be started.
+ *   argv          - Argument list
+ *   redirfile_in  - If input is redirected, this parameter will be non-NULL
+ *                   and will provide the full path to the file.
+ *   redirfile_out - If output is redirected, this parameter will be non-NULL
+ *                   and will provide the full path to the file.
+ *   oflags        - If output is redirected, this parameter will provide the
+ *                   open flags to use.  This will support file replacement
+ *                   of appending to an existing file.
  *
  * Returned Value:
  *   This is an end-user function, so it follows the normal convention:
@@ -80,7 +82,8 @@ extern "C"
  ****************************************************************************/
 
 int exec_builtin(FAR const char *appname, FAR char * const *argv,
-                 FAR const char *redirfile, int oflags);
+                 FAR const char *redirfile_in, FAR const char *redirfile_out,
+                 int oflags);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -654,15 +654,16 @@ enum nsh_npflags_e
 struct nsh_parser_s
 {
 #ifndef CONFIG_NSH_DISABLEBG
-  bool     np_bg;       /* true: The last command executed in background */
+  bool     np_bg;        /* true: The last command executed in background */
 #endif
-  bool     np_redirect; /* true: Output from the last command was re-directed */
-  bool     np_fail;     /* true: The last command failed */
+  bool     np_redir_out; /* true: Output from the last command was re-directed */
+  bool     np_redir_in;  /* true: Input from the last command was re-directed */
+  bool     np_fail;      /* true: The last command failed */
 #ifndef CONFIG_NSH_DISABLESCRIPT
-  uint8_t  np_flags;    /* See nsh_npflags_e above */
+  uint8_t  np_flags;     /* See nsh_npflags_e above */
 #endif
 #ifndef CONFIG_NSH_DISABLEBG
-  int      np_nice;     /* "nice" value applied to last background cmd */
+  int      np_nice;      /* "nice" value applied to last background cmd */
 #endif
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
@@ -852,7 +853,8 @@ int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[]);
 
 #ifdef CONFIG_NSH_BUILTIN_APPS
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile, int oflags);
+                FAR char **argv, FAR const char *redirfile_in,
+                FAR const char *redirfile_out, int oflags);
 #endif
 
 #ifdef CONFIG_NSH_FILE_APPS

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -859,7 +859,8 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
 #ifdef CONFIG_NSH_FILE_APPS
 int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile, int oflags);
+                FAR char **argv, FAR const char *redirfile_in,
+                FAR const char *redirfile_out, int oflags);
 #endif
 
 #ifndef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -98,6 +98,10 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
 
   OUTFD(pstate) = 1;
 
+  /* Setup stdin */
+
+  INFD(pstate) = 0;
+
   return OK;
 }
 

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -69,7 +69,8 @@
  ****************************************************************************/
 
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile, int oflags)
+                FAR char **argv, FAR const char *redirfile_in,
+                FAR const char *redirfile_out, int oflags)
 {
 #if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS)
   struct sigaction act;
@@ -101,7 +102,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
    * applications.
    */
 
-  ret = exec_builtin(cmd, argv, redirfile, oflags);
+  ret = exec_builtin(cmd, argv, redirfile_in, redirfile_out, oflags);
   if (ret >= 0)
     {
       /* The application was successfully started with pre-emption disabled.

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -158,8 +158,8 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_CAT
-  CMD_MAP("cat",      cmd_cat,      2, CONFIG_NSH_MAXARGUMENTS,
-    "<path> [<path> [<path> ...]]"),
+  CMD_MAP("cat",      cmd_cat,      1, CONFIG_NSH_MAXARGUMENTS,
+    "[<path> [<path> [<path> ...]]]"),
 #endif
 
 #ifndef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -140,6 +140,34 @@ static ssize_t nsh_consolewrite(FAR struct nsh_vtbl_s *vtbl,
 }
 
 /****************************************************************************
+ * Name: nsh_consoleread
+ *
+ * Description:
+ *   read a buffer to the remote shell window.
+ *
+ *   Currently only used by cat.
+ *
+ ****************************************************************************/
+
+static ssize_t nsh_consoleread(FAR struct nsh_vtbl_s *vtbl,
+                                FAR void *buffer, size_t nbytes)
+{
+  FAR struct console_stdio_s *pstate = (FAR struct console_stdio_s *)vtbl;
+  ssize_t ret;
+
+  /* Read the data to the output stream */
+
+  ret = read(INFD(pstate), buffer, nbytes);
+  if (ret < 0)
+    {
+      _err("ERROR: [%d] Failed to read buffer: %d\n",
+          INFD(pstate), errno);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: nsh_consolewrite
  *
  * Description:
@@ -380,6 +408,7 @@ FAR struct console_stdio_s *nsh_newconsole(bool isctty)
 #endif
       pstate->cn_vtbl.release     = nsh_consolerelease;
       pstate->cn_vtbl.write       = nsh_consolewrite;
+      pstate->cn_vtbl.read        = nsh_consoleread;
       pstate->cn_vtbl.ioctl       = nsh_consoleioctl;
       pstate->cn_vtbl.output      = nsh_consoleoutput;
 #ifndef CONFIG_NSH_DISABLE_ERROR_PRINT

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -44,6 +44,7 @@
 #define nsh_clone(v)            (v)->clone(v)
 #define nsh_release(v)          (v)->release(v)
 #define nsh_write(v,b,n)        (v)->write(v,b,n)
+#define nsh_read(v,b,n)         (v)->read(v,b,n)
 #define nsh_ioctl(v,c,a)        (v)->ioctl(v,c,a)
 #define nsh_linebuffer(v)       (v)->linebuffer(v)
 #define nsh_redirect(v,fi,fo,s) (v)->redirect(v,fi,fo,s)
@@ -112,6 +113,8 @@ struct nsh_vtbl_s
 #endif
   void (*release)(FAR struct nsh_vtbl_s *vtbl);
   ssize_t (*write)(FAR struct nsh_vtbl_s *vtbl, FAR const void *buffer,
+                   size_t nbytes);
+  ssize_t (*read)(FAR struct nsh_vtbl_s *vtbl, FAR void *buffer,
                    size_t nbytes);
   int (*ioctl)(FAR struct nsh_vtbl_s *vtbl, int cmd, unsigned long arg);
 #ifndef CONFIG_NSH_DISABLE_ERROR_PRINT

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -41,18 +41,18 @@
 
 /* Method access macros */
 
-#define nsh_clone(v)           (v)->clone(v)
-#define nsh_release(v)         (v)->release(v)
-#define nsh_write(v,b,n)       (v)->write(v,b,n)
-#define nsh_ioctl(v,c,a)       (v)->ioctl(v,c,a)
-#define nsh_linebuffer(v)      (v)->linebuffer(v)
-#define nsh_redirect(v,f,s)    (v)->redirect(v,f,s)
-#define nsh_undirect(v,s)      (v)->undirect(v,s)
-#define nsh_exit(v,s)          (v)->exit(v,s)
+#define nsh_clone(v)            (v)->clone(v)
+#define nsh_release(v)          (v)->release(v)
+#define nsh_write(v,b,n)        (v)->write(v,b,n)
+#define nsh_ioctl(v,c,a)        (v)->ioctl(v,c,a)
+#define nsh_linebuffer(v)       (v)->linebuffer(v)
+#define nsh_redirect(v,fi,fo,s) (v)->redirect(v,fi,fo,s)
+#define nsh_undirect(v,s)       (v)->undirect(v,s)
+#define nsh_exit(v,s)           (v)->exit(v,s)
 
 #ifdef CONFIG_CPP_HAVE_VARARGS
-#  define nsh_error(v, ...)    (v)->error(v, ##__VA_ARGS__)
-#  define nsh_output(v, ...)   (v)->output(v, ##__VA_ARGS__)
+#  define nsh_error(v, ...)     (v)->error(v, ##__VA_ARGS__)
+#  define nsh_output(v, ...)    (v)->output(v, ##__VA_ARGS__)
 #  define nsh_none(v, ...)     \
      do { if (0) nsh_output_none(v, ##__VA_ARGS__); } while (0)
 #else
@@ -85,7 +85,7 @@
 
 #else
 
-#  define INFD(p)      0
+#  define INFD(p)      ((p)->cn_infd)
 
 #endif
 
@@ -121,7 +121,8 @@ struct nsh_vtbl_s
   int (*output)(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...)
       printf_like(2, 3);
   FAR char *(*linebuffer)(FAR struct nsh_vtbl_s *vtbl);
-  void (*redirect)(FAR struct nsh_vtbl_s *vtbl, int fd, FAR uint8_t *save);
+  void (*redirect)(FAR struct nsh_vtbl_s *vtbl, int fd_in, int fd_out,
+                   FAR uint8_t *save);
   void (*undirect)(FAR struct nsh_vtbl_s *vtbl, FAR uint8_t *save);
   void (*exit)(FAR struct nsh_vtbl_s *vtbl, int status) noreturn_function;
 
@@ -163,6 +164,7 @@ struct console_stdio_s
 #ifdef CONFIG_NSH_ALTCONDEV
   int   cn_confd;     /* Console I/O file descriptor */
 #endif
+  int   cn_infd;      /* Input file descriptor (possibly redirected) */
   int   cn_outfd;     /* Output file descriptor (possibly redirected) */
   int   cn_errfd;     /* Error Output file descriptor (possibly redirected) */
 

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -791,6 +791,25 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         }
     }
 
+  if (argc == 1)
+    {
+      char *buf = malloc(BUFSIZ);
+
+      /* Dump from input */
+
+      while (true)
+        {
+          ssize_t n = nsh_read(vtbl, buf, BUFSIZ);
+
+          if (n == 0)
+            break;
+
+          nsh_write(vtbl, buf, n);
+        }
+
+      free(buf);
+    }
+
   return ret;
 }
 #endif

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -685,7 +685,8 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
    */
 
 #ifdef CONFIG_NSH_FILE_APPS
-  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile_out, oflags);
+  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile_in,
+                    redirfile_out, oflags);
   if (ret >= 0)
     {
       /* nsh_fileapp() returned 0 or 1.  This means that the built-in

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -54,7 +54,7 @@ static int nsh_script_redirect(FAR struct nsh_vtbl_s *vtbl,
       fd = open(CONFIG_NSH_SCRIPT_REDIRECT_PATH, 0666);
       if (fd > 0)
         {
-          nsh_redirect(vtbl, fd, save);
+          nsh_redirect(vtbl, 0, fd, save);
         }
     }
 

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -298,7 +298,8 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLEBG
   bool bgsave;
 #endif
-  bool redirsave;
+  bool redirsave_out;
+  bool redirsave_in;
   int ret;
 
   /* Get the current time */
@@ -315,7 +316,8 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLEBG
   bgsave    = vtbl->np.np_bg;
 #endif
-  redirsave = vtbl->np.np_redirect;
+  redirsave_out = vtbl->np.np_redir_out;
+  redirsave_in = vtbl->np.np_redir_in;
 
   /* Execute the command */
 
@@ -354,7 +356,8 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLEBG
   vtbl->np.np_bg       = bgsave;
 #endif
-  vtbl->np.np_redirect = redirsave;
+  vtbl->np.np_redir_out = redirsave_out;
+  vtbl->np.np_redir_out = redirsave_in;
 
   return ret;
 }

--- a/testing/cmocka/cmocka_main.c
+++ b/testing/cmocka/cmocka_main.c
@@ -182,7 +182,7 @@ int main(int argc, FAR char *argv[])
         }
 
       bypass[0] = (FAR char *)builtin->name;
-      ret = exec_builtin(builtin->name, bypass, NULL, 0);
+      ret = exec_builtin(builtin->name, bypass, NULL, NULL, 0);
       if (ret >= 0)
         {
           waitpid(ret, &ret, WUNTRACED);


### PR DESCRIPTION
## Summary

This is an attempt to refactor nsh to allow commands to have input redirects (`<`). It allows `<` to change the stdin descriptor when starting a nuttx task or to set the save/restore strucutures on the nsh handling.

I am not sure if this is the correct way to achieve this, so I open this PR to get feedback from the community. Please let me know if there is a better way or if I am misunderstanding or missing something.

I also plan to support `<<` style heredoc and pipes `|`. But those are not implemented yet.

If I get positive feedback, I could implement those in a future PR.

Partially fixes https://github.com/apache/nuttx-apps/issues/2454

## Impact

Now we can stdin and stdout redirection:

```
nsh> echo hello > oi
nsh> cat < oi
hello
nsh> cat < oi > ola
nsh> cat ola
hello
nsh> echo even works the other way around > oi2
nsh> cat > new < oi2
nsh> cat new
even works the other way around
```

## Testing

Manual testing. Still need to test how it works in telnet, usb console or altconsole.