### PR TITLE
dhrystone:Ignore warnings. 

### DIFF
--- a/benchmarks/dhrystone/Makefile
+++ b/benchmarks/dhrystone/Makefile
@@ -27,10 +27,10 @@ PRIORITY  = $(CONFIG_BENCHMARK_DHRYSTONE_PRIORITY)
 STACKSIZE = $(CONFIG_BENCHMARK_DHRYSTONE_STACKSIZE)
 MODULE    = $(CONFIG_BENCHMARK_DHRYSTONE)
 
-CFLAGS   += -DMSC_CLOCK
+CFLAGS   += -DMSC_CLOCK -Wno-implicit-int -Wno-strict-prototypes
+CFLAGS   += -Wno-implicit-function-declaration -Wno-return-type
 
 CSRCS    += dhrystone/v2.1/dhry_2.c
-
 MAINSRC   = dhrystone/v2.2/dry.c
 
 ifeq ($(wildcard dhrystone/.git),)


### PR DESCRIPTION
## Summary
Warnings have no impacton the program itelf.

The function implementation does not specify a return type, and is treated as a void return value function during use, so it is ignored. 
```
CC:  icmpv6_ping.c dhrystone/v2.1/dhry_2.c:30:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
   30 | Proc_6 (Enum_Val_Par, Enum_Ref_Par)
      | ^~~~~~

2. The implementation of some functions is opposite to the calling position, and the processing can be ignored dhrystone/v2.1/dhry_2.c:39:9: warning: implicit declaration of function ‘Func_3’ [-Wimplicit-function-declaration]
   39 |   if (! Func_3 (Enum_Val_Par))

3. This function is called from dhry_2.c and void behavior is expected. dhrystone/v2.1/dhry_2.c:30:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   30 | Proc_6 (Enum_Val_Par, Enum_Ref_Par)

4. In the old version of C language, if the function declaration return value is not set, the default is void; in the new version, it is int, but in dhrystone, these functions are called as void type functions by default. dhrystone/v2.2/dry.c:738:1: warning: control reaches end of non-void function [-Wreturn-type]
  738 | }
      | ^
dhrystone/v2.2/dry.c: In function ‘Proc_1’:
dhrystone/v2.2/dry.c:772:1: warning: control reaches end of non-void function [-Wreturn-type]
  772 | } /* Proc_1 */
      | ^
dhrystone/v2.2/dry.c: In function ‘Proc_2’:
dhrystone/v2.2/dry.c:795:1: warning: control reaches end of non-void function [-Wreturn-type]
  795 | } /* Proc_2 */
      | ^
dhrystone/v2.2/dry.c: In function ‘Proc_3’:
dhrystone/v2.2/dry.c:810:1: warning: control reaches end of non-void function [-Wreturn-type]
  810 | } /* Proc_3 */
      | ^
dhrystone/v2.2/dry.c: In function ‘Proc_4’:
dhrystone/v2.2/dry.c:822:1: warning: control reaches end of non-void function [-Wreturn-type]
  822 | } /* Proc_4 */
      | ^
dhrystone/v2.2/dry.c: In function ‘Proc_5’:
dhrystone/v2.2/dry.c:831:1: warning: control reaches end of non-void function [-Wreturn-type]
  831 | } /* Proc_5 */
      | ^
```

## Impact
  None,it just fix dhrystone benchmark warning

## Testing
  Local test pass
