### PR TITLE
Ramspeed improve

### DIFF
--- a/benchmarks/ramspeed/Kconfig
+++ b/benchmarks/ramspeed/Kconfig
@@ -6,6 +6,7 @@
 config BENCHMARK_RAMSPEED
 	tristate "RAM Speed Test"
 	default n
+	depends on LIBC_FLOATINGPOINT
 	---help---
 		Enable a simple RAM speed test.
 

--- a/benchmarks/ramspeed/ramspeed_main.c
+++ b/benchmarks/ramspeed/ramspeed_main.c
@@ -187,22 +187,6 @@ static void parse_commandline(int argc, FAR char **argv,
         }
     }
 
-  if (info->allocate_rw_address)
-    {
-      info->dest = malloc(info->size);
-      if (info->dest == NULL)
-        {
-          printf(RAMSPEED_PREFIX "Dest Alloc Memory Failed!\n");
-        }
-
-      info->src = malloc(info->size);
-      if (info->src == NULL)
-        {
-          free(info->dest);
-          printf(RAMSPEED_PREFIX "Src Alloc Memory Failed!\n");
-        }
-    }
-
   if ((info->dest == NULL && !info->allocate_rw_address) || info->size == 0)
     {
       printf(RAMSPEED_PREFIX "Missing required arguments\n");


### PR DESCRIPTION
## Summary
1. Fixed memleak caused by "ramspeed -a"
2. Add more print logs
3. Improve test accuracy, now print in double type in us time unit
4. Optional test item, if we do not pass in the src address, only memset will be executed

## Impact
  None

## Testing
  Local test pass
