### PR TITLE
nshlib/ddcmd:Fixed NSH_CMDOPT_DD_STATS output format warning

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -443,8 +443,8 @@ int cmd_dd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   total = ((uint64_t)sector * (uint64_t)dd.sectsize);
 
-  nsh_output(vtbl, "%llu bytes copied, %u usec, ",
-             total, (unsigned int)elapsed);
+  nsh_output(vtbl, "%" PRIu64 "bytes copied, %" PRIu64 " usec, ",
+             total, elapsed);
   nsh_output(vtbl, "%u KB/s\n" ,
              (unsigned int)(((double)total / 1024)
              / ((double)elapsed / USEC_PER_SEC)));


### PR DESCRIPTION
## Summary
Fixed NSH_CMDOPT_DD_STATS output format warning in 64-bit environment

```
In file included from nsh_ddcmd.c:44:
nsh_ddcmd.c: In function 'cmd_dd':
nsh_ddcmd.c:456:20: error: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  456 |   nsh_output(vtbl, "%llu bytes copied, %u usec, ",
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  457 |              total, (unsigned int)elapsed);
      |              ~~~~~
      |              |
      |              uint64_t {aka long unsigned int}
nsh_console.h:55:49: note: in definition of macro 'nsh_output'
   55 | #  define nsh_output(v, ...)   (v)->output(v, ##__VA_ARGS__)
      |                                                 ^~~~~~~~~~~
nsh_ddcmd.c:456:24: note: format string is defined here
  456 |   nsh_output(vtbl, "%llu bytes copied, %u usec, ",
      |                     ~~~^
      |                        |
      |                        long long unsigned int
      |                     %lu
cc1: all warnings being treated as errors
```

## Impact
  None

## Testing
  Local test pass
