### PR TITLE
Benchmark add cmake

### DIFF
--- a/benchmarks/fio/CMakeLists.txt
+++ b/benchmarks/fio/CMakeLists.txt
@@ -1,0 +1,169 @@
+# ##############################################################################
+# apps/benchmarks/fio/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BENCHMARK_FIO)
+
+  set(FIOAPP_DIR ${CMAKE_CURRENT_LIST_DIR}/fio)
+
+  if(NOT EXISTS ${FIOAPP_DIR})
+    FetchContent_Declare(
+      fio_fetch
+      URL https://github.com/ldorau/fio/archive/refs/heads/master.zip SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/fio BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/benchmarks/fio/fio
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30
+      PATCH_COMMAND
+        patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-external-fio-fix-compile-warning.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0002-external-fio-add-os-nuttx-support.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0003-external-fio-modify-smaller-size-for-nuttx.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0004-external-fio-fix-runtime-error-by-asan.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0005-external-fio-fix-compile-warning.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0006-external-fio-reinit-global-var-issue-when-run-multip.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0007-external-fio-add-engine-init.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0008-fio-fix-memory-leak-run-cpuio.fio.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0009-fio-fix-memory-leak-ioengine-filecreate.patch
+        COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/fio <
+        ${CMAKE_CURRENT_LIST_DIR}/0010-fio-fix-memory-leak-ioengine-exec.patch)
+
+    FetchContent_GetProperties(fio_fetch)
+    if(NOT fio_fetch_POPULATED)
+      FetchContent_Populate(fio_fetch)
+    endif()
+  endif()
+
+  file(GLOB LIB_SRCS ${FIOAPP_DIR}/lib/*.c)
+  file(GLOB CRC_SRCS ${FIOAPP_DIR}/crc/*.c)
+
+  set(CSRCS
+      ${LIB_SRCS}
+      ${CRC_SRCS}
+      ${FIOAPP_DIR}/gettime.c
+      ${FIOAPP_DIR}/ioengines.c
+      ${FIOAPP_DIR}/init.c
+      ${FIOAPP_DIR}/stat.c
+      ${FIOAPP_DIR}/log.c
+      ${FIOAPP_DIR}/time.c
+      ${FIOAPP_DIR}/filesetup.c
+      ${FIOAPP_DIR}/eta.c
+      ${FIOAPP_DIR}/verify.c
+      ${FIOAPP_DIR}/memory.c
+      ${FIOAPP_DIR}/io_u.c
+      ${FIOAPP_DIR}/parse.c
+      ${FIOAPP_DIR}/fio_sem.c
+      ${FIOAPP_DIR}/rwlock.c
+      ${FIOAPP_DIR}/pshared.c
+      ${FIOAPP_DIR}/options.c
+      ${FIOAPP_DIR}/smalloc.c
+      ${FIOAPP_DIR}/filehash.c
+      ${FIOAPP_DIR}/profile.c
+      ${FIOAPP_DIR}/debug.c
+      ${FIOAPP_DIR}/server.c
+      ${FIOAPP_DIR}/client.c
+      ${FIOAPP_DIR}/iolog.c
+      ${FIOAPP_DIR}/backend.c
+      ${FIOAPP_DIR}/libfio.c
+      ${FIOAPP_DIR}/flow.c
+      ${FIOAPP_DIR}/cconv.c
+      ${FIOAPP_DIR}/gettime-thread.c
+      ${FIOAPP_DIR}/helpers.c
+      ${FIOAPP_DIR}/json.c
+      ${FIOAPP_DIR}/idletime.c
+      ${FIOAPP_DIR}/td_error.c
+      ${FIOAPP_DIR}/zbd.c
+      ${FIOAPP_DIR}/profiles/tiobench.c
+      ${FIOAPP_DIR}/profiles/act.c
+      ${FIOAPP_DIR}/io_u_queue.c
+      ${FIOAPP_DIR}/filelock.c
+      ${FIOAPP_DIR}/steadystate.c
+      ${FIOAPP_DIR}/workqueue.c
+      ${FIOAPP_DIR}/rate-submit.c
+      ${FIOAPP_DIR}/optgroup.c
+      ${FIOAPP_DIR}/helper_thread.c
+      ${FIOAPP_DIR}/zone-dist.c
+      ${FIOAPP_DIR}/dedupe.c
+      ${FIOAPP_DIR}/engines/exec.c
+      ${FIOAPP_DIR}/engines/cpu.c
+      ${FIOAPP_DIR}/engines/sync.c
+      ${FIOAPP_DIR}/engines/ftruncate.c
+      ${FIOAPP_DIR}/engines/falloc.c
+      ${FIOAPP_DIR}/engines/fileoperations.c
+      ${FIOAPP_DIR}/engines/mmap.c
+      ${FIOAPP_DIR}/engines/null.c
+      ${FIOAPP_DIR}/engines/net.c)
+
+  set(CFLAGS
+      -DCONFIG_GETTIMEOFDAY
+      -DCONFIG_CLOCK_GETTIME
+      -DCONFIG_HAVE_GETTID
+      -DCONFIG_STATIC_ASSERT
+      -DCONFIG_LITTLE_ENDIAN
+      -DCONFIG_POSIX_FALLOCATE
+      -DCONFIG_HAVE_BOOL
+      -DFIO_INTERNAL
+      -DCONFIG_NO_SHM
+      -DFIO_VERSION=\"1.2.0\"
+      -DFIO_USE_GENERIC_SWAP
+      -DFIO_USE_GENERIC_INIT_RANDOM_STATE
+      -DFIO_USE_GENERIC_BDEV_SIZE
+      -DBLOOM_SIZE=1024*1024
+      -DBUF_SIZE=512*1024
+      -DMAX_POOLS=4
+      -DINITIAL_POOLS=2
+      -DINITIAL_SIZE=512*1024
+      -DCONFIG_SEED_BUCKETS=8
+      -DBITS_PER_LONG=32
+      -DXXH32_digest=fio_XXH32_digest
+      -DXXH32_update=fio_XXH32_update
+      -DXXH32=fio_XXH32
+      -Dparse_options=fio_parse_options
+      -Dparse_option=fio_parse_option)
+
+  set(INCDIR ${FIOAPP_DIR} ${FIOAPP_DIR}/arch ${FIOAPP_DIR}/crc
+             ${FIOAPP_DIR}/os)
+  include_directories(${INCDIR})
+
+  if(CONFIG_ARCH_ARM)
+    list(APPEND CFLAGS -D__ARM_ARCH_6__)
+  endif()
+
+  set(SRCS ${FIOAPP_DIR}/fio.c ${CSRCS})
+  nuttx_add_application(
+    NAME
+    fio
+    PRIORITY
+    ${CONFIG_BENCHMARK_FIO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_BENCHMARK_FIO_STACKSIZE}
+    COMPILE_FLAGS
+    ${CFLAGS}
+    SRCS
+    ${SRCS})
+
+endif()

--- a/benchmarks/iozone/CMakeLists.txt
+++ b/benchmarks/iozone/CMakeLists.txt
@@ -1,0 +1,87 @@
+# ##############################################################################
+# apps/benchmarks/iozone/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BENCHMARK_IOZONE)
+
+  # Define the directory and file paths
+  set(IOZONE_VERSION "${CONFIG_BENCHMARK_IOZONE_VERSION}") # Adjust this as
+                                                           # needed
+  set(IOZONE_DIR ${CMAKE_CURRENT_LIST_DIR}/iozone)
+  set(IOZONE_ZIP ${IOZONE_DIR}.tgz)
+  set(IOZONE_URL
+      "https://www.iozone.org/src/current/iozone${IOZONE_VERSION}.tgz")
+
+  # Download and unpack iozone if not already present
+  if(NOT EXISTS ${IOZONE_DIR})
+    FetchContent_Declare(
+      iozone_fetch
+      URL ${IOZONE_URL} SOURCE_DIR ${IOZONE_DIR}
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30
+      PATCH_COMMAND patch -p1 -d ${IOZONE_DIR} <
+                    ${CMAKE_CURRENT_LIST_DIR}/iozone.patch)
+
+    FetchContent_GetProperties(iozone_fetch)
+    if(NOT iozone_fetch_POPULATED)
+      FetchContent_Populate(iozone_fetch)
+    endif()
+  endif()
+
+  # Define source files
+  set(CSRCS ${IOZONE_DIR}/src/current/libbif.c)
+  set(MAINSRC ${IOZONE_DIR}/src/current/iozone.c)
+
+  # Define compile flags
+  set(CFLAGS
+      -Dunix
+      -DHAVE_ANSIC_C
+      -DHAVE_PREAD
+      -DNAME=\"nuttx\"
+      -DNO_MADVISE
+      -DNO_FORK
+      -D__FreeBSD__
+      -DNO_THREADS
+      -Wno-unused-parameter
+      -Wno-unused-function
+      -Wno-shadow
+      -Wno-unused-but-set-variable
+      -Wno-strict-prototypes
+      -Wno-misleading-indentation
+      -Wno-maybe-uninitialized
+      -DMAXBUFFERSIZE=32*1024
+      -DMAXSTREAMS=8
+      -DMAXNAMESIZE=NAME_MAX
+      -DRECLEN_START=1024)
+
+  # Add application to the build
+  set(SRCS ${IOZONE_DIR}/src/current/iozone.c ${CSRCS})
+  nuttx_add_application(
+    NAME
+    iozone
+    PRIORITY
+    ${CONFIG_BENCHMARK_IOZONE_PRIORITY}
+    STACKSIZE
+    ${CONFIG_BENCHMARK_IOZONE_STACKSIZE}
+    COMPILE_FLAGS
+    ${CFLAGS}
+    SRCS
+    ${SRCS})
+
+endif()


### PR DESCRIPTION
## Summary
Provides CmakeList support for the following benchmarks:
1. fio
2. iozone

## Impact
None

## Testing
Local test pass
