### PR TITLE
Revert commits from PR #2469

### DIFF
--- a/builtin/exec_builtin.c
+++ b/builtin/exec_builtin.c
@@ -43,15 +43,13 @@
  *   New application is run in a separate task context (and thread).
  *
  * Input Parameter:
- *   filename      - Name of the linked-in binary to be started.
- *   argv          - Argument list
- *   redirfile_in  - If input is redirected, this parameter will be non-NULL
- *                   and will provide the full path to the file.
- *   redirfile_out - If output is redirected, this parameter will be non-NULL
- *                   and will provide the full path to the file.
- *   oflags        - If output is redirected, this parameter will provide the
- *                   open flags to use.  This will support file replacement
- *                   of appending to an existing file.
+ *   filename  - Name of the linked-in binary to be started.
+ *   argv      - Argument list
+ *   redirfile - If output is redirected, this parameter will be non-NULL
+ *               and will provide the full path to the file.
+ *   oflags    - If output is redirected, this parameter will provide the
+ *               open flags to use.  This will support file replacement
+ *               of appending to an existing file.
  *
  * Returned Value:
  *   This is an end-user function, so it follows the normal convention:
@@ -61,8 +59,7 @@
  ****************************************************************************/
 
 int exec_builtin(FAR const char *appname, FAR char * const *argv,
-                 FAR const char *redirfile_in, FAR const char *redirfile_out,
-                 int oflags)
+                 FAR const char *redirfile, int oflags)
 {
   FAR const struct builtin_s *builtin;
   posix_spawnattr_t attr;
@@ -147,29 +144,14 @@ int exec_builtin(FAR const char *appname, FAR char * const *argv,
 
 #endif
 
-  /* Is input being redirected? */
-
-  if (redirfile_in)
-    {
-      /* Set up to close open redirfile and set to stdin (0) */
-
-      ret = posix_spawn_file_actions_addopen(&file_actions, 0,
-                                             redirfile_in, O_RDONLY, 0);
-      if (ret != 0)
-        {
-          serr("ERROR: posix_spawn_file_actions_addopen failed: %d\n", ret);
-          goto errout_with_actions;
-        }
-    }
-
   /* Is output being redirected? */
 
-  if (redirfile_out)
+  if (redirfile)
     {
       /* Set up to close open redirfile and set to stdout (1) */
 
       ret = posix_spawn_file_actions_addopen(&file_actions, 1,
-                                             redirfile_out, oflags, 0644);
+                                             redirfile, oflags, 0644);
       if (ret != 0)
         {
           serr("ERROR: posix_spawn_file_actions_addopen failed: %d\n", ret);

--- a/include/builtin/builtin.h
+++ b/include/builtin/builtin.h
@@ -64,15 +64,13 @@ extern "C"
  *   New application is run in a separate task context (and thread).
  *
  * Input Parameter:
- *   filename      - Name of the linked-in binary to be started.
- *   argv          - Argument list
- *   redirfile_in  - If input is redirected, this parameter will be non-NULL
- *                   and will provide the full path to the file.
- *   redirfile_out - If output is redirected, this parameter will be non-NULL
- *                   and will provide the full path to the file.
- *   oflags        - If output is redirected, this parameter will provide the
- *                   open flags to use.  This will support file replacement
- *                   of appending to an existing file.
+ *   filename  - Name of the linked-in binary to be started.
+ *   argv      - Argument list
+ *   redirfile - If output is redirected, this parameter will be non-NULL
+ *               and will provide the full path to the file.
+ *   oflags    - If output is redirected, this parameter will provide the
+ *               open flags to use.  This will support file replacement
+ *               of appending to an existing file.
  *
  * Returned Value:
  *   This is an end-user function, so it follows the normal convention:
@@ -82,8 +80,7 @@ extern "C"
  ****************************************************************************/
 
 int exec_builtin(FAR const char *appname, FAR char * const *argv,
-                 FAR const char *redirfile_in, FAR const char *redirfile_out,
-                 int oflags);
+                 FAR const char *redirfile, int oflags);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -654,16 +654,15 @@ enum nsh_npflags_e
 struct nsh_parser_s
 {
 #ifndef CONFIG_NSH_DISABLEBG
-  bool     np_bg;        /* true: The last command executed in background */
+  bool     np_bg;       /* true: The last command executed in background */
 #endif
-  bool     np_redir_out; /* true: Output from the last command was re-directed */
-  bool     np_redir_in;  /* true: Input from the last command was re-directed */
-  bool     np_fail;      /* true: The last command failed */
+  bool     np_redirect; /* true: Output from the last command was re-directed */
+  bool     np_fail;     /* true: The last command failed */
 #ifndef CONFIG_NSH_DISABLESCRIPT
-  uint8_t  np_flags;     /* See nsh_npflags_e above */
+  uint8_t  np_flags;    /* See nsh_npflags_e above */
 #endif
 #ifndef CONFIG_NSH_DISABLEBG
-  int      np_nice;      /* "nice" value applied to last background cmd */
+  int      np_nice;     /* "nice" value applied to last background cmd */
 #endif
 
 #ifndef CONFIG_NSH_DISABLESCRIPT
@@ -853,14 +852,12 @@ int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[]);
 
 #ifdef CONFIG_NSH_BUILTIN_APPS
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags);
+                FAR char **argv, FAR const char *redirfile, int oflags);
 #endif
 
 #ifdef CONFIG_NSH_FILE_APPS
 int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags);
+                FAR char **argv, FAR const char *redirfile, int oflags);
 #endif
 
 #ifndef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_altconsole.c
+++ b/nshlib/nsh_altconsole.c
@@ -98,10 +98,6 @@ static int nsh_clone_console(FAR struct console_stdio_s *pstate)
 
   OUTFD(pstate) = 1;
 
-  /* Setup stdin */
-
-  INFD(pstate) = 0;
-
   return OK;
 }
 

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -69,8 +69,7 @@
  ****************************************************************************/
 
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags)
+                FAR char **argv, FAR const char *redirfile, int oflags)
 {
 #if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS)
   struct sigaction act;
@@ -102,7 +101,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
    * applications.
    */
 
-  ret = exec_builtin(cmd, argv, redirfile_in, redirfile_out, oflags);
+  ret = exec_builtin(cmd, argv, redirfile, oflags);
   if (ret >= 0)
     {
       /* The application was successfully started with pre-emption disabled.

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -158,8 +158,8 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_CAT
-  CMD_MAP("cat",      cmd_cat,      1, CONFIG_NSH_MAXARGUMENTS,
-    "[<path> [<path> [<path> ...]]]"),
+  CMD_MAP("cat",      cmd_cat,      2, CONFIG_NSH_MAXARGUMENTS,
+    "<path> [<path> [<path> ...]]"),
 #endif
 
 #ifndef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -47,7 +47,6 @@ struct serialsave_s
 {
   int   cn_errfd;     /* Re-directed error output file descriptor */
   int   cn_outfd;     /* Re-directed output file descriptor */
-  int   cn_infd;      /* Re-directed input file descriptor */
 };
 
 /****************************************************************************
@@ -69,8 +68,8 @@ static int nsh_erroroutput(FAR struct nsh_vtbl_s *vtbl,
                            FAR const char *fmt, ...) printf_like(2, 3);
 #endif
 static FAR char *nsh_consolelinebuffer(FAR struct nsh_vtbl_s *vtbl);
-static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd_in,
-                                int fd_out, FAR uint8_t *save);
+static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd,
+                                FAR uint8_t *save);
 static void nsh_consoleundirect(FAR struct nsh_vtbl_s *vtbl,
                                 FAR uint8_t *save);
 static void nsh_consoleexit(FAR struct nsh_vtbl_s *vtbl,
@@ -101,14 +100,8 @@ static void nsh_closeifnotclosed(struct console_stdio_s *pstate)
       close(ERRFD(pstate));
     }
 
-  if (INFD(pstate) >= 0 && INFD(pstate) != STDIN_FILENO)
-    {
-      close(INFD(pstate));
-    }
-
   ERRFD(pstate) = -1;
   OUTFD(pstate) = -1;
-  INFD(pstate) = -1;
 }
 
 /****************************************************************************
@@ -134,34 +127,6 @@ static ssize_t nsh_consolewrite(FAR struct nsh_vtbl_s *vtbl,
     {
       _err("ERROR: [%d] Failed to send buffer: %d\n",
           OUTFD(pstate), errno);
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: nsh_consoleread
- *
- * Description:
- *   read a buffer to the remote shell window.
- *
- *   Currently only used by cat.
- *
- ****************************************************************************/
-
-static ssize_t nsh_consoleread(FAR struct nsh_vtbl_s *vtbl,
-                                FAR void *buffer, size_t nbytes)
-{
-  FAR struct console_stdio_s *pstate = (FAR struct console_stdio_s *)vtbl;
-  ssize_t ret;
-
-  /* Read the data to the output stream */
-
-  ret = read(INFD(pstate), buffer, nbytes);
-  if (ret < 0)
-    {
-      _err("ERROR: [%d] Failed to read buffer: %d\n",
-          INFD(pstate), errno);
     }
 
   return ret;
@@ -325,8 +290,8 @@ static void nsh_consolerelease(FAR struct nsh_vtbl_s *vtbl)
  *
  ****************************************************************************/
 
-static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd_in,
-                                int fd_out, FAR uint8_t *save)
+static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd,
+                                FAR uint8_t *save)
 {
   FAR struct console_stdio_s *pstate = (FAR struct console_stdio_s *)vtbl;
   FAR struct serialsave_s *ssave  = (FAR struct serialsave_s *)save;
@@ -341,13 +306,11 @@ static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd_in,
 
       ERRFD(ssave) = ERRFD(pstate);
       OUTFD(ssave) = OUTFD(pstate);
-      INFD(ssave) = INFD(pstate);
     }
 
   /* Set the fd of the new. */
 
-  OUTFD(pstate) = fd_out;
-  INFD(pstate) = fd_in;
+  OUTFD(pstate) = fd;
 }
 
 /****************************************************************************
@@ -367,7 +330,6 @@ static void nsh_consoleundirect(FAR struct nsh_vtbl_s *vtbl,
   nsh_closeifnotclosed(pstate);
   ERRFD(pstate) = ERRFD(ssave);
   OUTFD(pstate) = OUTFD(ssave);
-  INFD(pstate) = INFD(ssave);
 }
 
 /****************************************************************************
@@ -408,7 +370,6 @@ FAR struct console_stdio_s *nsh_newconsole(bool isctty)
 #endif
       pstate->cn_vtbl.release     = nsh_consolerelease;
       pstate->cn_vtbl.write       = nsh_consolewrite;
-      pstate->cn_vtbl.read        = nsh_consoleread;
       pstate->cn_vtbl.ioctl       = nsh_consoleioctl;
       pstate->cn_vtbl.output      = nsh_consoleoutput;
 #ifndef CONFIG_NSH_DISABLE_ERROR_PRINT
@@ -434,10 +395,6 @@ FAR struct console_stdio_s *nsh_newconsole(bool isctty)
       /* Initialize the output stream */
 
       OUTFD(pstate)               = STDOUT_FILENO;
-
-      /* Initialize the input stream */
-
-      INFD(pstate)               = STDIN_FILENO;
     }
 
   return pstate;

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -41,19 +41,18 @@
 
 /* Method access macros */
 
-#define nsh_clone(v)            (v)->clone(v)
-#define nsh_release(v)          (v)->release(v)
-#define nsh_write(v,b,n)        (v)->write(v,b,n)
-#define nsh_read(v,b,n)         (v)->read(v,b,n)
-#define nsh_ioctl(v,c,a)        (v)->ioctl(v,c,a)
-#define nsh_linebuffer(v)       (v)->linebuffer(v)
-#define nsh_redirect(v,fi,fo,s) (v)->redirect(v,fi,fo,s)
-#define nsh_undirect(v,s)       (v)->undirect(v,s)
-#define nsh_exit(v,s)           (v)->exit(v,s)
+#define nsh_clone(v)           (v)->clone(v)
+#define nsh_release(v)         (v)->release(v)
+#define nsh_write(v,b,n)       (v)->write(v,b,n)
+#define nsh_ioctl(v,c,a)       (v)->ioctl(v,c,a)
+#define nsh_linebuffer(v)      (v)->linebuffer(v)
+#define nsh_redirect(v,f,s)    (v)->redirect(v,f,s)
+#define nsh_undirect(v,s)      (v)->undirect(v,s)
+#define nsh_exit(v,s)          (v)->exit(v,s)
 
 #ifdef CONFIG_CPP_HAVE_VARARGS
-#  define nsh_error(v, ...)     (v)->error(v, ##__VA_ARGS__)
-#  define nsh_output(v, ...)    (v)->output(v, ##__VA_ARGS__)
+#  define nsh_error(v, ...)    (v)->error(v, ##__VA_ARGS__)
+#  define nsh_output(v, ...)   (v)->output(v, ##__VA_ARGS__)
 #  define nsh_none(v, ...)     \
      do { if (0) nsh_output_none(v, ##__VA_ARGS__); } while (0)
 #else
@@ -86,7 +85,7 @@
 
 #else
 
-#  define INFD(p)      ((p)->cn_infd)
+#  define INFD(p)      0
 
 #endif
 
@@ -114,8 +113,6 @@ struct nsh_vtbl_s
   void (*release)(FAR struct nsh_vtbl_s *vtbl);
   ssize_t (*write)(FAR struct nsh_vtbl_s *vtbl, FAR const void *buffer,
                    size_t nbytes);
-  ssize_t (*read)(FAR struct nsh_vtbl_s *vtbl, FAR void *buffer,
-                   size_t nbytes);
   int (*ioctl)(FAR struct nsh_vtbl_s *vtbl, int cmd, unsigned long arg);
 #ifndef CONFIG_NSH_DISABLE_ERROR_PRINT
   int (*error)(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...)
@@ -124,8 +121,7 @@ struct nsh_vtbl_s
   int (*output)(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...)
       printf_like(2, 3);
   FAR char *(*linebuffer)(FAR struct nsh_vtbl_s *vtbl);
-  void (*redirect)(FAR struct nsh_vtbl_s *vtbl, int fd_in, int fd_out,
-                   FAR uint8_t *save);
+  void (*redirect)(FAR struct nsh_vtbl_s *vtbl, int fd, FAR uint8_t *save);
   void (*undirect)(FAR struct nsh_vtbl_s *vtbl, FAR uint8_t *save);
   void (*exit)(FAR struct nsh_vtbl_s *vtbl, int status) noreturn_function;
 
@@ -167,7 +163,6 @@ struct console_stdio_s
 #ifdef CONFIG_NSH_ALTCONDEV
   int   cn_confd;     /* Console I/O file descriptor */
 #endif
-  int   cn_infd;      /* Input file descriptor (possibly redirected) */
   int   cn_outfd;     /* Output file descriptor (possibly redirected) */
   int   cn_errfd;     /* Error Output file descriptor (possibly redirected) */
 

--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -35,8 +35,6 @@
 #include <errno.h>
 #include <string.h>
 #include <libgen.h>
-#include <fcntl.h>
-
 #include <nuttx/lib/builtin.h>
 
 #include "nsh.h"
@@ -70,8 +68,7 @@
  ****************************************************************************/
 
 int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags)
+                FAR char **argv, FAR const char *redirfile, int oflags)
 {
   posix_spawn_file_actions_t file_actions;
   posix_spawnattr_t attr;
@@ -107,28 +104,11 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
       goto errout_with_actions;
     }
 
-  /* Handle redirection of input */
-
-  if (redirfile_in)
-    {
-      /* Set up to close open redirfile and set to stdin (0) */
-
-      ret = posix_spawn_file_actions_addopen(&file_actions, 0,
-                                             redirfile_in, O_RDONLY, 0);
-      if (ret != 0)
-        {
-          nsh_error(vtbl, g_fmtcmdfailed, cmd,
-                     "posix_spawn_file_actions_addopen",
-                     NSH_ERRNO);
-          goto errout_with_actions;
-        }
-    }
-
   /* Handle re-direction of output */
 
-  if (redirfile_out)
+  if (redirfile)
     {
-      ret = posix_spawn_file_actions_addopen(&file_actions, 1, redirfile_out,
+      ret = posix_spawn_file_actions_addopen(&file_actions, 1, redirfile,
                                              oflags, 0644);
       if (ret != 0)
         {

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -791,25 +791,6 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         }
     }
 
-  if (argc == 1)
-    {
-      char *buf = malloc(BUFSIZ);
-
-      /* Dump from input */
-
-      while (true)
-        {
-          ssize_t n = nsh_read(vtbl, buf, BUFSIZ);
-
-          if (n == 0)
-            break;
-
-          nsh_write(vtbl, buf, n);
-        }
-
-      free(buf);
-    }
-
   return ret;
 }
 #endif

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -131,8 +131,7 @@
 struct cmdarg_s
 {
   FAR struct nsh_vtbl_s *vtbl;      /* For front-end interaction */
-  int fd_in;                        /* FD for output redirection */
-  int fd_out;                       /* FD for output redirection */
+  int fd;                           /* FD for output redirection */
   int argc;                         /* Number of arguments in argv */
   FAR char *argv[MAX_ARGV_ENTRIES]; /* Argument list */
 };
@@ -177,13 +176,13 @@ static void nsh_alist_free(FAR struct nsh_vtbl_s *vtbl,
 static void nsh_releaseargs(struct cmdarg_s *arg);
 static pthread_addr_t nsh_child(pthread_addr_t arg);
 static struct cmdarg_s *nsh_cloneargs(FAR struct nsh_vtbl_s *vtbl,
-               int fd_in, int fd_out, int argc, FAR char *argv[]);
+               int fd, int argc, FAR char *argv[]);
 #endif
 
 static int nsh_saveresult(FAR struct nsh_vtbl_s *vtbl, bool result);
 static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
-               int argc, FAR char *argv[], FAR const char *redirfile_in,
-               FAR const char *redirfile_out, int oflags);
+               int argc, FAR char *argv[], FAR const char *redirfile,
+               int oflags);
 
 #ifdef CONFIG_NSH_CMDPARMS
 static FAR char *nsh_filecat(FAR struct nsh_vtbl_s *vtbl, FAR char *s1,
@@ -259,7 +258,7 @@ static int nsh_nice(FAR struct nsh_vtbl_s *vtbl, FAR char **ppcmd,
 
 #ifdef CONFIG_NSH_CMDPARMS
 static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
-               FAR const char *redirfile_out);
+               FAR const char *redirfile);
 #endif
 
 static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline);
@@ -276,9 +275,8 @@ static const char g_line_separator[]  = "\"'#;\n";
 #ifdef CONFIG_NSH_ARGCAT
 static const char g_arg_separator[]   = "`$";
 #endif
-static const char g_redirect_out1[]   = ">";
-static const char g_redirect_out2[]  = ">>";
-static const char g_redirect_in1[]   = "<";
+static const char g_redirect1[]       = ">";
+static const char g_redirect2[]       = ">>";
 #ifdef NSH_HAVE_VARS
 static const char g_exitstatus[]      = "?";
 static const char g_success[]         = "0";
@@ -456,16 +454,9 @@ static void nsh_releaseargs(struct cmdarg_s *arg)
    * the file descriptor
    */
 
-  if (vtbl->np.np_redir_out)
+  if (vtbl->np.np_redirect)
     {
-      close(arg->fd_out);
-    }
-
-  /* Same for the input */
-
-  if (vtbl->np.np_redir_in)
-    {
-      close(arg->fd_in);
+      close(arg->fd);
     }
 
   /* Released the cloned vtbl instance */
@@ -513,8 +504,7 @@ static pthread_addr_t nsh_child(pthread_addr_t arg)
 
 #ifndef CONFIG_NSH_DISABLEBG
 static struct cmdarg_s *nsh_cloneargs(FAR struct nsh_vtbl_s *vtbl,
-                                      int fd_in, int fd_out, int argc,
-                                      FAR char *argv[])
+                                      int fd, int argc, FAR char *argv[])
 {
   struct cmdarg_s *ret = (struct cmdarg_s *)zalloc(sizeof(struct cmdarg_s));
   int i;
@@ -522,8 +512,7 @@ static struct cmdarg_s *nsh_cloneargs(FAR struct nsh_vtbl_s *vtbl,
   if (ret)
     {
       ret->vtbl = vtbl;
-      ret->fd_in = fd_in;
-      ret->fd_out = fd_out;
+      ret->fd   = fd;
       ret->argc = argc;
 
       for (i = 0; i < argc; i++)
@@ -605,11 +594,9 @@ static int nsh_saveresult(FAR struct nsh_vtbl_s *vtbl, bool result)
 
 static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
                        int argc, FAR char *argv[],
-                       FAR const char *redirfile_in,
-                       FAR const char *redirfile_out, int oflags)
+                       FAR const char *redirfile, int oflags)
 {
-  int fd_in = STDIN_FILENO;
-  int fd_out = STDOUT_FILENO;
+  int fd = -1;
   int ret;
 
   /* DO NOT CHANGE THE ORDERING OF THE FOLLOWING STEPS
@@ -647,8 +634,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
    */
 
 #ifdef CONFIG_NSH_BUILTIN_APPS
-  ret = nsh_builtin(vtbl, argv[0], argv, redirfile_in, redirfile_out,
-                    oflags);
+  ret = nsh_builtin(vtbl, argv[0], argv, redirfile, oflags);
   if (ret >= 0)
     {
       /* nsh_builtin() returned 0 or 1.  This means that the built-in
@@ -685,8 +671,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
    */
 
 #ifdef CONFIG_NSH_FILE_APPS
-  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile_in,
-                    redirfile_out, oflags);
+  ret = nsh_fileapp(vtbl, argv[0], argv, redirfile, oflags);
   if (ret >= 0)
     {
       /* nsh_fileapp() returned 0 or 1.  This means that the built-in
@@ -707,7 +692,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 
   /* Redirected output? */
 
-  if (vtbl->np.np_redir_out)
+  if (vtbl->np.np_redirect)
     {
       /* Open the redirection file.  This file will eventually
        * be closed by a call to either nsh_release (if the command
@@ -715,26 +700,8 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
        * command is executed in the foreground.
        */
 
-      fd_out = open(redirfile_out, oflags, 0666);
-      if (fd_out < 0)
-        {
-          nsh_error(vtbl, g_fmtcmdfailed, argv[0], "open", NSH_ERRNO);
-          goto errout;
-        }
-    }
-
-  /* Redirected input? */
-
-  if (vtbl->np.np_redir_in)
-    {
-      /* Open the redirection file.  This file will eventually
-       * be closed by a call to either nsh_release (if the command
-       * is executed in the background) or by nsh_undirect if the
-       * command is executed in the foreground.
-       */
-
-      fd_in = open(redirfile_in, O_RDONLY, 0);
-      if (fd_in < 0)
+      fd = open(redirfile, oflags, 0666);
+      if (fd < 0)
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], "open", NSH_ERRNO);
           goto errout;
@@ -768,7 +735,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 
       /* Create a container for the command arguments */
 
-      args = nsh_cloneargs(bkgvtbl, fd_in, fd_out, argc, argv);
+      args = nsh_cloneargs(bkgvtbl, fd, argc, argv);
       if (!args)
         {
           nsh_release(bkgvtbl);
@@ -777,9 +744,9 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 
       /* Handle redirection of output via a file descriptor */
 
-      if (vtbl->np.np_redir_out || vtbl->np.np_redir_in)
+      if (vtbl->np.np_redirect)
         {
-          nsh_redirect(bkgvtbl, fd_in, fd_out, NULL);
+          nsh_redirect(bkgvtbl, fd, NULL);
         }
 
       /* Get the execution priority of this task */
@@ -857,11 +824,11 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
     {
       uint8_t save[SAVE_SIZE];
 
-      /* Handle redirection of stdin/stdout file descriptor */
+      /* Handle redirection of output via a file descriptor */
 
-      if (vtbl->np.np_redir_out || vtbl->np.np_redir_in)
+      if (vtbl->np.np_redirect)
         {
-          nsh_redirect(vtbl, fd_in, fd_out, save);
+          nsh_redirect(vtbl, fd, save);
         }
 
       /* Then execute the command in "foreground" -- i.e., while the user
@@ -877,7 +844,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
        * file descriptor.
        */
 
-      if (vtbl->np.np_redir_out || vtbl->np.np_redir_in)
+      if (vtbl->np.np_redirect)
         {
           nsh_undirect(vtbl, save);
         }
@@ -900,14 +867,9 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
 
 #ifndef CONFIG_NSH_DISABLEBG
 errout_with_redirect:
-  if (vtbl->np.np_redir_out)
+  if (vtbl->np.np_redirect)
     {
-      close(fd_out);
-    }
-
-  if (vtbl->np.np_redir_in)
-    {
-      close(fd_in);
+      close(fd);
     }
 #endif
 
@@ -1757,21 +1719,13 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
       if (*(pbegin + 1) == '>')
         {
           *saveptr = pbegin + 2;
-          argument = (FAR char *)g_redirect_out2;
+          argument = (FAR char *)g_redirect2;
         }
       else
         {
           *saveptr = pbegin + 1;
-          argument = (FAR char *)g_redirect_out1;
+          argument = (FAR char *)g_redirect1;
         }
-    }
-
-  /* Does the token begin with '<' -- redirection of input? */
-
-  if (*pbegin == '<')
-    {
-      *saveptr = pbegin + 1;
-      argument = (FAR char *)g_redirect_in1;
     }
 
   /* Does the token begin with '#' -- comment */
@@ -2457,7 +2411,7 @@ static int nsh_nice(FAR struct nsh_vtbl_s *vtbl, FAR char **ppcmd,
 
 #ifdef CONFIG_NSH_CMDPARMS
 static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
-                             FAR const char *redirfile_out)
+                             FAR const char *redirfile)
 {
   NSH_MEMLIST_TYPE memlist;
   NSH_ALIASLIST_TYPE alist;
@@ -2493,8 +2447,8 @@ static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
 
   /* Output is always redirected.  Remember the current redirection state */
 
-  redirsave = vtbl->np.np_redir_out;
-  vtbl->np.np_redir_out = true;
+  redirsave = vtbl->np.np_redirect;
+  vtbl->np.np_redirect = true;
 
   /* Parse out the command at the beginning of the line */
 
@@ -2552,7 +2506,7 @@ static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
 
   /* Then execute the command */
 
-  ret = nsh_execute(vtbl, argc, argv, NULL, redirfile_out,
+  ret = nsh_execute(vtbl, argc, argv, redirfile,
                     O_WRONLY | O_CREAT | O_TRUNC);
 
   /* Restore the backgrounding and redirection state */
@@ -2561,7 +2515,7 @@ exit:
 #ifndef CONFIG_NSH_DISABLEBG
   vtbl->np.np_bg       = bgsave;
 #endif
-  vtbl->np.np_redir_out = redirsave;
+  vtbl->np.np_redirect = redirsave;
 
   NSH_ALIASLIST_FREE(vtbl, &alist);
   NSH_MEMLIST_FREE(&memlist);
@@ -2584,16 +2538,11 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
   FAR char *argv[MAX_ARGV_ENTRIES];
   FAR char *saveptr;
   FAR char *cmd;
-  FAR char *redirfile_out = NULL;
-  FAR char *redirfile_in = NULL;
+  FAR char *redirfile = NULL;
   int       oflags = 0;
   int       argc;
   int       ret;
-  bool      redirect_out_save = false;
-  bool      redirect_in_save = false;
-  size_t redirect_out1_len = strlen(g_redirect_out1);
-  size_t redirect_out2_len = strlen(g_redirect_out2);
-  size_t redirect_in1_len = strlen(g_redirect_in1);
+  bool      redirect_save = false;
 
   /* Initialize parser state */
 
@@ -2605,8 +2554,7 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
   vtbl->np.np_bg       = false;
 #endif
 
-  vtbl->np.np_redir_out = false;
-  vtbl->np.np_redir_in = false;
+  vtbl->np.np_redirect = false;
 
   /* Parse out the command at the beginning of the line */
 
@@ -2671,13 +2619,16 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
    *   argv[0]:      The command name.
    *   argv[1]:      The beginning of argument (up to
    *                 CONFIG_NSH_MAXARGUMENTS)
+   *   argv[argc-3]: Possibly '>' or '>>'
+   *   argv[argc-2]: Possibly <file>
+   *   argv[argc-1]: Possibly '&'
    *   argv[argc]:   NULL terminating pointer
    *
    * Maximum size is CONFIG_NSH_MAXARGUMENTS+5
    */
 
   argv[0] = cmd;
-  for (argc = 1; argc < MAX_ARGV_ENTRIES - 1; )
+  for (argc = 1; argc < MAX_ARGV_ENTRIES - 1; argc++)
     {
       int isenvvar = 0; /* flag for if an environment variable gets expanded */
 
@@ -2734,81 +2685,6 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
               argv[argc] = pbegin;
             }
         }
-      else if (!strncmp(argv[argc], g_redirect_out2, redirect_out2_len))
-        {
-          FAR char *arg;
-          if (argv[argc][redirect_out2_len])
-            {
-              arg = &argv[argc][redirect_out2_len];
-            }
-          else
-            {
-              arg = nsh_argument(vtbl, &saveptr, &memlist, NULL, &isenvvar);
-            }
-
-          if (!arg)
-            {
-              nsh_error(vtbl, g_fmtarginvalid, cmd);
-              ret = ERROR;
-              goto dynlist_free;
-            }
-
-          redirect_out_save     = vtbl->np.np_redir_out;
-          vtbl->np.np_redir_out = true;
-          oflags                = O_WRONLY | O_CREAT | O_APPEND;
-          redirfile_out         = nsh_getfullpath(vtbl, arg);
-        }
-      else if (!strncmp(argv[argc], g_redirect_out1, redirect_out1_len))
-        {
-          FAR char *arg;
-          if (argv[argc][redirect_out1_len])
-            {
-              arg = &argv[argc][redirect_out1_len];
-            }
-          else
-            {
-              arg = nsh_argument(vtbl, &saveptr, &memlist, NULL, &isenvvar);
-            }
-
-          if (!arg)
-            {
-              nsh_error(vtbl, g_fmtarginvalid, cmd);
-              ret = ERROR;
-              goto dynlist_free;
-            }
-
-          redirect_out_save     = vtbl->np.np_redir_out;
-          vtbl->np.np_redir_out = true;
-          oflags                = O_WRONLY | O_CREAT | O_TRUNC;
-          redirfile_out         = nsh_getfullpath(vtbl, arg);
-        }
-      else if (!strncmp(argv[argc], g_redirect_in1, redirect_in1_len))
-        {
-          FAR char *arg;
-          if (argv[argc][redirect_in1_len])
-            {
-              arg = &argv[argc][redirect_in1_len];
-            }
-          else
-            {
-              arg = nsh_argument(vtbl, &saveptr, &memlist, NULL, &isenvvar);
-            }
-
-          if (!arg)
-            {
-              nsh_error(vtbl, g_fmtarginvalid, cmd);
-              ret = ERROR;
-              goto dynlist_free;
-            }
-
-          redirect_in_save     = vtbl->np.np_redir_in;
-          vtbl->np.np_redir_in = true;
-          redirfile_in         = nsh_getfullpath(vtbl, arg);
-        }
-      else
-        {
-          argc++;
-        }
     }
 
   /* Check if the command should run in background */
@@ -2820,6 +2696,33 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
       argc--;
     }
 #endif
+
+  /* Check if the output was re-directed using > or >> */
+
+  if (argc > 2)
+    {
+      /* Check for redirection to a new file */
+
+      if (strcmp(argv[argc - 2], g_redirect1) == 0)
+        {
+          redirect_save        = vtbl->np.np_redirect;
+          vtbl->np.np_redirect = true;
+          oflags               = O_WRONLY | O_CREAT | O_TRUNC;
+          redirfile            = nsh_getfullpath(vtbl, argv[argc - 1]);
+          argc                -= 2;
+        }
+
+      /* Check for redirection by appending to an existing file */
+
+      else if (strcmp(argv[argc - 2], g_redirect2) == 0)
+        {
+          redirect_save        = vtbl->np.np_redirect;
+          vtbl->np.np_redirect = true;
+          oflags               = O_WRONLY | O_CREAT | O_APPEND;
+          redirfile            = nsh_getfullpath(vtbl, argv[argc - 1]);
+          argc                -= 2;
+        }
+    }
 
   /* Last argument vector must be empty */
 
@@ -2834,22 +2737,16 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
 
   /* Then execute the command */
 
-  ret = nsh_execute(vtbl, argc, argv, redirfile_in, redirfile_out, oflags);
+  ret = nsh_execute(vtbl, argc, argv, redirfile, oflags);
 
   /* Free any allocated resources */
 
   /* Free the redirected output file path */
 
-  if (redirfile_out)
+  if (redirfile)
     {
-      nsh_freefullpath(redirfile_out);
-      vtbl->np.np_redir_out = redirect_out_save;
-    }
-
-  if (redirfile_in)
-    {
-      nsh_freefullpath(redirfile_in);
-      vtbl->np.np_redir_out = redirect_in_save;
+      nsh_freefullpath(redirfile);
+      vtbl->np.np_redirect = redirect_save;
     }
 
 dynlist_free:

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -54,7 +54,7 @@ static int nsh_script_redirect(FAR struct nsh_vtbl_s *vtbl,
       fd = open(CONFIG_NSH_SCRIPT_REDIRECT_PATH, 0666);
       if (fd > 0)
         {
-          nsh_redirect(vtbl, 0, fd, save);
+          nsh_redirect(vtbl, fd, save);
         }
     }
 

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -298,8 +298,7 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLEBG
   bool bgsave;
 #endif
-  bool redirsave_out;
-  bool redirsave_in;
+  bool redirsave;
   int ret;
 
   /* Get the current time */
@@ -316,8 +315,7 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLEBG
   bgsave    = vtbl->np.np_bg;
 #endif
-  redirsave_out = vtbl->np.np_redir_out;
-  redirsave_in = vtbl->np.np_redir_in;
+  redirsave = vtbl->np.np_redirect;
 
   /* Execute the command */
 
@@ -356,8 +354,7 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLEBG
   vtbl->np.np_bg       = bgsave;
 #endif
-  vtbl->np.np_redir_out = redirsave_out;
-  vtbl->np.np_redir_out = redirsave_in;
+  vtbl->np.np_redirect = redirsave;
 
   return ret;
 }

--- a/testing/cmocka/cmocka_main.c
+++ b/testing/cmocka/cmocka_main.c
@@ -182,7 +182,7 @@ int main(int argc, FAR char *argv[])
         }
 
       bypass[0] = (FAR char *)builtin->name;
-      ret = exec_builtin(builtin->name, bypass, NULL, NULL, 0);
+      ret = exec_builtin(builtin->name, bypass, NULL, 0);
       if (ret >= 0)
         {
           waitpid(ret, &ret, WUNTRACED);


### PR DESCRIPTION
## Summary

`echo $?` does not return any exit code. This is largely used by automated testing. This PR reverts it until it is properly fixed.

**Revert commits from PR #2469**

Revert "nsh_fileapp: handle input redirection"

This reverts commit e46347ec1bb7df1b2cf038fffc88a869f0b15de1.

Revert "feat(nsh_cat): allow cat to read from stdin"

This reverts commit 8fba726a7d7502553ca8d30baef07c124f18b01e.

Revert "feat(nsh): add console read"

This reverts commit 4104019e1cf8895dd6128cff90952be2e4ec90ee.

Revert "feat(nsh): input (stdin) redirection"

This reverts commit 96100b30f2b883057ea6b153dbfcf6691439c50e.

## Impact

Fix `echo $?` bug.

## Testing

```
nsh> ls
/:
 dev/
 proc/
nsh> echo $?
0
```

Internal CI testing (HW testing with all supported Espressif SoCs)