### PR TITLE
fix(nsh_parse): handle env variables correctly

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -2734,7 +2734,8 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
               argv[argc] = pbegin;
             }
         }
-      else if (!strncmp(argv[argc], g_redirect_out2, redirect_out2_len))
+
+      if (!strncmp(argv[argc], g_redirect_out2, redirect_out2_len))
         {
           FAR char *arg;
           if (argv[argc][redirect_out2_len])


### PR DESCRIPTION
## Summary

The PR #2469 broke handling of environment variables because an error in the if/else if control flow. I am sorry.

Thank you @tmedicci for reporting the problem. Here is the fix.

## Impact

Fixes https://github.com/apache/nuttx-apps/pull/2474:

```
NuttShell (NSH) NuttX-12.5.1
nsh> ls
/:
 bin/
 dev/
 etc/
 proc/
 tmp/
nsh> echo $?
0
nsh> ls lalala
nsh: ls: stat failed: 2
nsh> echo $?
1
nsh> ls lalala
nsh: ls: stat failed: 2
nsh> echo $? > /tmp/out
nsh> cat < /tmp/out
1
nsh> 
```

## Testing

Manually