### PR TITLE
cmake:add romfs/unionfs/tcpblaster/udpblaster exmaple app CMake build

### DIFF
--- a/examples/romfs/CMakeLists.txt
+++ b/examples/romfs/CMakeLists.txt
@@ -20,26 +20,37 @@
 
 if(CONFIG_EXAMPLES_ROMFS)
 
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/romfs_testdir.h
-    COMMAND tar zxf ${CMAKE_CURRENT_LIST_DIR}/testdir.tar.gz
-    COMMAND genromfs -f testdir.img -d testdir -V "ROMFS_Test"
-    COMMAND xxd -i testdir.img romfs_testdir.h
+  add_custom_target(
+    testdir
+    COMMAND ${CMAKE_COMMAND} -E tar zxf ${CMAKE_CURRENT_LIST_DIR}/testdir.tar.gz
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/testdir.tar.gz)
-  add_custom_target(testromfs
-                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/romfs_testdir.h)
+    DEPENDS ${CMAKE_CURRENT_LIST_DIR}/testdir.tar.gz
+    COMMENT "EXAMPLES ROMFS Extracting testdir.tar.gz...")
+
+  add_custom_target(
+    testdir_img
+    COMMAND genromfs -f testdir.img -d testdir -V "ROMFS_Test"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS testdir
+    COMMENT "EXAMPLES ROMFS Generating testdir.img...")
+
+  add_custom_target(
+    romfs_testdir_h
+    COMMAND xxd -i testdir.img > romfs_testdir.h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS testdir_img
+    COMMENT "EXAMPLES ROMFS Generating romfs_testdir.h...")
 
   nuttx_add_application(
     NAME
     romfs
     MODULE
     ${CONFIG_EXAMPLES_ROMFS}
+    SRCS
+    romfs_main.c
     INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS
-    testromfs
-    SRCS
-    romfs_main.c)
+    romfs_testdir_h)
 
 endif()

--- a/examples/tcpblaster/CMakeLists.txt
+++ b/examples/tcpblaster/CMakeLists.txt
@@ -19,5 +19,67 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_TCPBLASTER)
-  nuttx_add_application(NAME tcpblaster)
+
+  if(NOT CONFIG_EXAMPLES_TCPBLASTER_TARGET2
+     AND NOT CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK)
+    include(tcpblaster_host.cmake)
+  endif()
+
+  # Basic TCP networking test
+
+  set(CSRCS tcpblaster_cmdline.c)
+
+  if(CONFIG_EXAMPLES_TCPBLASTER_INIT)
+    list(APPEND CSRCS tcpblaster_netinit.c)
+  endif()
+
+  # Target 1 Files
+
+  if(CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK)
+    list(APPEND CSRCS tcpblaster_server.c tcpblaster_client.c)
+  elseif(CONFIG_EXAMPLES_TCPBLASTER_SERVER)
+    list(APPEND CSRCS tcpblaster_server.c)
+  else()
+    list(APPEND CSRCS tcpblaster_client.c)
+  endif()
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TCPBLASTER_PROGNAME1}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TCPBLASTER_PRIORITY1}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TCPBLASTER_STACKSIZE1}
+    MODULE
+    ${CONFIG_EXAMPLES_TCPBLASTER}
+    INCLUDE_DIRECTORIES
+    ${CMAKE_BINARY_DIR}/include/nuttx
+    SRCS
+    tcpblaster_target1.c
+    ${CSRCS})
+
+  # Target 2 Files
+
+  if(CONFIG_EXAMPLES_TCPBLASTER_TARGET2)
+    if(CONFIG_EXAMPLES_TCPBLASTER_SERVER)
+      list(APPEND CSRCS tcpblaster_client.c)
+    else()
+      list(APPEND CSRCS tcpblaster_server.c)
+    endif()
+    nuttx_add_application(
+      NAME
+      ${CONFIG_EXAMPLES_TCPBLASTER_PROGNAME2}
+      PRIORITY
+      ${CONFIG_EXAMPLES_TCPBLASTER_PRIORITY2}
+      STACKSIZE
+      ${CONFIG_EXAMPLES_TCPBLASTER_STACKSIZE2}
+      MODULE
+      ${CONFIG_EXAMPLES_TCPBLASTER}
+      INCLUDE_DIRECTORIES
+      ${CMAKE_BINARY_DIR}/include/nuttx
+      SRCS
+      tcpblaster_target2.c
+      ${CSRCS})
+  endif()
+
 endif()

--- a/examples/tcpblaster/tcpblaster_host.cmake
+++ b/examples/tcpblaster/tcpblaster_host.cmake
@@ -1,0 +1,55 @@
+# ##############################################################################
+# apps/examples/tcpblaster/tcpblaster_host.cmake
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+# Configure project
+cmake_minimum_required(VERSION 3.16)
+project(tcpblaster_host LANGUAGES C)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE
+      "Release"
+      CACHE STRING "Build type" FORCE)
+endif()
+
+message(STATUS "NuttX apps examples tcpblaster host")
+
+include_directories(${CMAKE_BINARY_DIR}/include/nuttx)
+
+add_compile_definitions(TCPBLASTER_HOST=1)
+
+if(CONFIG_EXAMPLES_TCPBLASTER_SERVER)
+  add_compile_definitions(CONFIG_EXAMPLES_TCPBLASTER_SERVER=1)
+  add_compile_definitions(
+    CONFIG_EXAMPLES_TCPBLASTER_SERVERIP=${CONFIG_EXAMPLES_TCPBLASTER_SERVERIP})
+
+endif()
+
+add_library(tcpblaster)
+target_sources(tcpblaster PRIVATE tcpblaster_cmdline.c)
+if(CONFIG_EXAMPLES_TCPBLASTER_SERVER)
+  target_sources(tcpblaster PRIVATE tcpblaster_client.c)
+  add_executable(tcpclient tcpblaster_host.c)
+  target_link_libraries(tcpclient PRIVATE tcpblaster)
+  install(TARGETS tcpclient DESTINATION bin)
+else()
+  target_sources(tcpblaster PRIVATE tcpblaster_server.c)
+  add_executable(tcpserver tcpblaster_host.c)
+  target_link_libraries(tcpserver PRIVATE tcpblaster)
+  install(TARGETS tcpserver DESTINATION bin)
+endif()

--- a/examples/udpblaster/udpblaster_host.cmake
+++ b/examples/udpblaster/udpblaster_host.cmake
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/examples/udpblaster/CMakeLists.txt
+# apps/examples/udpblaster/udpblaster.cmake
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
@@ -17,24 +17,23 @@
 # the License.
 #
 # ##############################################################################
+# Configure project
+cmake_minimum_required(VERSION 3.16)
+project(udpblaster_host LANGUAGES C)
 
-if(CONFIG_EXAMPLES_UDPBLASTER)
-
-  if(NOT CONFIG_EXAMPLES_TCPBLASTER_LOOPBACK)
-    include(udpblaster_host.cmake)
-  endif()
-
-  nuttx_add_application(
-    NAME
-    ${CONFIG_EXAMPLES_UDPBLASTER_PROGNAME}
-    PRIORITY
-    ${CONFIG_EXAMPLES_UDPBLASTER_PRIORITY}
-    STACKSIZE
-    ${CONFIG_EXAMPLES_UDPBLASTER_STACKSIZE}
-    MODULE
-    ${CONFIG_EXAMPLES_UDPBLASTER}
-    SRCS
-    udpblaster_target.c
-    udpblaster_text.c)
-
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE
+      "Release"
+      CACHE STRING "Build type" FORCE)
 endif()
+
+message(STATUS "NuttX apps examples udpblaster host")
+
+include_directories(${CMAKE_BINARY_DIR}/include/nuttx)
+
+add_compile_definitions(UDPBLASTER_HOST=1)
+add_library(udpblaster)
+target_sources(udpblaster PRIVATE udpblaster_text.c)
+add_executable(host udpblaster_host.c)
+target_link_libraries(host PRIVATE udpblaster)
+install(TARGETS host DESTINATION bin)

--- a/examples/unionfs/CMakeLists.txt
+++ b/examples/unionfs/CMakeLists.txt
@@ -19,5 +19,41 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_UNIONFS)
-  nuttx_add_application(NAME unionfs)
+
+  add_custom_target(
+    testdir
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_LIST_DIR}/atestdir atestdir
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_LIST_DIR}/btestdir btestdir
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "EXAMPLES UNIONFS Copy test dir...")
+
+  add_custom_target(
+    testdir_img
+    COMMAND genromfs -f atestdir.img -d atestdir -V "UNIONFS_FS1"
+    COMMAND genromfs -f btestdir.img -d btestdir -V "UNIONFS_FS2"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS testdir
+    COMMENT "EXAMPLES UNIONFS Generating testdir.img...")
+
+  add_custom_target(
+    romfs_testdir_h
+    COMMAND xxd -i atestdir.img > romfs_atestdir.h
+    COMMAND xxd -i btestdir.img > romfs_btestdir.h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS testdir_img
+    COMMENT "EXAMPLES UNIONFS Generating romfs_testdir.h...")
+
+  nuttx_add_application(
+    NAME
+    unionfs
+    MODULE
+    ${CONFIG_EXAMPLES_UNIONFS}
+    SRCS
+    unionfs_main.c
+    INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS
+    romfs_testdir_h)
 endif()

--- a/system/cdcacm/CMakeLists.txt
+++ b/system/cdcacm/CMakeLists.txt
@@ -19,5 +19,7 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_CDCACM)
-  nuttx_add_application(NAME cdcacm)
+  nuttx_add_application(NAME sercon SRCS cdcacm_main.c)
+
+  nuttx_add_application(NAME serdis)
 endif()

--- a/system/critmon/CMakeLists.txt
+++ b/system/critmon/CMakeLists.txt
@@ -19,5 +19,8 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_CRITMONITOR)
-  nuttx_add_application(NAME critmon)
+  nuttx_add_application(NAME critmon SRCS critmon.c)
+
+  nuttx_add_application(NAME critmon_start)
+  nuttx_add_application(NAME critmon_stop)
 endif()

--- a/system/stackmonitor/CMakeLists.txt
+++ b/system/stackmonitor/CMakeLists.txt
@@ -19,5 +19,7 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_STACKMONITOR)
-  nuttx_add_application(NAME stackmonitor)
+  nuttx_add_application(NAME stackmonitor_start SRCS stackmonitor.c)
+
+  nuttx_add_application(NAME stackmonitor_stop)
 endif()


### PR DESCRIPTION
## Summary
After https://github.com/apache/nuttx-apps/pull/2478
We have a range of legacy applications that do not conform to the specification.

This patch completes part of it.
1. Added example of romfs unionfs
2. Added cmake host support for udp tcp blaster
## Impact
**This will fix the current CI BB**
```shell
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x58): undefined reference to `udpblaster_main'
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x58): undefined reference to `romfs_main'
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x118): undefined reference to `tcpblaster_main'
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x40): undefined reference to `unionfs_main'
``` 
## Testing
CI 
