### PR TITLE
Revert "[cmake] builtin register support NONE srcs target"

### DIFF
--- a/builtin/CMakeLists.txt
+++ b/builtin/CMakeLists.txt
@@ -24,8 +24,6 @@ if(CONFIG_BUILTIN)
 
   # generate registry
   get_property(nuttx_app_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
-  get_property(only_registers GLOBAL PROPERTY NUTTX_APPS_ONLY_REGISTER)
-  list(APPEND nuttx_app_libs ${only_registers})
   set(builtin_list_string)
   set(builtin_proto_string)
   foreach(module ${nuttx_app_libs})


### PR DESCRIPTION
Reverts apache/nuttx-apps#2478

 Let's revert this modification first

There are cmake scripts in examples and system that do not meet this feature,
and they need to be modified synchronously before CI is performed together

```shell
/tools/gcc-aarch64-none-elf/bin/../lib/gcc/aarch64-none-elf/13.2.1/../../../../aarch64-none-elf/bin/ld: apps/builtin/libapps_builtin.a(builtin_list.c.obj):(.rodata.g_builtins+0x88): undefined reference to `sotest_main'

/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x58): undefined reference to `udpblaster_main'
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x58): undefined reference to `romfs_main'
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x118): undefined reference to `tcpblaster_main'
/usr/bin/ld: nuttx.rel:(.data.rel.ro.g_builtins+0x40): undefined reference to `unionfs_main'
``` 

I will add the missing application here and restore this feature🙏
https://github.com/apache/nuttx-apps/pull/2479