### PR TITLE
fix the ltp build error

### DIFF
--- a/testing/ltp/0011-ltp-fix-the-proc.h-header-file-duplicate-inclusion.patch
+++ b/testing/ltp/0011-ltp-fix-the-proc.h-header-file-duplicate-inclusion.patch
@@ -1,0 +1,37 @@
+From 6d38a0543d57f80954f9b2c2ec1f4a4c33b30894 Mon Sep 17 00:00:00 2001
+From: guoshichao <guoshichao@xiaomi.com>
+Date: Mon, 8 Jul 2024 16:38:22 +0800
+Subject: [PATCH] ltp: fix the "tst_process_state_wait3" multi define error
+
+VELAPLATFO-34850
+
+fix the link error by making the "tst_process_state_wait3" to "static
+inline" function
+
+Signed-off-by: guoshichao <guoshichao@xiaomi.com>
+
+diff --git a/testcases/open_posix_testsuite/include/proc.h b/testcases/open_posix_testsuite/include/proc.h
+index befb837..5d1d676 100644
+--- a/testcases/open_posix_testsuite/include/proc.h
++++ b/testcases/open_posix_testsuite/include/proc.h
+@@ -19,7 +19,7 @@
+ # include <errno.h>
+ # include <string.h>
+ 
+-int tst_process_state_wait3(pid_t pid, const char state,
++static inline int tst_process_state_wait3(pid_t pid, const char state,
+ 	long maxwait_s)
+ {
+ 	char proc_path[128], cur_state;
+@@ -58,7 +58,7 @@ int tst_process_state_wait3(pid_t pid, const char state,
+ 	return 1;
+ }
+ #else
+-int tst_process_state_wait3(pid_t pid PTS_ATTRIBUTE_UNUSED,
++static inline int tst_process_state_wait3(pid_t pid PTS_ATTRIBUTE_UNUSED,
+ 	const char state PTS_ATTRIBUTE_UNUSED, long maxwait_s)
+ {
+ 	struct timespec maxwait_ts;
+-- 
+2.45.1
+

--- a/testing/ltp/0012-ltp-fix-build-error.patch
+++ b/testing/ltp/0012-ltp-fix-build-error.patch
@@ -1,0 +1,32 @@
+From 9606a31fbff78592352bcccf667ab0eb7a26ef5a Mon Sep 17 00:00:00 2001
+From: fangxinyong <fangxinyong@xiaomi.com>
+Date: Tue, 29 Aug 2023 19:03:51 +0800
+Subject: [PATCH] ltp: fix build error
+
+VELAPLATFO-8233
+
+ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/18-1.c:171: error: "NSIG" redefined [-Werror]
+  171 | #define NSIG (sizeof(signals)/sizeof(int))
+In file included from /home/work/ssd1/workspace/MiRTOS-CI/nuttx/include/pthread.h:35,
+                 from ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/18-1.c:31:
+/home/work/ssd1/workspace/MiRTOS-CI/nuttx/include/signal.h:53: note: this is the location of the previous definition
+   53 | #define NSIG            _NSIG           /* _NSIG variant commonly used */
+
+Change-Id: I5a7d695612dd8f17ad735a369a9b904ee71f70ee
+Signed-off-by: fangxinyong <fangxinyong@xiaomi.com>
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/18-1.c b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/18-1.c
+index 0617210bf..dda0c3a09 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/18-1.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/pthread_sigmask/18-1.c
+@@ -168,6 +168,7 @@ static void *test(void *arg LTP_ATTRIBUTE_UNUSED)
+ 	sigset_t set;
+ 	int i, j = 0;
+ 	int signals[] = { SIGBUS, SIGKILL, SIGABRT, SIGCHLD, SIGHUP };
++#undef NSIG
+ #define NSIG (sizeof(signals)/sizeof(int))
+ 	int operation[] = { SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK };
+ 
+-- 
+2.45.1
+

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -257,6 +257,7 @@ $(LTP_UNPACK): ltp-$(LTPS_VERSION).zip
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0009-ltp-modify-user-code-for-fdcheck-compatibility.patch
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0010-ltp-fix-build-warning.patch
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0011-ltp-fix-the-proc.h-header-file-duplicate-inclusion.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0012-ltp-fix-build-error.patch
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(LTP_UNPACK)/.git),)

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -256,6 +256,7 @@ $(LTP_UNPACK): ltp-$(LTPS_VERSION).zip
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0008-test-ltp-fix-ltp_interfaces_sigaction_23_10-deadloop.patch
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0009-ltp-modify-user-code-for-fdcheck-compatibility.patch
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0010-ltp-fix-build-warning.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0011-ltp-fix-the-proc.h-header-file-duplicate-inclusion.patch
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(LTP_UNPACK)/.git),)


### PR DESCRIPTION
## Summary
1. fix the "proc.h" inclusion build error
2. fix the "NSIG" redefined build warning

## Impact

## Testing

