### PR TITLE
greenhills support: fix the warning issued by ghs compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.gcda
 *.hobj
 *.i
+*.inf
 *.lib
 *.lst
 *.o

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -1727,10 +1727,12 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
   FAR char *argument   = NULL;
 #ifdef CONFIG_NSH_QUOTE
   FAR char *prev;
-  bool escaped;
+  bool escaped = false;
 #endif
-  bool squote;
-  bool quoted;
+  bool squote = false;
+#ifdef CONFIG_NSH_ALIAS
+  bool quoted = false;
+#endif
 
   /* Find the beginning of the next token */
 
@@ -1794,11 +1796,7 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
        * make sure that we do not break up any quoted substrings.
        */
 
-      squote = false;
-      quoted = false;
 #ifdef CONFIG_NSH_QUOTE
-      escaped = false;
-
       for (prev = NULL, pend = pbegin; *pend != '\0'; prev = pend, pend++)
 #else
       for (pend = pbegin; *pend != '\0'; pend++)
@@ -1829,7 +1827,11 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
 
           /* Are we entering a quoted string ? */
 
+#ifdef CONFIG_NSH_ALIAS
           if ((quoted = (nsh_strchr(g_quote_separator, *pend) != NULL)))
+#else
+          if (nsh_strchr(g_quote_separator, *pend) != NULL)
+#endif
             {
               /* Yes, find the terminator and continue from there */
 

--- a/testing/ostest/fpu.c
+++ b/testing/ostest/fpu.c
@@ -102,8 +102,13 @@ typedef uintptr_t   uintreg_t;
 
 struct fpu_threaddata_s
 {
+#if XCPTCONTEXT_ALIGN > 1
   uintreg_t save1[XCPTCONTEXT_REGS] aligned_data(XCPTCONTEXT_ALIGN);
   uintreg_t save2[XCPTCONTEXT_REGS] aligned_data(XCPTCONTEXT_ALIGN);
+#else
+  uintreg_t save1[XCPTCONTEXT_REGS];
+  uintreg_t save2[XCPTCONTEXT_REGS];
+#endif
 
   /* These are just dummy values to force the compiler to do the
    * requested floating point computations without the nonsense


### PR DESCRIPTION
## Summary
1. fix the packed warning and variable unused warnings that issued by ghs compiler
2. update the .gitignore rule to exclude the intermediate file that generated during compiling

## Impact

## Testing

