### PR TITLE
greenhills support: fix the variables set but never used build warning

### DIFF
--- a/canutils/candump/candump.c
+++ b/canutils/candump/candump.c
@@ -99,7 +99,6 @@
 const char col_on [MAXCOL][19] = {BLUE, RED, GREEN, BOLD, MAGENTA, CYAN};
 const char col_off [] = ATTRESET;
 
-static char *cmdlinename[MAXSOCK];
 static __u32 dropcnt[MAXSOCK];
 static __u32 last_dropcnt[MAXSOCK];
 static char devname[MAXIFNAMES][IFNAMSIZ+1];
@@ -229,7 +228,7 @@ int main(int argc, char **argv)
 	unsigned char logfrmt = 0;
 	int count = 0;
 	int rcvbuf_size = 0;
-	int opt, ret;
+	int opt;
 	int currmax, numfilter;
 	int join_filter;
 	char *ptr, *nptr;
@@ -393,8 +392,6 @@ int main(int argc, char **argv)
 			perror("socket");
 			return 1;
 		}
-
-		cmdlinename[i] = ptr; /* save pointer to cmdline name of this socket */
 
 		if (nptr)
 			nbytes = nptr - ptr;  /* interface name is up the first ',' */
@@ -618,7 +615,7 @@ int main(int argc, char **argv)
 		if (timeout_current)
 			*timeout_current = timeout_config;
 
-		if ((ret = select(s[currmax-1]+1, &rdfs, NULL, NULL, timeout_current)) <= 0) {
+		if ((select(s[currmax-1]+1, &rdfs, NULL, NULL, timeout_current)) <= 0) {
 			//perror("select");
 			running = 0;
 			continue;


### PR DESCRIPTION
## Summary
apps/canutils: fix the build warning on greenhills compiler

## Impact

## Testing

