### PR TITLE
netutils/iptables: add cmake support.

### DIFF
--- a/netutils/iptables/CMakeLists.txt
+++ b/netutils/iptables/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/netutils/iptables/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_NETUTILS_IPTABLES)
+  target_sources(apps PRIVATE xtables.c)
+endif()


### PR DESCRIPTION
## Summary
add cmake support for xtables.c, solves the problem of missing symbols when compiling with cmake

## Impact

## Testing
cortex-m33 board
