### PR TITLE
apps/nxplayer: add ioctl stop when play completed

### DIFF
--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -1121,6 +1121,13 @@ static FAR void *nxplayer_playthread(pthread_addr_t pvarg)
             audinfo("Play complete.  outstanding=%d\n", outstanding);
             DEBUGASSERT(outstanding == 0);
 #endif
+
+#ifdef CONFIG_AUDIO_MULTI_SESSION
+            ioctl(pplayer->dev_fd, AUDIOIOC_STOP,
+                 (unsigned long)pplayer->session);
+#else
+            ioctl(pplayer->dev_fd, AUDIOIOC_STOP, 0);
+#endif
             running = false;
             break;
 


### PR DESCRIPTION
## Summary
In audio.c, when audio_start calls the driver’s start function, it needs to check upper->started. The issue occurs in the complete case which does not call ioctl STOP, so started is not reset to false and resulting in the inability to play again.
## Impact

## Testing
tested on vela sim.
