### PR TITLE
build: Fix rpserver and rpproxy CMake builds

### DIFF
--- a/system/argtable3/CMakeLists.txt
+++ b/system/argtable3/CMakeLists.txt
@@ -81,10 +81,11 @@ if(CONFIG_SYSTEM_ARGTABLE3)
 
   target_sources(argtable3 PRIVATE ${SRCS})
 
-  if(NOT EXISTS ${CMAKE_BINARY_DIR}/apps/include/argtable3.h)
-    file(CREATE_LINK ${CMAKE_CURRENT_LIST_DIR}/argtable3/src/argtable3.h
-         ${CMAKE_BINARY_DIR}/apps/include/argtable3.h SYMBOLIC)
-  endif()
+  set_property(
+    TARGET nuttx
+    APPEND
+    PROPERTY NUTTX_INCLUDE_DIRECTORIES
+             ${NUTTX_APPS_DIR}/system/argtable3/argtable3/src)
 
   target_compile_options(argtable3 PRIVATE -DARG_REPLACE_GETOPT=0)
 


### PR DESCRIPTION
## Summary

This fixes missing include directories for iperf application.

Make based build was able to proceed - CMake build had two aforementioned issues.

## Impact

Hard to estimate.

## Testing

Local playing around rpserver and rpproxy in sim flavor.
