### PR TITLE
fix build warning to [-Wstringop-overflow=].

### DIFF
--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -48,6 +48,7 @@ mbedtls/library/bignum.c_CFLAGS += -fno-lto
 ifeq ($(CONFIG_FRAME_POINTER),y)
   ifeq ($(CONFIG_DEBUG_OPTLEVEL),"-O3")
     mbedtls/library/sha256.c_CFLAGS += -O2
+    mbedtls/library/cmac.c_CFLAGS += -O2
   endif
 endif
 


### PR DESCRIPTION
## Summary
mbedtls/library/alignment.h:98:5: warning: writing 4 bytes into a region of size 0 [-Wstringop-overflow=]
   98 |     memcpy(p, &x, sizeof(x));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
mbedtls/library/cmac.c: In function 'mbedtls_cipher_cmac_finish':
mbedtls/library/cmac.c:288:19: note: at offset 20 into destination object 'M_last' of size 16
  288 |     unsigned char M_last[MBEDTLS_CIPHER_BLKSIZE_MAX];
      |                   ^~~~~~
## Impact

## Testing

