### PR TITLE
apps/audioutils:Add libmad library.

### DIFF
--- a/audioutils/libmad/.gitignore
+++ b/audioutils/libmad/.gitignore
@@ -1,0 +1,2 @@
+/libmad
+/*.zip

--- a/audioutils/libmad/CMakeLists.txt
+++ b/audioutils/libmad/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/audioutils/libmad/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_AUDIOUTILS_LIBMAD)
+
+  nuttx_add_library(libmad STATIC)
+
+  file(GLOB LIBMAD_SRCS libmad/*.c)
+  set(CSRCS ${LIBMAD_SRCS})
+  set(CFLAGS -Wno-shadow -Wno-stringop-overflow -DFPM_DEFAULT -DSIZEOF_INT=4)
+  set(INCDIR ${CMAKE_CURRENT_LIST_DIR}/libmad
+             ${CMAKE_CURRENT_LIST_DIR}/libmad/msvc++)
+
+  target_sources(libmad PRIVATE ${CSRCS})
+  target_include_directories(libmad PRIVATE ${INCDIR})
+  target_compile_options(libmad PRIVATE ${CFLAGS})
+
+endif()

--- a/audioutils/libmad/Kconfig
+++ b/audioutils/libmad/Kconfig
@@ -1,0 +1,8 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config AUDIOUTILS_LIBMAD
+	bool "Enable libmad"
+	default n

--- a/audioutils/libmad/Make.defs
+++ b/audioutils/libmad/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/audioutils/libmad/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_AUDIOUTILS_LIBMAD),)
+CONFIGURED_APPS += $(APPDIR)/audioutils/libmad
+endif

--- a/audioutils/libmad/Makefile
+++ b/audioutils/libmad/Makefile
@@ -1,0 +1,43 @@
+############################################################################
+# apps/audioutils/libmad/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+CSRCS += $(wildcard libmad/*.c)
+CFLAGS += -DFPM_DEFAULT -DSIZEOF_INT=4
+CFLAGS += -Wno-shadow -Wno-stringop-overflow
+
+# Download and unpack libmad if no git repo found
+ifeq ($(wildcard libmad/.git),)
+VERSION ?= master
+libmad.zip:
+	$(Q) curl -L https://github.com/markjeee/libmad/archive/refs/heads/master.zip -o libmad.zip
+	$(Q) unzip -o libmad.zip
+	$(Q) mv libmad-$(VERSION) libmad
+
+context:: libmad.zip
+
+distclean::
+	$(call DELDIR, libmad)
+	$(call DELFILE, libmad.zip)
+
+endif
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
libmad0-dev and libmad0-dev:i386 cannot be installed simultaneously, which causes conflicts when compiling sim m32 and sim m64. Therefore, the libmad library has been ported to apps/audioutils and will be compiled with nuttx-apps.

## Impact

## Testing

