### PR TITLE
util.c:Add mode when creating files in the wapi_save_config

### DIFF
--- a/wireless/wapi/src/util.c
+++ b/wireless/wapi/src/util.c
@@ -505,7 +505,7 @@ int wapi_save_config(FAR const char *ifname,
       goto errout;
     }
 
-  fd = open(confname, O_RDWR | O_CREAT | O_TRUNC);
+  fd = open(confname, O_RDWR | O_CREAT | O_TRUNC, 0644);
   if (fd < 0)
     {
       ret = -errno;


### PR DESCRIPTION
## Summary
 no permission bit was provided when creating the file, resulting in the loss of permission to create the file and ultimately unable to read it
## Impact
wapi save config
## Testing
![image](https://github.com/user-attachments/assets/1eb98867-3518-457e-8086-088b7072fe0d)

