### PR TITLE
tcpdump:fix tcpdump stack overflow bug

### DIFF
--- a/system/tcpdump/Kconfig
+++ b/system/tcpdump/Kconfig
@@ -26,6 +26,6 @@ config SYSTEM_TCPDUMP_PRIORITY
 
 config SYSTEM_TCPDUMP_STACKSIZE
 	int "tcpdump stack size"
-	default DEFAULT_TASK_STACKSIZE
+	default 4096
 
 endif


### PR DESCRIPTION
## Summary
The default stack size of the tcpdump tool is 2KB. Since the do_capture function in the tool allocates memory on the stack and consumes 1.5KB of memory, causing stackoverflow, the default stack size is modified and changed to 4k.
## Impact

## Testing

