### PR TITLE
mbedtls: fix build error when libcxx is enabled.

### DIFF
--- a/crypto/mbedtls/CMakeLists.txt
+++ b/crypto/mbedtls/CMakeLists.txt
@@ -77,7 +77,7 @@ if(CONFIG_CRYPTO_MBEDTLS)
   nuttx_export_header(TARGET mbedtls INCLUDE_DIRECTORIES ${MBEDTLS_DIR}/include)
   target_sources(mbedtls PRIVATE ${CSRCS})
   target_include_directories(mbedtls PRIVATE ${INCDIR})
-  target_compile_definitions(mbedtls PRIVATE __unix__)
+  target_compile_definitions(mbedtls PRIVATE unix)
 
   if(CONFIG_ARCH_SIM)
     target_compile_options(mbedtls PRIVATE -O0)

--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -36,7 +36,7 @@ MBEDTLS_UNPACKLIBDIR = $(MBEDTLS_UNPACKNAME)$(DELIM)library
 MBEDTLS_UNPACKPROGDIR = $(MBEDTLS_UNPACKNAME)$(DELIM)programs
 
 # This lets Mbed TLS better use some of the POSIX features we have
-CFLAGS += ${DEFINE_PREFIX}__unix__
+CFLAGS += ${DEFINE_PREFIX}unix
 
 mbedtls/library/bignum.c_CFLAGS += -fno-lto
 


### PR DESCRIPTION
## Summary
```
if  !defined(unix) && !defined(__unix) && !defined(__unix__) && \
    !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
    !defined(__HAIKU__) && !defined(__midipix__)
error
   "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in mbedtls_config.h"

nuttx/libs/libxx/libcxx/include/__config
nuttx/libs/libxx/libcxx/include/limits.h:40,
apps/crypto/mbedtls/mbedtls/include/mbedtls/check_config.h:31, apps/crypto/mbedtls/mbedtls/include/mbedtls/build_info.h:151, apps/crypto/mbedtls/mbedtls/library/common.h:26,
apps/crypto/mbedtls/mbedtls/library/entropy_poll.c:25

if defined(__NuttX__)
undef __linux__
undef __APPLE__
undef __FreeBSD__
undef __GLIBC__
undef __NetBSD__
undef _WIN32
undef __sun__
undef _AIX
/ For the current use of the __unix__ macro in this library, / NuttX is not __unix__.
/ This might need to be revisited in future.
undef __unix__
endif
```
## Impact

## Testing
sim:local
