### PR TITLE
can: Merge netpacket/can.h into nuttx/can.h

### DIFF
--- a/canutils/candump/candump.c
+++ b/canutils/candump/candump.c
@@ -62,7 +62,6 @@
 #include <net/if.h>
 
 #include <nuttx/can.h>
-#include <netpacket/can.h>
 
 #include "terminal.h"
 #include "lib.h"

--- a/canutils/cansend/cansend.c
+++ b/canutils/cansend/cansend.c
@@ -77,7 +77,6 @@
 #include <sys/socket.h>
 
 #include <nuttx/can.h>
-#include <netpacket/can.h>
 
 #include "lib.h"
 

--- a/canutils/lely-canopen/0001-NuttX-port.patch
+++ b/canutils/lely-canopen/0001-NuttX-port.patch
@@ -55,7 +55,6 @@ index 4fc133dd..b059c849 100644
  
 +#ifdef __NuttX__
 +#include <nuttx/can.h>
-+#include <netpacket/can.h>
 +#endif
 +
  int
@@ -99,7 +98,6 @@ index ca7e7d95..35d9a9f2 100644
 +#ifdef __NuttX__
 +#include <sys/ioctl.h>
 +#include <nuttx/can.h>
-+#include <netpacket/can.h>
 +#include <net/if.h>
 +#endif
 +

--- a/canutils/libcanutils/lib.c
+++ b/canutils/libcanutils/lib.c
@@ -49,7 +49,6 @@
 #include <sys/param.h>
 #include <sys/socket.h> /* for sa_family_t */
 #include <nuttx/can.h>
-#include <netpacket/can.h>
 
 #include "lib.h"
 

--- a/canutils/slcan/slcan.c
+++ b/canutils/slcan/slcan.c
@@ -47,7 +47,6 @@
 #include <net/if.h>
 #include <termios.h>
 #include <nuttx/can.h>
-#include <netpacket/can.h>
 
 #include "slcan.h"
 

--- a/examples/opencyphal/canard_main.c
+++ b/examples/opencyphal/canard_main.c
@@ -43,7 +43,6 @@
 #include <poll.h>
 
 #include <nuttx/can.h>
-#include <netpacket/can.h>
 
 #include "socketcan.h"
 

--- a/examples/opencyphal/socketcan.h
+++ b/examples/opencyphal/socketcan.h
@@ -33,7 +33,6 @@
 #include <sys/socket.h>
 
 #include <nuttx/can.h>
-#include <netpacket/can.h>
 
 #include <canard.h>
 


### PR DESCRIPTION
## Summary
This patch is associated with 'https://github.com/apache/nuttx/pull/13141', so it cannot be verified separately by CI. Please help to associate and review it. Thank you!

## Impact
can_send, can_dump, opencyphal

## Testing
Brush the system onto a development board with a CAN interface, connect the CAN interface to the CANoe device, and verify the message sending and receiving function using can_send/can_dump/opencyphal .
