### PR TITLE
apps/testing/drivertest_pwm.c: Fix apps/testing/drivertest_pwm.c compile_error

### DIFF
--- a/examples/capture/cap_main.c
+++ b/examples/capture/cap_main.c
@@ -213,6 +213,7 @@ int main(int argc, FAR char *argv[])
 {
   int8_t dutycycle;
   int32_t frequence;
+  int32_t edges;
   int fd;
   int exitval = EXIT_SUCCESS;
   int ret;
@@ -288,6 +289,24 @@ int main(int argc, FAR char *argv[])
       else
         {
           printf("pwm frequence: %"PRId32" Hz \n", frequence);
+        }
+
+      /* Get the edges data using the ioctl */
+
+      ret = ioctl(fd, CAPIOC_EDGES,
+                  (unsigned long)((uintptr_t)&edges));
+      if (ret < 0)
+        {
+          printf("cap_main: ioctl(CAPIOC_EDGES) failed: %d\n", errno);
+          exitval = EXIT_FAILURE;
+          goto errout_with_dev;
+        }
+
+      /* Print the sample data on successful return */
+
+      else
+        {
+          printf("pwm edges counting: %"PRId32" \n", edges);
         }
 
       /* Delay a little bit */

--- a/testing/drivertest/drivertest_pwm.c
+++ b/testing/drivertest/drivertest_pwm.c
@@ -221,6 +221,9 @@ static void test_case_pwm(FAR void **state)
 {
   int fd;
   int ret;
+#ifdef CONFIG_PWM_MULTICHAN
+  int i;
+#endif
   struct pwm_info_s info;
   FAR struct pwm_state_s *pwm_state;
   pwm_state = (FAR struct pwm_state_s *)*state;
@@ -235,14 +238,15 @@ static void test_case_pwm(FAR void **state)
   memset(&info, 0, sizeof(info));
 
   info.frequency = pwm_state->freq;
-  info.duty = b16divi(uitoub16(pwm_state->duty), 100);
 
 #ifdef CONFIG_PWM_MULTICHAN
   for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       info.channels[i].channel = i + 1;
-      info.channels[i].duty = info.duty;
+      info.channels[i].duty = b16divi(uitoub16(pwm_state->duty), 100);
     }
+#else
+  info.duty = b16divi(uitoub16(pwm_state->duty), 100);
 #endif
 
 #ifdef CONFIG_PWM_PULSECOUNT


### PR DESCRIPTION

Description: Divide info.duty into two parts: multi-channel and single-channel

## Summary

## Impact

## Testing

