### PR TITLE
Update System utility "settings.c" to correct compiler error

### DIFF
--- a/system/settings/settings.c
+++ b/system/settings/settings.c
@@ -609,7 +609,7 @@ static void save(void)
   g_settings.wrpend = true;
 
 #ifdef CONFIG_SYSTEM_SETTINGS_CACHED_SAVES
-  ret = timer_settime(g_settings.timerid, 0, &g_settings.trigger, NULL);
+  timer_settime(g_settings.timerid, 0, &g_settings.trigger, NULL);
 #else
   union sigval value =
   {


### PR DESCRIPTION
Silly error in settings.c causing compiler error when settings utility caching is enabled



