### PR TITLE
examples/nimble: fix example after update to latest master

### DIFF
--- a/examples/nimble/nimble_main.c
+++ b/examples/nimble/nimble_main.c
@@ -68,7 +68,6 @@
  ****************************************************************************/
 
 void ble_hci_sock_ack_handler(FAR void *param);
-void ble_hci_sock_init(void);
 void ble_hci_sock_set_device(int dev);
 
 /****************************************************************************
@@ -270,7 +269,6 @@ int main(int argc, FAR char *argv[])
 #endif
 
   nimble_port_init();
-  ble_hci_sock_init();
 
   /* Initialize services */
 


### PR DESCRIPTION
## Summary
- examples/nimble: fix example after update to latest master
this example is broken since bc68d954a
since https://github.com/apache/mynewt-nimble/commit/bf761837418da4cc1d55abb4be50b8308e7bf18a ble_hci_sock_init is called from nimble code, so we can't call it again in example code

## Impact

## Testing
nrf52840-dk/sdc_nimble example
