### PR TITLE
benchmark: Build osperf only when pipes and hpwork are enabled

### DIFF
--- a/benchmarks/osperf/Kconfig
+++ b/benchmarks/osperf/Kconfig
@@ -6,6 +6,8 @@
 config BENCHMARK_OSPERF
 	tristate "System performance profiling"
 	default n
+	depends on PIPES
+	depends on SCHED_HPWORK
 	---help---
 		Measure the performance of core system functions, such as thread
 		switching and the time required for semaphore execution


### PR DESCRIPTION
## Summary
Building osperf requires pipes and hpwork. However, the configurations for pipes and hpwork are disabled by default. These features should be enabled automatically when osperf is enabled, which would be helpful for developers configuring osperf, so we want to add the select statement.

## Impact
Without this change, the osperf fails to build with the following error:
```
fukui@herbtea:~/proj/package-hda/nuttxspace/nuttx$
:) make
Create version.h
LN: platform/board to /home/fukui/proj/package-hda/nuttxspace/apps/platform/dummy
Register: osperf
Register: hello
Register: nsh
Register: sh
Register: ostest
LD: nuttx.elf
ld: warning: intel64_vectors.o: missing .note.GNU-stack section implies executable stack
ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
ld: /home/fukui/proj/nuttxspace/nuttx/staging/libapps.a(osperf.c.home.fukui.proj.nuttxspace.apps.benchmarks.osperf_1.o): in function `hpwork_performance':
/home/fukui/proj/nuttxspace/apps/benchmarks/osperf/osperf.c:242:(.text+0x44d): undefined reference to `work_queue'
/home/fukui/proj/nuttxspace/apps/benchmarks/osperf/osperf.c:242:(.text+0x44d): relocation truncated to fit: R_X86_64_PLT32 against undefined symbol `work_queue'
ld: /home/fukui/proj/nuttxspace/nuttx/staging/libapps.a(osperf.c.home.fukui.proj.nuttxspace.apps.benchmarks.osperf_1.o): in function `poll_performance':
/home/fukui/proj/nuttxspace/apps/benchmarks/osperf/osperf.c:272:(.text+0x4dc): undefined reference to `pipe2'
/home/fukui/proj/nuttxspace/apps/benchmarks/osperf/osperf.c:272:(.text+0x4dc): relocation truncated to fit: R_X86_64_PLT32 against undefined symbol `pipe2'
make[1]: *** [Makefile:128: nuttx.elf] Error 1
make: *** [tools/Unix.mk:546: nuttx.elf] Error 2
```

## Testing
This change has been tested against the qemu-intel64 platform, and it should work for other platforms.

