### PR TITLE
nshlib: move g_builtin_prompt from data to rodata

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -886,7 +886,7 @@ static inline void help_builtins(FAR struct nsh_vtbl_s *vtbl)
 
   char line[HELP_LINELEN + HELP_TABSIZE + 1];
 
-  static const char *g_builtin_prompt = "\nBuiltin Apps:\n";
+  static FAR const char *const g_builtin_prompt = "\nBuiltin Apps:\n";
 
   /* Count the number of built-in commands and get the optimal column width */
 

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -36,6 +36,14 @@
 #ifndef CONFIG_NSH_DISABLESCRIPT
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_ETC_ROMFS
+static bool g_nsh_script_initialized;
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -227,15 +235,14 @@ int nsh_sysinitscript(FAR struct nsh_vtbl_s *vtbl)
 #ifdef CONFIG_ETC_ROMFS
 int nsh_initscript(FAR struct nsh_vtbl_s *vtbl)
 {
-  static bool initialized;
   bool already;
   int ret = OK;
 
-  /* Atomic test and set of the initialized flag */
+  /* Atomic test and set of the g_nsh_script_initialized flag */
 
   sched_lock();
-  already     = initialized;
-  initialized = true;
+  already                  = g_nsh_script_initialized;
+  g_nsh_script_initialized = true;
   sched_unlock();
 
   /* If we have not already executed the init script, then do so now */


### PR DESCRIPTION
## Summary

nshlib: move g_builtin_prompt from data to rodata

1. move g_builtin_prompt from data to rodata
2. add g_ prefix to some global variables

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check