### PR TITLE
ostest: smp_call only valid in FLAT BUILD

### DIFF
--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -596,7 +596,7 @@ static int user_main(int argc, char *argv[])
       vfork_test();
 #endif
 
-#ifdef CONFIG_SMP_CALL
+#if defined(CONFIG_SMP_CALL) && defined(CONFIG_BUILD_FLAT)
       printf("\nuser_main: smp call test\n");
       smp_call_test();
 #endif

--- a/testing/ostest/smp_call.c
+++ b/testing/ostest/smp_call.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/sched.h>
 
+#if defined(CONFIG_SMP_CALL) && defined(CONFIG_BUILD_FLAT)
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -116,3 +117,4 @@ void smp_call_test(void)
 
   printf("smp_call_test: Test success\n");
 }
+#endif


### PR DESCRIPTION
## Summary
smp_call only valid in FLAT BUILD

## Impact

## Testing

