### PR TITLE
nxcodec: Modify logic of judging the correctness of incoming pixformat

### DIFF
--- a/system/nxcodec/nxcodec.c
+++ b/system/nxcodec/nxcodec.c
@@ -114,13 +114,6 @@ int nxcodec_init(FAR nxcodec_t *codec)
       goto err0;
     }
 
-  if (codec->output.fdesc.pixelformat !=
-      codec->output.format.fmt.pix.pixelformat)
-    {
-      ret = -EINVAL;
-      goto err0;
-    }
-
   codec->output.format.type = codec->output.type;
 
   ret = nxcodec_context_set_format(&codec->output);
@@ -136,13 +129,6 @@ int nxcodec_init(FAR nxcodec_t *codec)
       printf("Failed to open output file %s \n", codec->output.filename);
       ret = -errno;
       goto err0;
-    }
-
-  if (codec->capture.fdesc.pixelformat !=
-      codec->capture.format.fmt.pix.pixelformat)
-    {
-      ret = -EINVAL;
-      goto err1;
     }
 
   codec->capture.format.type = codec->capture.type;

--- a/system/nxcodec/nxcodec_context.h
+++ b/system/nxcodec/nxcodec_context.h
@@ -45,7 +45,6 @@ typedef struct nxcodec_context_s
   int                       fd;
   enum v4l2_buf_type        type;
   struct v4l2_format        format;
-  struct v4l2_fmtdesc       fdesc;
   FAR nxcodec_context_buf_t *buf;
   int                       nbuffers;
 } nxcodec_context_t;


### PR DESCRIPTION
## Summary
emun_format gets all supported formats, matches the passed format parameter, and then sets it via try_fmt
## Impact
NA
## Testing
NA
