### PR TITLE
ltp: handle low accuracy of time in some platfrom

### DIFF
--- a/testing/ltp/0013-ltp-handle-low-accuracy-of-time-in-some-platfrom.patch
+++ b/testing/ltp/0013-ltp-handle-low-accuracy-of-time-in-some-platfrom.patch
@@ -1,0 +1,30 @@
+From 0d0288860baf2229f632e9ff2afd4d5f50466675 Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Fri, 6 Sep 2024 20:38:32 +0800
+Subject: [PATCH] ltp: handle low accuracy of time in some platfrom
+
+some platform use TICK to calculate the time, for example
+1tick = 1ms, when the test may run less then 1ms, then gettime()
+before + sleep = after
+
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ .../conformance/interfaces/clock_nanosleep/1-1.c                | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/1-1.c ltp/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/1-1.c
+index 7647003da..e1e52ffc2 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/1-1.c
++++ ltp/testcases/open_posix_testsuite/conformance/interfaces/clock_nanosleep/1-1.c
+@@ -47,7 +47,7 @@ int main(void)
+ 		slepts = slepts - 1;
+ 	}
+ 
+-	if ((slepts > 0) || (sleptns > SLEEPNSEC)) {
++	if ((slepts > 0) || (sleptns >= SLEEPNSEC)) {
+ 		printf("Test PASSED\n");
+ 		return PTS_PASS;
+ 	}
+-- 
+2.25.1
+

--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -258,6 +258,7 @@ $(LTP_UNPACK): ltp-$(LTPS_VERSION).zip
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0010-ltp-fix-build-warning.patch
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0011-ltp-fix-the-proc.h-header-file-duplicate-inclusion.patch
 	$(Q) patch -d $(LTP_UNPACK) -p1 < 0012-ltp-fix-build-error.patch
+	$(Q) patch -d $(LTP_UNPACK) -p1 < 0013-ltp-handle-low-accuracy-of-time-in-some-platfrom.patch
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(LTP_UNPACK)/.git),)


### PR DESCRIPTION


## Summary

ltp: handle low accuracy of time in some platfrom

some platform use TICK to calculate the time, for example 1tick = 1ms, when the test may run less then 1ms, then gettime() before + sleep = after

## Impact

ltp case

## Testing

sim
