### PR TITLE
system/uorb: using uorb.h to replace sensors header file

### DIFF
--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -25,8 +25,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/sensors/ioctl.h>
-#include <nuttx/sensors/sensor.h>
+#include <nuttx/uorb.h>
 
 #include <sys/time.h>
 #include <debug.h>


### PR DESCRIPTION
## Summary
system/uorb: using uorb.h to replace sensors header file 
## Impact

## Testing
Vela 
