### PR TITLE
Thttpd Fix: wrong calc offset

### DIFF
--- a/netutils/thttpd/thttpd.c
+++ b/netutils/thttpd/thttpd.c
@@ -473,7 +473,7 @@ static void handle_send(struct connect_s *conn, struct timeval *tv)
 
           /* And update how much of the file we wrote */
 
-          conn->offset         += nwritten;
+          conn->offset         += nread;
           conn->hc->bytes_sent += nwritten;
           ninfo("Wrote %d bytes\n", nwritten);
         }


### PR DESCRIPTION
## Summary

When 'httpd' sends a file, it does not correctly calculate the offset of the read file data.

It does not take into account the header, but accepts the packet size instead of the size of the file data that was read.

## Logs

```
[CPU1] httpd_start_request: File: "/data/www/css/main.css"

# Open the file for reading, it size - 469
[CPU1] handle_send: offset: 0 end_offset: 469 bytes_sent: 0

# Read data from the file - 52 bytes
[CPU1] handle_send: Read 52 bytes, buflen 256
[CPU1] tcp_max_wrb_size: tcp_max_wrb_size = 5840 for conn 0x3fc94a00
[CPU1] psock_tcp_send: new wrb 0x3fc95120 (non blocking)
[CPU1] psock_tcp_send: Queued WRB=0x3fc95120 pktlen=256 write_q(0x3fc95120,0x3fc95120)

# Sent - 256 bytes
[CPU1] handle_send: Wrote 256 bytes
[CPU0] tcp_callback: flags: 0010

# We see that the offset is 256, instead of 52
[CPU1] handle_send: offset: 256 end_offset: 469 bytes_sent: 256
[CPU0] psock_send_eventhandler: flags: 0010
[CPU1] handle_send: Read 256 bytes, buflen 256
```

## Testing

I do not know how to make unittests.

But after this patch, the http request began to work correctly.