### PR TITLE
.gitignore: Add .aider* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Make.dep
 build
 .ccls-cache
 compile_commands.json
+.aider*


### PR DESCRIPTION
## Summary
Add .aider* to .gitignore
## Impact
Minor
## Testing
CI
