### PR TITLE
New features and bug fix for Fastboot

### DIFF
--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -24,4 +24,11 @@ config SYSTEM_FASTBOOTD_DOWNLOAD_MAX
 	int "USB-fastboot download buffer size"
 	default 40960
 
+config FASTBOOTD_USB_BOARDCTL
+	bool "USB Board Control"
+	depends on BOARDCTL
+	depends on BOARDCTL_USBDEVCTRL
+	---help---
+		Connect usbdev before running fastboot daemon.
+
 endif # SYSTEM_FASTBOOTD

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -623,6 +623,42 @@ int main(int argc, FAR char **argv)
   char usbdev[32];
   int ret = OK;
 
+#ifdef CONFIG_FASTBOOTD_USB_BOARDCTL
+  struct boardioc_usbdev_ctrl_s ctrl;
+#  ifdef CONFIG_USBDEV_COMPOSITE
+    uint8_t dev = BOARDIOC_USBDEV_COMPOSITE;
+#  else
+    uint8_t dev = BOARDIOC_USBDEV_FASTBOOT;
+#  endif
+  FAR void *handle;
+
+  ctrl.usbdev   = dev;
+  ctrl.action   = BOARDIOC_USBDEV_INITIALIZE;
+  ctrl.instance = 0;
+  ctrl.config   = 0;
+  ctrl.handle   = NULL;
+
+  ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
+  if (ret < 0)
+    {
+      printf("boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", ret);
+      return ret;
+    }
+
+  ctrl.usbdev   = dev;
+  ctrl.action   = BOARDIOC_USBDEV_CONNECT;
+  ctrl.instance = 0;
+  ctrl.config   = 0;
+  ctrl.handle   = &handle;
+
+  ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
+  if (ret < 0)
+    {
+      printf("boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", ret);
+      return ret;
+    }
+#endif /* FASTBOOTD_USB_BOARDCTL */
+
   buffer = malloc(CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX);
   if (buffer == NULL)
     {

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -511,7 +511,10 @@ static void fastboot_reboot(FAR struct fastboot_ctx_s *context,
                             FAR const char *arg)
 {
 #ifdef CONFIG_BOARDCTL_RESET
+  fastboot_okay(context, "");
   boardctl(BOARDIOC_RESET, BOARDIOC_SOFTRESETCAUSE_USER_REBOOT);
+#else
+  fastboot_fail(context, "Operation not supported");
 #endif
 }
 
@@ -519,7 +522,10 @@ static void fastboot_reboot_bootloader(FAR struct fastboot_ctx_s *context,
                                        FAR const char *arg)
 {
 #ifdef CONFIG_BOARDCTL_RESET
+  fastboot_okay(context, "");
   boardctl(BOARDIOC_RESET, BOARDIOC_SOFTRESETCAUSE_ENTER_BOOTLOADER);
+#else
+  fastboot_fail(context, "Operation not supported");
 #endif
 }
 

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/mtd/mtd.h>
 #include <nuttx/version.h>
 
 #include <errno.h>
@@ -296,7 +297,15 @@ out:
 
 static int fastboot_flash_erase(int fd)
 {
-  return OK;
+  int ret;
+
+  ret = ioctl(fd, MTDIOC_BULKERASE, 0);
+  if (ret < 0)
+    {
+      printf("Erase device failed\n");
+    }
+
+  return ret;
 }
 
 static int

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -237,6 +237,7 @@ static void fastboot_flash_close(int fd)
 {
   if (fd >= 0)
     {
+      fsync(fd);
       close(fd);
     }
 }

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -362,6 +362,7 @@ static int
 fastboot_flash_program(FAR struct fastboot_ctx_s *context, int fd)
 {
   FAR char *chunk_ptr = context->download_buffer;
+  FAR char *end_ptr = chunk_ptr + context->download_size;
   FAR struct fastboot_sparse_header_s *sparse;
   uint32_t chunk_num;
   int ret = OK;
@@ -382,10 +383,9 @@ fastboot_flash_program(FAR struct fastboot_ctx_s *context, int fd)
     }
 
   chunk_num = sparse->total_chunks;
-
   chunk_ptr += FASTBOOT_SPARSE_HEADER;
 
-  while (chunk_num--)
+  while (chunk_ptr < end_ptr && chunk_num--)
     {
       FAR struct fastboot_chunk_header_s *chunk =
         (FAR struct fastboot_chunk_header_s *)chunk_ptr;

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -673,6 +673,7 @@ static int fastboot_filedump_upload(FAR struct fastboot_ctx_s *context)
     {
       fb_err("Invalid argument, offset: %" PRIdOFF "\n",
              context->upload_param.u.file.offset);
+      close(fd);
       return -errno;
     }
 
@@ -690,12 +691,14 @@ static int fastboot_filedump_upload(FAR struct fastboot_ctx_s *context)
                               nread) < 0)
         {
           fb_err("Upload failed (%zu bytes left)\n", size);
+          close(fd);
           return -errno;
         }
 
       size -= nread;
     }
 
+  close(fd);
   return 0;
 }
 

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -230,7 +230,7 @@ static void fastboot_okay(FAR struct fastboot_ctx_s *context,
 
 static int fastboot_flash_open(FAR const char *name)
 {
-  int fd = open(name, O_RDWR);
+  int fd = open(name, O_RDWR | O_CLOEXEC);
   if (fd < 0)
     {
       fb_err("Open %s error\n", name);
@@ -741,7 +741,7 @@ int main(int argc, FAR char **argv)
 
   snprintf(usbdev, sizeof(usbdev), "%s/ep%d",
            FASTBOOT_USBDEV, FASTBOOT_EP_BULKOUT_IDX + 1);
-  context.usbdev_in = open(usbdev, O_RDONLY);
+  context.usbdev_in = open(usbdev, O_RDONLY | O_CLOEXEC);
   if (context.usbdev_in < 0)
     {
       fb_err("open [%s] error\n", usbdev);
@@ -751,7 +751,7 @@ int main(int argc, FAR char **argv)
 
   snprintf(usbdev, sizeof(usbdev), "%s/ep%d",
            FASTBOOT_USBDEV, FASTBOOT_EP_BULKIN_IDX + 1);
-  context.usbdev_out = open(usbdev, O_WRONLY);
+  context.usbdev_out = open(usbdev, O_WRONLY | O_CLOEXEC);
   if (context.usbdev_out < 0)
     {
       fb_err("open [%s] error\n", usbdev);

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -847,7 +847,7 @@ static void fastboot_command_loop(FAR struct fastboot_ctx_s *context)
 
   while (1)
     {
-      char buffer[FASTBOOT_MSG_LEN];
+      char buffer[FASTBOOT_MSG_LEN + 1];
       size_t ncmds = nitems(g_fast_cmd);
       size_t index;
 

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -616,14 +616,17 @@ static void fastboot_publish(FAR struct fastboot_ctx_s *context,
   FAR struct fastboot_var_s *var;
 
   var = malloc(sizeof(*var));
-  if (var)
+  if (var == NULL)
     {
-      var->name = name;
-      var->string = string;
-      var->data = data;
-      var->next = context->varlist;
-      context->varlist = var;
+      printf("ERROR: Could not allocate the memory.\n");
+      return;
     }
+
+  var->name = name;
+  var->string = string;
+  var->data = data;
+  var->next = context->varlist;
+  context->varlist = var;
 }
 
 static void fastboot_create_publish(FAR struct fastboot_ctx_s *context)
@@ -654,7 +657,7 @@ static void fastboot_free_publish(FAR struct fastboot_ctx_s *context)
 
 int main(int argc, FAR char **argv)
 {
-  FAR struct fastboot_ctx_s context;
+  struct fastboot_ctx_s context;
   FAR void *buffer = NULL;
   char usbdev[32];
   int ret = OK;
@@ -722,7 +725,8 @@ int main(int argc, FAR char **argv)
       goto err_with_in;
     }
 
-  context.flash_fd = -1;
+  context.varlist         = NULL;
+  context.flash_fd        = -1;
   context.download_buffer = buffer;
   context.download_size   = 0;
   context.download_offset = 0;

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -107,6 +107,7 @@ struct fastboot_ctx_s
 {
   int usbdev_in;
   int usbdev_out;
+  int flash_fd;
   size_t download_max;
   size_t download_size;
   size_t download_offset;
@@ -398,18 +399,20 @@ static void fastboot_flash(FAR struct fastboot_ctx_s *context,
                            FAR const char *arg)
 {
   char blkdev[PATH_MAX];
-  int fd;
 
   snprintf(blkdev, PATH_MAX, FASTBOOT_BLKDEV, arg);
 
-  fd = fastboot_flash_open(blkdev);
-  if (fd < 0)
+  if (context->flash_fd < 0)
     {
-      fastboot_fail(context, "Flash open failure");
-      return;
+      context->flash_fd = fastboot_flash_open(blkdev);
+      if (context->flash_fd < 0)
+        {
+          fastboot_fail(context, "Flash open failure");
+          return;
+        }
     }
 
-  if (fastboot_flash_program(context, fd) < 0)
+  if (fastboot_flash_program(context, context->flash_fd) < 0)
     {
       fastboot_fail(context, "Image flash failure");
     }
@@ -418,7 +421,11 @@ static void fastboot_flash(FAR struct fastboot_ctx_s *context,
       fastboot_okay(context, "");
     }
 
-  fastboot_flash_close(fd);
+  if (context->total_imgsize == 0)
+    {
+      fastboot_flash_close(context->flash_fd);
+      context->flash_fd = -1;
+    }
 }
 
 static void fastboot_erase(FAR struct fastboot_ctx_s *context,
@@ -715,6 +722,7 @@ int main(int argc, FAR char **argv)
       goto err_with_in;
     }
 
+  context.flash_fd = -1;
   context.download_buffer = buffer;
   context.download_size   = 0;
   context.download_offset = 0;

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -557,6 +557,7 @@ static void fastboot_download(FAR struct fastboot_ctx_s *context,
     }
 
   download = context->download_buffer;
+  context->download_size = len;
 
   while (len > 0)
     {
@@ -564,6 +565,7 @@ static void fastboot_download(FAR struct fastboot_ctx_s *context,
                                 download, len);
       if (r < 0)
         {
+          context->download_size = 0;
           fb_err("fastboot_download usb read error\n");
           return;
         }
@@ -572,7 +574,6 @@ static void fastboot_download(FAR struct fastboot_ctx_s *context,
       download += r;
     }
 
-  context->download_size = len;
   fastboot_okay(context, "");
 }
 


### PR DESCRIPTION
## Summary
- New Feature
  - Auto download mode: [fastbootd:add delay ms for bootloader](https://github.com/apache/nuttx-apps/commit/a4556435a9ffbefb9708b54710412d69b6f515dd)   **-- by @anjiahao1** 
  - CMD: oem memdump & filedump : [system/fastboot: Support upload & oem(memdump, filedump) command](https://github.com/apache/nuttx-apps/commit/ac2665b2ab54eaa99caf20df3b71e48ccd23a711)
  - Retry if open EP failed: [system/fastboot: Retry if open EP failed](https://github.com/apache/nuttx-apps/commit/3fdd967aa133652d7d801165f9ef7c044a6064eb)
  - CMD: erase: [system/fastboot: erase - add driver independent](https://github.com/apache/nuttx-apps/commit/15a4fd99dd77d564a2648ed0c4a5ccbd0ec0b469), [system/fastboot: Complete the erase command](https://github.com/apache/nuttx-apps/commit/752829e050857a804c71af0d00f3722ba4ab3554)
- BugFix
  - [system/fastboot: fix crash when free invalid pointer](https://github.com/apache/nuttx-apps/commit/665962d4f955b91589d001666d9bc98c177d346a)  **-- by @Donny9**
  - [fastboot:enable O_CLOEXEC explicit](https://github.com/apache/nuttx-apps/commit/23361535fa95fe4a9c7f77bdbb15588c7bad7020)  **-- by wanggang26@xiaomi.com**
  -  [system/fastboot: Fix Out-of-bounds Write](https://github.com/apache/nuttx-apps/commit/cde41f48491e419a95c0997fda2f89692a4e44c1)
  - [system/fastboot: Fix that total_chunks of sparse_header maybe error](https://github.com/apache/nuttx-apps/commit/0db13892cf77108764d32671a9bd02c5db7a3f37)
  - [system/fastboot: Fix error that download_size always be zero](https://github.com/apache/nuttx-apps/commit/7873f36fbb8cf047b361fc3eb0acf87d1b348920)
  - [system/fastboot: Init total_imgsize to zero](https://github.com/apache/nuttx-apps/commit/97e817202679df50850c81c141590b4d136ba340)
  - [system/fastboot: Fix fd leak of fastboot_filedump_upload()](https://github.com/apache/nuttx-apps/commit/4da5b0f199f384a52f9a74718ce06de0d3040595)
  - [system/fastboot: Replace printf with syslog](https://github.com/apache/nuttx-apps/commit/4e478f9a30bfafdad7858d877a3544666b59f20b)
  - [Reduce the number of open() and close() to improve performance](https://github.com/apache/nuttx-apps/commit/5c220ffe4784edb150910d786ddfd7c4a15ba039)
  - [system/fastboot: fastboot flash - call fsync()](https://github.com/apache/nuttx-apps/commit/7772db0c6fc439fd863f37bcdbbd14c2e45d0ea3)
  - [system/fastboot: Support USB boardctl](https://github.com/apache/nuttx-apps/commit/f08fe95a381a6a8d3fe270c61f0e80aca515654a)
  - [fastboot tool: Status read failed while rebooting into bootloader](https://github.com/apache/nuttx-apps/commit/d2f7ac5b3f61366c608b887869da631642a8ab05)
- Depends
  - f08fe95a381a6a8d3fe270c61f0e80aca515654a depends on  https://github.com/apache/nuttx/pull/13367
## Impact

## Testing

