### PR TITLE
ppp: Fix wrong lcp_state handling on peer reconnection

### DIFF
--- a/netutils/pppd/lcp.c
+++ b/netutils/pppd/lcp.c
@@ -135,10 +135,11 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
       /* In case of new peer connection */
 
       ipcp_init(ctx);
-      
-      /* Clear LCP state to keep it in negotiation phase. LCP_TX_UP will be re-set
-       * once a CONF_ACK is received. */
-      
+
+      /* Clear LCP state to keep it in negotiation phase. LCP_TX_UP will be
+       * re-set once a CONF_ACK is received.
+       */
+
       ctx->lcp_state &= ~LCP_TX_UP;
 
       DEBUG1(("received [LCP Config Request id %u\n", id));

--- a/netutils/pppd/lcp.c
+++ b/netutils/pppd/lcp.c
@@ -135,7 +135,11 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
       /* In case of new peer connection */
 
       ipcp_init(ctx);
-      ctx->lcp_state &= ~LCP_RX_UP;
+      
+      /* Clear LCP state to keep it in negotiation phase. LCP_TX_UP will be re-set
+       * once a CONF_ACK is received. */
+      
+      ctx->lcp_state &= ~LCP_TX_UP;
 
       DEBUG1(("received [LCP Config Request id %u\n", id));
       if (scan_packet


### PR DESCRIPTION
If a PPP peer disconnects and then tries to reconnect it will send an 'LCP configure request' packet. The code that handles that scenario seems to be clearing the wrong `lcp_state` flag (`LCP_RX_UP` instead of `LCP_TX_UP`) and thus the nuttx ppp client will keep sending IPCP packets which are rightfully dropped by the new peer since it is still in the LCP negotiation phase.


