### PR TITLE
Bug fix for ADB

### DIFF
--- a/system/adb/logcat_service.c
+++ b/system/adb/logcat_service.c
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <sys/ioctl.h>
 
 #include <nuttx/syslog/ramlog.h>
 #include <unistd.h>
@@ -175,7 +176,9 @@ exit_stop_service:
 
 adb_service_t * logcat_service(adb_client_t *client, const char *params)
 {
+  int fd;
   int ret;
+
   logcat_service_t *service =
       (logcat_service_t *)malloc(sizeof(logcat_service_t));
 
@@ -189,17 +192,25 @@ adb_service_t * logcat_service(adb_client_t *client, const char *params)
 
   /* TODO parse params string to extract logcat parameters */
 
-  ret = open(CONFIG_SYSLOG_DEVPATH, O_RDONLY | O_CLOEXEC);
-
-  if (ret < 0)
+  fd = open(CONFIG_SYSLOG_DEVPATH, O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
     {
       adb_err("failed to open %s (%d)\n", CONFIG_SYSLOG_DEVPATH, errno);
       free(service);
       return NULL;
     }
 
+  ret = ioctl(fd, PIPEIOC_POLLINTHRD, 1);
+  if (ret < 0)
+    {
+      adb_err("failed to control %s (%d)\n", CONFIG_SYSLOG_DEVPATH, errno);
+      close(fd);
+      free(service);
+      return NULL;
+    }
+
   uv_handle_t *handle = adb_uv_get_client_handle(client);
-  ret = uv_poll_init(handle->loop, &service->poll, ret);
+  ret = uv_poll_init(handle->loop, &service->poll, fd);
   assert(ret == 0);
 
   service->poll.data = client;


### PR DESCRIPTION
## Summary
Boards may set default(CONFIG_RAMLOG_POLLTHRESHOLD) to a very large value, causes logcat "can not" get poll notify.

## Impact
adbd

## Testing

