### PR TITLE
Fix warning and depends of examples/sotest

### DIFF
--- a/examples/sotest/Kconfig
+++ b/examples/sotest/Kconfig
@@ -15,7 +15,7 @@ if EXAMPLES_SOTEST
 config EXAMPLES_SOTEST_BUILTINFS
 	bool "Built-in File System"
 	default y
-	depends on FS_ROMFS && BUILD_FLAT
+	depends on FS_ROMFS && BUILD_FLAT && BOARDCTL_ROMDISK
 	---help---
 		This example supports a very, non-standard but also very convenient
 		way of testing with example using CONFIG_EXAMPLES_SOTEST_BUILTINFS.

--- a/examples/sotest/sotest_main.c
+++ b/examples/sotest/sotest_main.c
@@ -102,7 +102,9 @@ extern const int g_sot_nexports;
 
 int main(int argc, FAR char *argv[])
 {
+#ifdef CONFIG_EXAMPLES_SOTEST_BUILTINFS
   char devname[32];
+#endif
 #if CONFIG_MODLIB_MAXDEPEND > 0
   FAR void *handle1;
 #endif


### PR DESCRIPTION
## Summary
1. Fix warning of unused variable 'devname' - f876f3bd330175e70db62a47ae759a9058ac49d7
2. Fix depends of SOTEST_BUILTINFS - c7418f13b8248e107cc3528fee92019e8096985f

Please see commit message for more details.

## Impact
examples/sotest

## Testing
- Configuration
```
./tools/configure.sh -l sim:sotest
```
- Run
```
nsh> sotest
main: Registering romdisk at /dev/ram3
main: Mounting ROMFS filesystem at target=/mnt/romfs with source=/dev/ram3
module_initialize:
module_initialize:
testfunc1: Hello, everyone!
   caller: Hello to you too!
testfunc2: Hope you are having a great day!
   caller: Not so bad so far.
testfunc3: Let's talk again very soon
   caller: Yes, don't be a stranger!
module_uninitialize: arg=0
module_uninitialize: arg=0
nsh>
```