### PR TITLE
module/sotest: Try devminor of romdisk

### DIFF
--- a/examples/sotest/Kconfig
+++ b/examples/sotest/Kconfig
@@ -35,13 +35,14 @@ config EXAMPLES_SOTEST_BUILTINFS
 
 if EXAMPLES_SOTEST_BUILTINFS
 
-config EXAMPLES_SOTEST_DEVMINOR
-	int "ROMFS Minor Device Number"
-	default 0
+config EXAMPLES_SOTEST_DEVMINOR_MAX
+	int "ROMFS Max Minor Device Number"
+	default 5
 	---help---
-		The minor device number of the ROMFS block. For example, the N in /dev/ramN.
+		The max minor device number of the ROMFS block will be tried.
+		For example, from /dev/ram0 to /dev/ramN.
 		Used for registering the RAM block driver that will hold the ROMFS file system
-		containing the SOTEST executables to be tested.  Default: 0
+		containing the SOTEST executables to be tested.  Default: 5
 
 endif # EXAMPLES_SOTEST_BUILTINFS
 

--- a/examples/sotest/sotest_main.c
+++ b/examples/sotest/sotest_main.c
@@ -71,8 +71,8 @@
 #  define NSECTORS(b)  (((b)+SECTORSIZE-1)/SECTORSIZE)
 #  define BINDIR       "/mnt/romfs"
 
-#  ifndef CONFIG_EXAMPLES_SOTEST_DEVMINOR
-#    define CONFIG_EXAMPLES_SOTEST_DEVMINOR 0
+#  ifndef CONFIG_EXAMPLES_SOTEST_DEVMINOR_MAX
+#    define CONFIG_EXAMPLES_SOTEST_DEVMINOR_MAX 5
 #  endif
 #else
 #  define BINDIR       CONFIG_EXAMPLES_SOTEST_BINDIR
@@ -125,26 +125,33 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_EXAMPLES_SOTEST_BUILTINFS
   /* Create a ROM disk for the ROMFS filesystem */
 
-  desc.minor    = CONFIG_EXAMPLES_SOTEST_DEVMINOR;     /* Minor device number of the ROM disk. */
+  desc.minor    = 0;                                   /* Minor device number of the ROM disk. */
   desc.nsectors = NSECTORS(romfs_img_len);             /* The number of sectors in the ROM disk */
   desc.sectsize = SECTORSIZE;                          /* The size of one sector in bytes */
   desc.image    = (FAR uint8_t *)romfs_img;            /* File system image */
 
-  printf("main: Registering romdisk at /dev/ram%d\n",
-         CONFIG_EXAMPLES_SOTEST_DEVMINOR);
-
-  ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
-
-  if (ret < 0)
+  for (; desc.minor <= CONFIG_EXAMPLES_SOTEST_DEVMINOR_MAX; desc.minor++)
     {
-      fprintf(stderr, "ERROR: romdisk_register failed: %s\n",
-              strerror(errno));
-      exit(EXIT_FAILURE);
+      printf("main: Registering romdisk at /dev/ram%d\n", desc.minor);
+
+      ret = boardctl(BOARDIOC_ROMDISK, (uintptr_t)&desc);
+      if (ret >= 0)
+        {
+          break;
+        }
+
+      if (errno != EEXIST ||
+          desc.minor == CONFIG_EXAMPLES_SOTEST_DEVMINOR_MAX)
+        {
+          fprintf(stderr, "ERROR: romdisk_register failed: %s\n",
+                  strerror(errno));
+          exit(EXIT_FAILURE);
+        }
     }
 
   /* Mount the file system */
 
-  sprintf(devname, SOTEST_DEVPATH_FMT, CONFIG_EXAMPLES_SOTEST_DEVMINOR);
+  sprintf(devname, SOTEST_DEVPATH_FMT, desc.minor);
   printf("main: Mounting ROMFS filesystem at target=%s with source=%s\n",
          BINDIR, devname);
 


### PR DESCRIPTION
## Summary
For case that /dev/ram${EXAMPLES_SOTEST_DEVMINOR} (e.g. "/dev/ram0") already exists, and users may not care which device to use.
e.g. Try from "/dev/ram0" to "/dev/ram${EXAMPLES_SOTEST_DEVMINOR_MAX} ("/dev/ram5" by default)"

## Impact
examples/sotest

## Testing
- Configuration
```
./tools/configure.sh -l sim:sotest
```
- Runtime
"/dev/ram0", "/dev/ram1" and "/dev/ram2" are already exist, using "/dev/ram3".
```
nsh> sotest
main: Registering romdisk at /dev/ram0
main: Registering romdisk at /dev/ram1
main: Registering romdisk at /dev/ram2
main: Registering romdisk at /dev/ram3
main: Mounting ROMFS filesystem at target=/mnt/romfs with source=/dev/ram3
module_initialize:
module_initialize:
testfunc1: Hello, everyone!
   caller: Hello to you too!
testfunc2: Hope you are having a great day!
   caller: Not so bad so far.
testfunc3: Let's talk again very soon
   caller: Yes, don't be a stranger!
module_uninitialize: arg=0
module_uninitialize: arg=0
nsh>
```

