### PR TITLE
nshlib: Support "-f" option for command "rm"

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -505,7 +505,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifdef NSH_HAVE_DIROPTS
 #  ifndef CONFIG_NSH_DISABLE_RM
-  CMD_MAP("rm",       cmd_rm,       2, 3, "[-r] <file-path>"),
+  CMD_MAP("rm",       cmd_rm,       2, 3, "[-rf] <file-path>"),
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary
In below two cases "rm" command with "-f" option will return 0:
1. Bad arguments
2. File not exists

Follow "rm" of GNU coreutils 8.32

## Impact
nshlib/nsh_command - "rm"

## Testing
Configuration
```
./tools/configure.sh -l sim:sotest
```
### GNU coreutils
```
$ rm --version
rm (GNU coreutils) 8.32
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Paul Rubin, David MacKenzie, Richard M. Stallman,
and Jim Meyering.

$ rm /FILE_NOT_EXISTS
rm: cannot remove '/FILE_NOT_EXISTS': No such file or directory
$ echo $?
1

$ rm -f
$ echo $?
0

$ rm -f /FILE_NOT_EXISTS
$ echo $?
0
```
### Without this patch
```
nsh> rm
nsh: rm: missing required argument(s)

nsh> rm /FILE_NOT_EXISTS
nsh: rm: unlink failed: 2
nsh> echo $?
1
```
### With this patch
```
nsh> rm -f
nsh> echo $?
0

nsh> rm -f /FILE_NOT_EXISTS
nsh> echo $?
0
```



