### PR TITLE
New features for tools/mksymtab.sh

### DIFF
--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -53,7 +53,9 @@ if [ -z "$varlist" ]; then
 
 # Remove the intersection between them, and the remaining symbols are found in the main image
     common=`echo "$varlist" | tr ' ' '\n' | grep -Fxf <(echo "$deflist" | tr ' ' '\n') | tr '\n' ' '`
-    varlist=`echo $varlist | sed "s/$common//g"`
+    if [ "x$common" != "x" ]; then
+      varlist=`echo $varlist | sed "s/$common//g"`
+    fi
   fi
 fi
 

--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -21,7 +21,7 @@
 
 export LC_ALL=C
 
-usage="Usage: $0 <imagedirpath> [symtabprefix]"
+usage="Usage: $0 <imagedirpath> [symtabprefix [additionalsymbolspath]]"
 
 # Check for the required directory path
 
@@ -36,6 +36,7 @@ fi
 # Get the symbol table prefix
 
 prefix=$2
+add_sym=$3
 
 # Extract all of the undefined symbols from the ELF files and create a
 # list of sorted, unique undefined variable names.
@@ -57,6 +58,18 @@ if [ -z "$varlist" ]; then
       varlist=`echo $varlist | sed "s/$common//g"`
     fi
   fi
+fi
+
+if [ "x$add_sym" != "x" ]; then
+  if [ -f $add_sym ]; then
+    varlist="${varlist}\n$(cat $add_sym)"
+  elif [ -d $add_sym ]; then
+    varlist="${varlist}\n$(find $add_sym -type f | xargs cat)"
+  else
+    echo $usage
+    exit 1
+  fi
+  varlist=$(echo -e "${varlist}" | sort -u)
 fi
 
 # Now output the symbol table as a structure in a C source file.  All

--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -62,9 +62,9 @@ fi
 
 if [ "x$add_sym" != "x" ]; then
   if [ -f $add_sym ]; then
-    varlist="${varlist}\n$(cat $add_sym)"
+    varlist="${varlist}\n$(cat $add_sym | grep -v "^,.*")"
   elif [ -d $add_sym ]; then
-    varlist="${varlist}\n$(find $add_sym -type f | xargs cat)"
+    varlist="${varlist}\n$(find $add_sym -type f | xargs cat | grep -v "^,.*")"
   else
     echo $usage
     exit 1
@@ -83,7 +83,7 @@ echo ""
 
 for string in $varlist; do
   var=`echo $string | sed -e "s/\"//g"`
-  echo "extern void *${var};"
+  echo "extern void *${var/,*/};"
 done
 
 echo ""
@@ -102,7 +102,7 @@ echo "{"
 
 for string in $varlist; do
   var=`echo $string | sed -e "s/\"//g"`
-  echo "  {\"${var}\", &${var}},"
+  echo "  {\"${var/*,/}\", &${var/,*/}},"
 done
 
 echo "};"

--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -44,7 +44,16 @@ varlist=`find $dir -name *-thunk.S 2>/dev/null | xargs grep -h asciz | cut -f3 |
 if [ -z "$varlist" ]; then
   execlist=`find $dir -type f 2>/dev/null`
   if [ ! -z "$execlist" ]; then
+
+# Get all undefined symbol names
     varlist=`nm $execlist 2>/dev/null | fgrep ' U ' | sed -e "s/^[ ]*//g" | cut -d' ' -f2 | sort | uniq`
+
+# Get all defined symbol names
+    deflist=`nm $execlist 2>/dev/null | fgrep -v -e ' U ' -e ':' | sed -e "s/^[0-9a-z]* //g" | cut -d' ' -f2 | sort | uniq`
+
+# Remove the intersection between them, and the remaining symbols are found in the main image
+    common=`echo "$varlist" | tr ' ' '\n' | grep -Fxf <(echo "$deflist" | tr ' ' '\n') | tr '\n' ' '`
+    varlist=`echo $varlist | sed "s/$common//g"`
   fi
 fi
 


### PR DESCRIPTION
## Summary
-  Exclude symbols that dynamic modules in bin/ call each other. - be3a91e87d4b60a296ed372bf2293a55f0447dcf (by @anjiahao1 )
    - Bugfix: Add check for sed expression. - 1973f15aca063e555562be325a812f035f3ad96a
- Support adding additional symbols that are not in undefined list. - b4d995f916ede75f6a95d30d5389ecae6c8ec1a6
    - For apps to be built in the future, the required symbols may not be included in the symbol table, and you will need to rebuild the NuttX kernel to run it.
    - With this patch, you can add symbols may be used in the future manually to the symbol table.
    - Extended usage:  - e3844a1b43182e6fa6343f8f74bcc4da2e11cbaa
        - The lines start with "," make no effects(as comments)
        - Support symbol name overriding
    - See commit message for more details.

## Impact
Build scripts that using mksymtab.sh to generate symbol tables.

## Testing
- b4d995f916ede75f6a95d30d5389ecae6c8ec1a6
```
$ nm ./hello_world.o | grep " U "
		 U __aeabi_unwind_cpp_pr1
		 U chreGetTime
		 U chreGetVersion
		 U chreLog
		 U __stack_chk_fail
		 U __stack_chk_guard

$ cat additional.txt -n
	 1  test_symbol
	 2  test_symbol

$ /PATH/TO/APPS/tools/mksymtab.sh ./hello_world.o MY_PREFIX -a additional.txt
#include <nuttx/compiler.h>
#include <nuttx/symtab.h>

extern void *__aeabi_unwind_cpp_pr1;
extern void *__stack_chk_fail;
extern void *__stack_chk_guard;
extern void *chreGetTime;
extern void *chreGetVersion;
extern void *chreLog;
extern void *test_symbol;

const struct symtab_s MY_PREFIX_exports[] =
{
  {"__aeabi_unwind_cpp_pr1", &__aeabi_unwind_cpp_pr1},
  {"__stack_chk_fail", &__stack_chk_fail},
  {"__stack_chk_guard", &__stack_chk_guard},
  {"chreGetTime", &chreGetTime},
  {"chreGetVersion", &chreGetVersion},
  {"chreLog", &chreLog},
  {"test_symbol", &test_symbol},
};

const int MY_PREFIX_nexports = sizeof(MY_PREFIX_exports) / sizeof(struct symtab_s);
```

- e3844a1b43182e6fa6343f8f74bcc4da2e11cbaa
```
$ cat exports.txt | grep atan2
atan2Override,atan2

$ /PATH/TO/APPS/tools/mksymtab.sh FOO BAR exports.txt | grep atan2
extern void *atan2Override;
{"atan2", &atan2Override},
```