### PR TITLE
uORB/uORB: Using array to save path for sensor_reginfo_s

### DIFF
--- a/system/uorb/sensor/topics.c
+++ b/system/uorb/sensor/topics.c
@@ -170,5 +170,5 @@ FAR const struct orb_metadata *orb_get_meta(FAR const char *name)
       return NULL;
     }
 
-  return state.priv;
+  return (FAR const struct orb_metadata *)(uintptr_t)state.priv;
 }

--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -70,7 +70,7 @@ static int orb_advsub_open(FAR const struct orb_metadata *meta, int flags,
   if (fd < 0)
     {
       struct sensor_reginfo_s reginfo;
-      reginfo.path    = path;
+      strlcpy(reginfo.path, path, NAME_MAX);
       reginfo.esize   = meta->o_size;
       reginfo.nbuffer = queue_size;
       reginfo.persist = !!(flags & SENSOR_PERSIST);


### PR DESCRIPTION
## Summary
Fix build error
- Error Log
```
CC:  procfs/fs_procfsversion.c uORB/uORB.c: In function ‘orb_advsub_open’:
uORB/uORB.c:73:23: error: assignment to expression with array type
   73 |       reginfo.path    = path;
      |                       ^
sensor/topics.c: In function ‘orb_get_meta’:
sensor/topics.c:173:15: warning: returning ‘uint64_t’ {aka ‘long long unsigned int’} from a function with return type ‘const struct orb_metadata *’ makes pointer from integer without a cast [-Wint-conversion]
  173 |   return state.priv;
      |          ~~~~~^~~~~
```
- Related: https://github.com/apache/nuttx/pull/13531
## Impact
system/uorb

## Testing
```
./tools/configure.sh -l sim:rpproxy
```
