### PR TITLE
examples/gps: The extended sentence may not supported by minmea

### DIFF
--- a/examples/gps/gps_main.c
+++ b/examples/gps/gps_main.c
@@ -128,16 +128,7 @@ int main(int argc, FAR char *argv[])
             }
             break;
 
-          case MINMEA_INVALID:
-          case MINMEA_UNKNOWN:
-          case MINMEA_SENTENCE_GSA:
-          case MINMEA_SENTENCE_GLL:
-          case MINMEA_SENTENCE_GST:
-          case MINMEA_SENTENCE_GSV:
-          case MINMEA_SENTENCE_GBS:
-          case MINMEA_SENTENCE_VTG:
-          case MINMEA_SENTENCE_ZDA:
-          case MINMEA_SENTENCE_LOR_LSQ:
+          default:
             {
             }
             break;


### PR DESCRIPTION
## Summary
Vendor may add extended sentence may not handled in switch, error if -Werror=switch enabled.
And extended sentence should not added to general examples.
Log:
```
  gps_main.c: In function 'gps_main':
  gps_main.c:140:16: error: 'MINMEA_SENTENCE_LOR_LSQ' undeclared (first use in this function)
             case MINMEA_SENTENCE_LOR_LSQ:
  	        ^
  gps_main.c:140:16: note: each undeclared identifier is reported only once for each function it appears in
```
## Impact
The example "examples/gps"

## Testing
```
./tools/configure.sh -l lilygo_tbeam_lora_gps:gps
```
compilation ok, failed in link stage, need check CI result.
