### PR TITLE
nshlib: add support for pkill command

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -428,6 +428,11 @@ config NSH_DISABLE_KILL
 	bool "Disable kill"
 	default DEFAULT_SMALL
 
+config NSH_DISABLE_PKILL
+	bool "Disable pkill"
+	default DEFAULT_SMALL
+	depends on FS_PROCFS
+
 config NSH_DISABLE_LOSETUP
 	bool "Disable losetup"
 	default DEFAULT_SMALL

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1181,6 +1181,9 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #ifndef CONFIG_NSH_DISABLE_KILL
   int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
+  int cmd_pkill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
+#endif
 #ifndef CONFIG_NSH_DISABLE_SLEEP
   int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -310,6 +310,10 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("kill",     cmd_kill,     2, 3, "[-<signal>] <pid>"),
 #endif
 
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
+  CMD_MAP("pkill",     cmd_pkill,     2, 3, "[-<signal>] <name>"),
+#endif
+
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #  if defined(CONFIG_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSETUP)
   CMD_MAP("losetup",  cmd_losetup,  3, 6,


### PR DESCRIPTION
## Summary
This command looks through the currently running processes and kills the those that match the selection criteria. This way system can send signal to processes by name and without knowing the IDs. The implementation match the one of `kill` and `pidof`.

Example (kill application hello):
`	pkill -15 hello`

The command can be turned off by `NSH_DISABLE_PKILL` option and depends on `FS_PROCFS`.

## Impact
New command.
