### PR TITLE
testing/ramtest: Fix not updated CMake file

### DIFF
--- a/testing/ramtest/CMakeLists.txt
+++ b/testing/ramtest/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # ##############################################################################
 
-if(CONFIG_SYSTEM_RAMTEST)
+if(CONFIG_TESTING_RAMTEST)
   nuttx_add_application(
     NAME
     ${CONFIG_TESTING_RAMTEST_PROGNAME}


### PR DESCRIPTION
## Summary
This issue was preventing ramtest to be displayed into nsh (this is why all modifications need to be tested!! "should work" doesn't work).

This is was discovered by user @nonpawite

## Impact
Users will be able to use ramtest again
## Testing
sim
