### PR TITLE
uORB: Add formatted string ("o_format") parameters and remove callback log ("cb") printing.

### DIFF
--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -25,10 +25,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <stdio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#include <nuttx/streams.h>
 #include <uORB/uORB.h>
 
 /****************************************************************************
@@ -322,3 +322,33 @@ int orb_group_count(FAR const struct orb_metadata *meta)
 
   return instance;
 }
+
+#ifdef CONFIG_DEBUG_UORB
+int orb_sscanf(FAR const char *buf, FAR const char *format, FAR void *data)
+{
+  struct lib_meminstream_s meminstream;
+  int lastc;
+
+  lib_meminstream(&meminstream, buf, strlen(buf));
+  return lib_bscanf(&meminstream.common, &lastc, format, data);
+}
+
+void orb_info(FAR const char *format, FAR const char *name,
+              FAR const void *data)
+{
+  struct va_format vaf;
+
+  vaf.fmt = format;
+  vaf.va  = (va_list *)data;
+  uorbinfo_raw("%s(now:%" PRIu64 "):%pB", name, orb_absolute_time(), &vaf);
+}
+
+int orb_fprintf(FAR FILE *stream, FAR const char *format,
+                FAR const void *data)
+{
+  struct lib_stdoutstream_s stdoutstream;
+
+  lib_stdoutstream(&stdoutstream, stream);
+  return lib_bsprintf(&stdoutstream.common, format, data);
+}
+#endif

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -29,6 +29,7 @@
 
 #include <sys/time.h>
 #include <debug.h>
+#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <syslog.h>
@@ -37,16 +38,14 @@
  * Public Types
  ****************************************************************************/
 
-struct orb_metadata;
-typedef void (*orb_print_message)(FAR const struct orb_metadata *meta,
-                                  FAR const void *buffer);
-
 struct orb_metadata
 {
   FAR const char   *o_name;     /* Unique object name */
   uint16_t          o_size;     /* Object size */
 #ifdef CONFIG_DEBUG_UORB
-  orb_print_message o_cb;       /* Function pointer of output topic message */
+  FAR const char   *o_format;   /* Format string used for structure input and
+                                 * output.
+                                 */
 #endif
 };
 
@@ -146,15 +145,15 @@ typedef uint64_t orb_abstime;
  * cb      The function pointer of output topic message.
  */
 #ifdef CONFIG_DEBUG_UORB
-#define ORB_DEFINE(name, structure, cb) \
+#define ORB_DEFINE(name, structure, format) \
   const struct orb_metadata g_orb_##name = \
   { \
     #name, \
     sizeof(structure), \
-    cb, \
+    format, \
   };
 #else
-#define ORB_DEFINE(name, structure, cb) \
+#define ORB_DEFINE(name, structure, format) \
   const struct orb_metadata g_orb_##name = \
   { \
     #name, \
@@ -719,6 +718,61 @@ int orb_group_count(FAR const struct orb_metadata *meta);
  ****************************************************************************/
 
 FAR const struct orb_metadata *orb_get_meta(FAR const char *name);
+
+#ifdef CONFIG_DEBUG_UORB
+/****************************************************************************
+ * Name: orb_scanf
+ *
+ * Description:
+ *   Convert string value to structure buffer.
+ *
+ * Input Parameters:
+ *   buf    Input string value.
+ *   format The uORB metadata.o_format.
+ *   data   Structure buffer pointer.
+ *
+ * Returned Value:
+ *   Zero (OK) or positive on success; a negated errno value on failure.
+ ****************************************************************************/
+
+int orb_sscanf(FAR const char *buf, FAR const char *format, FAR void *data);
+
+/****************************************************************************
+ * Name: orb_info
+ *
+ * Description:
+ *   Print sensor data.
+ *
+ * Input Parameters:
+ *   format The uORB metadata.o_format.
+ *   name   The uORB metadata.o_name.
+ *   data   Topic data that needs to be print.
+ *
+ * Returned Value:
+ *   Format string length on success, otherwise returns negative value.
+ ****************************************************************************/
+
+void orb_info(FAR const char *format, FAR const char *name,
+              FAR const void *data);
+
+/****************************************************************************
+ * Name: orb_fprintf
+ *
+ * Description:
+ *   Print sensor data to file.
+ *
+ * Input Parameters:
+ *   stream  file handle.
+ *   format  The uORB metadata.o_format.
+ *   data    Topic data that needs to be print.
+ *
+ * Returned Value:
+ *   String length on success, otherwise returns negative value.
+ ****************************************************************************/
+
+int orb_fprintf(FAR FILE *stream, FAR const char *format,
+                FAR const void *data);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary

1. New feature: uorb output structure data is replaced by a string by a callback function. You can print the content of the structure by giving the structure description string.
2. uorb listener adapts the o_format parameter and adds data output to the file

- This function converts strings to structures and structures to strings. It is used to record and replay uorb data for easy development and debugging.

## Impact

1. uorb debug output

## Testing
PC:ubuntu 2004, X86, SIM, GCC 13.1
order:
`uorb_listener -n 10 sensor_accel_uncal`
output
`sensor_accel_uncal(now:81651200):timestamp:81650900,x:0.138864,y:0.634463,z:9.938332,temperature:29.029297`
