### PR TITLE
CI: Improvement to speed up compilation and reduce download errors.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
             else
-                ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
+                ./cibuild.sh -c -A -N -R -S testlist/${{matrix.boards}}.dat
             fi
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
The simple improvement is designed to speed up compilation and reduce download errors on github and local.

.github\workflows\build.yml:
Added -S option. Enable storaged to the nxtmpdir folder for third-party packages.

For now I added in the folder this package

ESP_HAL_3RDPARTY_URL = https://github.com/espressif/esp-hal-3rdparty.git

ARCH
arch/xtensa/src/esp32/Make.defs
arch/xtensa/src/esp32s2/Make.defs
arch/xtensa/src/esp32s3/Make.defs
arch/risc-v/src/common/espressif/Make.defs
arch/risc-v/src/esp32c3-legacy/Make.defs

but other packages can also be added.

## Impact
None
The simple improvement is designed to speed up compilation and reduce download errors on github and local.
## Testing
CI GITHUB
see https://github.com/apache/nuttx/pull/13301