### PR TITLE
kasantest.c: fix the size passed by mm_initialize is incorrect and add CMakeLists.txt

### DIFF
--- a/testing/kasantest/CMakeLists.txt
+++ b/testing/kasantest/CMakeLists.txt
@@ -19,7 +19,14 @@
 # ##############################################################################
 
 if(CONFIG_TESTING_KASAN)
-  set(CFLAGS -Wno-error -Wno-use-after-free -Wno-array-bounds
-             -Wno-free-nonheap-object -Wno-stringop-overflow "-O0")
+  set(CFLAGS
+      -Wno-error
+      -Wno-use-after-free
+      -Wno-array-bounds
+      -Wno-unused-value
+      -Wno-unused-variable
+      -Wno-free-nonheap-object
+      -Wno-stringop-overflow
+      "-O0")
   nuttx_add_application(NAME kasantest COMPILE_FLAGS ${CFLAGS} SRCS kasantest.c)
 endif()

--- a/testing/kasantest/CMakeLists.txt
+++ b/testing/kasantest/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/testing/kasantest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_KASAN)
+  set(CFLAGS -Wno-error -Wno-use-after-free -Wno-array-bounds
+             -Wno-free-nonheap-object -Wno-stringop-overflow "-O0")
+  nuttx_add_application(NAME kasantest COMPILE_FLAGS ${CFLAGS} SRCS kasantest.c)
+endif()

--- a/testing/kasantest/Makefile
+++ b/testing/kasantest/Makefile
@@ -27,9 +27,9 @@ PROGNAME  = kasantest
 PRIORITY  = $(CONFIG_TESTING_KASAN_PRIORITY)
 STACKSIZE = $(CONFIG_TESTING_KASAN_STACKSIZE)
 
-CFLAGS += -Wno-error -Wno-use-after-free
+CFLAGS += -Wno-error -Wno-use-after-free -Wno-stringop-overflow
 CFLAGS += -Wno-array-bounds -Wno-free-nonheap-object
-CFLAGS += -Wno-stringop-overflow
+CFLAGS += -Wno-unused-value -Wno-unused-variable
 CFLAGS += "-O0"
 
 include $(APPDIR)/Application.mk

--- a/testing/kasantest/kasantest.c
+++ b/testing/kasantest/kasantest.c
@@ -294,20 +294,20 @@ static bool test_algorithm_perf(FAR struct mm_heap_s *heap, size_t size)
 #ifdef CONFIG_MM_KASAN_GLOBAL
 static bool test_global_underflow(FAR struct mm_heap_s *heap, size_t size)
 {
-  memset(g_kasan_globals - 31, 0x12, sizeof(g_kasan_globals));
+  memset(g_kasan_globals - 1, 0x12, sizeof(g_kasan_globals));
   return false;
 }
 
 static bool test_global_overflow(FAR struct mm_heap_s *heap, size_t size)
 {
-  memset(g_kasan_globals, 0xef, sizeof(g_kasan_globals) + 31);
+  memset(g_kasan_globals + sizeof(g_kasan_globals), 0xef, 1);
   return false;
 }
 #endif
 
 static int run_test(FAR const testcase_t *test)
 {
-  size_t heap_size = sizeof(g_kasan_heap);
+  size_t heap_size = sizeof(g_kasan_heap) - sizeof(run_t);
   FAR char *argv[3];
   FAR run_t *run;
   int status;


### PR DESCRIPTION
## Summary
1. fix the size passed by mm_initialize is incorrect
2.  add CMakeLists.txt
## Impact
* `testing/kasantest`.
## Testing
No
