### PR TITLE
build.yml:  Workflow aligned with nuttx repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,13 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     strategy:
+      max-parallel: 12
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v-01, risc-v-02, sim-01, sim-02, xtensa-01, xtensa-02]
+        boards: [
+          arm-01, other, risc-v-01, sim-01, xtensa-01,
+          arm-02, risc-v-02, sim-02, xtensa-02,
+          arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13
+        ]
 
     steps:
       - name: Download Source Artifact
@@ -173,6 +178,7 @@ jobs:
     runs-on: macos-13
     needs: Fetch-Source
     strategy:
+      max-parallel: 2
       matrix:
         boards: [macos, sim-01, sim-02]
     steps:
@@ -220,6 +226,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         boards: [msys2]
 
@@ -276,7 +283,7 @@ jobs:
           git config --global --add safe.directory /github/workspace/sources/nuttx
           git config --global --add safe.directory /github/workspace/sources/apps
           cd sources/nuttx/tools/ci
-          ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -g -i -A -C -N -R -S testlist/${{matrix.boards}}.dat
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
This PR modifies NuttX CI and GitHub Actions, to comply with ASF Policy.

According to ASF Policy: We should run at most 15 Concurrent Jobs: https://infra.apache.org/github-actions-policy.html

build.yml: Limit the GitHub Runners
see @lupyuen PR https://github.com/apache/nuttx/pull/13412

added -N -S options 

-N Use CMake with Ninja as the backend.
PR https://github.com/apache/nuttx/pull/12721

-S Adds the nxtmpdir folder for storing third-party packages.
PR https://github.com/apache/nuttx/pull/13301

## Impact
none
## Testing
CI
It complies with ASF Policy: The GitHub Runners did not exceed 15 during the build.