### PR TITLE
examples/userfs: Add initial value for d_ino

### DIFF
--- a/examples/userfs/userfs_main.c
+++ b/examples/userfs/userfs_main.c
@@ -140,19 +140,19 @@ static char g_file3_data[UFSTEST_FILE3_MXSIZE] = "This is file 3";
 static struct ufstest_file_s g_rootdir[UFSTEST_NFILES] =
 {
     {
-      { DTYPE_FILE, "File1" },
+      { DTYPE_FILE, 0, "File1" },
       UFSTEST_INIT_FILE1_SIZE,
       UFSTEST_FILE1_MXSIZE,
       g_file1_data
     },
     {
-      { DTYPE_FILE, "File2" },
+      { DTYPE_FILE, 0, "File2" },
       UFSTEST_INIT_FILE2_SIZE,
       UFSTEST_FILE2_MXSIZE,
       g_file2_data
     },
     {
-      { DTYPE_FILE, "File3" },
+      { DTYPE_FILE, 0, "File3" },
       UFSTEST_INIT_FILE3_SIZE,
       UFSTEST_FILE3_MXSIZE,
       g_file3_data


### PR DESCRIPTION
## Summary

Currently implementations of dirent.h do not have a field for the inode number, but it is required by POSIX.

For better compatibility with POSIX based applications, it is should be added even if it is not actually implemented.

Refer to https://github.com/apache/nuttx/pull/13556, should be merged together.

## Impact

* `include/dirent.h`.
* `include/nuttx/fs/hostfs.h`.
* Makes implementation compatible with POSIX.

## Testing

CI
