### PR TITLE
enable SOCK_CLOEXEC explicit

### DIFF
--- a/examples/netloop/lo_listener.c
+++ b/examples/netloop/lo_listener.c
@@ -182,7 +182,7 @@ static inline bool net_connection(struct net_listener_s *nls)
       printf("lo_listener: Accepting new connection on sd=%d\n",
              nls->listensd);
 
-      sd = accept(nls->listensd, NULL, NULL);
+      sd = accept4(nls->listensd, NULL, NULL, SOCK_CLOEXEC);
       if (sd < 0)
         {
           printf("lo_listener: accept failed: %d\n", errno);

--- a/examples/nettest/nettest_server.c
+++ b/examples/nettest/nettest_server.c
@@ -145,7 +145,12 @@ void nettest_server(void)
 
   printf("server: Accepting connections on port %d\n",
          CONFIG_EXAMPLES_NETTEST_SERVER_PORTNO);
+#ifdef __APPLE__
   acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
+#else
+  acceptsd = accept4(listensd, (struct sockaddr *)&myaddr, &addrlen,
+                     SOCK_CLOEXEC);
+#endif
   if (acceptsd < 0)
     {
       printf("server: accept failure: %d\n", errno);

--- a/examples/poll/net_listener.c
+++ b/examples/poll/net_listener.c
@@ -182,7 +182,7 @@ static inline bool net_connection(struct net_listener_s *nls)
       printf("net_listener: Accepting new connection on sd=%d\n",
              nls->listensd);
 
-      sd = accept(nls->listensd, NULL, NULL);
+      sd = accept4(nls->listensd, NULL, NULL, SOCK_CLOEXEC);
       if (sd < 0)
         {
           printf("net_listener: accept failed: %d\n", errno);

--- a/examples/poll/net_reader.c
+++ b/examples/poll/net_reader.c
@@ -278,7 +278,8 @@ void *net_reader(pthread_addr_t pvarg)
       printf("net_reader: Accepting new connections on port %d\n",
              LISTENER_PORT);
       addrlen = sizeof(struct sockaddr_in);
-      acceptsd = accept(listensd, (struct sockaddr *)&addr, &addrlen);
+      acceptsd = accept4(listensd, (struct sockaddr *)&addr, &addrlen,
+                         SOCK_CLOEXEC);
       if (acceptsd < 0)
         {
           printf("net_reader: accept failure: %d\n", errno);

--- a/examples/rpmsgsocket/rpsock_server.c
+++ b/examples/rpmsgsocket/rpsock_server.c
@@ -238,7 +238,8 @@ static int rpsock_stream_server(int argc, char *argv[])
         }
 
       printf("server: try accept ...\n");
-      new = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
+      new = accept4(listensd, (struct sockaddr *)&myaddr, &addrlen,
+                    SOCK_CLOEXEC);
       if (new < 0)
           break;
 

--- a/examples/tcp_ipc_server/tcp_ipc_server_main.c
+++ b/examples/tcp_ipc_server/tcp_ipc_server_main.c
@@ -243,9 +243,9 @@ int main(int argc, char *argv[])
       /* Wait for a new client socket connection */
 
       addr_size = sizeof server_storage;
-      new_socket_client_fd = accept(socket_server_fd,
-                                    (struct sockaddr *)&server_storage,
-                                    &addr_size);
+      new_socket_client_fd = accept4(socket_server_fd,
+                                     (struct sockaddr *)&server_storage,
+                                     &addr_size, SOCK_CLOEXEC);
 
       if (new_socket_client_fd < 0)
         {

--- a/examples/tcpblaster/tcpblaster_server.c
+++ b/examples/tcpblaster/tcpblaster_server.c
@@ -153,7 +153,12 @@ void tcpblaster_server(void)
 
   printf("server: Accepting connections on port %d\n",
          CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
+#ifdef __APPLE__
   acceptsd = accept(listensd, (FAR struct sockaddr *)&myaddr, &addrlen);
+#else
+  acceptsd = accept4(listensd, (FAR struct sockaddr *)&myaddr, &addrlen,
+                     SOCK_CLOEXEC);
+#endif
   if (acceptsd < 0)
     {
       printf("server: accept failure: %d\n", errno);

--- a/examples/tcpecho/tcpecho_main.c
+++ b/examples/tcpecho/tcpecho_main.c
@@ -244,7 +244,8 @@ static int tcpecho_server(void)
           /* new client connection */
 
           clilen = sizeof(cliaddr);
-          connfd = accept(listenfd, (struct sockaddr *)&cliaddr, &clilen);
+          connfd = accept4(listenfd, (struct sockaddr *)&cliaddr, &clilen,
+                           SOCK_CLOEXEC);
 
           ninfo("new client: %s\n",
                 inet_ntoa_r(cliaddr.sin_addr, inetaddr, sizeof(inetaddr)));

--- a/examples/ustream/ustream_server.c
+++ b/examples/ustream/ustream_server.c
@@ -132,7 +132,8 @@ int main(int argc, char *argv[])
     }
 #endif
 
-  acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
+  acceptsd = accept4(listensd, (struct sockaddr *)&myaddr, &addrlen,
+                     SOCK_CLOEXEC);
   if (acceptsd < 0)
     {
       printf("server: accept failure: %d\n", errno);

--- a/examples/xmlrpc/xmlrpc_main.c
+++ b/examples/xmlrpc/xmlrpc_main.c
@@ -410,7 +410,8 @@ int main(int argc, FAR char *argv[])
   for (; ; )
     {
       clilen = sizeof(cliaddr);
-      connfd = accept(listenfd, (struct sockaddr *)&cliaddr, &clilen);
+      connfd = accept4(listenfd, (struct sockaddr *)&cliaddr, &clilen,
+                       SOCK_CLOEXEC);
       if (connfd <= 0)
         {
           break;

--- a/netutils/ftpc/ftpc_socket.c
+++ b/netutils/ftpc/ftpc_socket.c
@@ -260,7 +260,8 @@ int ftpc_sockaccept(FAR struct ftpc_socket_s *acceptor,
     }
 
   addrlen  = sizeof(addr);
-  sock->sd = accept(acceptor->sd, (struct sockaddr *)&addr, &addrlen);
+  sock->sd = accept4(acceptor->sd, (struct sockaddr *)&addr, &addrlen,
+                     SOCK_CLOEXEC);
   if (sock->sd == -1)
     {
       nerr("ERROR: accept() failed: %d\n", errno);

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -915,7 +915,7 @@ static int ftpd_accept(int sd, FAR void *addr, FAR socklen_t *addrlen,
 
   /* Accept the connection -- waiting if necessary */
 
-  acceptsd = accept(sd, (FAR struct sockaddr *)addr, addrlen);
+  acceptsd = accept4(sd, (FAR struct sockaddr *)addr, addrlen, SOCK_CLOEXEC);
   if (acceptsd < 0)
     {
       int errval = errno;

--- a/netutils/iperf/iperf.c
+++ b/netutils/iperf/iperf.c
@@ -520,7 +520,7 @@ static int iperf_tcp_server(FAR struct iperf_ctrl_t *ctrl,
     {
       /* TODO need to change to non-block mode */
 
-      sockfd = accept(listen_socket, remote_addr, &addrlen);
+      sockfd = accept4(listen_socket, remote_addr, &addrlen, SOCK_CLOEXEC);
       if (sockfd < 0)
         {
           iperf_show_socket_error_reason("tcp server listen", listen_socket);

--- a/netutils/netcat/netcat_main.c
+++ b/netutils/netcat/netcat_main.c
@@ -175,7 +175,8 @@ int netcat_server(int argc, char * argv[])
     }
 
   addrlen = sizeof(struct sockaddr_in);
-  if ((conn = accept(id, (struct sockaddr *)&client, &addrlen)) != -1)
+  if ((conn = accept4(id, (struct sockaddr *)&client, &addrlen,
+                      SOCK_CLOEXEC)) != -1)
     {
       result = do_io(conn, outfd,
                      preallocated_iobuf, CONFIG_NETUTILS_NETCAT_BUFSIZE);

--- a/netutils/netlib/netlib_server.c
+++ b/netutils/netlib/netlib_server.c
@@ -92,7 +92,8 @@ void netlib_server(uint16_t portno,
       /* Accept the next connection */
 
       addrlen = sizeof(struct sockaddr_in);
-      acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
+      acceptsd = accept4(listensd, (struct sockaddr *)&myaddr, &addrlen,
+                         SOCK_CLOEXEC);
       if (acceptsd < 0)
         {
           nerr("ERROR: accept failure: %d\n", errno);

--- a/netutils/telnetd/telnetd_daemon.c
+++ b/netutils/telnetd/telnetd_daemon.c
@@ -197,7 +197,7 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       ninfo("Accepting connections on port %d\n", ntohs(config->d_port));
 
       addrlen = sizeof(addr);
-      acceptsd = accept(listensd, &addr.generic, &addrlen);
+      acceptsd = accept4(listensd, &addr.generic, &addrlen, SOCK_CLOEXEC);
       if (acceptsd < 0)
         {
           /* Just continue if a signal was received */

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -2355,7 +2355,8 @@ int httpd_get_conn(httpd_server *hs, int listen_fd, httpd_conn *hc)
 
   ninfo("accept() new connection on listen_fd %d\n", listen_fd);
   sz = sizeof(sa);
-  hc->conn_fd = accept(listen_fd, (struct sockaddr *)&sa, &sz);
+  hc->conn_fd = accept4(listen_fd, (struct sockaddr *)&sa, &sz,
+                        SOCK_CLOEXEC);
   if (hc->conn_fd < 0)
     {
       if (errno == EWOULDBLOCK)

--- a/netutils/webserver/httpd.c
+++ b/netutils/webserver/httpd.c
@@ -768,7 +768,8 @@ static void single_server(uint16_t portno, pthread_startroutine_t handler,
   for (; ; )
     {
       addrlen = sizeof(struct sockaddr_in);
-      acceptsd = accept(listensd, (FAR struct sockaddr *)&myaddr, &addrlen);
+      acceptsd = accept4(listensd, (FAR struct sockaddr *)&myaddr, &addrlen,
+                         SOCK_CLOEXEC);
 
       if (acceptsd < 0)
         {

--- a/system/gdbstub/gdbstub.c
+++ b/system/gdbstub/gdbstub.c
@@ -188,7 +188,7 @@ int main(int argc, FAR char *argv[])
         }
 
 reconnect:
-      if (((fd = accept(sock, NULL, NULL)) < 0))
+      if (((fd = accept4(sock, NULL, NULL, SOCK_CLOEXEC)) < 0))
         {
           fprintf(stderr, "ERROR: Failed to accept socket: %d\n", errno);
           return -errno;

--- a/system/telnet/telnet_chatd.c
+++ b/system/telnet/telnet_chatd.c
@@ -118,15 +118,15 @@ static void cleanup_exit(void)
           close(g_users[i].sock);
           free(g_users[i].name);
           telnet_free(g_users[i].telnet);
-      }
+        }
     }
 
   exit(1);
 }
 
 static void linebuffer_push(char *buffer, size_t size, int *linepos,
-                            char ch, void (*cb) (const char *line, int overflow,
-                                                 void *ud), void *ud)
+                            char ch, void (*cb) (const char *line,
+                            int overflow, void *ud), void *ud)
 {
   /* CRLF -- line terminator */
 
@@ -272,7 +272,8 @@ static void _online(const char *line, int overflow, void *ud)
   _message(user->name, line);
 }
 
-static void _input(struct user_s *user, const char *buffer, unsigned int size)
+static void _input(struct user_s *user, const char *buffer,
+                   unsigned int size)
 {
   unsigned int i;
 
@@ -329,6 +330,7 @@ static void _event_handler(struct telnet_s *telnet,
       break;
 
     default:
+
       /* Ignore */
 
       break;
@@ -383,7 +385,8 @@ int main(int argc, FAR char *argv[])
   /* Reuse address option */
 
   ret = 1;
-  setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, (void *)&ret, sizeof(ret));
+  setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, (void *)&ret,
+             sizeof(ret));
 
   /* Bind to listening addr/port */
 
@@ -414,7 +417,7 @@ int main(int argc, FAR char *argv[])
 
   /* Loop for ever */
 
-  for (;;)
+  for (; ; )
     {
       /* Prepare for poll */
 
@@ -448,8 +451,8 @@ int main(int argc, FAR char *argv[])
           /* Accept the sock */
 
           addrlen = sizeof(addr);
-          if ((ret = accept(listen_sock, (struct sockaddr *)&addr,
-                           &addrlen)) == -1)
+          if ((ret = accept4(listen_sock, (struct sockaddr *)&addr,
+                             &addrlen, SOCK_CLOEXEC)) == -1)
             {
               fprintf(stderr, "accept() failed: %d\n", errno);
               cleanup_exit();
@@ -477,12 +480,14 @@ int main(int argc, FAR char *argv[])
           /* Init, welcome */
 
           g_users[i].sock = ret;
-          g_users[i].telnet = telnet_init(g_telopts, _event_handler, 0, &g_users[i]);
+          g_users[i].telnet = telnet_init(g_telopts, _event_handler, 0,
+                                          &g_users[i]);
           telnet_negotiate(g_users[i].telnet, TELNET_WILL,
                            TELNET_TELOPT_COMPRESS2);
           telnet_printf(g_users[i].telnet, "Enter name: ");
 
-          telnet_negotiate(g_users[i].telnet, TELNET_WILL, TELNET_TELOPT_ECHO);
+          telnet_negotiate(g_users[i].telnet, TELNET_WILL,
+                           TELNET_TELOPT_ECHO);
         }
 
       /* Read from client */
@@ -498,7 +503,8 @@ int main(int argc, FAR char *argv[])
 
           if (pfd[i].revents & (POLLIN | POLLERR | POLLHUP))
             {
-              if ((ret = recv(g_users[i].sock, buffer, sizeof(buffer), 0)) > 0)
+              if ((ret =
+                       recv(g_users[i].sock, buffer, sizeof(buffer), 0)) > 0)
                 {
                   telnet_recv(g_users[i].telnet, buffer, ret);
                 }


### PR DESCRIPTION
## Summary
 leaking here means fork/vfork will duplicate fd without O_CLOEXEC flag to the child process.
## Impact
 net apps and utils
## Testing
please ignore mixed case warning:
```
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/netutils/thttpd/libhttpd.c:1857:2: error: Mixed case identifier found
Error: Process completed with exit code 1.
```