### PR TITLE
nshlib: enable O_CLOEXEC explicit to avoid potential fd leak

### DIFF
--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -119,7 +119,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
 
       /* Open the file containing the script */
 
-      vtbl->np.np_fd = open(fullpath, O_RDOK);
+      vtbl->np.np_fd = open(fullpath, O_RDOK | O_CLOEXEC);
       if (vtbl->np.np_fd < 0)
         {
           if (log)

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -598,7 +598,7 @@ static int cmd_rpmsg_once(FAR struct nsh_vtbl_s *vtbl,
       return ERROR;
     }
 
-  fd = open(path, 0);
+  fd = open(path, O_CLOEXEC);
   if (fd < 0)
     {
       nsh_output(vtbl, g_fmtarginvalid, path);


### PR DESCRIPTION

## Summary
 leaking here means fork/vfork will duplicate fd without O_CLOEXEC flag to the child process.
## Impact
 nshlib
## Testing
 ci test
