### PR TITLE
uorb: enable O_CLOEXEC explicit

### DIFF
--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -75,7 +75,7 @@ static int orb_advsub_open(FAR const struct orb_metadata *meta, int flags,
       reginfo.nbuffer = queue_size;
       reginfo.persist = !!(flags & SENSOR_PERSIST);
 
-      fd = open(ORB_USENSOR_PATH, O_WRONLY);
+      fd = open(ORB_USENSOR_PATH, O_WRONLY | O_CLOEXEC);
       if (fd < 0)
         {
           return fd;


### PR DESCRIPTION


## Summary
 to avoid potential fd leak which means fork/vfork will duplicate fd without O_CLOEXEC flag to the child process.
## Impact
 uorb
## Testing
 
