### PR TITLE
github/workflows: add PR size labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Assign labels based on the PR's size
+        uses: codelytv/pr-size-labeler@v1.10.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ignore_file_deletions: true
+          xs_label: 'Size: XS'
+          s_label: 'Size: S'
+          m_label: 'Size: M'
+          l_label: 'Size: L'
+          xl_label: 'Size: XL'


### PR DESCRIPTION
## Summary
Add workflow that assigns labels based on the PR's size.
The same as on kernel side: https://github.com/apache/nuttx/pull/13542

change from https://github.com/apache/nuttx/pull/13558 is not yet ported, because the apps repo requires different labels.

## Impact
Each PR will have a label assigned depending on its size:
xs_label: 'Size: XS', max size = 10
s_label: 'Size: S', max size = 100
m_label: 'Size: M', max size = 500
l_label: 'Size: L', max size = 1000
xl_label: 'Size: XL', > 1000


## Testing
not tested, should work the same as on NuttX repo
