### PR TITLE
Adapt %p* newly added LIBC_PRINT_EXTENSION kconfig configuration

### DIFF
--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -115,6 +115,7 @@ config ADBD_USB_SERVER
 
 config ADBD_LOGCAT_SERVICE
 	bool "ADB logcat support"
+	select LIBC_PRINT_EXTENSION
 	depends on RAMLOG_SYSLOG
 	default n
 	---help---

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -36,6 +36,7 @@ endif # UORB_TESTS
 
 config DEBUG_UORB
 	bool "uorb debug output"
+	select LIBC_PRINT_EXTENSION
 	default n
 
 if DEBUG_UORB

--- a/testing/monkey/Kconfig
+++ b/testing/monkey/Kconfig
@@ -7,6 +7,7 @@ menuconfig TESTING_MONKEY
 	tristate "Monkey test"
 	select UINPUT_TOUCH
 	select UINPUT_BUTTONS
+	select LIBC_PRINT_EXTENSION
 	default n
 
 if TESTING_MONKEY


### PR DESCRIPTION
## Summary
Adapt %p* newly added LIBC_PRINT_EXTENSION kconfig configuration(https://github.com/apache/nuttx/pull/13536)
## Impact
N/A
## Testing
PC:ubuntu 2004, X86, SIM, GCC 13.1
 build：./tools/configure.sh sim:nsh

./nuttx

