### PR TITLE
uorb:Added urob loop function module and supported epoll.

### DIFF
--- a/system/uorb/CMakeLists.txt
+++ b/system/uorb/CMakeLists.txt
@@ -27,8 +27,7 @@ if(CONFIG_UORB)
 
   nuttx_add_library(uorb STATIC)
 
-  file(GLOB_RECURSE CSRCS "sensor/*.c")
-  list(APPEND CSRCS uORB/uORB.c)
+  file(GLOB_RECURSE CSRCS "sensor/*.c" "uORB/*.c")
 
   if(CONFIG_UORB_LISTENER)
     nuttx_add_application(

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -26,6 +26,10 @@ config UORB_TESTS
 	bool "uorb unit tests"
 	default n
 
+config UORB_LOOP_MAX_EVENTS
+	int "uorb loop max events"
+	default 16
+
 if UORB_TESTS
 
 config UORB_SRORAGE_DIR

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -20,7 +20,7 @@
 
 include $(APPDIR)/Make.defs
 
-CSRCS    += uORB/uORB.c
+CSRCS    += $(wildcard uORB/*.c)
 CSRCS    += $(wildcard sensor/*.c)
 
 ifneq ($(CONFIG_UORB_LISTENER),)

--- a/system/uorb/uORB/epoll.c
+++ b/system/uorb/uORB/epoll.c
@@ -1,0 +1,185 @@
+/****************************************************************************
+ * apps/system/uorb/uORB/epoll.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <unistd.h>
+#include <sys/epoll.h>
+
+#include "internal.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int orb_loop_epoll_init(FAR struct orb_loop_s *loop);
+static int orb_loop_epoll_run(FAR struct orb_loop_s *loop);
+static int orb_loop_epoll_uninit(FAR struct orb_loop_s *loop);
+static int orb_loop_epoll_enable(FAR struct orb_loop_s *loop,
+                                 FAR struct orb_handle_s *handle, bool en);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct orb_loop_ops_s g_orb_loop_epoll_ops =
+{
+  .init   = orb_loop_epoll_init,
+  .run    = orb_loop_epoll_run,
+  .uninit = orb_loop_epoll_uninit,
+  .enable = orb_loop_epoll_enable,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int orb_loop_epoll_init(FAR struct orb_loop_s *loop)
+{
+  loop->running = false;
+  loop->fd = epoll_create1(EPOLL_CLOEXEC);
+  if (loop->fd < 0)
+    {
+      return -errno;
+    }
+
+  return OK;
+}
+
+static int orb_loop_epoll_run(FAR struct orb_loop_s *loop)
+{
+  struct epoll_event et[CONFIG_UORB_LOOP_MAX_EVENTS];
+  FAR struct orb_handle_s *handle;
+  int nfds;
+  int i;
+
+  if (loop->running)
+    {
+      return -EBUSY;
+    }
+
+  loop->running = true;
+  while (loop->running)
+    {
+      nfds = epoll_wait(loop->fd, et, CONFIG_UORB_LOOP_MAX_EVENTS, -1);
+      if (nfds == -1 && errno != EINTR)
+        {
+          return -errno;
+        }
+
+      for (i = 0; i < nfds; i++)
+        {
+          handle = et[i].data.ptr;
+          if (handle == NULL)
+            {
+              continue;
+            }
+
+          if (et[i].events & EPOLLIN)
+            {
+              if (handle->datain_cb != NULL)
+                {
+                  handle->datain_cb(handle, handle->arg);
+                }
+              else
+                {
+                  uorberr("epoll wait data in error! fd:%d", handle->fd);
+                }
+            }
+          else if (et[i].events & EPOLLOUT)
+            {
+              if (handle->dataout_cb != NULL)
+                {
+                  handle->dataout_cb(handle, handle->arg);
+                }
+              else
+                {
+                  uorberr("epoll wait data out error! fd:%d", handle->fd);
+                }
+            }
+          else if (et[i].events & EPOLLPRI)
+            {
+              if (handle->eventpri_cb != NULL)
+                {
+                  handle->eventpri_cb(handle, handle->arg);
+                }
+              else
+                {
+                  uorberr("epoll wait events pri error! fd:%d", handle->fd);
+                }
+            }
+          else if (et[i].events & EPOLLERR)
+            {
+              if (handle->eventerr_cb != NULL)
+                {
+                  handle->eventerr_cb(handle, handle->arg);
+                }
+              else
+                {
+                  uorberr("epoll wait events error! fd:%d", handle->fd);
+                }
+            }
+        }
+    }
+
+  return OK;
+}
+
+static int orb_loop_epoll_uninit(FAR struct orb_loop_s *loop)
+{
+  int ret;
+
+  loop->running = false;
+  ret = close(loop->fd);
+  if (ret < 0)
+    {
+      return -errno;
+    }
+
+  return ret;
+}
+
+static int orb_loop_epoll_enable(FAR struct orb_loop_s *loop,
+                                 FAR struct orb_handle_s *handle, bool en)
+{
+  struct epoll_event ev;
+  int ret;
+
+  if (en)
+    {
+      ev.events   = handle->events;
+      ev.data.ptr = handle;
+      ret = epoll_ctl(loop->fd, EPOLL_CTL_ADD, handle->fd, &ev);
+    }
+  else
+    {
+      ret = epoll_ctl(loop->fd, EPOLL_CTL_DEL, handle->fd, NULL);
+    }
+
+  if (ret < 0)
+    {
+      return -errno;
+    }
+
+  return ret;
+}

--- a/system/uorb/uORB/internal.h
+++ b/system/uorb/uORB/internal.h
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/system/uorb/uORB/internal.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APP_SYSTEM_UORB_UORB_INTERNAL_H
+#define __APP_SYSTEM_UORB_UORB_INTERNAL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern const struct orb_loop_ops_s g_orb_loop_epoll_ops;
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct orb_loop_ops_s
+{
+  CODE int (*init)(FAR struct orb_loop_s *loop);
+  CODE int (*run)(FAR struct orb_loop_s *loop);
+  CODE int (*uninit)(FAR struct orb_loop_s *loop);
+  CODE int (*enable)(FAR struct orb_loop_s *loop,
+                     FAR struct orb_handle_s *handle, bool en);
+};
+
+#endif /* __APP_SYSTEM_UORB_UORB_INTERNAL_H */

--- a/system/uorb/uORB/loop.c
+++ b/system/uorb/uORB/loop.c
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * apps/system/uorb/uORB/loop.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+
+#include "internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int orb_loop_init(FAR struct orb_loop_s *loop, enum orb_loop_type_e type)
+{
+  int ret = -EINVAL;
+
+  if (loop == NULL)
+    {
+      return ret;
+    }
+
+  switch (type)
+    {
+      case ORB_EPOLL_TYPE:
+        loop->ops = &g_orb_loop_epoll_ops;
+        break;
+
+      default:
+        uorberr("loop register type error! type:%d", type);
+        return ret;
+    }
+
+  ret = loop->ops->init(loop);
+  if (ret < 0)
+    {
+      uorberr("loop init failed! ret:%d", ret);
+      loop->ops = NULL;
+    }
+
+  return ret;
+}
+
+int orb_loop_run(FAR struct orb_loop_s *loop)
+{
+  return loop->ops->run(loop);
+}
+
+int orb_loop_deinit(FAR struct orb_loop_s *loop)
+{
+  int ret;
+
+  ret = loop->ops->uninit(loop);
+  if (ret >= 0)
+    {
+      loop->ops = NULL;
+    }
+
+  return ret;
+}
+
+int orb_handle_init(FAR struct orb_handle_s *handle, int fd, int events,
+                    FAR void *arg, orb_datain_cb_t datain_cb,
+                    orb_dataout_cb_t dataout_cb, orb_eventpri_cb_t pri_cb,
+                    orb_eventerr_cb_t err_cb)
+{
+  if (fd < 0)
+    {
+      return -EINVAL;
+    }
+
+  handle->fd = fd;
+  handle->arg    = arg;
+  handle->events = events;
+  handle->eventpri_cb = pri_cb;
+  handle->eventerr_cb = err_cb;
+  handle->datain_cb   = datain_cb;
+  handle->dataout_cb  = dataout_cb;
+
+  return OK;
+}
+
+int orb_handle_start(FAR struct orb_loop_s *loop,
+                     FAR struct orb_handle_s *handle)
+{
+  return loop->ops->enable(loop, handle, true);
+}
+
+int orb_handle_stop(FAR struct orb_loop_s *loop,
+                    FAR struct orb_handle_s *handle)
+{
+  return loop->ops->enable(loop, handle, false);
+}


### PR DESCRIPTION
## Summary

1. Added urob loop function module and supported epoll.
```
struct orb_handle_s  g_handle;
struct orb_handle_s  g_handle1;
struct orb_loop_s    g_loop;
int count = 0;

void *test_loop(void *arg)
{
  struct orb_loop_s *loop = arg;

  if ( loop == NULL)
    {
      return ((void *)0);
    }

  if(orb_loop_run(loop) < 0)
    {
      syslog(1, "&&&& THREAD  error!\n");
    }
  syslog(1, "&&&& THREAD  exit !\n");
  return ((void *)0);
}

int print_accel(FAR struct orb_handle_s *handle, FAR void *arg)
{
  int ret;
  struct sensor_accel accel;
  pthread_t id = pthread_self();

  ret = orb_copy(ORB_ID(sensor_accel), handle->fd, &accel);
  if (ret == OK)
    {
      syslog(1, "data [%d] -> fd:%d, x:%f, y:%f, z:%f handle:%p, threadid:%d",
             (int)arg, handle->fd, accel.x, accel.y, accel.z, handle, id);
    }
    count++;
  return OK;
}

int flush_accel(FAR struct orb_handle_s *handle, FAR void *arg)
{
  int ret;
  struct sensor_accel accel;
  pthread_t id = pthread_self();

  ret = orb_copy(ORB_ID(sensor_accel), handle->fd, &accel);
  if (ret == OK)
    {
      syslog(1, "flush [%d] -> fd:%d, x:%f, y:%f, z:%f handle:%p, threadid:%d",
             (int)arg, handle->fd, accel.x, accel.y, accel.z, handle, id);
    }
  return OK;
}

int state_accel(FAR struct orb_handle_s *handle, FAR void *arg)
{
  int ret;
  struct orb_state state;
  pthread_t id = pthread_self();

  ret =  orb_get_state(handle->fd, &state);
  if (ret == OK)
    {
      syslog(1, "/// state [%d] -> fd:%d, max:%u, min:%u, que:%u nsu:%u, " \
             "gen:%lu, handle:%p, threadid:%d",
             (int)arg, handle->fd, state.max_frequency, state.min_batch_interval,
             state.queue_size, state.nsubscribers, state.generation, handle, id);
    }
  return OK;
}

int start_loop(void)
{
  pthread_t ntid;
  int err;
  int fd_handle;
  int fd_handle1;

  fd_handle = orb_subscribe_multi(ORB_ID(sensor_accel), 0);

  err = orb_loop_init(&g_loop, ORB_EPOLL_TYPE);
  if (err < 0)
    {
      syslog(1, "init g_loop error! error:%d\n", err);
    }

  err = orb_handle_init(&g_handle, fd_handle, EPOLLIN,
                        (FAR void *)0, print_accel, flush_accel,
                        state_accel);
  if (err < 0)
    {
      syslog(1, "init g_handle error! error:%d\n", err);
    }
  
  err = orb_handle_start(&g_loop, &g_handle);
  if (err < 0)
    {
      syslog(1, "initg_ handle start error! error:%d\n", err);
    }

  err = pthread_create(&ntid, NULL, test_loop, &g_loop);
  if (err != 0)
    {
      syslog(1, "can't create thread\n");
    }

  usleep(100000);

  /* add handle 1; */

  fd_handle1 = orb_subscribe_multi(ORB_ID(sensor_accel), 1);

  err = orb_handle_init(&g_handle1, fd_handle1, EPOLLIN,
                        (FAR void *)1, print_accel, flush_accel,
                        state_accel);
  if (err < 0)
    {
      syslog(1, "init g_handle error! error:%d\n", err);
    }
  
  err = orb_handle_start(&g_loop, &g_handle1);
  if (err < 0)
    {
      syslog(1, "initg_ handle start error! error:%d\n", err);
    }

  usleep(500000);

  while (1)
  {
    if( count < 200)
      {
        usleep(50000);
        continue;
      }

    err = orb_loop_deinit(&g_loop);
    if (err < 0)
      {
        syslog(1, "deinit loop error! error:%d\n", err);
      }
    break;
  }

  orb_unsubscribe(fd_handle);

  syslog(1, "main thread exit\n");

}
```
## Impact
n/a

## Testing

- Environment:

OS and Version: Ubuntu 20.04.6 LTS x86_64
GCC Version: 13.1.0
SIM: ./tools/configure.sh sim:nsh

- Order:

./nuttx
