### PR TITLE
nshlib: Add missing newline in cmd_pidof output

### DIFF
--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -694,6 +694,8 @@ int cmd_pidof(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       nsh_output(vtbl, "%d ", pids[i]);
     }
 
+  nsh_output(vtbl, "\n");
+
   return OK;
 }
 #endif


### PR DESCRIPTION


## Summary
Add newline at the end of cmd_pidof to show nsh
prompt correctly.

Before this patch:
```
nsh> pidof wifi
3 nsh>
```

After:
```
nsh> pidof wifi
3
nsh>
```
## Impact
Minor
## Testing
Local
