### PR TITLE
ymodem:set the transport retry as optional

### DIFF
--- a/system/ymodem/rb_main.c
+++ b/system/ymodem/rb_main.c
@@ -331,6 +331,12 @@ static void show_usage(FAR const char *progname)
           "\t-t|--threshold <size>: Threshold for writing asynchronously."
           "Threshold must be less than or equal buffersize, Default: 0kB\n");
   fprintf(stderr,
+          "\t-i|--interval <time>: Waiting interval for transmitting data."
+          "Max:255 Min:1 Default:15 unit: 100 milliseconds\n");
+  fprintf(stderr,
+          "\t-r|--retry <retry>: Number of retries."
+          "Will try <retry> times to transmitting, Default:100\n");
+  fprintf(stderr,
           "\t-k <size>: Use a custom size to tansfer, Default: 1kB\n");
 
   exit(EXIT_FAILURE);
@@ -352,13 +358,17 @@ int main(int argc, FAR char *argv[])
       {"buffersize", 1, NULL, 'b'},
       {"skip_prefix", 1, NULL, 'p'},
       {"skip_suffix", 1, NULL, 's'},
-      {"threshold", 1, NULL, 't'}
+      {"threshold", 1, NULL, 't'},
+      {"interval", 1, NULL, 'i'},
+      {"retry", 1, NULL, 'r'},
     };
 
   memset(&priv, 0, sizeof(priv));
   memset(&ctx, 0, sizeof(ctx));
-  while ((ret = getopt_long(argc, argv, "b:d:f:hk:p:s:t:", options, NULL))
-         != ERROR)
+  ctx.interval = 15;
+  ctx.retry = 100;
+  while ((ret = getopt_long(argc, argv, "b:d:f:hk:p:s:t:i:r:",
+                            options, NULL)) != ERROR)
     {
       switch (ret)
         {
@@ -390,6 +400,12 @@ int main(int argc, FAR char *argv[])
             break;
           case 't':
             priv.threshold = atoi(optarg) * 1024;
+            break;
+          case 'i':
+            ctx.interval = atoi(optarg);
+            break;
+          case 'r':
+            ctx.retry = atoi(optarg);
             break;
 
           case '?':

--- a/system/ymodem/sb_main.c
+++ b/system/ymodem/sb_main.c
@@ -276,6 +276,12 @@ static void show_usage(FAR const char *progname)
           "\t-b|--buffersize <size>: Asynchronously send buffer size."
           "If greater than 0, accept data asynchronously, Default: 0kB\n");
   fprintf(stderr,
+          "\t-i|--interval <time>: Waiting interval for transmitting data."
+          "Max:255 Min:1 Default:15 unit: 100 milliseconds\n");
+  fprintf(stderr,
+          "\t-r|--retry <retry>: Number of retries."
+          "Will try <retry> times to transmitting, Default:100\n");
+  fprintf(stderr,
           "\t-k <size>: Use a custom size to tansfer, Default: 1kB\n");
 
   exit(EXIT_FAILURE);
@@ -294,10 +300,14 @@ int main(int argc, FAR char *argv[])
   struct option options[] =
     {
       {"buffersize", 1, NULL, 'b'},
+      {"interval", 1, NULL, 'i'},
+      {"retry", 1, NULL, 'r'},
     };
 
   memset(&priv, 0, sizeof(priv));
   memset(&ctx, 0, sizeof(ctx));
+  ctx.interval = 15;
+  ctx.retry = 100;
   while ((ret = getopt_long(argc, argv, "b:d:k:h", options, NULL))
          != ERROR)
     {
@@ -317,6 +327,13 @@ int main(int argc, FAR char *argv[])
               }
 
             break;
+          case 'i':
+            ctx.interval = atoi(optarg);
+            break;
+          case 'r':
+            ctx.retry = atoi(optarg);
+            break;
+
           case 'h':
           case '?':
           default:

--- a/system/ymodem/sbrb.py
+++ b/system/ymodem/sbrb.py
@@ -823,11 +823,12 @@ if __name__ == "__main__":
             tmp = fd_serial.read(len(("sb %s\r\n" % (recvfile)).encode()))
         else:
             if args.sendto:
-                fd_serial.write("rb\r\n".encode())
-                fd_serial.read(len("rb\r\n".encode()))
+                cmd = ("rb -f %s\r\n" % (args.sendto[0])).encode()
             else:
-                fd_serial.write(("rb\r\n").encode())
-                fd_serial.read(len(("rb\r\n").encode()))
+                cmd = ("rb\r\n").encode()
+
+            fd_serial.write(cmd)
+            fd_serial.read(len(cmd))
 
             fd_serial.reset_input_buffer()
         sbrb = ymodem(

--- a/system/ymodem/ymodem.c
+++ b/system/ymodem/ymodem.c
@@ -60,8 +60,6 @@
 #define CAN           0x18  /* Two of these in succession aborts transfer */
 #define CRC           0x43  /* 'C' == 0x43, request 16-bit CRC */
 
-#define MAX_RETRIES   100
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -216,7 +214,7 @@ recv_packet:
       /* other errors, like ETIMEDOUT, EILSEQ, EBADMSG... */
 
       tcflush(ctx->recvfd, TCIOFLUSH);
-      if (++retries > MAX_RETRIES)
+      if (++retries > ctx->retry)
         {
           ymodem_debug("recv_file: too many errors, cancel!!\n");
           goto cancel;
@@ -340,7 +338,7 @@ static int ymodem_send_file(FAR struct ymodem_ctx_s *ctx)
   int ret;
 
   ymodem_debug("waiting handshake\n");
-  for (retries = 0; retries < MAX_RETRIES; retries++)
+  for (retries = 0; retries < ctx->retry; retries++)
     {
       ret = ymodem_recv_cmd(ctx, CRC);
       if (ret >= 0)
@@ -349,7 +347,7 @@ static int ymodem_send_file(FAR struct ymodem_ctx_s *ctx)
         }
     }
 
-  if (retries >= MAX_RETRIES)
+  if (retries >= ctx->retry)
     {
       ymodem_debug("waiting handshake error\n");
       return -ETIMEDOUT;
@@ -581,7 +579,7 @@ int ymodem_recv(FAR struct ymodem_ctx_s *ctx)
   tcgetattr(ctx->recvfd, &term);
   memcpy(&saveterm, &term, sizeof(struct termios));
   cfmakeraw(&term);
-  term.c_cc[VTIME] = 15;
+  term.c_cc[VTIME] = ctx->interval;
   term.c_cc[VMIN] = 255;
   tcsetattr(ctx->recvfd, TCSANOW, &term);
 

--- a/system/ymodem/ymodem.h
+++ b/system/ymodem/ymodem.h
@@ -50,6 +50,8 @@ struct ymodem_ctx_s
   CODE int (*packet_handler)(FAR struct ymodem_ctx_s *ctx);
   size_t custom_size;
   FAR void *priv;
+  uint8_t interval;
+  int retry;
 
   /* Public data */
 


### PR DESCRIPTION
## Summary
The waiting duration of the rb/sb command can be determined based on the number of retransmissions, so that ymodem can restart to the normal system after running in the bootloader for a short period of time.

## Impact
ymodem
## Testing
use stm32 ymodem
