### PR TITLE
Update samples. move battery dump to system, fix problems report by coverity(unsigned compare with 0)

### DIFF
--- a/examples/gpio/gpio_main.c
+++ b/examples/gpio/gpio_main.c
@@ -67,6 +67,12 @@ static void show_usage(FAR const char *progname)
   fprintf(stderr, "\t 8: GPIO_INTERRUPT_RISING_PIN\n");
   fprintf(stderr, "\t 9: GPIO_INTERRUPT_FALLING_PIN\n");
   fprintf(stderr, "\t10: GPIO_INTERRUPT_BOTH_PIN\n");
+  fprintf(stderr, "\t11: GPIO_INTERRUPT_PIN_WAKEUP\n");
+  fprintf(stderr, "\t12: GPIO_INTERRUPT_HIGH_PIN_WAKEUP\n");
+  fprintf(stderr, "\t13: GPIO_INTERRUPT_LOW_PIN_WAKEUP\n");
+  fprintf(stderr, "\t14: GPIO_INTERRUPT_RISING_PIN_WAKEUP\n");
+  fprintf(stderr, "\t15: GPIO_INTERRUPT_FALLING_PIN_WAKEUP\n");
+  fprintf(stderr, "\t16: GPIO_INTERRUPT_BOTH_PIN_WAKEUP\n");
 }
 
 /****************************************************************************
@@ -308,6 +314,12 @@ int main(int argc, FAR char *argv[])
       case GPIO_INTERRUPT_RISING_PIN:
       case GPIO_INTERRUPT_FALLING_PIN:
       case GPIO_INTERRUPT_BOTH_PIN:
+      case GPIO_INTERRUPT_PIN_WAKEUP:
+      case GPIO_INTERRUPT_HIGH_PIN_WAKEUP:
+      case GPIO_INTERRUPT_LOW_PIN_WAKEUP:
+      case GPIO_INTERRUPT_RISING_PIN_WAKEUP:
+      case GPIO_INTERRUPT_FALLING_PIN_WAKEUP:
+      case GPIO_INTERRUPT_BOTH_PIN_WAKEUP:
         {
           printf("  Interrupt pin: Value=%u\n", invalue);
 

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -290,7 +290,7 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (argc == 4)
         {
           ctrl.domain = atoi(argv[3]);
-          if (ctrl.domain < 0 || ctrl.domain >= CONFIG_PM_NDOMAINS)
+          if (ctrl.domain >= CONFIG_PM_NDOMAINS)
             {
               nsh_error(vtbl, g_fmtargrange, argv[3]);
               return ERROR;

--- a/system/batterydump/Kconfig
+++ b/system/batterydump/Kconfig
@@ -3,26 +3,26 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 #
-config TESTING_BATTERYDUMP
-	tristate "Battery dump for test"
+config SYSTEM_BATTERYDUMP
+	tristate "Battery dump system tool"
 	default n
 	---help---
 		Enable the battery dump
 
-if TESTING_BATTERYDUMP
+if SYSTEM_BATTERYDUMP
 
-config TESTING_BATTERYDUMP_PROGNAME
+config SYSTEM_BATTERYDUMP_PROGNAME
 	string "Program name"
 	default "batterydump"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.
 
-config TESTING_BATTERYDUMP_PRIORITY
+config SYSTEM_BATTERYDUMP_PRIORITY
 	int "Battery dump task priority"
 	default 100
 
-config TESTING_BATTERYDUMP_STACKSIZE
+config SYSTEM_BATTERYDUMP_STACKSIZE
 	int "Battery dump stack size"
 	default DEFAULT_TASK_STACKSIZE
 

--- a/system/batterydump/Make.defs
+++ b/system/batterydump/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/testing/batterydump/Makefile
+# apps/system/batterydump/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,13 +18,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
-PROGNAME  = $(CONFIG_TESTING_BATTERYDUMP_PROGNAME)
-PRIORITY  = $(CONFIG_TESTING_BATTERYDUMP_PRIORITY)
-STACKSIZE = $(CONFIG_TESTING_BATTERYDUMP_STACKSIZE)
-MODULE    = $(CONFIG_TESTING_BATTERYDUMP)
-
-MAINSRC = batterydump.c
-
-include $(APPDIR)/Application.mk
+ifneq ($(CONFIG_SYSTEM_BATTERYDUMP),)
+CONFIGURED_APPS += $(APPDIR)/system/batterydump
+endif

--- a/system/batterydump/Makefile
+++ b/system/batterydump/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/testing/batterydump/Make.defs
+# apps/system/batterydump/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +18,13 @@
 #
 ############################################################################
 
-ifneq ($(CONFIG_TESTING_BATTERYDUMP),)
-CONFIGURED_APPS += $(APPDIR)/testing/batterydump
-endif
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_SYSTEM_BATTERYDUMP_PROGNAME)
+PRIORITY  = $(CONFIG_SYSTEM_BATTERYDUMP_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_BATTERYDUMP_STACKSIZE)
+MODULE    = $(CONFIG_SYSTEM_BATTERYDUMP)
+
+MAINSRC = batterydump.c
+
+include $(APPDIR)/Application.mk

--- a/system/batterydump/batterydump.c
+++ b/system/batterydump/batterydump.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/testing/batterydump/batterydump.c
+ * apps/system/batterydump/batterydump.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/testing/drivertest/drivertest_pm_runtime.c
+++ b/testing/drivertest/drivertest_pm_runtime.c
@@ -28,8 +28,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
 #include <string.h>
-#include <pthread.h>
 #include <cmocka.h>
 #include <nuttx/power/pm_runtime.h>
 

--- a/testing/drivertest/drivertest_regulator.c
+++ b/testing/drivertest/drivertest_regulator.c
@@ -28,8 +28,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
 #include <string.h>
-#include <pthread.h>
 #include <cmocka.h>
 #include <nuttx/power/consumer.h>
 

--- a/testing/drivertest/drivertest_regulator.c
+++ b/testing/drivertest/drivertest_regulator.c
@@ -446,10 +446,8 @@ static void test_regulator_supply_4(FAR void **state)
                                              &g_fake_regulator);
   assert_false(NULL == g_fake_regulator.rdev);
   test = regulator_get(REGULATOR_ID);
-  assert_false(NULL == test);
+  assert_true(NULL == test);
   g_fake_regulator_supply.state = 0;
-  ret = regulator_enable(test);
-  assert_true(ret < 0);
   g_fake_regulator_supply.rdev = regulator_register(
                                              &g_fake_regulator_supply_desc,
                                              &g_fake_regulator_ops,
@@ -457,7 +455,8 @@ static void test_regulator_supply_4(FAR void **state)
   assert_false(NULL == g_fake_regulator_supply.rdev);
   assert_int_equal(g_fake_regulator_supply.state, 0);
   assert_int_equal(g_fake_regulator.state, 0);
-
+  test = regulator_get(REGULATOR_ID);
+  assert_false(NULL == test);
   while (cnt--)
     {
       ret = regulator_enable(test);
@@ -499,6 +498,7 @@ static void test_regulator_mode(FAR void **state)
   int ret = 0;
 
   g_fake_regulator.lpmode = 0;
+  g_fake_regulator_desc.supply_name = NULL;
   g_fake_regulator.rdev = regulator_register(&g_fake_regulator_desc,
                                              &g_fake_regulator_ops,
                                              &g_fake_regulator);


### PR DESCRIPTION
## Summary
Add example for wakeup gpio type.
Update regulator samples.
move battery dump to system.
fix pmconfig command catched issue reported by coverity(unsigned compare with 0)

## Impact
more samples, 
batterydump now regard as a tool, not a test

## Testing
CI-test.
