### PR TITLE
greenhills support: fix green hills toolchain build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.a
+*.dbo
+*.dba
 *.adb
 *.asm
 *.dSYM

--- a/nshlib/nsh_alias.c
+++ b/nshlib/nsh_alias.c
@@ -392,7 +392,6 @@ int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR struct nsh_alias_s *alias;
   FAR char **arg;
-  int option;
   int ret = OK;
 
   /* Init, if necessary */
@@ -408,7 +407,7 @@ int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   /* If '-a' is provided, then just wipe them all */
 
-  if ((option = getopt(argc, argv, "a")) == 'a')
+  if (getopt(argc, argv, "a") == 'a')
     {
       alias_removeall(vtbl);
       return ret;

--- a/testing/ostest/semtimed.c
+++ b/testing/ostest/semtimed.c
@@ -77,7 +77,11 @@ static void ostest_gettime(struct timespec *tp)
       printf("ostest_gettime: ERROR: clock_gettime failed\n");
       ASSERT(false);
     }
+#ifdef CONFIG_SYSTEM_TIME64
   else if (tp->tv_sec < 0 || tp->tv_nsec < 0 ||
+#else
+  else if (tp->tv_nsec < 0 ||
+#endif
            tp->tv_nsec >= 1000 * 1000 * 1000)
     {
       printf("ostest_gettime: ERROR: clock_gettime returned bogus time\n");


### PR DESCRIPTION
## Summary
1. fix the variable set but never used warning
2. fix pointless comparison of unsigned integer with zero warning

## Impact
has no impact on current implementation

## Testing
1. has pass the ostest
2. has tested on gcc and ghs compiler

