### PR TITLE
coremark:Fix renaming issues with other libraries

### DIFF
--- a/benchmarks/coremark/Makefile
+++ b/benchmarks/coremark/Makefile
@@ -39,6 +39,7 @@ VPATH += $(COREMARK_UNPACKNAME)$(DELIM)posix
 DEPPATH += --dep-path $(COREMARK_UNPACKNAME)
 DEPPATH += --dep-path $(COREMARK_UNPACKNAME)$(DELIM)posix
 
+CFLAGS += -Dcrc16=coremark_crc16
 CFLAGS += -Wno-strict-prototypes -Wno-undef
 
 ifeq ($(CONFIG_COREMARK_MULTITHREAD_OVERRIDE),y)


### PR DESCRIPTION
## Summary
**Why is this change necessary?**
The crc16 naming implemented in coremark is duplicated in zblue.

**Changes**
The redefinition function is renamed inside the makefile
```
CFLAGS += -Dcrc16=coremark_crc16
```

## Impact

**Is a new feature added?:** NO
**Impact on build**: NO
**Impact on hardware**:NO, this change does not specifically target any particular hardware architectures or boards.
**Impact on documentation**: NO,This patch does not introduce any new features
**Impact on compatibility**: This implementation aims to be backward compatible. No existing functionality is expected to be broken.

## Testing

Build Host(s): Linux x86
Target(s): sim/nsh
coremark is OK
```
NuttShell (NSH) NuttX-12.3.0-vela
nsh> 
nsh> 
nsh> ls
/:
 bin/
 dev/
 etc/
 proc/
 tmp/
nsh> coremark
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 1395
Total time (secs): 13.950000
Iterations/Sec   : 7885.304659
Iterations       : 110000
Compiler version : GCC11.4.0
Compiler flags   : -g -fomit-frame-pointer
Memory location  : HEAP
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x33ff
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 7885.304659 / GCC11.4.0 -g -fomit-frame-pointer / HEAP
```