### PR TITLE
toolchain/ghs: Fix green hills toolchain build Vela warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.a
+*.dbo
+*.dba
 *.adb
 *.asm
 *.dSYM

--- a/nshlib/nsh_alias.c
+++ b/nshlib/nsh_alias.c
@@ -392,7 +392,6 @@ int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR struct nsh_alias_s *alias;
   FAR char **arg;
-  int option;
   int ret = OK;
 
   /* Init, if necessary */
@@ -408,7 +407,7 @@ int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   /* If '-a' is provided, then just wipe them all */
 
-  if ((option = getopt(argc, argv, "a")) == 'a')
+  if (getopt(argc, argv, "a") == 'a')
     {
       alias_removeall(vtbl);
       return ret;


### PR DESCRIPTION
## Summary
fix compiling warning in non-GNU compilers, variable never used.

Building C object apps/CMakeFiles/apps.dir/nshlib/nsh_alias.c.o
"apps/nshlib/nsh_alias.c", line 395: warning #550-D: variable "option" was set but never used
     int option;

## Impact
None

## Testing
Greenhills compilers build

