### PR TITLE
crypto/libsodium: fix libsodium compilation warning

### DIFF
--- a/crypto/libsodium/CMakeLists.txt
+++ b/crypto/libsodium/CMakeLists.txt
@@ -52,8 +52,14 @@ if(CONFIG_LIBSODIUM)
   # Flags
   # ############################################################################
 
-  set(CFLAGS -Wno-unused-function -Wno-undef -Wno-unused-variable
-             -Wno-deprecated-declarations -Wno-shadow)
+  set(CFLAGS
+      -DDEV_MODE
+      -DCONFIGURED=1
+      -Wno-unused-function
+      -Wno-undef
+      -Wno-unused-variable
+      -Wno-deprecated-declarations
+      -Wno-shadow)
 
   # ############################################################################
   # Sources

--- a/crypto/libsodium/Makefile
+++ b/crypto/libsodium/Makefile
@@ -33,6 +33,7 @@ LIBSODIUM_UNPACKTESTDIR = $(LIBSODIUM_UNPACKNAME)$(DELIM)test$(DELIM)default
 
 CSRCS += $(shell find $(LIBSODIUM_UNPACKLIBDIR) -name "*.c")
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/crypto/libsodium/libsodium/src/libsodium/include/sodium
+CFLAGS += -DDEV_MODE -DCONFIGURED=1
 CFLAGS += -Wno-unused-function -Wno-undef -Wno-unused-variable -Wno-deprecated-declarations \
           -Wno-shadow
 


### PR DESCRIPTION
## Summary
fix libsodium compilation warning with missing configuration
## Impact
N/A
## Testing
ci
