### PR TITLE
mbedtls/Kconfig: Fix mbedtls configuration dependency issue

### DIFF
--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -178,6 +178,7 @@ config MBEDTLS_X509_CSR_PARSE_C
 
 config MBEDTLS_X509_CRT_POOL
 	bool "Enable the X509 Certificate Pool"
+	depends on MBEDTLS_THREADING_C
 	default n
 
 config MBEDTLS_HAVE_ASM

--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -17,7 +17,7 @@ config MBEDTLS_VERSION
 
 config MBEDTLS_DEBUG_C
 	bool "This module provides debugging functions."
-	default DEBUG_FEATURES
+	default DEBUG_CRYPTO_INFO
 	---help---
 		This module provides debugging functions.
 


### PR DESCRIPTION
## Summary
1. change MBEDTLS_DEBUG_C dependence DEBUG_CRYPTO_INFO，because MBEDTLS_DEBUG_C is widely used
2. MBEDTLS_X509_CRT_POOL depends on MBEDTLS_THREADING_C.
## Impact
N/A
## Testing
ci
