### PR TITLE
tools/mksymtab.sh: Support multiple additional symbols` file

### DIFF
--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -36,7 +36,6 @@ fi
 # Get the symbol table prefix
 
 prefix=$2
-add_sym=$3
 
 # Extract all of the undefined symbols from the ELF files and create a
 # list of sorted, unique undefined variable names.
@@ -60,16 +59,19 @@ if [ -z "$varlist" ]; then
   fi
 fi
 
-if [ "x$add_sym" != "x" ]; then
-  if [ -f $add_sym ]; then
-    varlist="${varlist}\n$(cat $add_sym | grep -v "^,.*")"
-  elif [ -d $add_sym ]; then
-    varlist="${varlist}\n$(find $add_sym -type f | xargs cat | grep -v "^,.*")"
-  else
-    echo $usage
-    exit 1
-  fi
-  varlist=$(echo -e "${varlist}" | sort -u)
+if [ $# -gt 2 ]; then
+  shift 2
+  for add_sym in $@; do
+    if [ -f $add_sym ]; then
+      varlist="${varlist}\n$(cat $add_sym | grep -v "^,.*")"
+    elif [ -d $add_sym ]; then
+      varlist="${varlist}\n$(find $add_sym -type f | xargs cat | grep -v "^,.*")"
+    else
+      echo $usage
+      exit 1
+    fi
+    varlist=$(echo -e "${varlist}" | sort -u)
+  done
 fi
 
 # Now output the symbol table as a structure in a C source file.  All


### PR DESCRIPTION
## Summary
Add support for multiple additional symbols` file

## Impact
Makefiles calling mksymtab.sh, like apps/Makefile(selftest OK).
Forward compatible.

## Testing
1. Selftest
```
  $ cat basic.txt
  test_a
  test_b
  test_c

  $ cat math.txt
  acosf
  asinf
  atan2f
  ceilf
  cosf
  expf

  $ ./mksymtab.sh ./ g_TEST basic.txt
  #include <nuttx/compiler.h>
  #include <nuttx/symtab.h>

  extern void *test_a;
  extern void *test_b;
  extern void *test_c;

  const struct symtab_s g_TEST_exports[] =
  {
    {"test_a", &test_a},
    {"test_b", &test_b},
    {"test_c", &test_c},
  };

  const int g_TEST_nexports = sizeof(g_TEST_exports) / sizeof(struct symtab_s);

  $ ./mksymtab.sh ./ g_TEST basic.txt math.txt
  #include <nuttx/compiler.h>
  #include <nuttx/symtab.h>

  extern void *acosf;
  extern void *asinf;
  extern void *atan2f;
  extern void *ceilf;
  extern void *cosf;
  extern void *expf;
  extern void *test_a;
  extern void *test_b;
  extern void *test_c;

  const struct symtab_s g_TEST_exports[] =
  {
    {"acosf", &acosf},
    {"asinf", &asinf},
    {"atan2f", &atan2f},
    {"ceilf", &ceilf},
    {"cosf", &cosf},
    {"expf", &expf},
    {"test_a", &test_a},
    {"test_b", &test_b},
    {"test_c", &test_c},
  };

  const int g_TEST_nexports = sizeof(g_TEST_exports) / sizeof(struct symtab_s);
```

2. Github CI
