### PR TITLE
system/adb: fix build warning

### DIFF
--- a/system/adb/adb_banner.c
+++ b/system/adb/adb_banner.c
@@ -57,7 +57,8 @@ int adb_fill_connect_data(char *buf, size_t bufsize)
     {
       /* FIXME only keep first 4 bytes */
 
-      len = snprintf(buf, remaining, "device:%x:", *(uint32_t *)board_id);
+      len = snprintf(buf, remaining,
+                     "device:%" PRIx32 ":", *(uint32_t *)board_id);
     }
 #else
   len = snprintf(buf, remaining, "device:" CONFIG_ADBD_DEVICE_ID ":");


### PR DESCRIPTION
## Summary
adb_banner.c:60:47: error: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=], `PRIx32` is used in place of `%x`.
## Impact
system/adb/adb_banner 
## Testing
ci
