### PR TITLE
ostest: fix smp call test

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -139,7 +139,7 @@ if(CONFIG_TESTING_OSTEST)
     list(APPEND SRCS setjmp.c)
   endif()
 
-  if(CONFIG_SMP_CALL)
+  if(CONFIG_SMP)
     list(APPEND SRCS smp_call.c)
   endif()
 

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -134,7 +134,7 @@ ifeq ($(CONFIG_ARCH_SETJMP_H),y)
 CSRCS += setjmp.c
 endif
 
-ifeq ($(CONFIG_SMP_CALL),y)
+ifeq ($(CONFIG_SMP),y)
 CSRCS += smp_call.c
 endif
 

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -272,7 +272,7 @@ void setjmp_test(void);
 
 /* smp_call.c ***************************************************************/
 
-#ifdef CONFIG_SMP_CALL
+#ifdef CONFIG_SMP
 void smp_call_test(void);
 #endif
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -596,7 +596,7 @@ static int user_main(int argc, char *argv[])
       vfork_test();
 #endif
 
-#if defined(CONFIG_SMP_CALL) && defined(CONFIG_BUILD_FLAT)
+#if defined(CONFIG_SMP) && defined(CONFIG_BUILD_FLAT)
       printf("\nuser_main: smp call test\n");
       smp_call_test();
 #endif

--- a/testing/ostest/smp_call.c
+++ b/testing/ostest/smp_call.c
@@ -29,7 +29,7 @@
 
 #include <nuttx/sched.h>
 
-#if defined(CONFIG_SMP_CALL) && defined(CONFIG_BUILD_FLAT)
+#if defined(CONFIG_SMP) && defined(CONFIG_BUILD_FLAT)
 /****************************************************************************
  * Private Functions
  ****************************************************************************/


### PR DESCRIPTION

## Summary

Fix smp_call test not running.
CONFIG_SMP_CALL has been removed from https://github.com/apache/nuttx/pull/13282

## Impact

## Testing

ostest of qemu for arm64

```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -Bbuild -GNinja -DBOARD_CONFIG=boards/arm64/qemu/qemu-armv8a/configs/nsh_smp nuttx

 qemu-system-aarch64 -smp 4 -cpu cortex-a53 -semihosting -nographic -machine virt,virtualization=on,gic-version=3 -net none -chardev stdio,id=con,mux=on -serial chardev:con -mon chardev=con,mode=readline -kernel build/nuttx -s

```

