### PR TITLE
nshlib: support dd with conv=notrunc,nocreat

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -188,7 +188,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #ifndef CONFIG_NSH_DISABLE_DD
   CMD_MAP("dd",       cmd_dd,       3, 7,
     "if=<infile> of=<outfile> [bs=<sectsize>] [count=<sectors>] "
-    "[skip=<sectors>] [seek=<sectors>] [verify]"),
+    "[skip=<sectors>] [seek=<sectors>] [verify] [conv=<nocreat,notrunc>]"),
 #endif
 
 #if defined(CONFIG_NET) && defined(CONFIG_NET_ROUTE) && !defined(CONFIG_NSH_DISABLE_DELROUTE)


### PR DESCRIPTION


## Summary
nshlib: support dd with conv=notrunc,nocreat

refs to: https://man7.org/linux/man-pages/man1/dd.1.html
## Impact
support dd with new paramenter  conv=notrunc,nocreat
## Testing
Vela
