### PR TITLE
examples/mqttc_mbedtls: Add MQTT over TLS example

### DIFF
--- a/examples/mqttc_mbedtls/CMakeLists.txt
+++ b/examples/mqttc_mbedtls/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/mqttc_mbedtls/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MQTTC_MBEDTLS)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MQTTC_MBEDTLS_PROGNAME}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_MQTTC_MBEDTLS_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_MQTTC_MBEDTLS}
+    SRCS
+    mqttc_mbedtls_pub.c)
+endif()

--- a/examples/mqttc_mbedtls/Kconfig
+++ b/examples/mqttc_mbedtls/Kconfig
@@ -1,0 +1,31 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_MQTTC_MBEDTLS
+	tristate "Enable MQTT-C Example with MbedTLS support"
+	default n
+	depends on NETUTILS_MQTTC_WITH_MBEDTLS
+	---help---
+		Enable a MQTT-C publisher example with MbedTLS support
+
+if EXAMPLES_MQTTC_MBEDTLS
+
+config EXAMPLES_MQTTC_MBEDTLS_PROGNAME
+	string "Program name"
+	default "mqttc_mbedtls_pub"
+
+config EXAMPLES_MQTTC_MBEDTLS_STACKSIZE
+	int "Task's stack size"
+	default 8192
+
+config EXAMPLES_MQTTC_MBEDTLS_TXSIZE
+	int "TX Buffer size"
+	default 256
+
+config EXAMPLES_MQTTC_MBEDTLS_RXSIZE
+	int "RX Buffer size"
+	default 256
+
+endif

--- a/examples/mqttc_mbedtls/Make.defs
+++ b/examples/mqttc_mbedtls/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/mqttc_mbedtls/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_MQTTC_MBEDTLS),)
+CONFIGURED_APPS += $(APPDIR)/examples/mqttc_mbedtls
+endif

--- a/examples/mqttc_mbedtls/Makefile
+++ b/examples/mqttc_mbedtls/Makefile
@@ -1,0 +1,32 @@
+############################################################################
+# apps/examples/mqttc_mbedtls/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME = $(CONFIG_EXAMPLES_MQTTC_MBEDTLS_PROGNAME)
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_EXAMPLES_MQTTC_MBEDTLS_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_MQTTC_MBEDTLS)
+
+# MQTT-C MbedTLS example source code
+
+MAINSRC = mqttc_mbedtls_pub.c
+
+include $(APPDIR)/Application.mk

--- a/examples/mqttc_mbedtls/mbedtls_sockets.c
+++ b/examples/mqttc_mbedtls/mbedtls_sockets.c
@@ -1,0 +1,223 @@
+/****************************************************************************
+ * apps/examples/mqttc_mbedtls/mbedtls_sockets.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <mbedtls/error.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/ssl.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct mbedtls_context
+{
+  mbedtls_net_context net_ctx;
+  mbedtls_ssl_context ssl_ctx;
+  mbedtls_ssl_config ssl_conf;
+  mbedtls_x509_crt ca_crt;
+  mbedtls_entropy_context entropy;
+  mbedtls_ctr_drbg_context ctr_drbg;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void failed(const char *fn, int rv);
+static void cert_verify_failed(uint32_t rv);
+static void open_nb_socket(struct mbedtls_context *ctx,
+                           const char *hostname,
+                           const char *port,
+                           const char *ca_file);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: failed
+ *
+ * Description:
+ *   Facilitates error display for mbedtls functions
+ *
+ ****************************************************************************/
+
+static void failed(const char *fn, int rv)
+{
+  char buf[100];
+  mbedtls_strerror(rv, buf, sizeof(buf));
+  printf("%s failed with %x (%s)\n", fn, -rv, buf);
+  exit(1);
+}
+
+/****************************************************************************
+ * Name: cert_verify_failed
+ *
+ * Description:
+ *   Facilitates display of the reason why a certificate verification
+ *   failed
+ *
+ ****************************************************************************/
+
+static void cert_verify_failed(uint32_t rv)
+{
+  char buf[512];
+  mbedtls_x509_crt_verify_info(buf, sizeof(buf), "\t", rv);
+  printf("Certificate verification failed (%0" PRIx32 ")\n%s\n"
+          "Continuing without a valid certificate\n",
+          rv, buf);
+}
+
+/****************************************************************************
+ * Name: open_nb_socket
+ *
+ * Description:
+ *   Opens a non-blocking mbed TLS connection
+ *
+ ****************************************************************************/
+
+static void open_nb_socket(struct mbedtls_context *ctx,
+                           const char *hostname,
+                           const char *port,
+                           const char *ca_file)
+{
+  const unsigned char *additional = (const unsigned char *)"RANDOM";
+  size_t additional_len = 6;
+  int rv;
+
+  mbedtls_net_context *net_ctx = &ctx->net_ctx;
+  mbedtls_ssl_context *ssl_ctx = &ctx->ssl_ctx;
+  mbedtls_ssl_config *ssl_conf = &ctx->ssl_conf;
+  mbedtls_x509_crt *ca_crt = &ctx->ca_crt;
+  mbedtls_entropy_context *entropy = &ctx->entropy;
+  mbedtls_ctr_drbg_context *ctr_drbg = &ctx->ctr_drbg;
+
+  mbedtls_entropy_init(entropy);
+  mbedtls_ctr_drbg_init(ctr_drbg);
+
+  rv = mbedtls_ctr_drbg_seed(ctr_drbg, mbedtls_entropy_func, entropy,
+                             additional, additional_len);
+  if (rv != 0)
+    {
+      failed("mbedtls_ctr_drbg_seed", rv);
+    }
+
+  mbedtls_x509_crt_init(ca_crt);
+  rv = mbedtls_x509_crt_parse(ca_crt,
+                              (const unsigned char *)ca_file,
+                              strlen(ca_file) + 1);
+  rv = mbedtls_x509_crt_parse(ca_crt,
+                              (const unsigned char *)ca_file,
+                              strlen(ca_file) + 1);
+  if (rv != 0)
+    {
+      failed("mbedtls_x509_crt_parse", rv);
+    }
+
+  mbedtls_ssl_config_init(ssl_conf);
+  rv = mbedtls_ssl_config_defaults(ssl_conf, MBEDTLS_SSL_IS_CLIENT,
+                                   MBEDTLS_SSL_TRANSPORT_STREAM,
+                                   MBEDTLS_SSL_PRESET_DEFAULT);
+  if (rv != 0)
+    {
+      failed("mbedtls_ssl_config_defaults", rv);
+    }
+
+  mbedtls_ssl_conf_ca_chain(ssl_conf, ca_crt, NULL);
+  mbedtls_ssl_conf_authmode(ssl_conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+  mbedtls_ssl_conf_rng(ssl_conf, mbedtls_ctr_drbg_random, ctr_drbg);
+
+  mbedtls_net_init(net_ctx);
+  rv = mbedtls_net_connect(net_ctx, hostname, port, MBEDTLS_NET_PROTO_TCP);
+  if (rv != 0)
+    {
+      failed("mbedtls_net_connect", rv);
+    }
+
+  rv = mbedtls_net_set_nonblock(net_ctx);
+  if (rv != 0)
+    {
+      failed("mbedtls_net_set_nonblock", rv);
+    }
+
+  mbedtls_ssl_init(ssl_ctx);
+  rv = mbedtls_ssl_setup(ssl_ctx, ssl_conf);
+  if (rv != 0)
+    {
+      failed("mbedtls_ssl_setup", rv);
+    }
+
+  rv = mbedtls_ssl_set_hostname(ssl_ctx, hostname);
+  if (rv != 0)
+    {
+      failed("mbedtls_ssl_set_hostname", rv);
+    }
+
+  mbedtls_ssl_set_bio(ssl_ctx, net_ctx,
+                      mbedtls_net_send, mbedtls_net_recv, NULL);
+
+  for (; ; )
+    {
+      rv = mbedtls_ssl_handshake(ssl_ctx);
+      uint32_t want = 0;
+
+      if (rv == MBEDTLS_ERR_SSL_WANT_READ)
+        {
+          want |= MBEDTLS_NET_POLL_READ;
+        }
+      else if (rv == MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+          want |= MBEDTLS_NET_POLL_WRITE;
+        }
+      else
+        {
+          break;
+        }
+    }
+
+  if (rv != 0)
+    {
+      failed("mbedtls_ssl_handshake", rv);
+    }
+
+  uint32_t result = mbedtls_ssl_get_verify_result(ssl_ctx);
+  if (result != 0)
+    {
+      if (result == (uint32_t)-1)
+        {
+          failed("mbedtls_ssl_get_verify_result", (int)result);
+        }
+      else
+        {
+          cert_verify_failed(result);
+        }
+    }
+}

--- a/examples/mqttc_mbedtls/mqttc_mbedtls_pub.c
+++ b/examples/mqttc_mbedtls/mqttc_mbedtls_pub.c
@@ -1,0 +1,253 @@
+/****************************************************************************
+ * apps/examples/mqttc_mbedtls/mqttc_mbedtls_pub.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <mqtt.h>
+#include "mbedtls_sockets.c"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static FAR void *client_refresher(FAR void *client);
+static void safe_exit(int status,
+                      mqtt_pal_socket_handle sockfd,
+                      pthread_t *client_daemon);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: client_refresher
+ *
+ * Description:
+ *   The client's refresher. This function triggers back-end routines to
+ *   handle ingress/egress traffic to the broker.
+ *
+ ****************************************************************************/
+
+static FAR void *client_refresher(FAR void *client)
+{
+  while (1)
+    {
+      mqtt_sync((FAR struct mqtt_client *) client);
+      usleep(100000U);
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: safe_exit
+ *
+ * Description:
+ *   Safely closes the sockfd and cancels the client_daemon before exit.
+ *
+ ****************************************************************************/
+
+static void safe_exit(int status,
+                      mqtt_pal_socket_handle sockfd,
+                      pthread_t *client_daemon)
+{
+  if (client_daemon != NULL)
+    {
+      pthread_cancel(*client_daemon);
+    }
+
+  mbedtls_ssl_free(sockfd);
+
+  exit(status); /* XXX free the rest of contexts */
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, const char *argv[])
+{
+  enum MQTTErrors mqtterr;
+  const char *addr;
+  const char *port;
+  const char *topic;
+  char msg[256] = "test_message";
+
+  const char *ca_file =
+  (char *)"-----BEGIN CERTIFICATE-----\n\
+      MIIEAzCCAuugAwIBAgIUBY1hlCGvdj4NhBXkZ/uLUZNILAwwDQYJKoZIhvcNAQEL\
+      BQAwgZAxCzAJBgNVBAYTAkdCMRcwFQYDVQQIDA5Vbml0ZWQgS2luZ2RvbTEOMAwG\
+      A1UEBwwFRGVyYnkxEjAQBgNVBAoMCU1vc3F1aXR0bzELMAkGA1UECwwCQ0ExFjAU\
+      BgNVBAMMDW1vc3F1aXR0by5vcmcxHzAdBgkqhkiG9w0BCQEWEHJvZ2VyQGF0Y2hv\
+      by5vcmcwHhcNMjAwNjA5MTEwNjM5WhcNMzAwNjA3MTEwNjM5WjCBkDELMAkGA1UE\
+      BhMCR0IxFzAVBgNVBAgMDlVuaXRlZCBLaW5nZG9tMQ4wDAYDVQQHDAVEZXJieTES\
+      MBAGA1UECgwJTW9zcXVpdHRvMQswCQYDVQQLDAJDQTEWMBQGA1UEAwwNbW9zcXVp\
+      dHRvLm9yZzEfMB0GCSqGSIb3DQEJARYQcm9nZXJAYXRjaG9vLm9yZzCCASIwDQYJ\
+      KoZIhvcNAQEBBQADggEPADCCAQoCggEBAME0HKmIzfTOwkKLT3THHe+ObdizamPg\
+      UZmD64Tf3zJdNeYGYn4CEXbyP6fy3tWc8S2boW6dzrH8SdFf9uo320GJA9B7U1FW\
+      Te3xda/Lm3JFfaHjkWw7jBwcauQZjpGINHapHRlpiCZsquAthOgxW9SgDgYlGzEA\
+      s06pkEFiMw+qDfLo/sxFKB6vQlFekMeCymjLCbNwPJyqyhFmPWwio/PDMruBTzPH\
+      3cioBnrJWKXc3OjXdLGFJOfj7pP0j/dr2LH72eSvv3PQQFl90CZPFhrCUcRHSSxo\
+      E6yjGOdnz7f6PveLIB574kQORwt8ePn0yidrTC1ictikED3nHYhMUOUCAwEAAaNT\
+      MFEwHQYDVR0OBBYEFPVV6xBUFPiGKDyo5V3+Hbh4N9YSMB8GA1UdIwQYMBaAFPVV\
+      6xBUFPiGKDyo5V3+Hbh4N9YSMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL\
+      BQADggEBAGa9kS21N70ThM6/Hj9D7mbVxKLBjVWe2TPsGfbl3rEDfZ+OKRZ2j6AC\
+      6r7jb4TZO3dzF2p6dgbrlU71Y/4K0TdzIjRj3cQ3KSm41JvUQ0hZ/c04iGDg/xWf\
+      +pp58nfPAYwuerruPNWmlStWAXf0UTqRtg4hQDWBuUFDJTuWuuBvEXudz74eh/wK\
+      sMwfu1HFvjy5Z0iMDU8PUDepjVolOCue9ashlS4EB5IECdSR2TItnAIiIwimx839\
+      LdUdRudafMu5T5Xma182OC0/u/xRlEm+tvKGGmfFcN0piqVl8OrSPBgIlb+1IKJE\
+      m/XriWr/Cq4h/JfB7NTsezVslgkBaoU=\n\
+      -----END CERTIFICATE-----\n";
+
+  struct mbedtls_context ctx;
+  mqtt_pal_socket_handle sockfd;
+
+  if (argc > 1)
+    {
+      ca_file = argv[1];
+    }
+
+  if (argc > 2) /* Get address (if present) */
+    {
+      addr = argv[2];
+    }
+  else
+    {
+      addr = "test.mosquitto.org";
+    }
+
+  if (argc > 3) /* Get port number (if present) */
+    {
+      port = argv[3];
+    }
+  else
+    {
+      port = "8883";
+    }
+
+  if (argc > 4) /* Get the topic name to publish */
+    {
+      topic = argv[4];
+    }
+  else
+    {
+      topic = "test_topic";
+    }
+
+  /* Open the non-blocking TCP socket (connecting to the broker) */
+
+  open_nb_socket(&ctx, addr, port, ca_file);
+  sockfd = &ctx.ssl_ctx;
+
+  if (sockfd == NULL)
+    {
+      safe_exit(EXIT_FAILURE, sockfd, NULL);
+    }
+
+  /* Setup a client */
+
+  struct mqtt_client client;
+  uint8_t sendbuf[CONFIG_EXAMPLES_MQTTC_MBEDTLS_TXSIZE];
+  uint8_t recvbuf[CONFIG_EXAMPLES_MQTTC_MBEDTLS_RXSIZE];
+  mqtterr = mqtt_init(&client,
+                      sockfd,
+                      sendbuf,
+                      sizeof(sendbuf),
+                      recvbuf,
+                      sizeof(recvbuf),
+                      NULL);
+
+  if (mqtterr != MQTT_OK)
+    {
+      fprintf(stderr, "ERROR! mqtt_init() failed.\n");
+      safe_exit(EXIT_FAILURE, sockfd, NULL);
+    }
+
+  mqtterr = mqtt_connect(&client,
+                          "publishing_client",
+                          NULL,
+                          NULL,
+                          0,
+                          NULL,
+                          NULL,
+                          0,
+                          400);
+
+  if (mqtterr != MQTT_OK)
+    {
+      fprintf(stderr, "ERROR! mqtt_connect() failed.\n");
+      safe_exit(EXIT_FAILURE, sockfd, NULL);
+    }
+
+  /* Check for successful broker connection */
+
+  if (client.error != MQTT_OK)
+    {
+      fprintf(stderr, "Error: %s\n", mqtt_error_str(client.error));
+      safe_exit(EXIT_FAILURE, sockfd, NULL);
+    }
+  else
+    {
+      fprintf(stdout, "Success: Connected to broker!\n");
+    }
+
+  /* Start a thread to refresh the client (handle egress and ingress client
+   * traffic)
+   */
+
+  pthread_t client_daemon;
+  if (pthread_create(&client_daemon, NULL, client_refresher, &client))
+    {
+      fprintf(stderr, "Failed to start client daemon.\n");
+      safe_exit(EXIT_FAILURE, sockfd, NULL);
+    }
+
+  fprintf(stdout, "%s is ready to begin publishing.\n", argv[0]);
+
+  /* Print and publish a message */
+
+  fprintf(stdout, "%s published : \"%s\"", argv[0], msg);
+
+  mqtt_publish(&client, topic, msg, strlen(msg) + 1, MQTT_PUBLISH_QOS_2);
+
+  /* Check for errors */
+
+  if (client.error != MQTT_OK)
+    {
+      fprintf(stderr, "error: %s\n", mqtt_error_str(client.error));
+      safe_exit(EXIT_FAILURE, sockfd, &client_daemon);
+    }
+
+  /* Disconnect */
+
+  fprintf(stdout, "\n%s disconnecting from %s\n", argv[0], addr);
+  sleep(1);
+
+  /* Exit */
+
+  safe_exit(EXIT_SUCCESS, sockfd, &client_daemon);
+  return EXIT_SUCCESS;
+}

--- a/netutils/mqttc/Kconfig
+++ b/netutils/mqttc/Kconfig
@@ -25,12 +25,38 @@ config NETUTILS_MQTTC_EXAMPLE_STACKSIZE
 
 endif
 
-config NETUTILS_MQTTC_WITH_MBEDTLS
-	bool "Enable MQTT-C with mbedtls"
-	default n
-
 config NETUTILS_MQTTC_VERSION
 	string "MQTT-C Version"
 	default "1.1.5"
 
+endif	
+
+config NETUTILS_MQTTC_WITH_MBEDTLS
+	tristate "Enable MQTT-C with mbedtls"
+	default n
+	---help---
+		Enable MQTT-C with mbedtls
+
+if NETUTILS_MQTTC_WITH_MBEDTLS
+
+config NETUTILS_MQTTC_EXAMPLE_WITH_MBEDTLS
+	tristate "Enable MQTT-C example with mbedtls"
+	default n
+	---help---
+		Enable MQTT-C example with mbedtls
+
+if NETUTILS_MQTTC_EXAMPLE_WITH_MBEDTLS
+
+config NETUTILS_MQTTC_EXAMPLE_STACKSIZE_WITH_MBEDTLS
+	int "Task's stack size"
+	default 8192
+
 endif
+
+config NETUTILS_MQTTC_WITH_MBEDTLS_VERSION
+	string "MQTT-C Version"
+	default "1.1.5"
+
+endif
+
+

--- a/netutils/mqttc/Kconfig
+++ b/netutils/mqttc/Kconfig
@@ -25,20 +25,6 @@ config NETUTILS_MQTTC_EXAMPLE_STACKSIZE
 
 endif
 
-config NETUTILS_MQTTC_VERSION
-	string "MQTT-C Version"
-	default "1.1.5"
-
-endif	
-
-config NETUTILS_MQTTC_WITH_MBEDTLS
-	tristate "Enable MQTT-C with mbedtls"
-	default n
-	---help---
-		Enable MQTT-C with mbedtls
-
-if NETUTILS_MQTTC_WITH_MBEDTLS
-
 config NETUTILS_MQTTC_EXAMPLE_WITH_MBEDTLS
 	tristate "Enable MQTT-C example with mbedtls"
 	default n
@@ -53,7 +39,7 @@ config NETUTILS_MQTTC_EXAMPLE_STACKSIZE_WITH_MBEDTLS
 
 endif
 
-config NETUTILS_MQTTC_WITH_MBEDTLS_VERSION
+config NETUTILS_MQTTC_VERSION
 	string "MQTT-C Version"
 	default "1.1.5"
 


### PR DESCRIPTION

## Summary
examples/mqttc_mbedtls: Add MQTT over TLS example using mbedTLS library

## Impact
N/A

## Testing
On ESP32 board
