### PR TITLE
luasyslog: add cmake support

### DIFF
--- a/interpreters/luamodules/CMakeLists.txt
+++ b/interpreters/luamodules/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# apps/interpreters/luamodules/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "LUA Modules")

--- a/interpreters/luamodules/luasyslog/CMakeLists.txt
+++ b/interpreters/luamodules/luasyslog/CMakeLists.txt
@@ -1,0 +1,77 @@
+# ##############################################################################
+# apps/interpreters/luamodules/luasyslog/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LUA_LSYSLOG_MODULE)
+
+  # ############################################################################
+  # Config and Fetch luasyslog
+  # ############################################################################
+
+  set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/lsyslog)
+
+  if(NOT EXISTS ${SRC_DIR})
+    set(LSYSLOG_URL https://github.com/lunarmodules/luasyslog/archive/refs/tags)
+    FetchContent_Declare(
+      lsyslog_fetch
+      URL ${LSYSLOG_URL}/${CONFIG_LUA_LSYSLOG_VERSION}.tar.gz SOURCE_DIR
+          ${SRC_DIR}
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(lsyslog_fetch)
+
+    if(NOT lua_fetch_POPULATED)
+      FetchContent_Populate(lsyslog_fetch)
+    endif()
+  endif()
+
+  # ############################################################################
+  # Flags
+  # ############################################################################
+  set(LUA_SYSTEM_READLINE_DEF
+      [=[
+#define openlog(a,b,c) {(void)a; (void)c;}
+#define closelog() {}
+]=])
+
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/def_lua_readline.h
+       "${LUA_SYSTEM_READLINE_DEF}")
+  list(APPEND CFLAGS
+       "SHELL:-include ${CMAKE_CURRENT_BINARY_DIR}/def_lua_readline.h")
+
+  # ############################################################################
+  # Sources
+  # ############################################################################
+
+  set(CSRCS ${SRC_DIR}/lsyslog.c)
+
+  # ############################################################################
+  # Include Directory
+  # ############################################################################
+
+  # ############################################################################
+  # Library Configuration
+  # ############################################################################
+
+  target_sources(apps PRIVATE ${CSRCS})
+
+  # register lua mod
+  nuttx_add_luamod(MODS lsyslog)
+endif()


### PR DESCRIPTION

## Summary
Add luasyslog cmake support as an example.

## Impact
No impact. 

## Testing
1. Build and run
```
cmake -Bbuild -GNinja -DBOARD_CONFIG=boards/sim/sim/sim/configs/lua nuttx
ninjia -C build
./build/nuttx
```

2. Test
```
nsh>
nsh> lua
Lua 5.4.0  Copyright (C) 1994-2020 Lua.org, PUC-Rio
> for k,v in pairs(lsyslog)
>> do
>> print(k,v)
>> end
open    function: 0x402d49c0
FACILITY_LOCAL4 0.0
FACILITY_AUTH   0.0
_COPYRIGHT      Copyright (C) 1994-2021 Nicolas Casalini (DarkGod)
FACILITY_DAEMON 0.0
FACILITY_LOCAL1 0.0
LOG_WARNING     4.0
close   function: 0x402d4990
FACILITY_AUTHPRIV       0.0
LOG_ALERT       1.0
_DESCRIPTION    LuaSyslog allows to use log to an unix Syslog daemon, direct or via LuaLogging
FACILITY_CRON   0.0
FACILITY_FTP    0.0
LOG_DEBUG       7.0
FACILITY_LOCAL0 0.0
LOG_NOTICE      5.0
FACILITY_LOCAL5 0.0
LOG_EMERG       0.0
FACILITY_LPR    0.0
_VERSION        LuaSyslog 2.0.1
FACILITY_LOCAL7 0.0
FACILITY_KERN   0.0
log     function: 0x402d4944
FACILITY_LOCAL2 0.0
LOG_INFO        6.0
FACILITY_NEWS   0.0
FACILITY_LOCAL6 0.0
FACILITY_SYSLOG 0.0
FACILITY_USER   0.0
FACILITY_LOCAL3 0.0
FACILITY_UUCP   0.0
LOG_ERR 3.0
FACILITY_MAIL   0.0
LOG_CRIT        2.0
> lsyslog.log(lsyslog.LOG_EMERG, "Hello")
Hello
>
```
