### PR TITLE
usbserial: Add config for customize direction, message and wait time

### DIFF
--- a/examples/usbserial/Kconfig
+++ b/examples/usbserial/Kconfig
@@ -20,6 +20,58 @@ config EXAMPLES_USBSERIAL_BUFSIZE
 		The size of the array that is used as an I/O buffer for USB serial
 		data transfers.
 
+choice
+	prompt "USB serial transfer"
+	default EXAMPLES_USBSERIAL_INANDOUT
+	---help---
+		Select usb serial transfer in or out
+
+config EXAMPLES_USBSERIAL_INANDOUT
+	bool "in and out"
+
+config EXAMPLES_USBSERIAL_INONLY
+	bool "in only"
+
+config EXAMPLES_USBSERIAL_OUTONLY
+	bool "out only"
+
+endchoice # USBSERIAL in or out
+
+config EXAMPLES_USBSERIAL_CONFIG_WAIT
+	bool "Config waiting time"
+	default n
+	---help---
+		Config waiting time after transfer
+
+if EXAMPLES_USBSERIAL_CONFIG_WAIT
+
+config EXAMPLES_USBSERIAL_IN_WAITING_TIME
+	int "In waiting time (ms)"
+	default 100
+
+config EXAMPLES_USBSERIAL_OUT_WAITING_TIME
+	int "Out waiting time (ms)"
+	default 100
+
+endif # USERSERIAL config wait
+
+choice
+	prompt "USB serial message"
+	default EXAMPLES_USBSERIAL_SMALLANDBIG
+	---help---
+		Select usb serial small or big message
+
+config EXAMPLES_USBSERIAL_SMALLANDBIG
+	bool "small and big"
+
+config EXAMPLES_USBSERIAL_ONLYSMALL
+	bool "only small"
+
+config EXAMPLES_USBSERIAL_ONLYBIG
+	bool "only big"
+
+endchoice # USBSERIAL small or big message
+
 config EXAMPLES_USBSERIAL_TRACEINIT
 	bool "USB Trace Initialization"
 	default n

--- a/examples/usbserial/usbserial_main.c
+++ b/examples/usbserial/usbserial_main.c
@@ -456,12 +456,20 @@ int main(int argc, FAR char *argv[])
                 }
             }
 
+#ifdef CONFIG_EXAMPLES_USBSERIAL_CONFIG_WAIT
+          usleep(CONFIG_EXAMPLES_USBSERIAL_OUT_WAITING_TIME * 1000);
+#else
           sleep(1);
+#endif /* CONFIG_EXAMPLES_USBSERIAL_CONFIG_WAIT */
         }
 
 #else /* CONFIG_EXAMPLES_USBSERIAL_INONLY */
       printf("usbserial_main: Waiting\n");
+#ifdef CONFIG_EXAMPLES_USBSERIAL_CONFIG_WAIT
+      usleep(CONFIG_EXAMPLES_USBSERIAL_IN_WAITING_TIME * 1000);
+#else
       sleep(5);
+#endif /* CONFIG_EXAMPLES_USBSERIAL_CONFIG_WAIT */
 #endif /* CONFIG_EXAMPLES_USBSERIAL_INONLY */
 
       /* If USB tracing is enabled, then dump all collected trace data


### PR DESCRIPTION
## Summary
There are config macro in the usbserial code, such as INONLY / OUTONLY for direction, ONLYSMALL / ONLYBIG for message, but user cannot choose it, so add  these config macro to Kconfig to enable user customize for usbserial use, and also add in/out waiting time config for customization.

## Impact
impact to usbserial app

## Testing
Test with esp32s3-devkit/usb_device
