### PR TITLE
apps/Makefile: Support passing additional arguments to mksymtab.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 endif
 
 # Symbol table for loadable apps.
+#   SYMTABEXT: Extra arguments for mksymtab.sh
 
 SYMTABSRC = symtab_apps.c
 SYMTABOBJ = $(SYMTABSRC:.c=$(OBJEXT))
@@ -119,7 +120,7 @@ else
 
 $(SYMTABSRC): $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_all)
 	$(Q) $(MAKE) install
-	$(Q) $(APPDIR)$(DELIM)tools$(DELIM)mksymtab.sh $(BINDIR) >$@.tmp
+	$(Q) $(APPDIR)$(DELIM)tools$(DELIM)mksymtab.sh $(BINDIR) $(SYMTABEXT) >$@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 ifneq ($(CONFIG_ARM_TOOLCHAIN_GHS),y)

--- a/tools/mksymtab.sh
+++ b/tools/mksymtab.sh
@@ -21,21 +21,45 @@
 
 export LC_ALL=C
 
-usage="Usage: $0 <imagedirpath> [symtabprefix [additionalsymbolspath]]"
+usage() {
+  if [ $# -ne 0 ]; then
+    echo "ERROR: $@"
+  fi
+  echo -e "\nUsage: $0 <imagedirpath> [symtabprefix] [-a additionalsymbolspath]"
+  exit 1
+}
 
 # Check for the required directory path
 
 dir=$1
 if [ -z "$dir" ]; then
-  echo "ERROR: Missing <imagedirpath>"
-  echo ""
-  echo $usage
-  exit 1
+  usage "Missing <imagedirpath>"
 fi
 
 # Get the symbol table prefix
 
-prefix=$2
+if [ "x${2:0:1}" != "x-" ]; then
+  prefix=$2
+  OPTIND=3
+else
+  OPTIND=2
+fi
+
+# Parse remaining arguments
+
+while getopts a: opt; do
+  case $opt in
+    a)
+      addlist="${addlist[@]} $OPTARG"
+      ;;
+    \?)
+      usage
+  esac
+done
+
+if [ $OPTIND != $(($# + 1)) ]; then
+  usage "Arguments remaining: \"${@:$OPTIND}\""
+fi
 
 # Extract all of the undefined symbols from the ELF files and create a
 # list of sorted, unique undefined variable names.
@@ -59,20 +83,16 @@ if [ -z "$varlist" ]; then
   fi
 fi
 
-if [ $# -gt 2 ]; then
-  shift 2
-  for add_sym in $@; do
-    if [ -f $add_sym ]; then
-      varlist="${varlist}\n$(cat $add_sym | grep -v "^,.*")"
-    elif [ -d $add_sym ]; then
-      varlist="${varlist}\n$(find $add_sym -type f | xargs cat | grep -v "^,.*")"
-    else
-      echo $usage
-      exit 1
-    fi
-    varlist=$(echo -e "${varlist}" | sort -u)
-  done
-fi
+for addsym in ${addlist[@]}; do
+  if [ -f $addsym ]; then
+    varlist="${varlist}\n$(cat $addsym | grep -v "^,.*")"
+  elif [ -d $addsym ]; then
+    varlist="${varlist}\n$(find $addsym -type f | xargs cat | grep -v "^,.*")"
+  else
+    usage
+  fi
+  varlist=$(echo -e "${varlist}" | sort -u)
+done
 
 # Now output the symbol table as a structure in a C source file.  All
 # undefined symbols are declared as void* types.  If the toolchain does


### PR DESCRIPTION
## Summary
1. tools/mksymtab.sh: Use getopts for parameter parsing
2. apps/Makefile: Passing additional arguments to mksymtab

## Impact
Usage of mksymtab.sh about param "additionalsymbolspath" changed, has checked by searching in nuttx-apps and nuttx.
"additionalsymbolspath" should not depends on "symtabprefix".
```
# Without this PR
usage="Usage: $0 <imagedirpath> [symtabprefix [additionalsymbolspath]]"
# With this PR
usage="Usage: $0 <imagedirpath> [symtabprefix] [-a additionalsymbolspath]"
```

## Testing
1. Selftest result attached to commit message
2. Github NuttX CI
