### PR TITLE
github: sync labels with nuttx repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/001_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/001_bug_report.yml
@@ -13,7 +13,7 @@
 name: Bug report
 description: Report a bug to improve NuttX stability
 title: "[BUG] <title>"
-labels: [👀 needs triage, bug]
+labels: [👀 needs triage, "Type: bug"]
 body:
   - type: markdown
     attributes:
@@ -47,11 +47,11 @@ body:
       label: On which OS does this issue occur?
       multiple: true
       options:
-        - "[BSD]"
-        - "[Linux]"
-        - "[Mac]"
-        - "[Windows]"
-        - "[Other]"
+        - "[OS: BSD]"
+        - "[OS: Linux]"
+        - "[OS: Mac]"
+        - "[OS: Windows]"
+        - "[OS: Other]"
     validations:
       required: true
 
@@ -78,25 +78,25 @@ body:
       description: What architecture(s) are you seeing the problem on?
       multiple: true
       options:
-        - "[all]"
-        - "[arm]"
-        - "[arm64]"
-        - "[avr]"
-        - "[ceva]"
-        - "[hc]"
-        - "[mips]"
-        - "[misoc]"
-        - "[openrisc]"
-        - "[renesas]"
-        - "[risc-v]"
-        - "[simulator]"
-        - "[sparc]"
-        - "[tricore]"
-        - "[x86]"
-        - "[x86_64]"
-        - "[xtensa]"
-        - "[z16]"
-        - "[z80]"
+        - "[Arch: all]"
+        - "[Arch: arm]"
+        - "[Arch: arm64]"
+        - "[Arch: avr]"
+        - "[Arch: ceva]"
+        - "[Arch: hc]"
+        - "[Arch: mips]"
+        - "[Arch: misoc]"
+        - "[Arch: openrisc]"
+        - "[Arch: renesas]"
+        - "[Arch: risc-v]"
+        - "[Arch: simulator]"
+        - "[Arch: sparc]"
+        - "[Arch: tricore]"
+        - "[Arch: x86]"
+        - "[Arch: x86_64]"
+        - "[Arch: xtensa]"
+        - "[Arch: z16]"
+        - "[Arch: z80]"
     validations:
       required: true
 
@@ -107,25 +107,25 @@ body:
       description: What area(s) are you seeing the problem on?
       multiple: true
       options:
-        - "[Other]"
-        - "[Applications]"
-        - "[Api]"
-        - "[Board support]"
-        - "[Build System]"
-        - "[Configuring]"
-        - "[Debugging]"
-        - "[Drivers]"
-        - "[File System]"
-        - "[Installing]"
-        - "[Kconfig]"
-        - "[Kernel]"
-        - "[Memory Management]"
-        - "[Native port]"
-        - "[Networking]"
-        - "[OS Components]"
-        - "[Posix]"
-        - "[Sensors]"
-        - "[Specific Peripheral]"
+        - "[Area: Other]"
+        - "[Area: Applications]"
+        - "[Area: Api]"
+        - "[Area: Board support]"
+        - "[Area: Build System]"
+        - "[Area: Configuring]"
+        - "[Area: Debugging]"
+        - "[Area: Drivers]"
+        - "[Area: File System]"
+        - "[Area: Installing]"
+        - "[Area: Kconfig]"
+        - "[Area: Kernel]"
+        - "[Area: Memory Management]"
+        - "[Area: Native port]"
+        - "[Area: Networking]"
+        - "[Area: OS Components]"
+        - "[Area: Posix]"
+        - "[Area: Sensors]"
+        - "[Area: Specific Peripheral]"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/002_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/002_feature_request.yml
@@ -13,7 +13,7 @@
 name: Feature request
 description: Request an enhancement for NuttX
 title: "[FEATURE] <title>"
-labels: [enhancement]
+labels: ["Type: enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/003_help.yml
+++ b/.github/ISSUE_TEMPLATE/003_help.yml
@@ -13,7 +13,7 @@
 name: General Help
 description: Get general support regarding NuttX
 title: "[HELP] <title>"
-labels: [question]
+labels: ["Type: question"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -28,12 +28,15 @@ jobs:
           script: |
             const body = context.payload.issue.body;
             const bodySplit = body.split(/\[|\]/).map(e => e.toLowerCase());
-            const oskeywords = ['other', 'bsd', 'linux', 'mac', 'windows'];
-            const archkeywords1 = ['all', 'arm', 'arm64', 'avr', 'ceva', 'hc', 'mips', 'misoc', 'openrisc', 'renesas'];
-            const archkeywords2 = ['risc-v', 'simulator', 'sparc', 'tricore', 'x86', 'x86_64', 'xtensa', 'z16', 'z80', 'renesas'];
-            const areakeywords1 = ['applications', 'api', 'board support', 'build system', 'configuring', 'debugging', 'drivers', 'file system', 'installing', 'kconfig'];
-            const areakeywords2 = ['kernel', 'memory management', 'native port', 'networking', 'os components', 'posix', 'sensors', 'specific peripheral', 'openrisc', 'renesas'];
-            const keywords = [...oskeywords, ...archkeywords1, ...archkeywords2, ...areakeywords1, ...areakeywords2];
+            const oskeywords = ['os: other', 'os: bsd', 'os: Linux', 'os: mac', 'os: windows'];
+            const archkeywords1 = ['arch: all', 'arch: arm', 'arch: arm64', 'arch: avr', 'arch: ceva'];
+            const archkeywords2 = ['arch: hc', 'arch: mips', 'arch: misoc', 'arch: openrisc', 'arch:renesas'];
+            const archkeywords3 = ['arch: risc-v', 'arch: simulator', 'arch: sparc', 'arch: tricore'];
+            const archkeywords4 = ['arch: x86', 'arch: x86_64', 'arch: xtensa', 'arch: z16', 'arch: z80', 'arch:renesas'];
+            const areakeywords1 = ['area: applications', 'area: api', 'area: board support', 'area: build system'];
+            const areakeywords2 = ['area: configuring', 'area: debugging', 'area: drivers', 'area: file system', 'area: installing', 'area: kconfig'];
+            const areakeywords3 = ['area: kernel', 'area: memory management', 'area: native port', 'area: networking'];
+            const areakeywords4 = ['area: os components', 'area: posix', 'area: sensors', 'area: specific peripheral'];
             var keywordsfound = new Set();
             for (const keyword of keywords) {
               if (bodySplit.includes(keyword)) {


### PR DESCRIPTION
## Summary
sync github lables with main NuttX repo: https://github.com/apache/nuttx/pull/13545

"Area:" labels don't quite fit into nuttx-apps, but I'll fix them later with auto labeler support

## Impact
no imact on users, only github labels

## Testing
tested on nuttx repo
