### PR TITLE
fix build error

### DIFF
--- a/examples/nettest/nettest_server.c
+++ b/examples/nettest/nettest_server.c
@@ -145,11 +145,11 @@ void nettest_server(void)
 
   printf("server: Accepting connections on port %d\n",
          CONFIG_EXAMPLES_NETTEST_SERVER_PORTNO);
-#ifdef __APPLE__
-  acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
-#else
+#ifdef __NuttX__
   acceptsd = accept4(listensd, (struct sockaddr *)&myaddr, &addrlen,
                      SOCK_CLOEXEC);
+#else
+  acceptsd = accept(listensd, (struct sockaddr *)&myaddr, &addrlen);
 #endif
   if (acceptsd < 0)
     {

--- a/examples/tcpblaster/tcpblaster_server.c
+++ b/examples/tcpblaster/tcpblaster_server.c
@@ -153,11 +153,11 @@ void tcpblaster_server(void)
 
   printf("server: Accepting connections on port %d\n",
          CONFIG_EXAMPLES_TCPBLASTER_SERVER_PORTNO);
-#ifdef __APPLE__
-  acceptsd = accept(listensd, (FAR struct sockaddr *)&myaddr, &addrlen);
-#else
+#ifdef __NuttX__
   acceptsd = accept4(listensd, (FAR struct sockaddr *)&myaddr, &addrlen,
                      SOCK_CLOEXEC);
+#else
+  acceptsd = accept(listensd, (FAR struct sockaddr *)&myaddr, &addrlen);
 #endif
   if (acceptsd < 0)
     {


### PR DESCRIPTION

## Summary
[linguini@pastabox nuttx]$ make -j
CC:  tcpblaster_server.c
LN: platform/board to
/home/linguini/cuinspace/pico-nuttx/apps/platform/dummy tcpblaster_server.c: In function ‘tcpblaster_server’: tcpblaster_server.c:159:14: error: implicit declaration of function ‘accept4’; did you mean ‘accept’? [-Wimplicit-function-declaration]
  159 |   acceptsd = accept4(listensd, (FAR struct sockaddr *)&myaddr,
&addrlen,
      |              ^~~~~~~
      |              accept
make[3]: *** [Makefile:92: tcpblaster_server.hobj] Error 1
make[2]: *** [Makefile:53:
/home/linguini/cuinspace/pico-nuttx/apps/examples/tcpblaster_context]
Error 2
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:180: context] Error 2
make: *** [tools/Unix.mk:457:
/home/linguini/cuinspace/pico-nuttx/apps/.context] Error 2
make: *** Waiting for unfinished jobs....
## Impact
from https://github.com/apache/nuttx-apps/issues/2632
## Testing
 CI TEST
