### PR TITLE
net: Remove IFF_DOWN flag to compatible with Linux/*BSD

### DIFF
--- a/lte/alt1250/alt1250_netdev.c
+++ b/lte/alt1250/alt1250_netdev.c
@@ -60,7 +60,7 @@ void alt1250_netdev_unregister(FAR struct alt1250_s *dev)
 
 void alt1250_netdev_ifdown(FAR struct alt1250_s *dev)
 {
-  dev->net_dev.d_flags = IFF_DOWN;
+  dev->net_dev.d_flags = ~IFF_UP;
 #ifdef CONFIG_NET_IPv4
   memset(&dev->net_dev.d_ipaddr, 0, sizeof(dev->net_dev.d_ipaddr));
   memset(&dev->net_dev.d_draddr, 0, sizeof(dev->net_dev.d_draddr));

--- a/lte/alt1250/usock_handlers/alt1250_ioctl_ifreq.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctl_ifreq.c
@@ -399,14 +399,9 @@ int usockreq_ioctl_ifreq(FAR struct alt1250_s *dev,
     {
       ret = do_ifup(dev, req, usock_result, usock_xid, ackinfo);
     }
-  else if (if_req->ifr_flags & IFF_DOWN)
-    {
-      ret = do_ifdown(dev, req, usock_result, usock_xid, ackinfo);
-    }
   else
     {
-      dbg_alt1250("unexpected ifr_flags:0x%02x\n", if_req->ifr_flags);
-      *usock_result = -EINVAL;
+      ret = do_ifdown(dev, req, usock_result, usock_xid, ackinfo);
     }
 
   return ret;

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -904,7 +904,7 @@ static int netinit_monitor(void)
 
               ninfo("Taking the link down\n");
 
-              ifr.ifr_flags = IFF_DOWN;
+              ifr.ifr_flags = 0;
               ret = ioctl(sd, SIOCSIFFLAGS, (unsigned long)&ifr);
               if (ret < 0)
                 {

--- a/netutils/netlib/netlib_setifstatus.c
+++ b/netutils/netlib/netlib_setifstatus.c
@@ -118,8 +118,6 @@ int netlib_ifdown(const char *ifname)
 
           /* Perform the ioctl to ifup flag */
 
-          req.ifr_flags |= IFF_DOWN;
-
           ret = ioctl(sockfd, SIOCSIFFLAGS, (unsigned long)&req);
           close(sockfd);
         }


### PR DESCRIPTION
## Summary

turn off interface by checking IFF_UP flag isn't set: https://github.com/apache/nuttx/issues/1838
depends on https://github.com/apache/nuttx/pull/13842

## Impact

improve the combability

## Testing

internal test