### PR TITLE
system/adbd: Fix typo error(CONFIG_ADB_SERVER->CONFIG_SYSTEM_ADBD)

### DIFF
--- a/system/adb/CMakeLists.txt
+++ b/system/adb/CMakeLists.txt
@@ -92,7 +92,7 @@ if(CONFIG_SYSTEM_ADBD)
 
   nuttx_add_application(
     MODULE
-    ${CONFIG_ADB_SERVER}
+    ${CONFIG_SYSTEM_ADBD}
     NAME
     ${CONFIG_ADBD_PROGNAME}
     SRCS


### PR DESCRIPTION
## Summary

make adb generate elf binary correctly

## Impact

adbd

## Testing

ci