### PR TITLE
CI: Sync the Build Workflow from nuttx repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # Fetch the source from nuttx and nuttx-apps repos
   Fetch-Source:
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +43,7 @@ jobs:
           REF=$GITHUB_REF
 
           # If a base ref is set this is a PR and we will want to use
-          # the base ref instead of the ref that triggered the event.
+          # the base ref instead of the ref that triggered the event
           if [ ${GITHUB_BASE_REF} ]; then
             REF=refs/heads/$GITHUB_BASE_REF
           fi
@@ -81,7 +83,7 @@ jobs:
           fi
 
           echo "name=$OS_REF" >> $GITHUB_OUTPUT
-          echo "app_ref=$APPS_REF" >> $GITHUB_OUTPUT
+          echo "apps_ref=$APPS_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
@@ -110,8 +112,23 @@ jobs:
           name: source-bundle
           path: sources.tar.gz
 
-  Linux:
+  # Select the Linux Builds based on PR Arch Label
+  Linux-Arch:
+    uses: apache/nuttx-apps/.github/workflows/arch.yml@master
     needs: Fetch-Source
+    with:
+      os: Linux
+      boards: |
+        [
+          "arm-01", "other", "risc-v-01", "sim-01", "xtensa-01",
+          "arm-02", "risc-v-02", "sim-02", "xtensa-02",
+          "arm-03", "arm-04", "arm-05", "arm-06", "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12", "arm-13"
+        ]
+
+  # Run the selected Linux Builds
+  Linux:
+    needs: Linux-Arch
+    if: ${{ needs.Linux-Arch.outputs.skip_all_builds != '1' }}
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -119,13 +136,10 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        boards: [
-          arm-01, other, risc-v-01, sim-01, xtensa-01,
-          arm-02, risc-v-02, sim-02, xtensa-02,
-          arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13
-        ]
+        boards: ${{ fromJSON(needs.Linux-Arch.outputs.selected_builds) }}
 
     steps:
+
       - name: Download Source Artifact
         uses: actions/download-artifact@v4
         with:
@@ -162,7 +176,7 @@ jobs:
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
             else
-                ./cibuild.sh -c -A -N -R testlist/${{matrix.boards}}.dat
+                ./cibuild.sh -c -A -N -R -S testlist/${{matrix.boards}}.dat
             fi
 
       - uses: actions/upload-artifact@v4
@@ -172,15 +186,26 @@ jobs:
           path: buildartifacts/
         continue-on-error: true
 
+  # Select the macOS Builds based on PR Arch Label
+  macOS-Arch:
+    uses: apache/nuttx-apps/.github/workflows/arch.yml@master
+    needs: Fetch-Source
+    with:
+      os: Linux
+      boards: |
+        ["macos", "sim-01", "sim-02"]
+
+  # Run the selected macOS Builds
   macOS:
     permissions:
       contents: none
     runs-on: macos-13
-    needs: Fetch-Source
+    needs: macOS-Arch
+    if: ${{ needs.macOS-Arch.outputs.skip_all_builds != '1' }}
     strategy:
       max-parallel: 2
       matrix:
-        boards: [macos, sim-01, sim-02]
+        boards: ${{ fromJSON(needs.macOS-Arch.outputs.selected_builds) }}
     steps:
       - name: Download Source Artifact
         uses: actions/download-artifact@v4
@@ -221,14 +246,25 @@ jobs:
           path: buildartifacts/
         continue-on-error: true
 
-  msys2:
+  # Select the msys2 Builds based on PR Arch Label
+  msys2-Arch:
+    uses: apache/nuttx-apps/.github/workflows/arch.yml@master
     needs: Fetch-Source
+    with:
+      os: Linux
+      boards: |
+        ["msys2"]
+
+  # Run the selected msys2 Builds
+  msys2:
+    needs: msys2-Arch
+    if: ${{ needs.msys2-Arch.outputs.skip_all_builds != '1' }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        boards: [msys2]
+        boards: ${{ fromJSON(needs.msys2-Arch.outputs.selected_builds) }}
 
     defaults:
       run:
@@ -283,7 +319,7 @@ jobs:
           git config --global --add safe.directory /github/workspace/sources/nuttx
           git config --global --add safe.directory /github/workspace/sources/apps
           cd sources/nuttx/tools/ci
-          ./cibuild.sh -g -i -A -C -N -R -S testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -g -i -A -C -N -R testlist/${{matrix.boards}}.dat
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

This PR syncs the CI Build Workflow `build.yml` from `nuttx` repo to `nuttx-apps`. The updated `build.yml` consolidates these changes:
- https://github.com/apache/nuttx/pull/13301
- https://github.com/apache/nuttx/pull/13806
- https://github.com/apache/nuttx/pull/13862

`build.yml` from `nuttx` repo was slightly modified for `nuttx-apps`:
- All References to `apache/nuttx/.../arch.yml` were changed to `apache/nuttx-apps/.../arch.yml` (we decouple them so they are easier to update)
- Removed `pull_request > paths-ignore` and `push > paths-ignore` (following the existing convention)

## Impact

With the updated `build.yml`, `nuttx-apps` will be built according to the PR Arch Labels, as explained here: https://github.com/apache/nuttx/issues/13775

This has no impact on `nuttx-apps`, since Arch Labels are not used in this repo. CI Build Workflow shall run the exact same way as before.

## Testing

We verified that CI Build Workflow runs the exact same way as before.

With the updated `build.yml`, CI Build Workflow successfully recompiles `examples/hello` when we Submit a PR: https://github.com/lupyuen5/label-nuttx-apps/actions/runs/11229943812

Also when we Merge a PR: https://github.com/lupyuen5/label-nuttx-apps/actions/runs/11230244326
