### PR TITLE
system/dhcp6c: add NET_ICMPv6_AUTOCONF dependency

### DIFF
--- a/system/dhcp6c/Kconfig
+++ b/system/dhcp6c/Kconfig
@@ -7,7 +7,7 @@ config SYSTEM_DHCPC_RENEW6
 	tristate "DHCP IPv6 Address Renewal"
 	default n
 	select NETUTILS_DHCP6C
-	depends on NET_UDP && NET_IPv6
+	depends on NET_UDP && NET_IPv6 && NET_ICMPv6_AUTOCONF
 	---help---
 		Enable the DHCP client 'renew6' command
 


### PR DESCRIPTION
## Summary

Add missing dependency `NET_ICMPv6_AUTOCONF`.

See #2412 

## Impact

Previously the build failed if NET_ICMPv6_AUTOCONF was disabled (due to the missing `netlib_obtain_ipv6addr` symbol).


## Testing

Compile-tested only.

See #2412: after the change the build via `sim:nsh` failed *later* (probably sim-specific).
