### PR TITLE
fsutils/mkmbr/mkmbr.c: fix null pointer access when not all device space is defined in mbr

### DIFF
--- a/fsutils/mkmbr/mkmbr.c
+++ b/fsutils/mkmbr/mkmbr.c
@@ -111,8 +111,10 @@ int main(int argc, FAR char *argv[])
   int argn;
   int fd;
   int ret;
+  int nr_part;
 
-  if (argc < 4 || argc % 2 != 0)
+  nr_part = (argc - 2) / 2;
+  if (argc < 4 || argc % 2 != 0 || nr_part > 4)
     {
       print_usage();
       return EINVAL;
@@ -133,7 +135,7 @@ int main(int argc, FAR char *argv[])
   next = 1;
   bsize = st.st_size / 512;
   mbr_init(&mbr);
-  for (partn = 0; partn < 4 && next < bsize; partn++)
+  for (partn = 0; partn < nr_part && next < bsize; partn++)
     {
       argn = 2 * (partn + 1);
       if (!strcmp(argv[argn], "auto"))


### PR DESCRIPTION
## Summary

argv[argn] is accessed out of range when there are neither four partitions are specified nor the last partition is of auto size.
`mkmbr /dev/mmcsd1 233 666 auto 1234` -> `partn = 2` -> `argv[6]` -> panic
```
#0  0x4005544b in ?? ()
#1  0x42056a90 in mkmbr_main (argc=<optimized out>, argv=<optimized out>) at mkmbr.c:140
#2  0x42007449 in nxtask_startup (entrypt=0x420569e8 <mkmbr_main>, argc=6, argv=0x3ca01a60) at sched/task_startup.c:70
#3  0x42003be4 in nxtask_start () at task/task_start.c:114
```

Fix the problem by adding a number of partition variable `nr_part` based on input argument number.

## Impact

Null pointer bug fixed.
Make `mkmbr` command support divide the device into less than four partitions with space left at the end.

## Testing

```
nsh> mkmbr /dev/mmcsd1 233 666 auto 1234
nsh> hexdump /dev/mmcsd1
/dev/mmcsd1 at 00000000:                                               # the first sector is the MBR just created by mkmbr
0000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................ # first 446 bytes are reserved
0010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
...
01a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
01b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
01c0: 00 00 83 00 00 00 e9 00 00 00 9a 02 00 00 00 00 ................ # first partition: 233 == 0xe9, 666 == 0x029a
01d0: 00 00 83 00 00 00 83 03 00 00 d2 04 00 00 00 00 ................ # second partition: 233 + 666 == 0x0383, 1234 == 0x04d2
01e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................ # third and fourth partitions are not defined
01f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 55 aa ..............U. # 0x55aa is boot signature
...
```