### PR TITLE
Application.mk:no need to add DEPPATH by default

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -147,9 +147,6 @@ RUSTELFFLAGS ?= $(RUSTFLAGS)
 DELFFLAGS ?= $(DFLAGS)
 SWIFTELFFLAGS ?= $(SWIFTFLAGS)
 
-DEPPATH += --dep-path .
-DEPPATH += --obj-path .
-
 VPATH += :.
 
 # Targets follow

--- a/interpreters/toywasm/Makefile
+++ b/interpreters/toywasm/Makefile
@@ -156,6 +156,13 @@ VPATH += $(TOYWASM_UNPACK)/libwasi_threads
 VPATH += $(TOYWASM_UNPACK)/libdyld
 VPATH += src
 
+DEPPATH += --dep-path $(TOYWASM_UNPACK)/cli
+DEPPATH += --dep-path $(TOYWASM_UNPACK)/lib
+DEPPATH += --dep-path $(TOYWASM_UNPACK)/libwasi
+DEPPATH += --dep-path $(TOYWASM_UNPACK)/libwasi_threads
+DEPPATH += --dep-path $(TOYWASM_UNPACK)/cllibdyldi
+DEPPATH += --dep-path src
+
 $(TOYWASM_TARBALL):
 	$(Q) echo "Downloading $(TOYWASM_TARBALL)"
 	$(Q) curl -O -L $(TOYWASM_URL)


### PR DESCRIPTION
## Summary

After:https://github.com/apache/nuttx/pull/13958

current directory is always added in mkdeps.c for dep-path there is no need to manually add multiple times

## Impact

Generation of Make.dep

## Testing
CI build 
