### PR TITLE
Keep the dhcpv6 renew process name the same in cmake and makefile

### DIFF
--- a/system/dhcp6c/CMakeLists.txt
+++ b/system/dhcp6c/CMakeLists.txt
@@ -21,7 +21,7 @@
 if(CONFIG_SYSTEM_DHCPC_RENEW6)
   nuttx_add_application(
     NAME
-    dhcpc6
+    ${CONFIG_DHCPC_RENEW6_PROGNAME}
     SRCS
     renew6_main.c
     STACKSIZE


### PR DESCRIPTION
## Summary

Keep the dhcpv6 renew process name the same in cmake and makefile

## Impact

Minor

## Testing

Nuttx CI & Vela CI
