### PR TITLE
system/gprof: Support gprof tool

### DIFF
--- a/system/gprof/Kconfig
+++ b/system/gprof/Kconfig
@@ -1,0 +1,23 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_GPROF
+	tristate "gprof tool"
+	default n
+	depends on SCHED_GPROF || SIM_GPROF
+	---help---
+		Enable support for the 'gprof' command.
+
+if SYSTEM_GPROF
+
+config SYSTEM_GPROF_PRIORITY
+	int "gprof task priority"
+	default 100
+
+config SYSTEM_GPROF_STACKSIZE
+	int "gprof stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/system/gprof/Make.defs
+++ b/system/gprof/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/gprof/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_GPROF),)
+CONFIGURED_APPS += $(APPDIR)/system/gprof
+endif

--- a/system/gprof/Makefile
+++ b/system/gprof/Makefile
@@ -1,0 +1,29 @@
+############################################################################
+# apps/system/gprof/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME = gprof
+PRIORITY = $(CONFIG_SYSTEM_GPROF_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_GPROF_STACKSIZE)
+
+MAINSRC = gprof.c
+
+include $(APPDIR)/Application.mk

--- a/system/gprof/gprof.c
+++ b/system/gprof/gprof.c
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * apps/system/gprof/gprof.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/gmon.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern uint8_t _stext[];
+extern uint8_t _etext[];
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  if (argc < 2)
+    {
+      goto help;
+    }
+
+  if (strcmp(argv[1], "dump") == 0)
+    {
+#ifndef CONFIG_DISABLE_ENVIRON
+      FAR const char *output = argc < 3 ? "gmon.out" : argv[2];
+      setenv("GMON_OUT_PREFIX", output, true);
+#else
+      fprintf(stderr, "gprof: Environment not supported\n");
+#endif
+      _mcleanup();
+    }
+  else if (strcmp(argv[1], "start") == 0)
+    {
+      monstartup((uintptr_t)&_stext, (uintptr_t)&_etext);
+      moncontrol(1);
+    }
+  else if (strcmp(argv[1], "stop") == 0)
+    {
+      moncontrol(0);
+    }
+  else
+    {
+      goto help;
+    }
+
+  return EXIT_SUCCESS;
+
+help:
+  printf("Usage: gprof <command> [<args>]\n"
+        "  gprof dump [output]\n"
+        "  gprof start\n"
+        "  gprof stop\n");
+  return EXIT_FAILURE;
+}
+


### PR DESCRIPTION
## Summary
It can perform statistics on running hot spots or record function calls

arm-none-eabi-gprof nuttx/nuttx gmon.out -b
Flat profile:

```
Each sample counts as 0.001 seconds.
  %   cumulative   self              self     total
 time   seconds   seconds    calls   s/call   s/call  name
 66.41      3.55     3.55       43     0.08     0.08  sdelay
 33.44      5.34     1.79       44     0.04     0.04  delay
  0.07      5.34     0.00                             up_idle
  0.04      5.34     0.00                             nx_start
  0.02      5.34     0.00                             fdtdump_main
  0.02      5.34     0.00                             nxsem_wait
  0.00      5.34     0.00        1     0.00     5.34  hello_main
  0.00      5.34     0.00        1     0.00     0.00  singal_handler

granularity: each sample hit covers 4 byte(s) for 0.02% of 5.34 seconds

index % time    self  children    called     name
                0.00    5.34       1/1           nxtask_startup [2]
[1]     99.9    0.00    5.34       1         hello_main [1]
                3.55    0.00      43/43          sdelay [3]
                1.79    0.00      44/44          delay [4]
-----------------------------------------------
                                                 <spontaneous>
[2]     99.9    0.00    5.34                 nxtask_startup [2]
                0.00    5.34       1/1           hello_main [1]
-----------------------------------------------
                3.55    0.00      43/43          hello_main [1]
[3]     66.4    3.55    0.00      43         sdelay [3]
-----------------------------------------------
                1.79    0.00      44/44          hello_main [1]
[4]     33.4    1.79    0.00      44         delay [4]
-----------------------------------------------
                                                 <spontaneous>
[5]      0.1    0.00    0.00                 up_idle [5]
-----------------------------------------------
                                                 <spontaneous>
[6]      0.0    0.00    0.00                 nx_start [6]
-----------------------------------------------
                                                 <spontaneous>
[7]      0.0    0.00    0.00                 fdtdump_main [7]
-----------------------------------------------
                                                 <spontaneous>
[8]      0.0    0.00    0.00                 nxsem_wait [8]
-----------------------------------------------
                0.00    0.00       1/1           nxsig_deliver [3553]
[9]      0.0    0.00    0.00       1         singal_handler [9]
-----------------------------------------------

Index by function name

   [4] delay                   [6] nx_start                [9] singal_handler
   [7] fdtdump_main            [8] nxsem_wait              [5] up_idle
   [1] hello_main              [3] sdelay
```

Depends on https://github.com/apache/nuttx/pull/13999

## Impact


## Testing

