### PR TITLE
{Bp-2668} canutils/libobd2: replace field ch_unused with ch_tcf

### DIFF
--- a/canutils/libobd2/obd_sendrequest.c
+++ b/canutils/libobd2/obd_sendrequest.c
@@ -96,7 +96,7 @@ int obd_send_request(FAR struct obd_dev_s *dev, uint8_t opmode, uint8_t pid)
 #ifdef CONFIG_CAN_EXTID
   dev->can_txmsg.cm_hdr.ch_extid  = extended;            /* Standard/Extend mode   */
 #endif
-  dev->can_txmsg.cm_hdr.ch_unused = 0;                   /* Unused                 */
+  dev->can_txmsg.cm_hdr.ch_tcf = 0;                   /* Unused                 */
 
   /* Single Frame with two bytes data */
 


### PR DESCRIPTION
## Summary
https://github.com/apache/nuttx-apps/pull/2635 replaced ch_unused with ch_tcf

## Impact
RELEASE

## Testing
CI
