### PR TITLE
build.yml[bugfix]:disable CMake Ninja for Msys2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,7 +319,7 @@ jobs:
           git config --global --add safe.directory /github/workspace/sources/nuttx
           git config --global --add safe.directory /github/workspace/sources/apps
           cd sources/nuttx/tools/ci
-          ./cibuild.sh -g -i -A -C -N -R testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION

## Summary

* MSYS2 + CMAKE + NINJA build is broken due a limit of 8192 characters for command line arguments on Windows.
* Ninja generator in CMake needs to be disabled until a solution is found, use Makefile generator.
* This is a quick fix for CI builds ending up with `parameter list too long` errors.

## Impact

* MSYS2 CI Build system: Makefile generator is used by CMake in place of Ninja (may result in slower builds).

## Testing

* CI build.
* Local machine with Windows (see https://github.com/apache/nuttx/pull/13971#issuecomment-2401902929).