### PR TITLE
{Bp-2658} fsutils/mkmbr/mkmbr.c: fix null pointer access when not all device sp…

### DIFF
--- a/fsutils/mkmbr/mkmbr.c
+++ b/fsutils/mkmbr/mkmbr.c
@@ -111,8 +111,10 @@ int main(int argc, FAR char *argv[])
   int argn;
   int fd;
   int ret;
+  int nr_part;
 
-  if (argc < 4 || argc % 2 != 0)
+  nr_part = (argc - 2) / 2;
+  if (argc < 4 || argc % 2 != 0 || nr_part > 4)
     {
       print_usage();
       return EINVAL;
@@ -133,7 +135,7 @@ int main(int argc, FAR char *argv[])
   next = 1;
   bsize = st.st_size / 512;
   mbr_init(&mbr);
-  for (partn = 0; partn < 4 && next < bsize; partn++)
+  for (partn = 0; partn < nr_part && next < bsize; partn++)
     {
       argn = 2 * (partn + 1);
       if (!strcmp(argv[argn], "auto"))


### PR DESCRIPTION
## Summary
…ace is defined in mbr

argv[argn] is accessed out of range when there are neither four partitions are specified nor the last partition is of auto size. Add a number of partition variable based on input argument number.

Reviewed-by: Yuezhang Mo <Yuezhang.Mo@sony.com>
Reviewed-by: Jacky Cao <Jacky.Cao@sony.com>
Tested-by: Yinzhe Wu <Yinzhe.Wu@sony.com>

## Impact
RELEASE

## Testing
CI
