### PR TITLE
CI: Sync the Build Workflow from nuttx repo

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -38,19 +38,28 @@ jobs:
           # If PR is Not Created or Modified: Build all targets
           pr=${{github.event.pull_request.number}}
           if [[ "$pr" == "" ]]; then
+            echo "Not a Created or Modified PR, will build all targets"
             exit
           fi
 
-          # Get the Labels for the PR: "Arch: risc-v \n Size: XS"
+          # Get the Labels for the PR: "Arch: risc-v \n Board: risc-v \n Size: XS"
           # If GitHub CLI Fails: Build all targets
           labels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq '.labels[] | .name' || echo "")
           numlabels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq '.[] | length' || echo "")
           echo "numlabels=$numlabels" | tee -a $GITHUB_OUTPUT
 
-          # Identify the Size and Arch Labels
+          # Identify the Size, Arch and Board Labels
           if [[ "$labels" == *"Size: "* ]]; then
             echo 'labels_contain_size=1' | tee -a $GITHUB_OUTPUT
           fi
+          if [[ "$labels" == *"Arch: "* ]]; then
+            echo 'labels_contain_arch=1' | tee -a $GITHUB_OUTPUT
+          fi
+          if [[ "$labels" == *"Board: "* ]]; then
+            echo 'labels_contain_board=1' | tee -a $GITHUB_OUTPUT
+          fi
+
+          # Get the Arch Label
           if [[ "$labels" == *"Arch: arm64"* ]]; then
             echo 'arch_contains_arm64=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Arch: arm"* ]]; then
@@ -64,6 +73,22 @@ jobs:
           elif [[ "$labels" == *"Arch: xtensa"* ]]; then
             echo 'arch_contains_xtensa=1' | tee -a $GITHUB_OUTPUT
           fi
+
+          # Get the Board Label
+          if [[ "$labels" == *"Board: arm64"* ]]; then
+            echo 'board_contains_arm64=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: arm"* ]]; then
+            echo 'board_contains_arm=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: risc-v"* ]]; then
+            echo 'board_contains_riscv=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: simulator"* ]]; then
+            echo 'board_contains_sim=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: x86_64"* ]]; then
+            echo 'board_contains_x86_64=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: xtensa"* ]]; then
+            echo 'board_contains_xtensa=1' | tee -a $GITHUB_OUTPUT
+          fi
+
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -73,22 +98,61 @@ jobs:
         run: |
 
           # Fetch the outputs from the previous step
+          numlabels=${{ steps.get-arch.outputs.numlabels }}
+          labels_contain_size=${{ steps.get-arch.outputs.labels_contain_size }}
+          labels_contain_arch=${{ steps.get-arch.outputs.labels_contain_arch }}
+          labels_contain_board=${{ steps.get-arch.outputs.labels_contain_board }}
           arch_contains_arm=${{ steps.get-arch.outputs.arch_contains_arm }}
           arch_contains_arm64=${{ steps.get-arch.outputs.arch_contains_arm64 }}
           arch_contains_riscv=${{ steps.get-arch.outputs.arch_contains_riscv }}
           arch_contains_sim=${{ steps.get-arch.outputs.arch_contains_sim }}
           arch_contains_x86_64=${{ steps.get-arch.outputs.arch_contains_x86_64 }}
           arch_contains_xtensa=${{ steps.get-arch.outputs.arch_contains_xtensa }}
-          labels_contain_size=${{ steps.get-arch.outputs.labels_contain_size }}
-          numlabels=${{ steps.get-arch.outputs.numlabels }}
+          board_contains_arm=${{ steps.get-arch.outputs.board_contains_arm }}
+          board_contains_arm64=${{ steps.get-arch.outputs.board_contains_arm64 }}
+          board_contains_riscv=${{ steps.get-arch.outputs.board_contains_riscv }}
+          board_contains_sim=${{ steps.get-arch.outputs.board_contains_sim }}
+          board_contains_x86_64=${{ steps.get-arch.outputs.board_contains_x86_64 }}
+          board_contains_xtensa=${{ steps.get-arch.outputs.board_contains_xtensa }}
 
           # inputs.boards is a JSON Array: ["arm-01", "risc-v-01", "xtensa-01", ...]
           # We compact and remove the newlines
           boards=$( echo '${{ inputs.boards }}' | jq --compact-output ".")
           numboards=$( echo "$boards" | jq "length" )
 
-          # We consider only PRs with 2 labels, including size
-          if [[ "$numlabels" != "2" || "$labels_contain_size" != "1" ]]; then
+          # We consider only Simple PRs with:
+          # Arch + Size Labels Only
+          # Board + Size Labels Only
+          # Arch + Board + Size Labels Only
+          if [[ "$labels_contain_size" != "1" ]]; then
+            echo "Size Label Missing, will build all targets"
+            quit=1
+          elif [[ "$numlabels" == "2" && "$labels_contain_arch" == "1" ]]; then
+            echo "Arch + Size Labels Only"
+          elif [[ "$numlabels" == "2" && "$labels_contain_board" == "1" ]]; then
+            echo "Board + Size Labels Only"
+          elif [[ "$numlabels" == "3" && "$labels_contain_arch" == "1"  && "$labels_contain_board" == "1" ]]; then
+            # Arch and Board must be the same
+            if [[
+              "$arch_contains_arm" != "$board_contains_arm" ||
+              "$arch_contains_arm64" != "$board_contains_arm64" ||
+              "$arch_contains_riscv" != "$board_contains_riscv" ||
+              "$arch_contains_sim" != "$board_contains_sim" ||
+              "$arch_contains_x86_64" != "$board_contains_x86_64" ||
+              "$arch_contains_xtensa" != "$board_contains_xtensa"
+            ]]; then
+              echo "Arch and Board are not the same, will build all targets"
+              quit=1
+            else
+              echo "Arch + Board + Size Labels Only"
+            fi
+          else
+            echo "Not a Simple PR, will build all targets"
+            quit=1
+          fi
+
+          # If Not a Simple PR: Build all targets
+          if [[ "$quit" == "1" ]]; then
             echo "selected_builds=$boards" | tee -a $GITHUB_OUTPUT
             exit
           fi
@@ -100,38 +164,38 @@ jobs:
             board=$( echo "$boards" | jq ".[$i]" )
             skip_build=0
             
-            # For "Arch: arm": Build arm-01, arm-02, ...
-            if [[ "$arch_contains_arm" == "1" ]]; then
+            # For "Arch / Board: arm": Build arm-01, arm-02, ...
+            if [[ "$arch_contains_arm" == "1" || "$board_contains_arm" == "1" ]]; then
               if [[ "$board" != *"arm"* ]]; then
                 skip_build=1
               fi
 
-            # For "Arch: arm64": Build other
-            elif [[ "$arch_contains_arm64" == "1" ]]; then
+            # For "Arch / Board: arm64": Build other
+            elif [[ "$arch_contains_arm64" == "1" || "$board_contains_arm64" == "1" ]]; then
               if [[ "$board" != *"other"* ]]; then
                 skip_build=1
               fi
 
-            # For "Arch: risc-v": Build risc-v-01, risc-v-02
-            elif [[ "$arch_contains_riscv" == "1" ]]; then
+            # For "Arch / Board: risc-v": Build risc-v-01, risc-v-02
+            elif [[ "$arch_contains_riscv" == "1" || "$board_contains_riscv" == "1" ]]; then
               if [[ "$board" != *"risc-v"* ]]; then
                 skip_build=1
               fi
   
-            # For "Arch: simulator": Build sim-01, sim-02
-            elif [[ "$arch_contains_sim" == "1" ]]; then
+            # For "Arch / Board: simulator": Build sim-01, sim-02
+            elif [[ "$arch_contains_sim" == "1" || "$board_contains_sim" == "1" ]]; then
               if [[ "$board" != *"sim"* ]]; then
                 skip_build=1
               fi
 
-            # For "Arch: x86_64": Build other
-            elif [[ "$arch_contains_x86_64" == "1" ]]; then
+            # For "Arch / Board: x86_64": Build other
+            elif [[ "$arch_contains_x86_64" == "1" || "$board_contains_x86_64" == "1" ]]; then
               if [[ "$board" != *"other"* ]]; then
                 skip_build=1
               fi
   
-            # For "Arch: xtensa": Build xtensa-01, xtensa-02
-            elif [[ "$arch_contains_xtensa" == "1" ]]; then
+            # For "Arch / Board: xtensa": Build xtensa-01, xtensa-02
+            elif [[ "$arch_contains_xtensa" == "1" || "$board_contains_xtensa" == "1" ]]; then
               if [[ "$board" != *"xtensa"* ]]; then
                 skip_build=1
               fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,11 @@ jobs:
         [
           "arm-01", "other", "risc-v-01", "sim-01", "xtensa-01",
           "arm-02", "risc-v-02", "sim-02", "xtensa-02",
-          "arm-03", "arm-04", "arm-05", "arm-06", "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12", "arm-13"
+          "arm-03", "risc-v-03",
+          "arm-04", "risc-v-04",
+          "arm-05", "risc-v-05",
+          "arm-06", "risc-v-06",
+          "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12", "arm-13", "arm-14"
         ]
 
   # Run the selected Linux Builds


### PR DESCRIPTION
## Summary

This PR syncs the CI Build Workflow from `nuttx` repo to `nuttx-apps`, with the following updates:
- https://github.com/apache/nuttx/pull/13954
- https://github.com/apache/nuttx/pull/14011
- https://github.com/apache/nuttx/pull/14022

To follow the existing convention, `build.yml` from `nuttx` repo was slightly modified for `nuttx-apps`:
- All References to `apache/nuttx/.../arch.yml` were changed to `apache/nuttx-apps/.../arch.yml`
- Removed `pull_request > paths-ignore` and `push > paths-ignore`

## Impact

Arm32 Build Jobs shall be extended to `arm-14` and RISC-V Build Jobs to `risc-v-06`. This will reduce the time to build Arm32 and RISC-V Jobs.

The Updated Build Rules in `arch.yml` will not impact the building of NuttX Apps. That's because Board Labels are not used in the `nuttx-app` repo.

## Testing

We verified that CI Build Workflow runs correctly, with Arm32 Build Jobs extended to `arm-14` and RISC-V Build Jobs to `risc-v-06`.

With the updated `build.yml`, CI Build Workflow successfully recompiles `examples/hello` when we Submit a PR: https://github.com/lupyuen5/label-nuttx-apps/actions/runs/11283370051

Also when we Merge a PR: https://github.com/lupyuen5/label-nuttx-apps/actions/runs/11283510569
