### PR TITLE
libuv: Remove GCCVER and add compilation options directly.

### DIFF
--- a/system/libuv/CMakeLists.txt
+++ b/system/libuv/CMakeLists.txt
@@ -44,23 +44,15 @@ if(CONFIG_LIBUV)
     endif()
   endif()
 
-  if(NOT DEFINED GCCVER)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} --version
-                    OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
-    string(REGEX MATCH "\\+\\+.* ([0-9]+)\\.[0-9]+" GCC_VERSION_REGEX
-                 "${GCC_VERSION_OUTPUT}")
-    set(GCCVER ${CMAKE_MATCH_1})
-  endif()
   # ############################################################################
   # Flags
   # ############################################################################
 
-  set(CFLAGS -Wno-shadow -DDEF_THREADPOOL_SIZE=CONFIG_LIBUV_THREADPOOL_SIZE
-             -DDEF_THREADPOOL_STACKSIZE=CONFIG_LIBUV_THREAD_STACKSIZE)
+  set(CFLAGS
+      -Wno-shadow -Wno-dangling-pointer
+      -DDEF_THREADPOOL_SIZE=CONFIG_LIBUV_THREADPOOL_SIZE
+      -DDEF_THREADPOOL_STACKSIZE=CONFIG_LIBUV_THREAD_STACKSIZE)
 
-  if(GCCVER EQUAL 12)
-    list(APPEND CFLAGS -Wno-dangling-pointer)
-  endif()
   # ############################################################################
   # Sources
   # ############################################################################

--- a/system/libuv/Makefile
+++ b/system/libuv/Makefile
@@ -49,16 +49,9 @@ CFLAGS += -I$(LIBUV_UNPACK)/src
 CFLAGS += -I$(LIBUV_UNPACK)/src/unix
 CFLAGS += -I$(LIBUV_UNPACK)/test
 CFLAGS += -Wno-shadow
+CFLAGS += -Wno-dangling-pointer
 CFLAGS += -DDEF_THREADPOOL_SIZE=CONFIG_LIBUV_THREADPOOL_SIZE
 CFLAGS += -DDEF_THREADPOOL_STACKSIZE=CONFIG_LIBUV_THREAD_STACKSIZE
-
-ifeq ($(GCCVER),)
-  export GCCVER = $(shell $(CC) --version | grep gcc | sed -r 's/.* ([0-9]+\.[0-9]+).*/\1/' | cut -d'.' -f1)
-endif
-
-ifeq ($(GCCVER),12)
-  CFLAGS += -Wno-dangling-pointer
-endif
 
 VPATH += $(LIBUV_UNPACK)/src
 VPATH += $(LIBUV_UNPACK)/src/unix


### PR DESCRIPTION
## Summary

## Impact

## Testing

