### PR TITLE
noteprintf: fix compile warnings

### DIFF
--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -45,17 +45,7 @@
 
 int main(int argc, FAR char *argv[])
 {
-  struct binary
-    {
-      uint8_t val1;
-      uint8_t val2;
-    } binary =
-      {
-        .val1        = 0x01,
-        .val2        = 0x02
-      };
-
-  char *str      = "shced note test";
+  char *str      = "sched note test";
   int count      = 0;
   char c         = 1;
   short s        = 2;
@@ -80,7 +70,7 @@ int main(int argc, FAR char *argv[])
   while (1)
     {
       sched_note_printf(NOTE_TAG_ALWAYS,
-                        "shced note test count = %d.", count++);
+                        "sched note test count = %d.", count++);
       sched_note_mark(NOTE_TAG_ALWAYS, str);
       sched_note_printf(NOTE_TAG_ALWAYS, "%hhd", c);
       sched_note_printf(NOTE_TAG_ALWAYS, "%hd", s);


### PR DESCRIPTION


## Summary

```
noteprintf_main.c:52:7: warning: unused variable 'binary' [-Wunused-variable]
   52 |     } binary =
```

Fix typo.


## Impact

No impact.

## Testing

Tested with configuration: `stm32f429i-disco:systemview`
