### PR TITLE
lsan: add system cmd lsan support

### DIFF
--- a/system/lsan/CMakeLists.txt
+++ b/system/lsan/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ##############################################################################
+# apps/system/lsan/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_LSAN)
+  nuttx_add_application(
+    MODULE
+    ${CONFIG_SYSTEM_LSAN}
+    NAME
+    ${CONFIG_SYSTEM_LSAN_PROGNAME}
+    STACKSIZE
+    ${CONFIG_SYSTEM_LSAN_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_LSAN_PRIORITY}
+    SRCS
+    lsan_main.c)
+
+endif()

--- a/system/lsan/Kconfig
+++ b/system/lsan/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_LSAN
+	bool "lsan memory leak detection"
+	default y
+	depends on SIM_ASAN
+	---help---
+		Alsans support for the LeakSanitizer (lsan) memory leak detection tool.
+
+if SYSTEM_LSAN
+
+config SYSTEM_LSAN_PROGNAME
+	string "lsan program name"
+	default "lsan"
+	---help---
+		This is the name of the program that will be used when the lsan
+		program is installed.
+
+config SYSTEM_LSAN_PRIORITY
+	int "lsan task priority"
+	default 100
+
+config SYSTEM_LSAN_STACKSIZE
+	int "lsan stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/system/lsan/Make.defs
+++ b/system/lsan/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/system/lsan/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_LSAN),)
+CONFIGURED_APPS += $(APPDIR)/system/lsan
+endif

--- a/system/lsan/Makefile
+++ b/system/lsan/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/system/lsan/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Standalone lsan command
+
+PROGNAME = $(CONFIG_SYSTEM_LSAN_PROGNAME)
+PRIORITY = $(CONFIG_SYSTEM_LSAN_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_LSAN_STACKSIZE)
+MODULE = $(CONFIG_SYSTEM_LSAN)
+
+# Files
+
+MAINSRC = lsan_main.c
+
+include $(APPDIR)/Application.mk

--- a/system/lsan/lsan_main.c
+++ b/system/lsan/lsan_main.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/lsan/lsan_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+extern void __lsan_do_recoverable_leak_check(void);
+
+int main(int argc, FAR char *argv[])
+{
+  __lsan_do_recoverable_leak_check();
+  return 0;
+}


### PR DESCRIPTION
## Summary

lsan: add system cmd lsan support

The Alsans support for the LeakSanitizer (lsan) memory leak detection tool.

ref:
    https://github.com/gcc-mirror/gcc/blob/master/libsanitizer/include/sanitizer/lsan_interface.h
    
This tool used for runtime check memleak on the SIM platfrom.


## Impact

new tool

## Testing

sim