### PR TITLE
coremark/Makefile: avoid crc function multiple definition

### DIFF
--- a/benchmarks/coremark/Makefile
+++ b/benchmarks/coremark/Makefile
@@ -85,6 +85,11 @@ else
 CFLAGS += ${DEFINE_PREFIX}ITERATIONS=0
 endif
 
+CFLAGS += ${DEFINE_PREFIX}crcu8=coremark_crcu8
+CFLAGS += ${DEFINE_PREFIX}crcu16=coremark_crcu16
+CFLAGS += ${DEFINE_PREFIX}crcu32=coremark_crcu32
+CFLAGS += ${DEFINE_PREFIX}crc16=coremark_crc16
+
 CSRCS += core_list_join.c
 CSRCS += core_matrix.c
 CSRCS += core_state.c


### PR DESCRIPTION
## Summary
/data/project/oh2/rel-4.0/prebuilts/gcc/linux/arm/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld: crc16_sw.c.data.project.oh2.rel-4.0.external.zblue.zblue_1.o (symbol from plugin): in function `crc16':
(.text+0x0): multiple definition of `crc16'; core_util.c.data.project.oh2.rel-4.0.apps.benchmarks.coremark_1.o (symbol from plugin):(.text+0x0): first defined here

## Impact
coremark

## Testing
compile with coremark
