### PR TITLE
system/system: add config SYSTEM_SYSTEM_DUMPINFO

### DIFF
--- a/system/system/Kconfig
+++ b/system/system/Kconfig
@@ -41,4 +41,10 @@ config SYSTEM_SYSTEM_PRIORITY
 	---help---
 		The priority of the shell.
 
+config SYSTEM_SYSTEM_DUMPINFO
+	bool "dump the system information"
+	default n
+	---help---
+		Dump the system information when the system() command is executed.
+
 endif

--- a/system/system/system.c
+++ b/system/system/system.c
@@ -31,6 +31,8 @@
 #include <assert.h>
 #include <debug.h>
 #include <errno.h>
+#include <execinfo.h>
+#include <syslog.h>
 
 #include "nshlib/nshlib.h"
 
@@ -67,6 +69,11 @@ int system(FAR const char *cmd)
   int errcode;
   int rc;
   int ret;
+
+#ifdef CONFIG_SYSTEM_SYSTEM_DUMPINFO
+  syslog(LOG_INFO, "SYSTEM cmd=%s\n", cmd);
+  dump_stack();
+#endif
 
   /* REVISIT: If cmd is NULL, then system() should return a non-zero value to
    * indicate if the command processor is available or zero if it is not.


### PR DESCRIPTION
## Summary
In some cases, applicationes use system() to excute the nsh command, but it's hard to find out who used the system function to execute the nsh command, so  add this config to print the call backtrace and the command content.

## Impact
system command

## Testing
sim
