### PR TITLE
osperf/osperf: move close pipefd after pthread_join

### DIFF
--- a/benchmarks/osperf/osperf.c
+++ b/benchmarks/osperf/osperf.c
@@ -281,9 +281,9 @@ static size_t poll_performance(void)
   poll(&fds, 1, -1);
   performance_end(&result);
 
+  pthread_join(ret, NULL);
   close(pipefd[0]);
   close(pipefd[1]);
-  pthread_join(ret, NULL);
   return performance_gettime(&result);
 }
 


### PR DESCRIPTION
## Summary
Avoid the new thread write the closed pipe

## Impact
osperf

## Testing
sim
