### PR TITLE
ADB: Hotplug check and QEMU pipe

### DIFF
--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -113,6 +113,13 @@ config ADBD_USB_SERVER
 	---help---
 		Run adb daemon on USB bus
 
+config ADBD_USB_HOTPLUG_BYTIMER
+	bool "Using 1s timer to check usb hotplug"
+	depends on ADBD_USB_SERVER
+	default n
+	---help---
+		Using 1s timer to check usb hotplug
+
 config ADBD_LOGCAT_SERVICE
 	bool "ADB logcat support"
 	select LIBC_PRINT_EXTENSION

--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -132,6 +132,20 @@ config ADBD_USB_HOTPLUG_BYNOTIFY
 
 endchoice # Check usb hotplug
 
+config ADBD_QEMU_SERVER
+	bool "QEMU pipe transport support"
+	depends on GOLDFISH_PIPE
+	default n
+	---help---
+		Run adb daemon on qemu pipe
+
+config ADBD_QEMU_SERVER_PORT
+	int "QEMU pipe transport port"
+	depends on ADBD_QEMU_SERVER
+	default 5555
+	---help---
+		Port used by adb daemon qemu pipe server
+
 config ADBD_LOGCAT_SERVICE
 	bool "ADB logcat support"
 	select LIBC_PRINT_EXTENSION

--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -113,12 +113,24 @@ config ADBD_USB_SERVER
 	---help---
 		Run adb daemon on USB bus
 
+choice
+	prompt "Check usb hotplug"
+	default ADBD_USB_HOTPLUG_BYTIMER
+
 config ADBD_USB_HOTPLUG_BYTIMER
 	bool "Using 1s timer to check usb hotplug"
 	depends on ADBD_USB_SERVER
-	default n
 	---help---
 		Using 1s timer to check usb hotplug
+
+config ADBD_USB_HOTPLUG_BYNOTIFY
+	bool "Using fs notify to check usb hotplug"
+	depends on ADBD_USB_SERVER
+	depends on FS_NOTIFY
+	---help---
+		Using fs notify to monitor usb hotplug
+
+endchoice # Check usb hotplug
 
 config ADBD_LOGCAT_SERVICE
 	bool "ADB logcat support"

--- a/system/adb/Makefile
+++ b/system/adb/Makefile
@@ -61,6 +61,10 @@ ifeq ($(CONFIG_ADBD_USB_SERVER),y)
 CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv_client_usb.c
 endif
 
+ifeq ($(CONFIG_ADBD_QEMU_SERVER),y)
+CSRCS += $(ADB_UNPACKNAME)/hal/hal_uv_client_qemu.c
+endif
+
 ifeq ($(CONFIG_ADBD_AUTHENTICATION),y)
 CSRCS += $(ADB_UNPACKNAME)/adb_auth_key.c
 endif


### PR DESCRIPTION
## Summary
1. Add timer to check usb hotplug event
2. Using inotify to check usb hotplug event
3. Implement ADB function through qemu pipe

Only Kconfig and Makefile, for implement please see microADB
## Impact
system/adb

## Testing
CI
