### PR TITLE
wapi_json_load: the buf need add null character

### DIFF
--- a/wireless/wapi/src/util.c
+++ b/wireless/wapi/src/util.c
@@ -89,12 +89,13 @@ static FAR void *wapi_json_load(FAR const char *confname)
       return NULL;
     }
 
-  buf = malloc(sb.st_size);
+  buf = malloc(sb.st_size + 1);
   if (!buf)
     {
       goto errout;
     }
 
+  buf[sb.st_size] = '\0';
   fd = open(confname, O_RDONLY);
   if (fd < 0)
     {


### PR DESCRIPTION
wapi_json_load: the buf need add null character

If the buf no null character, the strlen acces buf maybe out of bounds

## Summary

## Impact

## Testing

