### PR TITLE
uORB:Fixed the problem that uorb output cannot wrap after deleting lib_libbsprintf automatic wrapping.

### DIFF
--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -370,7 +370,7 @@ void orb_info(FAR const char *format, FAR const char *name,
   vaf.va  = (va_list *)data;
 
   lib_stdoutstream(&stdoutstream, stdout);
-  lib_sprintf(&stdoutstream.common, "%s(now:%" PRIu64 "):%pB",
+  lib_sprintf(&stdoutstream.common, "%s(now:%" PRIu64 "):%pB\n",
               name, orb_absolute_time(), &vaf);
 }
 


### PR DESCRIPTION
## Summary

- uORB:Fixed the problem that uorb output cannot wrap after deleting lib_libbsprintf automatic wrapping.

## Impact
N/A
## Testing

- Environment:

  1.   OS and Version: Ubuntu 20.04.6 LTS x86_64
  2.   GCC Version: 13.1.0
  3.   SIM: ./tools/configure.sh sim:nsh

- Order:

  1. ./nuttx 
  2. uorb_listener -r 50 -n 100  sensor_accel_uncal
