### PR TITLE
examples/bmi160:bmi160 add urob mode example.

### DIFF
--- a/examples/bmi160/CMakeLists.txt
+++ b/examples/bmi160/CMakeLists.txt
@@ -19,6 +19,11 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SIXAXIS)
+  if(CONFIG_EXAMPLES_SIXAXIS_UORB)
+    set(CSRC sixaxis_main.c)
+  else()
+    set(CSRC sixaxis_uorb_main.c)
+  endif()
   nuttx_add_application(
     NAME
     ${CONFIG_EXAMPLES_SIXAXIS_PROGNAME}
@@ -27,5 +32,5 @@ if(CONFIG_EXAMPLES_SIXAXIS)
     STACKSIZE
     ${CONFIG_EXAMPLES_SIXAXIS_STACKSIZE}
     SRCS
-    sixaxis_main.c)
+    ${CSRC})
 endif()

--- a/examples/bmi160/Kconfig
+++ b/examples/bmi160/Kconfig
@@ -11,6 +11,13 @@ config EXAMPLES_SIXAXIS
 
 if EXAMPLES_SIXAXIS
 
+config EXAMPLES_SIXAXIS_UORB
+	bool "BMI160 sensor uorb example"
+	default n
+	---help---
+		Enables Work with the UORB or Character Device interface.
+		If not set, the Character Device is used by default.
+
 config EXAMPLES_SIXAXIS_PROGNAME
 	string "Program name"
 	default "sixaxis"

--- a/examples/bmi160/Makefile
+++ b/examples/bmi160/Makefile
@@ -28,6 +28,10 @@ STACKSIZE = $(CONFIG_EXAMPLES_SIXAXIS_STACKSIZE)
 
 # sixaxis Example
 
+ifeq ($(CONFIG_EXAMPLES_SIXAXIS_UORB),)
 MAINSRC = sixaxis_main.c
+else
+MAINSRC = sixaxis_uorb_main.c
+endif
 
 include $(APPDIR)/Application.mk

--- a/examples/bmi160/sixaxis_uorb_main.c
+++ b/examples/bmi160/sixaxis_uorb_main.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * apps/examples/bmi160/sixaxis_uorb_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <poll.h>
+#include <errno.h>
+#include <sensor/accel.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ACC_TIMEOUT      1000
+#define READ_TIMES       100
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * sixaxis_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  FAR const struct orb_metadata *meta;
+  struct sensor_accel accel_data;
+  struct pollfd fds;
+  int ret = OK;
+  int fd;
+  int i;
+
+  meta = ORB_ID(sensor_accel_uncal);
+  fd = orb_subscribe_multi(meta, 0);
+  if (fd < 0)
+    {
+      printf("sensor accel subscribe error! return:%d\n", fd);
+      return fd;
+    }
+
+  fds.fd     = fd;
+  fds.events = POLLIN;
+
+  for (i = 0; i < READ_TIMES; i++)
+    {
+      if (poll(&fds, 1, ACC_TIMEOUT) > 0)
+        {
+          if (fds.revents & POLLIN)
+            {
+              ret = orb_copy(meta, fd, &accel_data);
+#ifdef CONFIG_DEBUG_UORB
+              if (ret == OK && meta->o_format != NULL)
+                {
+                  orb_info(meta->o_format, meta->o_name, &accel_data);
+                }
+#endif
+            }
+        }
+      else if (errno != EINTR)
+        {
+          printf("Waited for %d milliseconds without a message. "
+                 "Giving up. err:%d", ACC_TIMEOUT, errno);
+          break;
+        }
+    }
+
+  orb_unsubscribe(fd);
+  printf("sensor accel read examples exit.\n");
+
+  return ret;
+}


### PR DESCRIPTION
## Summary
examples/bmi160:bmi160 add urob mode example.
## Impact
N/A
## Testing

- Environment:

  1.   OS and Version: Ubuntu 20.04.6 LTS x86_64
  2.   GCC Version: 13.1.0
  3.   SIM: ./tools/configure.sh sim:nsh

- Order:

  1. ./nuttx 
  2. sixaxis
