### PR TITLE
drivertest/Makefile: add CONFIG_BUILD_FLAT limit for drivertest_block.c

### DIFF
--- a/testing/drivertest/Makefile
+++ b/testing/drivertest/Makefile
@@ -29,7 +29,7 @@ MAINSRC  += drivertest_simple.c
 PROGNAME += cmocka_driver_simple
 endif
 
-ifeq ($(CONFIG_BCH),y)
+ifeq ($(CONFIG_BCH)$(CONFIG_BUILD_FLAT),yy)
 CFLAGS += ${INCDIR_PREFIX}${TOPDIR}/fs
 PROGNAME += cmocka_driver_block
 MAINSRC  += drivertest_block.c


### PR DESCRIPTION

## Summary
If BUILD_FLAT is not enabled, the app and CPU run in user mode and kernel mode respectively. The kernel and app are in different memory address spaces. Different apps are in the same memory address space. drivertest_block.c cannot directly call the kernel API.
## Impact
Rpmsg blk driver test
## Testing
Test in vela
