### PR TITLE
nsh/fsutils: fix build break if CONFIG_NSH_DISABLE_PKILL not disabled

### DIFF
--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1394,7 +1394,7 @@ int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
  *
  ****************************************************************************/
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+#ifdef CONFIG_FS_PROCFS
 ssize_t nsh_getpid(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
                    FAR pid_t *pids, size_t count);
 #endif

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -63,7 +63,7 @@ struct getpid_arg_s
  *
  ****************************************************************************/
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+#ifdef CONFIG_FS_PROCFS
 static int getpid_callback(FAR struct nsh_vtbl_s *vtbl,
                            FAR const char *dirpath,
                            FAR struct dirent *entryp, FAR void *pvarg)
@@ -604,7 +604,7 @@ FAR char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
  *
  ****************************************************************************/
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PIDOF)
+#ifdef CONFIG_FS_PROCFS
 ssize_t nsh_getpid(FAR struct nsh_vtbl_s *vtbl, FAR const char *name,
                    FAR pid_t *pids, size_t count)
 {


### PR DESCRIPTION
## Summary

nsh/fsutils: fix build break if CONFIG_NSH_DISABLE_PKILL not disabled

```
arm-none-eabi/bin/ld: apps/libapps.a(nsh_proccmds.c.obj): in function `cmd_pkill':
apps/nshlib/nsh_proccmds.c:861:(.text.cmd_pkill+0x38): undefined reference to `nsh_getpid'
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

ci-check