### PR TITLE
nshlib: Fix stack-buffer-overflow of nsh_redirect()

### DIFF
--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -71,7 +71,7 @@
  * See struct serialsave_s in nsh_console.c
  */
 
-#define SAVE_SIZE (2 * sizeof(int))
+#define SAVE_SIZE (3 * sizeof(int))
 
 /* Are we using the NuttX console for I/O?  Or some other character device? */
 

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -2855,10 +2855,12 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
       vtbl->np.np_redir_out = redirect_out_save;
     }
 
+  /* Free the redirected input file path */
+
   if (redirfile_in)
     {
       nsh_freefullpath(redirfile_in);
-      vtbl->np.np_redir_out = redirect_in_save;
+      vtbl->np.np_redir_in = redirect_in_save;
     }
 
 dynlist_free:


### PR DESCRIPTION
## Summary
The NSH hangs after exec the test command.
`nsh_redirect()` needs to save three fd(stderr, stdout and stdin) but array length is only two, stack buffer overflowed!

- Config
```
  sim:nsh
```

- Command
```
  cat < /etc/init.d/rc.sysinit
```

Related: https://github.com/apache/nuttx-apps/pull/2469

## Impact
nsh/redirect

## Testing
- Selftest as summary shown
- Apache:NuttX CI
