### PR TITLE
ramspeed: fix -r -w parameter ignored, report align issue

### DIFF
--- a/benchmarks/ramspeed/ramspeed_main.c
+++ b/benchmarks/ramspeed/ramspeed_main.c
@@ -150,15 +150,26 @@ static void parse_commandline(int argc, FAR char **argv,
             break;
           case 'r':
             OPTARG_TO_VALUE(info->src, const void *, 16);
+            if (((uintptr_t)info->src & ALIGN_MASK) != 0)
+              {
+                printf(RAMSPEED_PREFIX "<read-adress> must align\n");
+                exit(EXIT_FAILURE);
+              }
+
             break;
           case 'w':
             OPTARG_TO_VALUE(info->dest, void *, 16);
+            if (((uintptr_t)info->src & ALIGN_MASK) != 0)
+              {
+                printf(RAMSPEED_PREFIX "<write-adress> must align\n");
+                exit(EXIT_FAILURE);
+              }
             break;
           case 's':
             OPTARG_TO_VALUE(info->size, size_t, 10);
             if (info->size < 32)
               {
-                printf(RAMSPEED_PREFIX "<size> must >= 32");
+                printf(RAMSPEED_PREFIX "<size> must >= 32\n");
                 exit(EXIT_FAILURE);
               }
 
@@ -187,13 +198,23 @@ static void parse_commandline(int argc, FAR char **argv,
         }
     }
 
-  if ((info->dest == NULL && !info->allocate_rw_address) || info->size == 0)
+  if (!info->allocate_rw_address && info->dest == NULL)
     {
-      printf(RAMSPEED_PREFIX "Missing required arguments\n");
+      /* We allow only set write address to test memset only.
+       * But if need test read by specific address, need write address also.
+       */
+
+      printf(RAMSPEED_PREFIX "Required Address Failed\n");
       goto out;
     }
-  else
+  else if (info->allocate_rw_address)
     {
+      if (info->size == 0)
+        {
+          printf(RAMSPEED_PREFIX "Required Size Failed\n");
+          goto out;
+        }
+
       /* We need to automatically apply for memory */
 
       printf(RAMSPEED_PREFIX "Allocate RW buffers on heap\n");


### PR DESCRIPTION
## Summary
We may want to test ramspeed by specific address, but be ignored.
print the not-aligned address, the last patch here is aim to solve align issue. we just need report the not-aligned manually input address.

## Impact
fix bug now can use manual address to test the ram speed.
exit when not aligned address input.

## Testing
CI-test, local arm-v8m board.
