### PR TITLE
telnet: Configure the telnet session stack to be the same as nsh

### DIFF
--- a/system/telnetd/Kconfig
+++ b/system/telnetd/Kconfig
@@ -40,6 +40,6 @@ config SYSTEM_TELNETD_SESSION_PRIORITY
 
 config SYSTEM_TELNETD_SESSION_STACKSIZE
 	int "Telnetd session task stack size"
-	default 3072
+	default SYSTEM_NSH_STACKSIZE
 
 endif # SYSTEM_TELNETD


### PR DESCRIPTION
## Summary
Using the default 3K stack size will result in insufficient stack when executing certain commands.

## Impact

Telnet.

## Testing

Local testing revealed 3K stack overflow on certain commands. This fixes the issue.