### PR TITLE
examples: fix usrsocktest compiler warning

### DIFF
--- a/examples/usrsocktest/usrsocktest_basic_connect.c
+++ b/examples/usrsocktest/usrsocktest_basic_connect.c
@@ -109,7 +109,7 @@ static void setup(FAR struct usrsocktest_daemon_conf_s *dconf)
 
 static void teardown(void)
 {
-  int ret;
+  int unused_data ret;
 
   if (sd >= 0)
     {

--- a/examples/usrsocktest/usrsocktest_basic_daemon.c
+++ b/examples/usrsocktest/usrsocktest_basic_daemon.c
@@ -502,7 +502,7 @@ TEST_SETUP(basic_daemon)
 
 TEST_TEAR_DOWN(basic_daemon)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_basic_getsockname.c
+++ b/examples/usrsocktest/usrsocktest_basic_getsockname.c
@@ -235,7 +235,7 @@ TEST_SETUP(basic_getsockname)
 
 TEST_TEAR_DOWN(basic_getsockname)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_basic_getsockopt.c
+++ b/examples/usrsocktest/usrsocktest_basic_getsockopt.c
@@ -214,7 +214,7 @@ TEST_SETUP(basic_getsockopt)
 
 TEST_TEAR_DOWN(basic_getsockopt)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_basic_send.c
+++ b/examples/usrsocktest/usrsocktest_basic_send.c
@@ -291,7 +291,7 @@ TEST_SETUP(basic_send)
 
 TEST_TEAR_DOWN(basic_send)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_basic_setsockopt.c
+++ b/examples/usrsocktest/usrsocktest_basic_setsockopt.c
@@ -182,7 +182,7 @@ TEST_SETUP(basic_setsockopt)
 
 TEST_TEAR_DOWN(basic_setsockopt)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_block_recv.c
+++ b/examples/usrsocktest/usrsocktest_block_recv.c
@@ -558,7 +558,7 @@ TEST_SETUP(block_recv)
 
 TEST_TEAR_DOWN(block_recv)
 {
-  int ret;
+  int unused_data ret;
 
   if (sd >= 0)
     {

--- a/examples/usrsocktest/usrsocktest_block_send.c
+++ b/examples/usrsocktest/usrsocktest_block_send.c
@@ -358,7 +358,7 @@ TEST_SETUP(block_send)
 
 TEST_TEAR_DOWN(block_send)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_chardev.c
+++ b/examples/usrsocktest/usrsocktest_chardev.c
@@ -97,7 +97,7 @@ TEST_SETUP(char_dev)
 
 TEST_TEAR_DOWN(char_dev)
 {
-  int ret;
+  int unused_data ret;
 
   if (us_fd >= 0)
     {

--- a/examples/usrsocktest/usrsocktest_daemon.c
+++ b/examples/usrsocktest/usrsocktest_daemon.c
@@ -274,7 +274,7 @@ static FAR void *find_endpoint(FAR struct daemon_priv_s *priv,
                                in_addr_t ipaddr)
 {
   FAR struct sockaddr_in *endpaddr;
-  int ok;
+  int unused_data ok;
 
   endpaddr = malloc(sizeof(*endpaddr));
   usrsocktest_endp_malloc_cnt++;

--- a/examples/usrsocktest/usrsocktest_multi_thread.c
+++ b/examples/usrsocktest/usrsocktest_multi_thread.c
@@ -144,7 +144,7 @@ TEST_SETUP(multithread)
 
 TEST_TEAR_DOWN(multithread)
 {
-  int ret;
+  int unused_data ret;
   int i;
 
   for (i = 0; i < nitems(tids); i++)

--- a/examples/usrsocktest/usrsocktest_noblock_connect.c
+++ b/examples/usrsocktest/usrsocktest_noblock_connect.c
@@ -72,7 +72,7 @@ TEST_SETUP(no_block_connect)
 
 TEST_TEAR_DOWN(no_block_connect)
 {
-  int ret;
+  int unused_data ret;
 
   if (sd >= 0)
     {

--- a/examples/usrsocktest/usrsocktest_noblock_recv.c
+++ b/examples/usrsocktest/usrsocktest_noblock_recv.c
@@ -461,7 +461,7 @@ TEST_SETUP(no_block_recv)
 
 TEST_TEAR_DOWN(no_block_recv)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_noblock_send.c
+++ b/examples/usrsocktest/usrsocktest_noblock_send.c
@@ -351,7 +351,7 @@ TEST_SETUP(no_block_send)
 
 TEST_TEAR_DOWN(no_block_send)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_nodaemon.c
+++ b/examples/usrsocktest/usrsocktest_nodaemon.c
@@ -95,7 +95,7 @@ TEST_SETUP(no_daemon)
 
 TEST_TEAR_DOWN(no_daemon)
 {
-  int ret;
+  int unused_data ret;
 
   if (sd >= 0)
     {

--- a/examples/usrsocktest/usrsocktest_poll.c
+++ b/examples/usrsocktest/usrsocktest_poll.c
@@ -570,7 +570,7 @@ TEST_SETUP(poll)
 
 TEST_TEAR_DOWN(poll)
 {
-  int ret;
+  int unused_data ret;
   if (sd >= 0)
     {
       ret = close(sd);

--- a/examples/usrsocktest/usrsocktest_remote_disconnect.c
+++ b/examples/usrsocktest/usrsocktest_remote_disconnect.c
@@ -972,7 +972,7 @@ TEST_SETUP(remote_disconnect)
 
 TEST_TEAR_DOWN(remote_disconnect)
 {
-  int ret;
+  int unused_data ret;
 
   if (sd >= 0)
     {

--- a/examples/usrsocktest/usrsocktest_wake_with_signal.c
+++ b/examples/usrsocktest/usrsocktest_wake_with_signal.c
@@ -648,7 +648,7 @@ TEST_SETUP(wake_with_signal)
 
 TEST_TEAR_DOWN(wake_with_signal)
 {
-  int ret;
+  int unused_data ret;
   int i;
 
   for (i = 0; i < MAX_THREADS; i++)


### PR DESCRIPTION
## Summary
error: variable 'ret' set but not used [-Werror=unused-but-set-variable]
   112 |   int ret;

## Impact

## Testing
sim
