### PR TITLE
quickjs: fix mp_mul multiple definition

### DIFF
--- a/interpreters/quickjs/Makefile
+++ b/interpreters/quickjs/Makefile
@@ -30,6 +30,7 @@ CSRCS = quickjs.c libregexp.c libbf.c libunicode.c cutils.c
 
 VERSION=\"$(QUICKJS_VERSION)\"
 
+CFLAGS += -Dmp_add=qjs_mp_add -Dmp_sub=qjs_mp_sub -Dmp_mul=qjs_mp_mul
 CFLAGS += -DCONFIG_VERSION=$(VERSION) -Wno-shadow
 CFLAGS += -Wno-array-bounds -I$(QUICKJS_UNPACK)
 CFLAGS += -D__linux__ -include alloca.h


### PR DESCRIPTION
## Summary
in function `mp_mul':
apps/interpreters/quickjs/quickjs/libbf.c:1179: multiple definition of `mp_mul'; nuttx/staging/libapps.a:apps/math/libtommath/libtommath/bn_mp_mul.c:8: first defined here


## Impact

## Testing
sim
