### PR TITLE
telenet: fix telenet compilation error when system_nsh is not enabled

### DIFF
--- a/system/telnetd/Kconfig
+++ b/system/telnetd/Kconfig
@@ -40,6 +40,6 @@ config SYSTEM_TELNETD_SESSION_PRIORITY
 
 config SYSTEM_TELNETD_SESSION_STACKSIZE
 	int "Telnetd session task stack size"
-	default SYSTEM_NSH_STACKSIZE
+	default DEFAULT_TASK_STACKSIZE
 
 endif # SYSTEM_TELNETD


### PR DESCRIPTION
## Summary
telenet: fix telenet compilation error when system_nsh is not enabled

telnetd.c:57:5: error: 'CONFIG_SYSTEM_TELNETD_SESSION_STACKSIZE' undeclared (first use in this function); did you mean 'CONFIG_SYSTEM_TELNETD_SESSION_PRIORITY'?
   57 |     CONFIG_SYSTEM_TELNETD_SESSION_STACKSIZE,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     CONFIG_SYSTEM_TELNETD_SESSION_PRIORITY

## Impact

## Testing

