### PR TITLE
apps/benchmarks/dhrystone: Fix compilation errors

### DIFF
--- a/benchmarks/dhrystone/CMakeLists.txt
+++ b/benchmarks/dhrystone/CMakeLists.txt
@@ -44,7 +44,10 @@ if(CONFIG_BENCHMARK_DHRYSTONE)
     endif()
   endif()
 
-  set(CFLAGS -DMSC_CLOCK)
+  set(CFLAGS
+      -DMSC_CLOCK -Wno-maybe-uninitialized -Wno-implicit-int
+      -Wno-strict-prototypes -Wno-implicit-function-declaration
+      -Wno-return-type)
   set(SRCS dhrystone/v2.2/dry.c dhrystone/v2.1/dhry_2.c)
 
   nuttx_add_application(

--- a/benchmarks/dhrystone/Makefile
+++ b/benchmarks/dhrystone/Makefile
@@ -29,6 +29,7 @@ MODULE    = $(CONFIG_BENCHMARK_DHRYSTONE)
 
 CFLAGS   += -DMSC_CLOCK -Wno-implicit-int -Wno-strict-prototypes
 CFLAGS   += -Wno-implicit-function-declaration -Wno-return-type
+CFLAGS   += -Wno-maybe-uninitialized
 
 CSRCS    += dhrystone/v2.1/dhry_2.c
 MAINSRC   = dhrystone/v2.2/dry.c


### PR DESCRIPTION
Error details:
dhrystone/v2.2/dry.c:714:3: error: 'Int_2_Loc' may be used uninitialized [-Werror=maybe-uninitialized]
  714 |   fprintf (stderr, "Int_2_Loc:           %d\n", Int_2_Loc);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
dhrystone/v2.2/dry.c:543:25: note: 'Int_2_Loc' was declared here
  543 |   REG   One_Fifty       Int_2_Loc;
      |                         ^~~~~~~~~

## Summary

## Impact

## Testing

