### PR TITLE
Revert "add test for longjump with 0 as return value"

### DIFF
--- a/testing/ostest/setjmp.c
+++ b/testing/ostest/setjmp.c
@@ -32,23 +32,17 @@
  * Public Functions
  ****************************************************************************/
 
-void jump_with_retval(jmp_buf buf, int ret)
+void setjmp_test(void)
 {
-  volatile bool did_jump = false;
   int value;
+  jmp_buf buf;
+
+  printf("setjmp_test: Initializing jmp_buf\n");
 
   if ((value = setjmp(buf)) == 0)
     {
       printf("setjmp_test: Try jump\n");
-
-      if (did_jump)
-        {
-          ASSERT(!"setjmp retutns zero after calling longjmp");
-        }
-
-      did_jump = true;
-      printf("setjmp_test: About to jump, longjmp with ret val: %d\n", ret);
-      longjmp(buf, ret);
+      longjmp(buf, 123);
 
       /* Unreachable */
 
@@ -56,32 +50,7 @@ void jump_with_retval(jmp_buf buf, int ret)
     }
   else
     {
-      /* If we provide 0 as the return value to longjmp()
-       * we expect it substitute to 1 for us.
-       */
-
-      if (ret == 0)
-        {
-          ret = 1;
-        }
-
-      ASSERT(value == ret);
+      ASSERT(value == 123);
       printf("setjmp_test: Jump succeed\n");
     }
-}
-
-void setjmp_test(void)
-{
-  jmp_buf buf;
-
-  printf("setjmp_test: Initializing jmp_buf\n");
-
-  jump_with_retval(buf, 123);
-
-  /* Pls ref to:
-   * the longjmp should never make setjmp returns 0
-   * https://pubs.opengroup.org/onlinepubs/009604599/functions/longjmp.html
-   */
-
-  jump_with_retval(buf, 0);
 }


### PR DESCRIPTION
## Summary

Revert "add test for longjump with 0 as return value"

This reverts commit 63542f83c2985723071ae7e428311213008aa108.

user_main: setjmp test
setjmp_test: Initializing jmp_buf
setjmp_test: Try jump
setjmp_test: About to jump, longjmp with ret val: 123
setjmp_test: Jump succeed
setjmp_test: Try jump
setjmp_test: About to jump, longjmp with ret val: 0
setjmp_test: Try jump
dump_assert_info: Current Version: NuttX  10.4.0 11e0262ae8 Oct 14 2024 12:53:49 sim
dump_assert_info: Assertion failed : at file: setjmp.c:46 task: ostest process: ostest 0x7de654
sched_dumpstack: backtrace:
sched_dumpstack: [ 6] [<0xb211b1>] host_backtrace+0x2d/0x41
sched_dumpstack: [ 6] [<0x7a39b2>] up_backtrace+0x10a/0x189
sched_dumpstack: [ 6] [<0x78dc79>] sched_backtrace+0x4d/0x9a
sched_dumpstack: [ 6] [<0x7974e5>] sched_dumpstack+0x5e/0x141
sched_dumpstack: [ 6] [<0x78c679>] dump_running_task+0x2e/0x31
sched_dumpstack: [ 6] [<0x78c83d>] dump_assert_info+0x1c1/0x1dd
sched_dumpstack: [ 6] [<0x78c9df>] _assert+0x146/0x1bd
sched_dumpstack: [ 6] [<0x749df4>] __assert+0x2f/0x34
sched_dumpstack: [ 6] [<0x7df66c>] jump_with_retval+0x7f/0x11b
sched_dumpstack: [ 6] [<0x7df76c>] setjmp_test+0x64/0x82
sched_dumpstack: [ 6] [<0x7dea60>] user_main+0x40c/0x514
sched_dumpstack: [ 6] [<0x74a9ed>] nxtask_startup+0x57/0x5e
sched_dumpstack: [ 6] [<0x740db9>] nxtask_start+0xdf/0xe9
sched_dumpstack: [ 6] [<0x756757>] pre_start+0x2b/0x2e
ostest_main: Exiting with status 256
stdio_test: Standard I/O Check: fprintf to stderr


## Impact

ostest

## Testing

CI

