### PR TITLE
apps: Fix compilation error after nuttx/arch.h excluded

### DIFF
--- a/examples/oneshot/oneshot_main.c
+++ b/examples/oneshot/oneshot_main.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include <nuttx/clock.h>
 #include <nuttx/timers/oneshot.h>
 
 /****************************************************************************

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -40,10 +40,10 @@
 
 #include <nuttx/version.h>
 #include <nuttx/sched_note.h>
-#include "nshlib/nshlib.h"
 
 #include "nsh.h"
 #include "nsh_console.h"
+#include "nshlib/nshlib.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/system/coredump/coredump.c
+++ b/system/coredump/coredump.c
@@ -36,6 +36,8 @@
 
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/streams.h>
+#include <nuttx/sched.h>
+#include <nuttx/coredump.h>
 
 /****************************************************************************
  * Private Types

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/system/ntpc/ntpcstatus_main.c
+++ b/system/ntpc/ntpcstatus_main.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/clock.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/system/readline/readline.c
+++ b/system/readline/readline.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "system/readline.h"
 

--- a/testing/drivertest/drivertest_oneshot.c
+++ b/testing/drivertest/drivertest_oneshot.c
@@ -38,6 +38,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <syslog.h>
+#include <nuttx/clock.h>
 #include <nuttx/timers/oneshot.h>
 
 /****************************************************************************

--- a/testing/drivertest/drivertest_watchdog.c
+++ b/testing/drivertest/drivertest_watchdog.c
@@ -42,6 +42,8 @@
 #include <stdint.h>
 #include <cmocka.h>
 #include <time.h>
+
+#include <nuttx/arch.h>
 #include <nuttx/timers/watchdog.h>
 
 /****************************************************************************

--- a/testing/getprime/getprime_main.c
+++ b/testing/getprime/getprime_main.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/clock.h>
 
 #include <assert.h>
 #include <pthread.h>

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -370,7 +370,7 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
-#if !defined(CONFIG_DISABLE_PTHREAD) && \
+#if !defined(CONFIG_DISABLE_PTHREAD) && defined(__KERNEL__) && \
     (defined(CONFIG_SCHED_LPWORK) || defined(CONFIG_SCHED_HPWORK))
       /* Check work queues */
 


### PR DESCRIPTION
## Summary
The `nuttx/arch.h` included in `userspace.h` will cause some unnecessary headers to be introduced in the user program (such as `net.h`). We are trying to remove the inclusion of `nuttx/arch.h`. In order to avoid compilation errors, we first need to add the missing header file inclusion in `nuttx-apps` after removing `nuttx/arch.h`.

## Impact
This patch fix compilation error after excluding nuttx/arch.h.

## Testing
Tested on QEMU/arm64 and QEMU/x86_64
