### PR TITLE
rtc: change localtime to gmtime.

### DIFF
--- a/testing/drivertest/drivertest_rtc.c
+++ b/testing/drivertest/drivertest_rtc.c
@@ -229,7 +229,7 @@ static void add_timeout(struct rtc_time * rtc_tm, const int delay)
   timesp = timegm((struct tm *)rtc_tm);
   timesp += delay;
 
-  tm = localtime(&timesp);
+  tm = gmtime(&timesp);
   rtc_tm->tm_sec = tm->tm_sec;
   rtc_tm->tm_min = tm->tm_min;
   rtc_tm->tm_hour = tm->tm_hour;


### PR DESCRIPTION
## Summary
Use gmtime to avoid time zone issues
## Impact
N/A
## Testing
ci
