### PR TITLE
cmd_date:Set optind to zero in the error case.

### DIFF
--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -434,6 +434,7 @@ int cmd_date(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   return ret;
 
 errout:
+  optind = 0;
   nsh_error(vtbl, errfmt, argv[0]);
   return ERROR;
 }


### PR DESCRIPTION
## Summary
Fix the date command sets an invalid month and then sets a valid month.
## Impact
N/A
## Testing
CI
