### PR TITLE
nshlib/nsh_parse: support use \\ to pass '\' to argument

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -216,7 +216,7 @@ static FAR char *nsh_envexpand(FAR struct nsh_vtbl_s *vtbl,
                FAR char *varname);
 #endif
 
-#if defined(CONFIG_NSH_QUOTE) && defined(CONFIG_NSH_ARGCAT)
+#if defined(CONFIG_NSH_QUOTE)
 static void nsh_dequote(FAR char *cmdline);
 #else
 #  define nsh_dequote(c)
@@ -1306,7 +1306,7 @@ static FAR char *nsh_envexpand(FAR struct nsh_vtbl_s *vtbl,
  * Name: nsh_dequote
  ****************************************************************************/
 
-#if defined(CONFIG_NSH_QUOTE) && defined(CONFIG_NSH_ARGCAT)
+#if defined(CONFIG_NSH_QUOTE)
 static void nsh_dequote(FAR char *cmdline)
 {
   FAR char *ptr;


### PR DESCRIPTION
## Summary
Now the nsh can use \\ to pass '\' to the command

## Impact
nsh

## Testing
sim:nsh
