### PR TITLE
apps/nshlib/cmd_cd: Modify the logic of cd

### DIFF
--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -583,7 +583,7 @@ FAR char *nsh_getdirpath(FAR struct nsh_vtbl_s *vtbl,
       snprintf(vtbl->iobuffer, IOBUFFERSIZE, "%s/%s", dirpath, path);
     }
 
-  return strdup(vtbl->iobuffer);
+  return lib_realpath(vtbl->iobuffer, NULL, true);
 }
 #endif
 


### PR DESCRIPTION
## Summary
Modify the implementation logic of changing directory. There's an error handling the path incluing "../" or "./"

bug examples:

nsh> cd proc/self/group
nsh> cd ../..
nsh: cd: chdir failed: 2

nsh> pwd
/proc/self
nsh> ls
/proc/self:
 status
 cmdline
 stack
 group/
nsh> cd ./group
nsh: cd: chdir failed: 2

## Impact
No

## Testing
No

depends on https://github.com/apache/nuttx/pull/14365