### PR TITLE
netutils: introduce libwebsockets support

### DIFF
--- a/netutils/libwebsockets/Kconfig
+++ b/netutils/libwebsockets/Kconfig
@@ -1,0 +1,19 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NETUTILS_LIBWEBSOCKETS
+	bool "libwebsockets library (current version)"
+	default n
+	depends on NET && OPENSSL_MBEDTLS_WRAPPER
+	---help---
+		Enables the libwebsockets library.
+
+if NETUTILS_LIBWEBSOCKETS
+
+config NETUTILS_LIBWEBSOCKETS_VERSION
+	string "Version number"
+	default "4.3.1"
+
+endif

--- a/netutils/libwebsockets/Make.defs
+++ b/netutils/libwebsockets/Make.defs
@@ -1,0 +1,29 @@
+#############################################################################
+# apps/netutils/libwebsockets/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#############################################################################
+
+ifeq ($(CONFIG_NETUTILS_LIBWEBSOCKETS),y)
+CONFIGURED_APPS += $(APPDIR)/netutils/libwebsockets
+
+# Allows `<libwebsockets/<>.h>` import.
+
+CFLAGS +=  ${INCDIR_PREFIX}$(APPDIR)/netutils/libwebsockets/libwebsockets/include
+CXXFLAGS +=  ${INCDIR_PREFIX}$(APPDIR)/netutils/libwebsockets/libwebsockets/include
+
+endif

--- a/netutils/libwebsockets/Makefile
+++ b/netutils/libwebsockets/Makefile
@@ -1,0 +1,151 @@
+#############################################################################
+# apps/netutils/libwebsockets/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#############################################################################
+
+include $(APPDIR)/Make.defs
+
+LIBWEBSOCKETS_URL     ?= "https://github.com/warmcat/libwebsockets/archive"
+
+LIBWEBSOCKETS_VERSION := $(patsubst "%",%,$(CONFIG_NETUTILS_LIBWEBSOCKETS_VERSION))
+LIBWEBSOCKETS_TARBALL  = v$(LIBWEBSOCKETS_VERSION).tar.gz
+LIBWEBSOCKETS_UNPACK   = libwebsockets
+
+word-dot = $(word $2,$(subst ., ,$1))
+
+CFLAGS += \
+	-DLWS_LIBRARY_VERSION_MAJOR=$(call word-dot,$(LIBWEBSOCKETS_VERSION),1) \
+	-DLWS_LIBRARY_VERSION_MINOR=$(call word-dot,$(LIBWEBSOCKETS_VERSION),2) \
+	-DLWS_LIBRARY_VERSION_PATCH=$(call word-dot,$(LIBWEBSOCKETS_VERSION),3) \
+	-DLWS_LIBRARY_VERSION_PATCH_ELABORATED=$(call word-dot,$(LIBWEBSOCKETS_VERSION),3)-unknown \
+	-DLWS_LIBRARY_VERSION=\"$(LIBWEBSOCKETS_VERSION)-unknown\"
+
+CFLAGS += \
+	-I. \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/core \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/event-libs \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/system/smd \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/system/metrics \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/core-net \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/roles \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/roles/http \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/roles/h1 \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/roles/h2 \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/roles/ws \
+	-I$(LIBWEBSOCKETS_UNPACK)/lib/tls
+
+CSRCS += \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-caps.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-misc.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-init.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-file.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-pipe.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-service.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-sockets.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/plat/unix/unix-fds.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/alloc.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/buflist.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/context.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/lws_dll2.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/lws_map.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/libwebsockets.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/logs.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core/vfs.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/base64-decode.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/cache-ttl/lws-cache-ttl.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/cache-ttl/heap.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/cache-ttl/file.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/dir.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/prng.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/lws-ring.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/lwsac/lwsac.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/lwsac/cached-file.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/lejp.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/misc/sha-1.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/system/system.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/system/smd/smd.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/dummy-callback.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/output.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/close.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/network.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/vhost.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/pollfd.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/service.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/sorted-usec-list.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/wsi.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/wsi-timeout.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/adopt.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/state.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/client.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/connect.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/connect2.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/connect3.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/connect4.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/sort-dns.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/core-net/client/conmon.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/pipe/ops-pipe.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/http/header.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/http/date.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/http/parsers.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/http/cookie.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/h1/ops-h1.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/h2/http2.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/h2/hpack.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/h2/ops-h2.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/ws/ops-ws.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/ws/client-ws.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/ws/client-parser-ws.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/raw-skt/ops-raw-skt.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/raw-file/ops-raw-file.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/http/client/client-http.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/event-libs/poll/poll.c
+
+CSRCS += \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/tls.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/tls-network.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/tls-sessions.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/tls-client.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-tls.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-extensions.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-x509.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-ssl.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-session.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-client.c \
+
+ifeq ($(wildcard $(LIBWEBSOCKETS_UNPACK)/.git),)
+$(LIBWEBSOCKETS_TARBALL):
+	$(Q) echo "Downloading libwebsockets-$(LIBWEBSOCKETS_VERSION)"
+	$(Q) curl -O -L $(LIBWEBSOCKETS_URL)/$(LIBWEBSOCKETS_TARBALL)
+
+$(LIBWEBSOCKETS_UNPACK): $(LIBWEBSOCKETS_TARBALL)
+	$(Q) echo "Unpacking: $(LIBWEBSOCKETS_TARBALL) -> $(LIBWEBSOCKETS_UNPACK)"
+	$(Q) tar zxf $(LIBWEBSOCKETS_TARBALL)
+	$(Q) mv libwebsockets-$(LIBWEBSOCKETS_VERSION) $(LIBWEBSOCKETS_UNPACK)
+	$(Q) echo "Patching $(LIBWEBSOCKETS_UNPACK)"
+	$(Q) patch -p0 < libwebsockets.patch
+	$(Q) touch $(LIBWEBSOCKETS_UNPACK)
+
+context:: $(LIBWEBSOCKETS_UNPACK)
+
+distclean::
+	$(call DELFILE, $(LIBWEBSOCKETS_TARBALL))
+	$(call DELDIR, $(LIBWEBSOCKETS_UNPACK))
+endif
+
+include $(APPDIR)/Application.mk

--- a/netutils/libwebsockets/Makefile
+++ b/netutils/libwebsockets/Makefile
@@ -128,6 +128,17 @@ CSRCS += \
 	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-session.c \
 	$(LIBWEBSOCKETS_UNPACK)/lib/tls/mbedtls/mbedtls-client.c \
 
+ifneq ($(CONFIG_NETUTILS_MQTTC),)
+	CFLAGS += -I$(LIBWEBSOCKETS_UNPACK)/lib/roles/mqtt
+
+	CSRCS += \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/mqtt/mqtt.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/mqtt/ops-mqtt.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/mqtt/primitives.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/mqtt/client/client-mqtt.c \
+	$(LIBWEBSOCKETS_UNPACK)/lib/roles/mqtt/client/client-mqtt-handshake.c
+endif
+
 ifeq ($(wildcard $(LIBWEBSOCKETS_UNPACK)/.git),)
 $(LIBWEBSOCKETS_TARBALL):
 	$(Q) echo "Downloading libwebsockets-$(LIBWEBSOCKETS_VERSION)"

--- a/netutils/libwebsockets/libwebsockets.patch
+++ b/netutils/libwebsockets/libwebsockets.patch
@@ -1,0 +1,112 @@
+--- libwebsockets/include/libwebsockets.h
++++ libwebsockets/include/libwebsockets.h
+@@ -146,7 +146,7 @@ typedef int suseconds_t;
+ #include <sys/capability.h>
+ #endif
+ 
+-#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__QNX__) || defined(__OpenBSD__)
++#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__QNX__) || defined(__OpenBSD__) || defined(__NuttX__)
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #endif
+ 
+--- libwebsockets/lib/plat/unix/private-lib-plat-unix.h
++++ libwebsockets/lib/plat/unix/private-lib-plat-unix.h
+@@ -123,7 +123,7 @@ typedef pthread_mutex_t lws_mutex_t;
+ 
+ #endif
+ 
+-#if defined (__sun) || defined(__HAIKU__) || defined(__QNX__) || defined(__ANDROID__)
++#if defined (__sun) || defined(__HAIKU__) || defined(__QNX__) || defined(__ANDROID__) || defined(__NuttX__)
+ #include <syslog.h>
+ 
+ #if defined(__ANDROID__)
+ 
+--- libwebsockets/lib/plat/unix/unix-sockets.c
++++ libwebsockets/lib/plat/unix/unix-sockets.c
+@@ -171,7 +171,7 @@ lws_plat_set_socket_options(struct lws_vhost *vhost, int fd, int unix_skt)
+ 
+ 	/* Disable Nagle */
+ 	optval = 1;
+-#if defined (__sun) || defined(__QNX__)
++#if defined (__sun) || defined(__QNX__) || defined(__NuttX__)
+ 	if (!unix_skt && setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (const void *)&optval, optlen) < 0)
+ 		return 1;
+ #elif !defined(__APPLE__) && \
+@@ -190,6 +190,7 @@ lws_plat_set_socket_options(struct lws_vhost *vhost, int fd, int unix_skt)
+ 	return lws_plat_set_nonblocking(fd);
+ }
+ 
++#if !defined(__NuttX__)
+ static const int ip_opt_lws_flags[] = {
+ 	LCCSCF_IP_LOW_LATENCY, LCCSCF_IP_HIGH_THROUGHPUT,
+ 	LCCSCF_IP_HIGH_RELIABILITY
+@@ -210,6 +211,7 @@ static const char *ip_opt_names[] = {
+ #endif
+ };
+ #endif
++#endif
+ 
+ int
+ lws_plat_set_socket_options_ip(lws_sockfd_type fd, uint8_t pri, int lws_flags)
+@@ -237,7 +239,8 @@ lws_plat_set_socket_options_ip(lws_sockfd_type fd, uint8_t pri, int lws_flags)
+       !defined(__sun) && \
+       !defined(__HAIKU__) && \
+       !defined(__CYGWIN__) && \
+-      !defined(__QNX__)
++      !defined(__QNX__) && \
++      !defined(__NuttX__)
+ 
+ 	/* the BSDs don't have SO_PRIORITY */
+ 
+@@ -255,6 +258,7 @@ lws_plat_set_socket_options_ip(lws_sockfd_type fd, uint8_t pri, int lws_flags)
+ 	}
+ #endif
+ 
++#if !defined(__NuttX__)
+ 	for (n = 0; n < 4; n++) {
+ 		if (!(lws_flags & ip_opt_lws_flags[n]))
+ 			continue;
+@@ -272,6 +276,7 @@ lws_plat_set_socket_options_ip(lws_sockfd_type fd, uint8_t pri, int lws_flags)
+ 			lwsl_notice("%s: set ip flag %s\n", __func__,
+ 				    ip_opt_names[n]);
+ 	}
++#endif
+ 
+ 	return ret;
+ }
+ 
+--- libwebsockets/lib/roles/ws/client-ws.c
++++ libwebsockets/lib/roles/ws/client-ws.c
+@@ -257,15 +257,15 @@ lws_client_ws_upgrade(struct lws *wsi, const char **cce)
+ 	}
+ 
+ 	if (wsi->http.ah->http_response == 401) {
+-		lwsl_wsi_warn(wsi, "got bad HTTP response '%d'",
+-			      wsi->http.ah->http_response);
++		lwsl_wsi_warn(wsi, "got bad HTTP response '%ld'",
++			      (long)wsi->http.ah->http_response);
+ 		*cce = "HS: ws upgrade unauthorized";
+ 		goto bail3;
+ 	}
+ 
+ 	if (wsi->http.ah->http_response != 101) {
+-		lwsl_wsi_warn(wsi, "got bad HTTP response '%d'",
+-			      wsi->http.ah->http_response);
++		lwsl_wsi_warn(wsi, "got bad HTTP response '%ld'",
++			      (long)wsi->http.ah->http_response);
+ 		*cce = "HS: ws upgrade response not 101";
+ 		goto bail3;
+ 	}
+ 
+--- libwebsockets/lib/secure-streams/system/auth-sigv4/sign.c
++++ libwebsockets/lib/secure-streams/system/auth-sigv4/sign.c
+@@ -459,7 +459,7 @@ lws_ss_sigv4_set_aws_key(struct lws_context* context, uint8_t idx,
+ 
+ #if defined(__linux__) || defined(__APPLE__) || defined(WIN32) || \
+ 	defined(__FreeBSD__) || defined(__NetBSD__) || defined(__ANDROID__) || \
+-	defined(__sun) || defined(__OpenBSD__)
++	defined(__sun) || defined(__OpenBSD__) || defined(__NuttX__)
+ 
+ /* ie, if we have filesystem ops */
+ 

--- a/netutils/libwebsockets/lws_config.h
+++ b/netutils/libwebsockets/lws_config.h
@@ -1,0 +1,382 @@
+/****************************************************************************
+ * apps/netutils/libwebsockets/lws_config.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_NETUTILS_LIBWEBSOCKETS_LWS_CONFIG_H
+#define __APPS_NETUTILS_LIBWEBSOCKETS_LWS_CONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef NDEBUG
+  #ifndef _DEBUG
+    #define _DEBUG
+  #endif
+#endif
+
+/* LWS_LIBRARY_VERSION_NUMBER looks like 1005001 for e.g. version 1.5.1 */
+#define LWS_LIBRARY_VERSION_NUMBER (LWS_LIBRARY_VERSION_MAJOR * 1000000) + \
+          (LWS_LIBRARY_VERSION_MINOR * 1000) + \
+          LWS_LIBRARY_VERSION_PATCH
+#define LWS_MAX_SMP 1
+
+/* #undef LWS_ESP_PLATFORM */
+
+/* #undef LWS_LIBRARY_VERSION_NUMBER */
+
+/* #undef LWS_EXT_PTHREAD_LIBRARIES */
+
+/* #undef LWS_AVOID_SIGPIPE_IGN */
+#define LWS_BUILD_HASH "unknown"
+/* #undef LWS_BUILTIN_GETIFADDRS */
+#define LWS_CLIENT_HTTP_PROXYING
+/* #undef LWS_DETECTED_PLAT_IOS */
+
+/* #undef LWS_FALLBACK_GETHOSTBYNAME */
+#define LWS_HAS_INTPTR_T
+#define LWS_HAS_GETOPT_LONG
+/* #undef LWS_HAVE__ATOI64 */
+#define LWS_HAVE_ATOLL
+/* #undef LWS_HAVE_BN_bn2binpad */
+#define LWS_HAVE_CLOCK_GETTIME
+/* #undef LWS_HAVE_EC_POINT_get_affine_coordinates */
+
+/* #undef LWS_HAVE_EC_KEY_new_by_curve_name */
+
+/* #undef LWS_HAVE_ECDSA_SIG_set0 */
+
+/* #undef LWS_HAVE_EVP_MD_CTX_free */
+
+/* #undef LWS_HAVE_EVP_aes_128_wrap */
+
+/* #undef LWS_HAVE_EVP_aes_128_cfb8 */
+
+/* #undef LWS_HAVE_EVP_aes_128_cfb128 */
+
+/* #undef LWS_HAVE_EVP_aes_192_cfb8 */
+
+/* #undef LWS_HAVE_EVP_aes_192_cfb128 */
+
+/* #undef LWS_HAVE_EVP_aes_256_cfb8 */
+
+/* #undef LWS_HAVE_EVP_aes_256_cfb128 */
+
+/* #undef LWS_HAVE_EVP_aes_128_ofb */
+
+/* #undef LWS_HAVE_EVP_aes_128_xts */
+
+/* #undef LWS_HAVE_EVP_aes_128_ctr */
+
+/* #undef LWS_HAVE_EVP_aes_128_ecb */
+
+/* #undef LWS_HAVE_EVP_PKEY_new_raw_private_key */
+
+/* #define LWS_HAVE_EXECVPE */
+#define LWS_HAVE_LOCALTIME_R
+#define LWS_HAVE_GMTIME_R
+#define LWS_HAVE_CTIME_R
+#define LWS_HAVE_GETGRGID_R
+#define LWS_HAVE_GETGRNAM_R
+#define LWS_HAVE_GETPWUID_R
+#define LWS_HAVE_GETPWNAM_R
+/* #undef LWS_HAVE_LIBCAP */
+
+/* #undef LWS_HAVE_HMAC_CTX_new */
+#define LWS_HAVE_MALLOC_H
+/* #define LWS_HAVE_MALLOC_TRIM */
+#define LWS_HAVE_MALLOC_USABLE_SIZE
+#ifdef CONFIG_CRYPTO_MBEDTLS
+#define LWS_HAVE_mbedtls_md_setup
+#define LWS_HAVE_mbedtls_net_init
+#define LWS_HAVE_mbedtls_rsa_complete
+#define LWS_HAVE_mbedtls_internal_aes_encrypt
+#define LWS_HAVE_mbedtls_ssl_conf_alpn_protocols
+#define LWS_HAVE_mbedtls_ssl_get_alpn_protocol
+#define LWS_HAVE_mbedtls_ssl_conf_sni
+#define LWS_HAVE_mbedtls_ssl_set_hs_ca_chain
+#define LWS_HAVE_mbedtls_ssl_set_hs_own_cert
+#define LWS_HAVE_mbedtls_ssl_set_hs_authmode
+#define LWS_HAVE_mbedtls_ssl_set_verify
+#define LWS_HAVE_mbedtls_x509_crt_parse_file
+#define LWS_HAVE_MBEDTLS_NET_SOCKETS
+/* #undef LWS_HAVE_MBEDTLS_AUTH_KEY_ID */
+
+#endif
+/* #undef LWS_HAVE_NEW_UV_VERSION_H */
+
+/* #undef LWS_HAVE_OPENSSL_ECDH_H */
+
+/* #undef LWS_HAVE_OPENSSL_STACK */
+
+#ifdef CONFIG_PIPES
+#define LWS_HAVE_PIPE2
+#endif
+#ifdef CONFIG_EVENT_FD
+#define LWS_HAVE_EVENTFD
+#endif
+#ifndef CONFIG_DISABLE_PTHREAD
+#define LWS_HAVE_PTHREAD_H
+#endif
+/* #undef LWS_HAVE_RSA_SET0_KEY */
+
+/* #undef LWS_HAVE_RSA_verify_pss_mgf1 */
+
+/* #undef LWS_HAVE_SSL_CTX_get0_certificate */
+
+/* #undef LWS_HAVE_SSL_CTX_load_verify_file */
+
+/* #undef LWS_HAVE_SSL_CTX_load_verify_dir */
+
+/* #undef LWS_HAVE_SSL_CTX_set1_param */
+
+/* #undef LWS_HAVE_SSL_CTX_set_ciphersuites */
+
+/* #undef LWS_HAVE_SSL_EXTRA_CHAIN_CERTS */
+
+/* #undef LWS_HAVE_SSL_get0_alpn_selected */
+
+/* #undef LWS_HAVE_SSL_CTX_EVP_PKEY_new_raw_private_key */
+
+/* #undef LWS_HAVE_SSL_set_alpn_protos */
+
+/* #undef LWS_HAVE_SSL_SET_INFO_CALLBACK */
+
+/* #undef LWS_HAVE_SSL_SESSION_set_time */
+
+/* #undef LWS_HAVE_SSL_SESSION_up_ref */
+
+/* #undef LWS_HAVE__STAT32I64 */
+
+#define LWS_HAVE_STDINT_H
+/* #undef LWS_HAVE_SYS_CAPABILITY_H */
+#define LWS_HAVE_TIMEGM
+/* #undef LWS_HAVE_TLS_CLIENT_METHOD */
+
+/* #undef LWS_HAVE_TLSV1_2_CLIENT_METHOD */
+#define LWS_HAVE_SUSECONDS_T
+/* #undef LWS_HAVE_UV_VERSION_H */
+#define LWS_HAVE_VFORK
+/* #undef LWS_HAVE_X509_get_key_usage */
+
+/* #undef LWS_HAVE_X509_VERIFY_PARAM_set1_host */
+#define LWS_LOGGING_BITFIELD_CLEAR 0
+#define LWS_LOGGING_BITFIELD_SET 0
+#define LWS_LOG_TAG_LIFECYCLE
+/* #undef LWS_MINGW_SUPPORT */
+
+/* #undef LWS_NO_CLIENT */
+#define LWS_NO_DAEMONIZE
+#define LWS_OPENSSL_CLIENT_CERTS "/etc/ssl/certs"
+#define LWS_OPENSSL_SUPPORT
+/* #undef LWS_PLAT_OPTEE */
+#define LWS_PLAT_UNIX
+/* #undef LWS_PLAT_FREERTOS */
+
+/* #undef LWS_ROLE_CGI */
+
+/* #undef LWS_ROLE_DBUS */
+#define LWS_ROLE_H1
+#define LWS_ROLE_H2
+#define LWS_ROLE_RAW
+#define LWS_ROLE_RAW_FILE
+/* #undef LWS_ROLE_RAW_PROXY */
+#define LWS_ROLE_WS
+#ifdef CONFIG_NETUTILS_MQTTC
+#define LWS_ROLE_MQTT
+#endif
+/* #undef LWS_SHA1_USE_OPENSSL_NAME */
+#define LWS_SSL_CLIENT_USE_OS_CA_CERTS
+/* #undef LWS_SSL_SERVER_WITH_ECDH_CERT */
+#define LWS_SUPPRESS_DEPRECATED_API_WARNINGS
+/* #undef LWS_TLS_LOG_PLAINTEXT_RX */
+
+/* #undef LWS_TLS_LOG_PLAINTEXT_TX */
+
+/* #undef LWS_WITH_ABSTRACT */
+
+/* #undef LWS_WITH_ACCESS_LOG */
+
+/* #undef LWS_WITH_ACME */
+
+/* #undef LWS_WITH_ALSA */
+
+/* #undef LWS_WITH_SYS_ASYNC_DNS */
+
+/* #undef LWS_WITH_BORINGSSL */
+
+/* #undef LWS_WITH_CGI */
+#define LWS_WITH_CONMON
+/* #undef LWS_WITH_COSE */
+#define LWS_WITH_CUSTOM_HEADERS
+/* #undef LWS_WITH_DEPRECATED_LWS_DLL */
+
+/* #undef LWS_WITH_DETAILED_LATENCY */
+#define LWS_WITH_DIR
+/* #undef LWS_WITH_DRIVERS */
+
+/* #undef LWS_WITH_ESP32 */
+
+/* #undef LWS_HAVE_EVBACKEND_LINUXAIO */
+
+/* #undef LWS_HAVE_EVBACKEND_IOURING */
+
+/* #undef LWS_WITH_EXTERNAL_POLL */
+#define LWS_WITH_FILE_OPS
+/* #undef LWS_WITH_FSMOUNT */
+
+/* #undef LWS_WITH_FTS */
+
+/* #undef LWS_WITH_GENCRYPTO */
+
+/* #undef LWS_WITH_GENERIC_SESSIONS */
+
+/* #undef LWS_WITH_GLIB */
+
+/* #undef LWS_WITH_GTK */
+#define LWS_WITH_HTTP2
+#define LWS_WITH_HTTP_BASIC_AUTH
+/* #undef LWS_WITH_HTTP_BROTLI */
+
+/* #undef LWS_HTTP_HEADERS_ALL */
+
+/* #undef LWS_WITH_HTTP_PROXY */
+
+/* #undef LWS_WITH_HTTP_STREAM_COMPRESSION */
+#define LWS_WITH_HTTP_UNCOMMON_HEADERS
+#ifdef CONFIG_NET_IPv6
+#define LWS_WITH_IPV6
+#endif
+/* #undef LWS_WITH_JOSE */
+
+/* #undef LWS_WITH_CBOR */
+#define LWS_WITH_CBOR_FLOAT
+#define LWS_WITH_LEJP
+/* #undef LWS_WITH_LIBEV */
+
+/* #undef LWS_WITH_LIBEVENT */
+
+/* #undef LWS_WITH_LIBUV */
+
+/* #undef LWS_WITH_SDEVENT */
+#define LWS_WITH_LWSAC
+#define LWS_LOGS_TIMESTAMP
+#ifdef CONFIG_CRYPTO_MBEDTLS
+#define LWS_WITH_MBEDTLS
+#endif
+/* #undef LWS_WITH_MINIZ */
+
+/* #undef LWS_WITH_NETLINK */
+#define LWS_WITH_NETWORK
+/* #undef LWS_WITH_NO_LOGS */
+#define LWS_WITH_CACHE_NSCOOKIEJAR
+#define LWS_WITH_CLIENT
+#define LWS_WITHOUT_EXTENSIONS
+/* #undef LWS_WITH_SERVER */
+
+/* #undef LWS_WITH_SPAWN */
+
+/* #undef LWS_WITH_PEER_LIMITS */
+
+/* #undef LWS_WITH_PLUGINS */
+
+/* #undef LWS_WITH_PLUGINS_BUILTIN */
+
+/* #undef LWS_WITH_POLARSSL */
+#define LWS_WITH_POLL
+/* #undef LWS_WITH_RANGES */
+
+/* #undef LWS_WITH_RFC6724 */
+
+/* #undef LWS_WITH_SECURE_STREAMS */
+
+/* #undef LWS_WITH_SECURE_STREAMS_CPP */
+
+/* #undef LWS_WITH_SECURE_STREAMS_SYS_AUTH_API_AMAZON_COM */
+
+/* #undef LWS_WITH_SECURE_STREAMS_PROXY_API */
+
+/* #undef LWS_WITH_SECURE_STREAMS_STATIC_POLICY_ONLY */
+
+/* #undef LWS_WITH_SECURE_STREAMS_AUTH_SIGV4 */
+
+/* #undef LWS_WITH_SECURE_STREAMS_BUFFER_DUMP */
+
+/* #undef LWS_WITH_SS_DIRECT_PROTOCOL_STR */
+
+/* #undef LWS_WITH_SELFTESTS */
+
+/* #undef LWS_WITH_SEQUENCER */
+
+/* #undef LWS_WITH_SERVER_STATUS */
+#define LWS_WITH_SYS_SMD
+/* #undef LWS_WITH_SMTP */
+
+/* #undef LWS_WITH_SOCKS5 */
+
+/* #undef LWS_WITH_STATEFUL_URLDECODE */
+
+/* #undef LWS_WITH_STATS */
+
+/* #undef LWS_WITH_STRUCT_SQLITE3 */
+
+/* #undef LWS_WITH_STRUCT_JSON */
+
+/* #undef LWS_WITH_SUL_DEBUGGING */
+
+/* #undef LWS_WITH_SQLITE3 */
+
+/* #undef LWS_WITH_SYS_DHCP_CLIENT */
+
+/* #undef LWS_WITH_SYS_FAULT_INJECTION */
+
+/* #undef LWS_WITH_SYS_METRICS */
+
+/* #undef LWS_WITH_SYS_NTPCLIENT */
+#define LWS_WITH_SYS_STATE
+/* #undef LWS_WITH_THREADPOOL */
+#ifdef CONFIG_CRYPTO_MBEDTLS
+#define LWS_WITH_TLS
+/* #undef LWS_WITH_TLS_JIT_TRUST */
+#define LWS_WITH_TLS_SESSIONS
+#endif
+#ifdef CONFIG_NET_UDP
+#define LWS_WITH_UDP
+#endif
+/* #undef LWS_WITH_ULOOP */
+#define LWS_WITH_UNIX_SOCK
+/* #undef LWS_WITH_ZIP_FOPS */
+
+/* #undef USE_OLD_CYASSL */
+
+/* #undef USE_WOLFSSL */
+
+/* #undef LWS_WITH_EVENT_LIBS */
+
+/* #undef LWS_WITH_EVLIB_PLUGINS */
+
+/* #undef LWS_WITH_LIBUV_INTERNAL */
+
+/* #undef LWS_WITH_PLUGINS_API */
+
+/* #define LWS_HAVE_RTA_PREF */
+
+#endif

--- a/netutils/libwebsockets/lws_config_private.h
+++ b/netutils/libwebsockets/lws_config_private.h
@@ -1,0 +1,153 @@
+/****************************************************************************
+ * apps/netutils/libwebsockets/lws_config_private.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_NETUTILS_LIBWEBSOCKETS_LWS_CONFIG_PRIVATE_H
+#define __APPS_NETUTILS_LIBWEBSOCKETS_LWS_CONFIG_PRIVATE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef NDEBUG
+  #ifndef _DEBUG
+    #define _DEBUG
+  #endif
+#endif
+/* #undef LWIP_PROVIDE_ERRNO */
+
+/* Define to 1 to use CyaSSL as a replacement for OpenSSL.
+ * LWS_OPENSSL_SUPPORT needs to be set also for this to work.
+ */
+
+/* #undef USE_CYASSL */
+
+/* Define to 1 if you have the `fork' function. */
+#define LWS_HAVE_FORK
+
+#ifndef CONFIG_DISABLE_ENVIRON
+/* Define to 1 if you have the `getenv' function. */
+#define LWS_HAVE_GETENV
+#endif
+
+/* Define to 1 if you have the <in6addr.h> header file. */
+
+/* #undef LWS_HAVE_IN6ADDR_H */
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function,
+ *and to 0 otherwise.
+ */
+#define LWS_HAVE_MALLOC
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define LWS_HAVE_MEMORY_H
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define LWS_HAVE_NETINET_IN_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define LWS_HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define LWS_HAVE_STDLIB_H
+
+/* Define to 1 if you have the `strerror' function. */
+#define LWS_HAVE_STRERROR
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define LWS_HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#define LWS_HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+#define LWS_HAVE_SYS_PRCTL_H
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#define LWS_HAVE_SYS_RESOURCE_H
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define LWS_HAVE_SYS_SOCKET_H
+
+/* Define to 1 if you have the <sys/sockio.h> header file. */
+#define LWS_HAVE_SYS_SOCKIO_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define LWS_HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define LWS_HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define LWS_HAVE_UNISTD_H
+
+/* #undef LWS_HAVE_TCP_USER_TIMEOUT */
+
+/* Define to 1 if you have the `vfork' function. */
+#define LWS_HAVE_VFORK
+
+/* Define to 1 if you have the <vfork.h> header file. */
+
+/* #undef LWS_HAVE_VFORK_H */
+
+/* Define to 1 if `fork' works. */
+#define LWS_HAVE_WORKING_FORK
+
+/* Define to 1 if `vfork' works. */
+#define LWS_HAVE_WORKING_VFORK
+
+/* Define to 1 if execvpe() exists */
+#define LWS_HAVE_EXECVPE
+
+/* Define to 1 if you have the <zlib.h> header file. */
+
+/* #undef LWS_HAVE_ZLIB_H */
+
+/* #undef LWS_HAVE_GETLOADAVG */
+
+/* Define to the sub-directory in which libtool stores
+ * uninstalled libraries.
+ */
+
+#undef LT_OBJDIR // We're not using libtool
+
+/* Define to rpl_malloc if the replacement function should be used. */
+
+/* #undef malloc */
+
+/* Define to rpl_realloc if the replacement function should be used. */
+
+/* #undef realloc */
+
+/* Define to 1 if we have getifaddrs */
+#define LWS_HAVE_GETIFADDRS
+
+/* Define if the inline keyword doesn't exist. */
+
+/* #undef inline */
+
+/* #undef LWS_WITH_ZLIB */
+#define LWS_HAS_PTHREAD_SETNAME_NP
+
+/* Defined if you have the <inttypes.h> header file. */
+#define LWS_HAVE_INTTYPES_H
+
+#endif


### PR DESCRIPTION
## Summary
1. netutils: introduce libwebsockets support
2. Fix to compile failure after mqttc is enabled
## Impact

## Testing

