### PR TITLE
zlib:Support using Kconfig to control memory usage in zlib

### DIFF
--- a/system/zlib/Kconfig
+++ b/system/zlib/Kconfig
@@ -90,4 +90,18 @@ config UTILS_UNZIP_STACKSIZE
 
 endif # UTILS_UNZIP
 
+config LIB_ZLIB_MAX_WBITS
+  int "Zlib max wbits"
+  default 15
+  range 8 15
+  ---help---
+    Default windowBits. memory usage (1 << (windowBits+2)) bytes.
+
+config LIB_ZLIB_MAX_MEM_LEVEL
+  int "Zlib max mem level"
+  default 8
+  range 1 9
+  ---help---
+    Default memLevel. memory usage (1 << (memLevel+9)) bytes.
+
 endif # LIB_ZLIB

--- a/system/zlib/Makefile
+++ b/system/zlib/Makefile
@@ -85,4 +85,7 @@ PROGNAME += zlib_infcover_test
 MAINSRC += zlib/test/infcover.c
 endif
 
+CFLAGS += -DMAX_WBITS=$(CONFIG_LIB_ZLIB_MAX_WBITS)
+CFLAGS += -DMAX_MEM_LEVEL=$(CONFIG_LIB_ZLIB_MAX_MEM_LEVEL)
+
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
zlib:Support using Kconfig to control memory usage in zlib
## Impact
zlib
## Testing
qmeu with zlib