### PR TITLE
nshlib:Add macro restrictions to code that uses floating point numbers

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -516,6 +516,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
 
       if ((lsflags & LSFLAGS_SIZE) != 0)
         {
+#ifdef CONFIG_HAVE_FLOAT
           if (lsflags & LSFLAGS_HUMANREADBLE && buf.st_size >= KB)
             {
               if (buf.st_size >= GB)
@@ -532,6 +533,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
                 }
             }
           else
+#endif
             {
               nsh_output(vtbl, "%12" PRIdOFF, buf.st_size);
             }
@@ -1535,10 +1537,11 @@ int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
             lsflags |= LSFLAGS_SIZE;
             break;
 
+#ifdef CONFIG_HAVE_FLOAT
           case 'h':
             lsflags |= LSFLAGS_HUMANREADBLE;
             break;
-
+#endif
           case '?':
           default:
             nsh_error(vtbl, g_fmtarginvalid, argv[0]);


### PR DESCRIPTION
## Summary
nshlib:Add macro restrictions to code that uses floating point numbers
## Impact
nsh fs
## Testing
qmue

some paltform can't use flaot
