### PR TITLE
nshlib/cmd_cat: Avoid casting -1 to size_t as count of nsh_write()

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -801,12 +801,13 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
       while (true)
         {
-          ssize_t n = nsh_read(vtbl, buf, BUFSIZ);
+          ret = nsh_read(vtbl, buf, BUFSIZ);
+          if (ret <= 0)
+            {
+              break;
+            }
 
-          if (n == 0)
-            break;
-
-          nsh_write(vtbl, buf, n);
+          nsh_write(vtbl, buf, ret);
         }
 
       free(buf);


### PR DESCRIPTION
## Summary
e.g. Casting "-1" to `size_t` is equals to a very large value.

## Impact
cmd_cat

## Testing
CI

