### PR TITLE
apps/mbedtls: add compilation configuration

### DIFF
--- a/crypto/mbedtls/CMakeLists.txt
+++ b/crypto/mbedtls/CMakeLists.txt
@@ -90,6 +90,14 @@ if(CONFIG_CRYPTO_MBEDTLS)
       list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/source/md5_alt.c)
     endif()
 
+    if(CONFIG_MBEDTLS_POLY1305_ALT)
+      list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/source/poly1305_alt.c)
+    endif()
+
+    if(CONFIG_MBEDTLS_RIPEMD160_ALT)
+      list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/source/ripemd160_alt.c)
+    endif()
+
     if(CONFIG_MBEDTLS_SHA1_ALT)
       list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/source/sha1_alt.c)
     endif()
@@ -100,6 +108,10 @@ if(CONFIG_CRYPTO_MBEDTLS)
 
     if(CONFIG_MBEDTLS_SHA512_ALT)
       list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/source/sha512_alt.c)
+    endif()
+
+    if(CONFIG_MBEDTLS_BIGNUM_ALT)
+      list(APPEND CSRCS ${CMAKE_CURRENT_LIST_DIR}/source/bignum_alt.c)
     endif()
 
   endif()

--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -72,6 +72,10 @@ config MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 	depends on MBEDTLS_SSL_DTLS_HELLO_VERIFY
 	default y
 
+config MBEDTLS_BLOWFISH_C
+	bool "Enable the Blowfish block cipher."
+	default n
+
 config MBEDTLS_CAMELLIA_C
 	bool "Enable the Camellia block cipher."
 	default y
@@ -402,6 +406,10 @@ config MBEDTLS_AESCE_C
 	bool "Enable AES cryptographic extension support on 64-bit Arm."
 	depends on MBEDTLS_HAVE_ASM
 	default y
+
+config MBEDTLS_ARC4_C
+	bool "Enable the ARCFOUR stream cipher."
+	default n
 
 config MBEDTLS_ARIA_C
 	bool "Enable the ARIA block cipher."


### PR DESCRIPTION
## Summary
1.Supplement cmake to compile POLY1305/RIPEMD160/Bignum algorithms 
2.Add blowfish and arc4 algorithm configuration
## Impact
compile
## Testing
ci