### PR TITLE
examples/sotest: Correct the path in the log

### DIFF
--- a/examples/sotest/main/sotest_main.c
+++ b/examples/sotest/main/sotest_main.c
@@ -176,7 +176,7 @@ int main(int argc, FAR char *argv[])
   handle1 = dlopen(BINDIR "/modprint", RTLD_NOW | RTLD_LOCAL);
   if (handle1 == NULL)
     {
-      fprintf(stderr, "ERROR: dlopen(/modprint) failed\n");
+      fprintf(stderr, "ERROR: dlopen(%s/modprint) failed\n", BINDIR);
       exit(EXIT_FAILURE);
     }
 #endif
@@ -186,7 +186,7 @@ int main(int argc, FAR char *argv[])
   handle2 = dlopen(BINDIR "/sotest", RTLD_NOW | RTLD_LOCAL);
   if (handle2 == NULL)
     {
-      fprintf(stderr, "ERROR: dlopen(/sotest) failed\n");
+      fprintf(stderr, "ERROR: dlopen(%s/sotest) failed\n", BINDIR);
       exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
## Summary
 Correct the path in the log.
```diff
- ERROR: dlopen(/sotest) failed
+ ERROR: dlopen(/mnt/sotest/romfs/sotest) failed
```

## Impact
sotest

## Testing
- Selftest
- CI
