### PR TITLE
build(bugfix):fix Make.dep location missing when specifying PREFIX, hide invalid cp output from ar

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -370,7 +370,7 @@ register::
 endif
 
 $(PREFIX).depend: Makefile $(wildcard $(foreach SRC, $(SRCS), $(addsuffix /$(SRC), $(subst :, ,$(VPATH))))) $(DEPCONFIG)
-	$(shell echo "# Gen Make.dep automatically" >Make.dep)
+	$(shell echo "# Gen Make.dep automatically" >$(PREFIX)Make.dep)
 	$(call SPLITVARIABLE,ALL_DEP_OBJS,$^,100)
 	$(foreach BATCH, $(ALL_DEP_OBJS_TOTAL), \
 	  $(shell $(MKDEP) $(DEPPATH) --obj-suffix .c$(SUFFIX)$(OBJEXT) "$(CC)" -- $(CFLAGS) -- $(filter %.c,$(ALL_DEP_OBJS_$(BATCH))) >>$(PREFIX)Make.dep) \

--- a/Make.defs
+++ b/Make.defs
@@ -163,7 +163,7 @@ endef
 
 define AROBJSRULES
 $(1) : $(2)
-	cp $(2) $(1)
+	@ cp $(2) $(1)
 endef
 
 # CLEANAROBJS - del AR target files exclusively


### PR DESCRIPTION
## Summary

1. PREFIX needs to be added to Make.dep to avoid Make.dep regeneration during incremental compilation .
2. AROBJSRULES is just the .o file in the copy archive. Its output content is worthless, so we hide it by default.

## Impact
fix Make.dep files are generated repeatedly during incremental compilation
hide unhelpful output

## Testing
cmake -B build -DBOARD_CONFIG=qemu-armv7a:nsh
