### PR TITLE
CI: Disable all jobs for macOS and Windows

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -97,6 +97,13 @@ jobs:
         id: select-builds
         run: |
 
+          # Skip all macOS and Windows Builds
+          if [[ "${{ inputs.os }}" != "Linux" ]]; then
+            echo "Skipping all macOS and Windows Builds"
+            echo "skip_all_builds=1" | tee -a $GITHUB_OUTPUT
+            exit
+          fi
+
           # Fetch the outputs from the previous step
           numlabels=${{ steps.get-arch.outputs.numlabels }}
           labels_contain_size=${{ steps.get-arch.outputs.labels_contain_size }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
     uses: apache/nuttx-apps/.github/workflows/arch.yml@master
     needs: Fetch-Source
     with:
-      os: Linux
+      os: macOS
       boards: |
         ["macos", "sim-01", "sim-02"]
 
@@ -255,7 +255,7 @@ jobs:
     uses: apache/nuttx-apps/.github/workflows/arch.yml@master
     needs: Fetch-Source
     with:
-      os: Linux
+      os: msys2
       boards: |
         ["msys2"]
 


### PR DESCRIPTION
## Summary

This PR disables all CI Jobs for macOS and Windows, to reduce GitHub Cost. Details here: https://github.com/apache/nuttx/issues/14376

## Impact

CI Jobs for macOS and Windows will no longer run, until we find a way to manage their costs.

## Testing

We tested the skipping of macOS and Windows jobs: https://github.com/lupyuen5/label-nuttx/actions/runs/11379543159
