### PR TITLE
nshlib/dd: Add support for reading from/writing to standard input/output

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -186,7 +186,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_DD
-  CMD_MAP("dd",       cmd_dd,       3, 7,
+  CMD_MAP("dd",       cmd_dd,       1, 7,
     "if=<infile> of=<outfile> [bs=<sectsize>] [count=<sectors>] "
     "[skip=<sectors>] [seek=<sectors>] [verify] [conv=<nocreat,notrunc>]"),
 #endif


### PR DESCRIPTION
## Summary
Add support for reading from/writing to standard input/output.
~~The feature depends on https://github.com/apache/nuttx-apps/pull/2737~~

## Impact
nshlib/cmd_dd

## Testing
#### General tests
```bash
# 1. Input from stdin and output to stdout
#   Keyboard input: 12345AAAAABBBBB
nsh> dd bs=5
1234512345AAAAAAAAAABBBBBBBBBB

# 2. Input from file and output to stdout
nsh> dd if=/etc/init.d/rc.sysinit
mkrd -m 2 -s 512 1024
mkfatfs /dev/ram2
mount -t vfat /dev/ram2 "/tmp"

# 3. Input from stdin and output to file
#    Keyboard input: QWERT
dd of=/data/dd_stdout bs=5
#    Then, cat the output file in host (based on HostFS):
$ cat ../nuttx/dd_stdout
QWERT
```