### PR TITLE
Various improvements to FOC example

### DIFF
--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -47,6 +47,24 @@ config EXAMPLES_FOC_PERF
 	bool "Enable performance meassurements"
 	default n
 
+if EXAMPLES_FOC_PERF
+
+config EXAMPLES_FOC_PERF_LIVE
+	bool "Print FOC perf results on each max value change"
+	default n
+	---help---
+		With this option perf results are printed every time the maximum value
+		changes. The disadvantage of this method is that printing can directly
+		affect the pref result but it gives results in real time.
+
+config EXAMPLES_FOC_PERF_EXIT
+	bool "Print FOC perf results on thread exit"
+	default y
+	---help---
+		With this option perf results are printed on control thread exit.
+
+endif # EXAMPLES_FOC_PERF
+
 choice
 	prompt "FOC modulation selection"
 	default EXAMPLES_FOC_MODULATION_SVM3

--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -112,18 +112,28 @@ config EXAMPLES_FOC_STATE_USE_MODEL_PMSM
 		Use PMSM model instead of real hardware
 
 choice
-	prompt "FOC sensored or sensorless configuration"
+	prompt "FOC motor controller type"
 	default EXAMPLES_FOC_SENSORLESS
 
 config EXAMPLES_FOC_SENSORLESS
-	bool "FOC example sensorless configuration"
+	bool "FOC example sensorless motor controller"
 	select EXAMPLES_FOC_ANGOBS
+	---help---
+		Use sensorless controller, no angle sensor required.
 
 config EXAMPLES_FOC_SENSORED
-	bool "FOC example sensored configuration"
+	bool "FOC example sensored motor controller"
 	select EXAMPLES_FOC_HAVE_ALIGN
+	---help---
+		Use sensored controller, angle sensor for motor required.
 
 endchoice #
+
+config EXAMPLES_FOC_RUN_DISABLE
+	bool "FOC Disable motor controller"
+	---help---
+		Disable motor controller logic. Requested dq is always [0, 0].
+		Useful for testing and benchmarking.
 
 menu "Motor phy"
 
@@ -673,10 +683,6 @@ endmenu # FOC controller parameters
 config EXAMPLES_FOC_HAVE_RUN
 	bool
 	default !EXAMPLES_FOC_RUN_DISABLE
-
-config EXAMPLES_FOC_RUN_DISABLE
-	bool "FOC Disable FOC motor controller"
-	default n
 
 config EXAMPLES_FOC_NXSCOPE
 	bool "FOC nxscope support"

--- a/examples/foc/Kconfig
+++ b/examples/foc/Kconfig
@@ -47,6 +47,24 @@ config EXAMPLES_FOC_PERF
 	bool "Enable performance meassurements"
 	default n
 
+config EXAMPLES_FOC_CONTROL_CRITSEC
+	bool "Protect controller thread with critical section"
+	default y
+	depends on BUILD_FLAT
+	---help---
+		Protect controller thread with critical section.
+
+		If the controller frequency is high, system timer interrupts will
+		eventually interrupt the controller function, thereby increasing the
+		execution time. This may lead to skipping the control cycle, which
+		negatively affects the control algorithm.
+
+		With this option enabled, interrupts are disabled for the duration
+		of the controller function execution.
+
+		This option uses the kernel internal API directly, which means
+		it won't work outside of FLAT build.
+
 if EXAMPLES_FOC_PERF
 
 config EXAMPLES_FOC_PERF_LIVE

--- a/examples/foc/foc_device.c
+++ b/examples/foc/foc_device.c
@@ -209,6 +209,12 @@ int foc_dev_params_set(FAR struct foc_device_s *dev)
   foc_perf_end(&dev->perf);
 #endif
 
+#ifdef CONFIG_EXAMPLES_FOC_PERF_LIVE
+  /* Print perf live stats */
+
+  foc_perf_live(&dev->perf);
+#endif
+
 errout:
   return ret;
 }

--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -50,6 +50,16 @@
 #  error
 #endif
 
+/* Critical section */
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_CRITSEC
+#  define foc_enter_critical() irqstate_t intflags = enter_critical_section()
+#  define foc_leave_critical() leave_critical_section(intflags)
+#else
+#  define foc_enter_critical()
+#  define foc_leave_critical()
+#endif
+
 /****************************************************************************
  * Private Type Definition
  ****************************************************************************/
@@ -340,6 +350,8 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
 
   while (motor.mq.quit == false)
     {
+      foc_enter_critical();
+
       if (motor.mq.start == true)
         {
           /* Get FOC device state */
@@ -390,6 +402,7 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
 
           /* Start from the beginning of the control loop */
 
+          foc_leave_critical();
           continue;
         }
 
@@ -397,6 +410,7 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
 
       if (motor.mq.start == false)
         {
+          foc_leave_critical();
           usleep(1000);
           continue;
         }
@@ -503,6 +517,8 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
       /* Increase counter */
 
       motor.time += 1;
+
+      foc_leave_critical();
     }
 
 errout:

--- a/examples/foc/foc_fixed16_thr.c
+++ b/examples/foc/foc_fixed16_thr.c
@@ -503,13 +503,6 @@ int foc_fixed16_thr(FAR struct foc_ctrl_env_s *envp)
       /* Increase counter */
 
       motor.time += 1;
-
-#ifdef CONFIG_EXAMPLES_FOC_PERF
-      if (dev.perf.max_changed)
-        {
-          PRINTF_PERF("max=%" PRId32 "\n", dev.perf.max);
-        }
-#endif
     }
 
 errout:
@@ -531,6 +524,12 @@ errout:
     {
       PRINTF("ERROR: foc_device_deinit %d failed %d\n", envp->id, ret);
     }
+
+#ifdef CONFIG_EXAMPLES_FOC_PERF_EXIT
+  /* Print final perf stats */
+
+  foc_perf_exit(&dev.perf);
+#endif
 
   PRINTF("foc_fixed16_thr %d exit\n", envp->id);
 

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -516,13 +516,6 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
       /* Increase counter */
 
       motor.time += 1;
-
-#ifdef CONFIG_EXAMPLES_FOC_PERF
-      if (dev.perf.max_changed)
-        {
-          PRINTF_PERF("max=%" PRId32 "\n", dev.perf.max);
-        }
-#endif
     }
 
 errout:
@@ -544,6 +537,12 @@ errout:
     {
       PRINTF("ERROR: foc_device_deinit %d failed %d\n", envp->id, ret);
     }
+
+#ifdef CONFIG_EXAMPLES_FOC_PERF_EXIT
+  /* Print final perf stats */
+
+  foc_perf_exit(&dev.perf);
+#endif
 
   PRINTF("foc_float_thr %d exit\n", envp->id);
 

--- a/examples/foc/foc_float_thr.c
+++ b/examples/foc/foc_float_thr.c
@@ -50,6 +50,16 @@
 #  error
 #endif
 
+/* Critical section */
+
+#ifdef CONFIG_EXAMPLES_FOC_CONTROL_CRITSEC
+#  define foc_enter_critical() irqstate_t intflags = enter_critical_section()
+#  define foc_leave_critical() leave_critical_section(intflags)
+#else
+#  define foc_enter_critical()
+#  define foc_leave_critical()
+#endif
+
 /****************************************************************************
  * Private Type Definition
  ****************************************************************************/
@@ -353,6 +363,8 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
 
   while (motor.mq.quit == false)
     {
+      foc_enter_critical();
+
       if (motor.mq.start == true)
         {
           /* Get FOC device state */
@@ -403,6 +415,7 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
 
           /* Start from the beginning of the control loop */
 
+          foc_leave_critical();
           continue;
         }
 
@@ -410,6 +423,7 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
 
       if (motor.mq.start == false)
         {
+          foc_leave_critical();
           usleep(1000);
           continue;
         }
@@ -516,6 +530,8 @@ int foc_float_thr(FAR struct foc_ctrl_env_s *envp)
       /* Increase counter */
 
       motor.time += 1;
+
+      foc_leave_critical();
     }
 
 errout:

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -581,6 +581,8 @@ errout:
   return ret;
 }
 
+#if defined(CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP) || \
+    defined(CONFIG_EXAMPLES_FOC_VELOBS)
 /****************************************************************************
  * Name: foc_motor_vel_reset
  ****************************************************************************/
@@ -614,6 +616,7 @@ static int foc_motor_vel_reset(FAR struct foc_motor_b16_s *motor)
 #endif
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: foc_motor_state
@@ -1071,6 +1074,7 @@ static int foc_motor_ang_get(FAR struct foc_motor_b16_s *motor)
 #ifdef CONFIG_EXAMPLES_FOC_HAVE_VEL
   ain.vel   = motor->vel.set;
 #endif
+  ain.state = &motor->foc_state;
   ain.angle = motor->angle_now;
   ain.dir   = motor->dir;
 
@@ -1123,6 +1127,14 @@ static int foc_motor_ang_get(FAR struct foc_motor_b16_s *motor)
     }
 
   motor->angle_obs = aout.angle;
+#endif
+
+#ifndef CONFIG_EXAMPLES_FOC_HAVE_RUN
+  /* Dummy value when motor controller disabled */
+
+  UNUSED(ain);
+  aout.type  = FOC_ANGLE_TYPE_ELE;
+  aout.angle = 0;
 #endif
 
   /* Store electrical angle from sensor or observer */
@@ -1247,7 +1259,8 @@ static int foc_motor_vel_get(FAR struct foc_motor_b16_s *motor)
   /* Get motor electrical velocity now */
 
 #if defined(CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP) && \
-    !defined(CONFIG_EXAMPLES_FOC_VELOBS)
+    !defined(CONFIG_EXAMPLES_FOC_VELOBS) ||       \
+    !defined(CONFIG_EXAMPLES_FOC_HAVE_RUN)
   /* No velocity feedback - assume that electical velocity is velocity set
    * in a open-loop contorller.
    */

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -1613,8 +1613,17 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
   ret = foc_routine_cfg_b16(&motor->align, &align_cfg);
   if (ret < 0)
     {
+#  ifndef CONFIG_EXAMPLES_FOC_RUN_DISABLE
       PRINTFV("ERROR: foc_routine_cfg_b16 failed %d!\n", ret);
       goto errout;
+#  else
+      /* When motor controller is disabled, most likely we don't care about
+       * align routine failure
+       */
+
+      PRINTFV("ignore align routine failure\n", ret);
+      ret = OK;
+#  endif
     }
 #endif
 
@@ -1647,8 +1656,17 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
   ret = foc_routine_cfg_b16(&motor->ident, &ident_cfg);
   if (ret < 0)
     {
+#  ifndef CONFIG_EXAMPLES_FOC_RUN_DISABLE
       PRINTFV("ERROR: foc_ident_cfg_b16 failed %d!\n", ret);
       goto errout;
+#  else
+      /* When motor controller is disabled, most likely we don't care about
+       * ident routine failure
+       */
+
+      PRINTFV("ident align routine failure\n", ret);
+      ret = OK;
+#  endif
     }
 #endif
 

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -1665,8 +1665,9 @@ int foc_motor_init(FAR struct foc_motor_b16_s *motor,
       motor->ctrl_state = FOC_CTRL_STATE_INIT;
     }
 
-#if defined(CONFIG_EXAMPLES_FOC_SENSORED) ||  \
-    defined(CONFIG_EXAMPLES_FOC_HAVE_RUN) ||  \
+#if defined(CONFIG_EXAMPLES_FOC_SENSORED)   || \
+    defined(CONFIG_EXAMPLES_FOC_HAVE_RUN)   || \
+    defined(CONFIG_EXAMPLES_FOC_HAVE_ALIGN) || \
     defined(CONFIG_EXAMPLES_FOC_HAVE_IDENT)
 errout:
 #endif

--- a/examples/foc/foc_motor_b16.c
+++ b/examples/foc/foc_motor_b16.c
@@ -121,11 +121,11 @@ static int foc_motor_align(FAR struct foc_motor_b16_s *motor, FAR bool *done)
           goto errout;
         }
 
-      PRINTF("Aling results:\n");
+      PRINTFV("Aling results:\n");
 #ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
-      PRINTF("  dir    = %.2f\n", b16tof(final.dir));
+      PRINTFV("  dir    = %.2f\n", b16tof(final.dir));
 #endif
-      PRINTF("  offset = %.2f\n", b16tof(final.offset));
+      PRINTFV("  offset = %.2f\n", b16tof(final.offset));
 
       *done = true;
     }

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -1655,8 +1655,9 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
       motor->ctrl_state = FOC_CTRL_STATE_INIT;
     }
 
-#if defined(CONFIG_EXAMPLES_FOC_SENSORED) ||  \
-    defined(CONFIG_EXAMPLES_FOC_HAVE_RUN) ||  \
+#if defined(CONFIG_EXAMPLES_FOC_SENSORED)   || \
+    defined(CONFIG_EXAMPLES_FOC_HAVE_RUN)   || \
+    defined(CONFIG_EXAMPLES_FOC_HAVE_ALIGN) || \
     defined(CONFIG_EXAMPLES_FOC_HAVE_IDENT)
 errout:
 #endif

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -121,11 +121,11 @@ static int foc_motor_align(FAR struct foc_motor_f32_s *motor, FAR bool *done)
           goto errout;
         }
 
-      PRINTF("Aling results:\n");
+      PRINTFV("Aling results:\n");
 #ifdef CONFIG_INDUSTRY_FOC_ALIGN_DIR
-      PRINTF("  dir    = %.2f\n", final.dir);
+      PRINTFV("  dir    = %.2f\n", final.dir);
 #endif
-      PRINTF("  offset = %.2f\n", final.offset);
+      PRINTFV("  offset = %.2f\n", final.offset);
 
       *done = true;
     }

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -559,6 +559,8 @@ errout:
   return ret;
 }
 
+#if defined(CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP) || \
+    defined(CONFIG_EXAMPLES_FOC_VELOBS)
 /****************************************************************************
  * Name: foc_motor_vel_reset
  ****************************************************************************/
@@ -592,6 +594,7 @@ static int foc_motor_vel_reset(FAR struct foc_motor_f32_s *motor)
 #endif
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: foc_motor_state
@@ -1108,6 +1111,14 @@ static int foc_motor_ang_get(FAR struct foc_motor_f32_s *motor)
   motor->angle_obs = aout.angle;
 #endif
 
+#ifndef CONFIG_EXAMPLES_FOC_HAVE_RUN
+  /* Dummy value when motor controller disabled */
+
+  UNUSED(ain);
+  aout.type  = FOC_ANGLE_TYPE_ELE;
+  aout.angle = 0.0f;
+#endif
+
   /* Store electrical angle from sensor or observer */
 
   if (aout.type == FOC_ANGLE_TYPE_ELE)
@@ -1233,7 +1244,8 @@ static int foc_motor_vel_get(FAR struct foc_motor_f32_s *motor)
   /* Get motor electrical velocity now */
 
 #if defined(CONFIG_EXAMPLES_FOC_HAVE_OPENLOOP) && \
-    !defined(CONFIG_EXAMPLES_FOC_VELOBS)
+    !defined(CONFIG_EXAMPLES_FOC_VELOBS) ||       \
+    !defined(CONFIG_EXAMPLES_FOC_HAVE_RUN)
   /* No velocity feedback - assume that electical velocity is
    * velocity set
    */
@@ -1957,12 +1969,6 @@ int foc_motor_control(FAR struct foc_motor_f32_s *motor)
       case FOC_CTRL_STATE_IDLE:
         {
           motor->foc_mode = FOC_HANDLER_MODE_IDLE;
-
-#ifndef CONFIG_EXAMPLES_FOC_HAVE_RUN
-          /* Terminate */
-
-          motor->ctrl_state += 1;
-#endif
 
           break;
         }

--- a/examples/foc/foc_motor_f32.c
+++ b/examples/foc/foc_motor_f32.c
@@ -1600,8 +1600,17 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
   ret = foc_routine_cfg_f32(&motor->align, &align_cfg);
   if (ret < 0)
     {
+#  ifndef CONFIG_EXAMPLES_FOC_RUN_DISABLE
       PRINTFV("ERROR: foc_routine_cfg_f32 failed %d!\n", ret);
       goto errout;
+#  else
+      /* When motor controller is disabled, most likely we don't care about
+       * align routine failure
+       */
+
+      PRINTFV("ignore align routine failure\n", ret);
+      ret = OK;
+#  endif
     }
 #endif
 
@@ -1631,8 +1640,17 @@ int foc_motor_init(FAR struct foc_motor_f32_s *motor,
   ret = foc_routine_cfg_f32(&motor->ident, &ident_cfg);
   if (ret < 0)
     {
+#  ifndef CONFIG_EXAMPLES_FOC_RUN_DISABLE
       PRINTFV("ERROR: foc_ident_cfg_f32 failed %d!\n", ret);
       goto errout;
+#  else
+      /* When motor controller is disabled, most likely we don't care about
+       * ident routine failure
+       */
+
+      PRINTFV("ident align routine failure\n", ret);
+      ret = OK;
+#  endif
     }
 #endif
 

--- a/examples/foc/foc_perf.c
+++ b/examples/foc/foc_perf.c
@@ -27,10 +27,49 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <string.h>
+#include <stdio.h>
 
 #include <nuttx/clock.h>
 
 #include "foc_perf.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define PRINTF_PERF(format, ...) printf(format, ##__VA_ARGS__)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_perf_exec
+ ****************************************************************************/
+
+static bool foc_perf_exec(struct foc_perf_s *p, FAR uint32_t *exec)
+{
+  bool tmp = p->exec_max_changed;
+
+  *exec = p->exec_max;
+  p->exec_max_changed = false;
+
+  return tmp;
+}
+
+/****************************************************************************
+ * Name: foc_perf_per
+ ****************************************************************************/
+
+static bool foc_perf_per(struct foc_perf_s *p, FAR uint32_t *per)
+{
+  bool tmp = p->per_max_changed;
+
+  *per = p->per_max;
+  p->per_max_changed = false;
+
+  return tmp;
+}
 
 /****************************************************************************
  * Public Functions
@@ -53,7 +92,7 @@ int foc_perf_init(struct foc_perf_s *p)
 
 void foc_perf_start(struct foc_perf_s *p)
 {
-  p->now = perf_gettime();
+  p->exec = perf_gettime();
 }
 
 /****************************************************************************
@@ -62,13 +101,72 @@ void foc_perf_start(struct foc_perf_s *p)
 
 void foc_perf_end(struct foc_perf_s *p)
 {
-  p->now = perf_gettime() - p->now;
+  uint32_t now = perf_gettime();
+  uint32_t tmp = 0;
 
-  p->max_changed = false;
-
-  if (p->now > p->max)
+  if (p->per > 0)
     {
-      p->max = p->now;
-      p->max_changed = true;
+      tmp = now - p->per;
     }
+
+  p->per = now;
+  p->exec = now - p->exec;
+
+  p->exec_max_changed = false;
+  p->per_max_changed = false;
+
+  if (p->exec > p->exec_max)
+    {
+      p->exec_max = p->exec;
+      p->exec_max_changed = true;
+    }
+
+  if (tmp > p->per_max)
+    {
+      p->per_max = tmp;
+      p->per_max_changed = true;
+    }
+}
+
+/****************************************************************************
+ * Name: foc_perf_live
+ ****************************************************************************/
+
+void foc_perf_live(struct foc_perf_s *p)
+{
+  uint32_t perf = 0;
+
+  if (foc_perf_exec(p, &perf))
+    {
+      PRINTF_PERF("exec ticks=%" PRId32 "\n", perf);
+    }
+
+  if (foc_perf_per(p, &perf))
+    {
+      PRINTF_PERF("per ticks=%" PRId32 "\n", perf);
+    }
+}
+
+/****************************************************************************
+ * Name: foc_perf_exit
+ ****************************************************************************/
+
+void foc_perf_exit(struct foc_perf_s *p)
+{
+  struct timespec ts;
+  uint32_t max = 0;
+
+  PRINTF_PERF("===============================\n");
+
+  foc_perf_exec(p, &max);
+  perf_convert(max, &ts);
+  PRINTF_PERF("exec ticks=%" PRId32 "\n", max);
+  PRINTF_PERF("  nsec=%" PRId32 "\n", ts.tv_nsec);
+
+  foc_perf_per(p, &max);
+  perf_convert(max, &ts);
+  PRINTF_PERF("per ticks=%" PRId32 "\n", max);
+  PRINTF_PERF("  nsec=%" PRId32 "\n", ts.tv_nsec);
+
+  PRINTF_PERF("===============================\n");
 }

--- a/examples/foc/foc_perf.h
+++ b/examples/foc/foc_perf.h
@@ -28,20 +28,41 @@
 #include <nuttx/config.h>
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define PRINTF_PERF(format, ...) printf(format, ##__VA_ARGS__)
-
-/****************************************************************************
  * Public Type Definition
  ****************************************************************************/
 
+/* The diagram below illustrates the operation of a simple FOC ocntroller
+ * performance measurement tool:
+ *
+ *     | notify      | notify      | notify
+ *     v             v             v
+ *        ctrl          ctrl
+ *      |------|      |------|      |---
+ *      | BUSY | wait | BUSY | wait |
+ *  ____|      |------|      |------|
+ *
+ *      ^      ^      ^
+ *      | exec |      |
+ *      |<---->|      |
+ *      |             |
+ *      |     per     |
+ *      |<----------->|
+ *
+ *
+ *  exec   - FOC control loop execution time
+ *  per    - FOC control loop period
+ *  notify - notification event from FOC device,
+ *           called with CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ frequency
+ */
+
 struct foc_perf_s
 {
-  bool     max_changed;
-  uint32_t max;
-  uint32_t now;
+  bool     exec_max_changed;    /* Max execution time changed */
+  bool     per_max_changed;     /* Max period changed */
+  uint32_t exec_max;            /* Control loop execution max */
+  uint32_t per_max;             /* Control loop period max */
+  uint32_t exec;                /* Temporary storage */
+  uint32_t per;                 /* Temporary storage */
 };
 
 /****************************************************************************
@@ -51,5 +72,7 @@ struct foc_perf_s
 int foc_perf_init(struct foc_perf_s *p);
 void foc_perf_start(struct foc_perf_s *p);
 void foc_perf_end(struct foc_perf_s *p);
+void foc_perf_live(struct foc_perf_s *p);
+void foc_perf_exit(struct foc_perf_s *p);
 
 #endif /* __APPS_EXAMPLES_FOC_FOC_PERF_H */

--- a/examples/foc/foc_thr.h
+++ b/examples/foc/foc_thr.h
@@ -112,7 +112,7 @@ enum foc_controller_state_e
 struct foc_ctrl_env_s
 {
   mqd_t                     mqd;   /* Control msg queue */
-  int                       id;    /* FOC device id */
+  uint8_t                   id;    /* FOC device id */
   int                       inst;  /* Type specific instance counter */
   int                       type;  /* Controller type */
   FAR struct foc_thr_cfg_s *cfg;   /* Control thread configuration */


### PR DESCRIPTION
## Summary
* examples/foc: fix snprintf warning
    
    fix snprintf warning:
    
        foc_thr.c:110:39: warning: '%d' directive output may be truncated writing between 1 and 11 bytes into a region of size 7 [-Wformat-truncation=]
          110 |   snprintf(mqname, sizeof(mqname), "%s%d", CONTROL_MQ_MQNAME, envp->id);
              |                                       ^~
        foc_thr.c:110:36: note: directive argument in the range [-2147483648, 0]
          110 |   snprintf(mqname, sizeof(mqname), "%s%d", CONTROL_MQ_MQNAME, envp->id);
              |                                    ^~~~~~
        foc_thr.c:110:3: note: 'snprintf' output between 5 and 15 bytes into a destination of size 10
          110 |   snprintf(mqname, sizeof(mqname), "%s%d", CONTROL_MQ_MQNAME, envp->id);
              |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
* examples/foc: fix compilation error
    
    fix compilatgion error:
    
        foc_motor_f32.c: In function 'foc_motor_init':
        foc_motor_f32.c:1574:7: error: label 'errout' used but not defined
         1574 |       goto errout;

*  examples/foc: improve perf monitor
    
    improve FOC perf monitor:
    
    - add options to choose when perf result should be printed
    - measure the controller thread call period
 
* examples/foc: fix option that disable motor controller
    
    fix some compiler error when EXAMPLES_FOC_RUN_DISABLE is enabled

* examples/foc: print aling results only when verbose output enabled
    
    it is a costly operation that takes a lot of time and is not of much value
    
* examples/foc: ignore error for align and ident routines when motor controller disabled
    
    CONFIG_EXAMPLES_FOC_RUN_DISABLE option is used for tests and benchmarks, so we don't
    care about wrong results for motor identification and sensor alignment routines
    
* examples/foc: protect control loop with critical section
    
    If the controller frequency is high, system timer interrupts will
    eventually interrupt the controller function, thereby increasing the
    execution time. This may lead to skipping the control cycle, which
    negatively affects the control algorithm.
    
    With this option enabled, interrupts are disabled for the duration
    of the controller function execution.
    
    Here example results from CONFIG_EXAMPLES_FOC_PERF output
    for b-g431b-esc1 board with CONFIG_EXAMPLES_FOC_NOTIFIER_FREQ=10000:
    
    1. CONFIG_EXAMPLES_FOC_CONTROL_CRITSEC=n
    
      exec ticks=5258
        nsec=30929
      per ticks=21268
        nsec=125105
    
    2. CONFIG_EXAMPLES_FOC_CONTROL_CRITSEC=y
    
      exec ticks=3428
        nsec=20164
      per ticks=19203
        nsec=112958
    
    The difference is ~12us!
    
## Impact
various improvements for FOC example which can help verify the "hard real-time" performances of NuttX (missing the control algorithm deadlines in the case of FOC may have critical consequences for the system)

## Testing
b-g431b-esc1 board
