### PR TITLE
CI: Skip jobs arm-08 to arm-14 when a Complex PR is created / updated

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -160,6 +160,15 @@ jobs:
 
           # If Not a Simple PR: Build all targets
           if [[ "$quit" == "1" ]]; then
+            # If PR was Created or Modified: Exclude arm-08 to arm-14
+            pr=${{github.event.pull_request.number}}
+            if [[ "$pr" != "" ]]; then
+              echo "Excluding arm-08 to arm-14"
+              boards=$( 
+                echo '${{ inputs.boards }}' |
+                jq --compact-output 'map(select(test("arm-0[8-9]") == false and test("arm-1.+") == false))'
+              )
+            fi
             echo "selected_builds=$boards" | tee -a $GITHUB_OUTPUT
             exit
           fi


### PR DESCRIPTION
## Summary

When we submit or update a Complex PR that affects All Architectures (Arm, RISC-V, Xtensa, etc): CI Workflow shall run only half the jobs. Previously CI Workflow will run `arm-01` to `arm-14`, now we will run only `arm-01` to `arm-07`.

When the Complex PR is Merged: CI Workflow will still run all jobs `arm-01` to `arm-14`

Simple PRs with One Single Arch / Board will build the same way as before: `arm-01` to `arm-14`

This is explained here: https://github.com/apache/nuttx/issues/14376

Note that this version of `arch.yml` has diverged from `nuttx` repo, since we are unable to merge https://github.com/apache/nuttx/pull/14377

## Impact

When we submit or update a Complex PR: CI Workflow shall run only half the jobs: `arm-01` to `arm-07` (instead of `arm-01` to `arm-14`)

No changes to the CI Workflow when we merge a Complex PR. No impact for Simple PRs.

## Testing

Creating a Simple PR will run jobs `arm-01` to `arm-14` (like before)
https://github.com/lupyuen5/label-nuttx/actions/runs/11380165777

Creating a Complex PR will only run jobs `arm-01` to `arm-07` (skipping `arm-08` to `arm-14`)
https://github.com/lupyuen5/label-nuttx/actions/runs/11380214455

Merging a Complex PR will run all jobs `arm-01` to `arm-14` (like before)
https://github.com/lupyuen5/label-nuttx/actions/runs/11380246952
