### PR TITLE
wireless/wapi.c: Initialize variables to avoid abnormal

### DIFF
--- a/wireless/wapi/src/wapi.c
+++ b/wireless/wapi/src/wapi.c
@@ -911,6 +911,7 @@ static int wapi_country_cmd(int sock, int argc, FAR char **argv)
 
   if (argc == 1)
     {
+      memset(country, 0, sizeof(country));
       ret = wapi_get_country(sock, argv[0], country);
       if (ret >= 0)
         {


### PR DESCRIPTION
## Summary
wireless/wapi.c: Initialize variables to avoid abnormal data when wapi get country code
## Impact
Fix that using uninitialized variables cannot correctly read country code
## Testing
Verify use esp32s3-devkitc
```
nsh> wapi country wlan0
CN
```

