### PR TITLE
uorb:Fixed the abnormal issue of printing uint16 with PRIu16.

### DIFF
--- a/system/uorb/sensor/ppgd.c
+++ b/system/uorb/sensor/ppgd.c
@@ -31,7 +31,7 @@
 #ifdef CONFIG_DEBUG_UORB
 static const char sensor_ppgd_format[] =
   "timestamp:%" PRIu64 ",ppg0:%" PRIu32 ",ppg1:%" PRIu32 ","
-  "current:%" PRIu32 ",gain0:%" PRIu16 ",gain1:%" PRIu16 "";
+  "current:%" PRIu32 ",gain0:%hu,gain1:%hu";
 #endif
 
 /****************************************************************************

--- a/system/uorb/sensor/ppgq.c
+++ b/system/uorb/sensor/ppgq.c
@@ -31,8 +31,8 @@
 #ifdef CONFIG_DEBUG_UORB
 static const char sensor_ppgq_format[] =
   "timestamp:%" PRIu64 ",ppg0:%" PRIu32 ",ppg1:%" PRIu32 ",ppg2:%" PRIu32 ","
-  "ppg3:%" PRIu32 ",current:%" PRIu32 ",gain0:%" PRIu16 ",gain1:%" PRIu16 ","
-  "gain2:%" PRIu16 ",gain3:%" PRIu16 "";
+  "ppg3:%" PRIu32 ",current:%" PRIu32 ",gain0:%hu,gain1:%hu,gain2:%hu,"
+  "gain3:%hu";
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The PRIu16 macro in the system is defined as "u", and "hu" is required. In Linux and Nuttx, PRIu32 PRIu16 PRIu8 are all defined as "u", but %pB prints the structure and needs its offset. %pB gets the offset through sizeof(short int)

## Impact
N/A

## Testing
Environment:
OS and Version: Ubuntu 20.04.6 LTS x86_64
GCC Version: 13.1.0
SIM: ./tools/configure.sh sim:nsh

Order:
./nuttx 

uorb_listener -n 10 sensor_ppgd

