### PR TITLE
CI: Split the targets in sim-01 and add sim-03

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         [
           "arm-01", "risc-v-01", "sim-01", "xtensa-01", "arm64-01", "x86_64-01", "other",
           "arm-02", "risc-v-02", "sim-02", "xtensa-02",
-          "arm-03", "risc-v-03",
+          "arm-03", "risc-v-03", "sim-03",
           "arm-04", "risc-v-04",
           "arm-05", "risc-v-05",
           "arm-06", "risc-v-06",
@@ -197,7 +197,7 @@ jobs:
     with:
       os: macOS
       boards: |
-        ["macos", "sim-01", "sim-02"]
+        ["macos", "sim-01", "sim-02", "sim-03"]
 
   # Run the selected macOS Builds
   macOS:


### PR DESCRIPTION
## Summary

This PR syncs the Simulator Targets `sim-01`, `sim-02`, `sim-03` from `nuttx` repo to `nuttx-apps`: https://github.com/apache/nuttx/pull/14428

## Impact

When we create or modify a Complex PR, the CI Checks for Simulator will complete earlier. This is explained here: https://github.com/apache/nuttx/issues/14376

## Testing

See https://github.com/apache/nuttx/pull/14428
