### PR TITLE
Add to nuttx apps a simple app to test spi slave driver.

### DIFF
--- a/examples/spislv_test/CMakeLists.txt
+++ b/examples/spislv_test/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/examples/spislv_test/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_SPISLV)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_SPISLV_PROGNAME}
+    SRCS
+    spislv_test.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_SPISLV_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_SPISLV_PRIORITY})
+endif()

--- a/examples/spislv_test/Kconfig
+++ b/examples/spislv_test/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_SPISLV
+	tristate "\"SPI Slave Test\" example"
+	default n
+	---help---
+		Enable the "SPI Slave Test" example. 
+		This tool can be used together with the SPI tool to validate communication between two devices.
+
+if EXAMPLES_SPISLV
+
+config EXAMPLES_SPISLV_PROGNAME
+	string "Program name"
+	default "spislv"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_SPISLV_PRIORITY
+	int "Spislv task priority"
+	default 100
+
+config EXAMPLES_SPISLV_STACKSIZE
+	int "Spislv stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/spislv_test/Make.defs
+++ b/examples/spislv_test/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/examples/spislv/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_SPISLV),)
+CONFIGURED_APPS += $(APPDIR)/examples/spislv_test
+endif

--- a/examples/spislv_test/Makefile
+++ b/examples/spislv_test/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/spislv_test/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# SPI SLAVE TEST built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_SPISLV_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_SPISLV_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_SPISLV_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_SPISLV)
+
+# SPI SLAVE TEST Example
+
+MAINSRC = spislv_test.c
+
+include $(APPDIR)/Application.mk

--- a/examples/spislv_test/spislv_test.c
+++ b/examples/spislv_test/spislv_test.c
@@ -1,0 +1,102 @@
+/****************************************************************************
+ * apps/examples/spislv_test/spislv_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define SOURCE_FILE "/dev/spislv2"
+#define BUFFER_SIZE 256
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * spislv_test
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int fd;
+  char buffer[BUFFER_SIZE];
+  ssize_t bytes_read;
+  ssize_t i;
+
+  printf("Slave started!!\n");
+  fd = open(SOURCE_FILE, O_RDWR);
+
+  if (fd < 0)
+    {
+      printf("Failed to open %s: %s\n", SOURCE_FILE, strerror(errno));
+      return 0;
+    }
+
+  while (1)
+    {
+      /* Read the number from the source file */
+
+      printf("Slave: Reading from %s\n", SOURCE_FILE);
+      bytes_read = read(fd, buffer, BUFFER_SIZE - 1);
+
+      if (bytes_read < 0)
+        {
+          printf("Failed to read from %s: %s\n",
+                    SOURCE_FILE, strerror(errno));
+          close(fd);
+          return 0;
+        }
+      else if (bytes_read > 0)
+        {
+          buffer[bytes_read] = '\0';
+
+          /* Print buffer in hexadecimal format */
+
+          printf("Slave: Read value in hex: ");
+          for (i = 0; i < bytes_read; ++i)
+            {
+              printf("%02x ", (unsigned char)buffer[i]);
+            }
+
+          printf("\n");
+
+          /* Write the same value back */
+
+          printf("Slave: Writing %d bytes back to %s\n",
+                    bytes_read, SOURCE_FILE);
+          ssize_t bytes_written = write(fd, buffer, bytes_read);
+          if (bytes_written < 0)
+            {
+              printf("Failed to write to %s: %s\n",
+                        SOURCE_FILE, strerror(errno));
+              close(fd);
+              return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This app can be used to test spi slave driver. Using this app will be more fast to users test and verify spi slave driver.
For instance whats happened here: https://github.com/apache/nuttx/issues/13855#issuecomment-2426461702

## Impact
No impact, new feature.

## Testing
This app was used to test lower half changes done in this PR: https://github.com/apache/nuttx/pull/14420
