### PR TITLE
netutils/connectedhomeip: use CONFIG_CXX_STANDARD instead of hard code

### DIFF
--- a/netutils/connectedhomeip/CMakeLists.txt
+++ b/netutils/connectedhomeip/CMakeLists.txt
@@ -182,7 +182,7 @@ if(CONFIG_MATTER)
 
   set(MATTER_FLAGS
       -DCHIP_HAVE_CONFIG_H
-      -std=c++17
+      -std=${CONFIG_CXX_STANDARD}
       -Wno-undef
       -DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>
   )


### PR DESCRIPTION
## Summary
as c++ versions are upgraded, hard code compilation options can cause build error.

## Impact

## Testing
sim:local
