### PR TITLE
app/system/vi: Fix broken VI editor

### DIFF
--- a/system/termcurses/tcurses_vt100.c
+++ b/system/termcurses/tcurses_vt100.c
@@ -1500,11 +1500,11 @@ FAR struct termcurses_s *tcurses_vt100_initialize(int in_fd, int out_fd)
 
               priv->lflag = cfg.c_lflag;
 
-              /* If ECHO enabled, disable it */
+              /* If ECHO and ICANON enabled, disable it */
 
-              if (cfg.c_lflag & ECHO)
+              if (cfg.c_lflag & (ECHO | ICANON))
                 {
-                  cfg.c_lflag &= ~ECHO;
+                  cfg.c_lflag &= ~(ECHO | ICANON);
                   tcsetattr(priv->in_fd, TCSANOW, &cfg);
                 }
             }
@@ -1546,9 +1546,10 @@ static int tcurses_vt100_terminate(FAR struct termcurses_s *dev)
 
       if (isatty(priv->in_fd))
         {
-          if (tcgetattr(priv->in_fd, &cfg) == 0 && priv->lflag & ECHO)
+          if ((priv->lflag & (ECHO | ICANON))
+              && tcgetattr(priv->in_fd, &cfg) == 0)
             {
-              cfg.c_lflag |= ECHO;
+              cfg.c_lflag = priv->lflag;
               tcsetattr(priv->in_fd, TCSANOW, &cfg);
             }
         }

--- a/system/vi/vi.c
+++ b/system/vi/vi.c
@@ -559,6 +559,7 @@ static void vi_write(FAR struct vi_s *vi, FAR const char *buffer,
             {
               fprintf(stderr, "ERROR: write to stdout failed: %d\n",
                       errcode);
+              vi_release(vi);
               exit(EXIT_FAILURE);
             }
         }
@@ -635,6 +636,7 @@ static int vi_getch(FAR struct vi_s *vi)
                 {
                   fprintf(stderr, "ERROR: read from stdin failed: %d\n",
                           errcode);
+                  vi_release(vi);
                   exit(EXIT_FAILURE);
                 }
             }


### PR DESCRIPTION
## Summary

1. Since Nuttx commit https://github.com/apache/nuttx/commit/df5c876932c4c82e8aee32adca651bb99d9d6200 , the serial driver enable ICANON flag as default. This broken the VI and all keystrokes inputs are buffered. So disable it in termcurses.

2. If the VI exits in an error condition it will break the console.  This is because release_vi was not called to restore the console configuration, so fix it.

## Impact

All VI-enabled boards.

## Testing

Test in Ubuntu 24.20 use sim:nsh.

