### PR TITLE
{Bp-2655} examples: fix noteprint compile error 

### DIFF
--- a/examples/gpio/gpio_main.c
+++ b/examples/gpio/gpio_main.c
@@ -67,6 +67,12 @@ static void show_usage(FAR const char *progname)
   fprintf(stderr, "\t 8: GPIO_INTERRUPT_RISING_PIN\n");
   fprintf(stderr, "\t 9: GPIO_INTERRUPT_FALLING_PIN\n");
   fprintf(stderr, "\t10: GPIO_INTERRUPT_BOTH_PIN\n");
+  fprintf(stderr, "\t11: GPIO_INTERRUPT_PIN_WAKEUP\n");
+  fprintf(stderr, "\t12: GPIO_INTERRUPT_HIGH_PIN_WAKEUP\n");
+  fprintf(stderr, "\t13: GPIO_INTERRUPT_LOW_PIN_WAKEUP\n");
+  fprintf(stderr, "\t14: GPIO_INTERRUPT_RISING_PIN_WAKEUP\n");
+  fprintf(stderr, "\t15: GPIO_INTERRUPT_FALLING_PIN_WAKEUP\n");
+  fprintf(stderr, "\t16: GPIO_INTERRUPT_BOTH_PIN_WAKEUP\n");
 }
 
 /****************************************************************************
@@ -308,6 +314,12 @@ int main(int argc, FAR char *argv[])
       case GPIO_INTERRUPT_RISING_PIN:
       case GPIO_INTERRUPT_FALLING_PIN:
       case GPIO_INTERRUPT_BOTH_PIN:
+      case GPIO_INTERRUPT_PIN_WAKEUP:
+      case GPIO_INTERRUPT_HIGH_PIN_WAKEUP:
+      case GPIO_INTERRUPT_LOW_PIN_WAKEUP:
+      case GPIO_INTERRUPT_RISING_PIN_WAKEUP:
+      case GPIO_INTERRUPT_FALLING_PIN_WAKEUP:
+      case GPIO_INTERRUPT_BOTH_PIN_WAKEUP:
         {
           printf("  Interrupt pin: Value=%u\n", invalue);
 

--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -81,30 +81,29 @@ int main(int argc, FAR char *argv[])
     {
       sched_note_printf(NOTE_TAG_ALWAYS,
                         "shced note test count = %d.", count++);
-      sched_note_string(NOTE_TAG_ALWAYS, str);
-      sched_note_dump(NOTE_TAG_ALWAYS, 1, &binary, sizeof(struct binary));
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 2, "%hhd", c);
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 3, "%hd", s);
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 4, "%d", i);
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 5, "%ld", l);
+      sched_note_mark(NOTE_TAG_ALWAYS, str);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%hhd", c);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%hd", s);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%d", i);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%ld", l);
 #ifdef CONFIG_HAVE_LONG_LONG
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 6, "%lld", ll);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%lld", ll);
 #endif
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 7, "%jd", im);
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 8, "%zd", sz);
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 9, "%td", ptr);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%jd", im);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%zd", sz);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%td", ptr);
 #ifdef CONFIG_HAVE_FLOAT
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 10, "%e", f);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%e", f);
 #endif
 #ifdef CONFIG_HAVE_DOUBLE
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 11, "%le", d);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%le", d);
 #endif
 #ifdef CONFIG_HAVE_LONG_DOUBLE
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 12, "%Le", ld);
+      sched_note_printf(NOTE_TAG_ALWAYS, "%Le", ld);
 #endif
-      sched_note_bprintf(NOTE_TAG_ALWAYS, 13,
-                         "%hhd  %hd  %d  %ld  %lld  %jd  %zd  %td",
-                          c,    s,   i,  l,    ll,  im,  sz,  ptr);
+      sched_note_printf(NOTE_TAG_ALWAYS,
+                        "%hhd  %hd  %d  %ld  %lld  %jd  %zd  %td",
+                        c,    s,   i,  l,    ll,  im,  sz,  ptr);
       usleep(10);
     }
 

--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -45,17 +45,7 @@
 
 int main(int argc, FAR char *argv[])
 {
-  struct binary
-    {
-      uint8_t val1;
-      uint8_t val2;
-    } binary =
-      {
-        .val1        = 0x01,
-        .val2        = 0x02
-      };
-
-  char *str      = "shced note test";
+  char *str      = "sched note test";
   int count      = 0;
   char c         = 1;
   short s        = 2;
@@ -80,7 +70,7 @@ int main(int argc, FAR char *argv[])
   while (1)
     {
       sched_note_printf(NOTE_TAG_ALWAYS,
-                        "shced note test count = %d.", count++);
+                        "sched note test count = %d.", count++);
       sched_note_mark(NOTE_TAG_ALWAYS, str);
       sched_note_printf(NOTE_TAG_ALWAYS, "%hhd", c);
       sched_note_printf(NOTE_TAG_ALWAYS, "%hd", s);

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -581,7 +581,7 @@ static int cmd_rpmsg_once(FAR struct nsh_vtbl_s *vtbl,
 
       ping.times = atoi(argv[3]);
       ping.len   = atoi(argv[4]);
-      ping.ack   = atoi(argv[5]);
+      ping.cmd   = atoi(argv[5]);
       ping.sleep = atoi(argv[6]);
 
       cmd = RPMSGIOC_PING;
@@ -640,15 +640,17 @@ static int cmd_rpmsg_help(FAR struct nsh_vtbl_s *vtbl, int argc,
 {
   nsh_output(vtbl, "%s <panic|dump> <path>\n", argv[0]);
 #ifdef CONFIG_RPMSG_PING
-  nsh_output(vtbl, "%s ping <path> <times> <length> <ack> "
+  nsh_output(vtbl, "%s ping <path> <times> <length> <cmd> "
              "<period(ms)>\n\n", argv[0]);
   nsh_output(vtbl, "<times>      Number of ping operations.\n");
   nsh_output(vtbl, "<length>     The length of each ping packet.\n");
-  nsh_output(vtbl, "<ack>        Whether the peer acknowlege or "
+  nsh_output(vtbl, "<cmd>        Whether the peer acknowlege or "
              "check data.\n");
-  nsh_output(vtbl, "             0 - No acknowledge and check.\n");
-  nsh_output(vtbl, "             1 - Acknowledge, no data check.\n");
-  nsh_output(vtbl, "             2 - Acknowledge and data check.\n");
+  nsh_output(vtbl, "             Bit0 - Request need ack or not.\n");
+  nsh_output(vtbl, "             Bit1 - Check the data or not.\n");
+  nsh_output(vtbl, "             Bit2 - Random length or not.\n");
+  nsh_output(vtbl, "             Bit4~7 - Request or response or other"
+                                          "command for future use.\n");
   nsh_output(vtbl, "<sleep(ms)>  Sleep interval between two operations.\n");
 #endif
   nsh_output(vtbl, "<path>       Rpmsg device path.\n\n");

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -119,6 +119,7 @@ static FAR const char * const g_resetflag[] =
   "panic",
   "bootloader",
   "recovery",
+  "restore",
   "factory",
   NULL
 };

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <nuttx/power/pm.h>
+#include <nuttx/rpmsg/rpmsg.h>
 #include <nuttx/rptun/rptun.h>
 #include <nuttx/streams.h>
 #include <sys/boardctl.h>

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -291,7 +291,7 @@ int cmd_pmconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (argc == 4)
         {
           ctrl.domain = atoi(argv[3]);
-          if (ctrl.domain < 0 || ctrl.domain >= CONFIG_PM_NDOMAINS)
+          if (ctrl.domain >= CONFIG_PM_NDOMAINS)
             {
               nsh_error(vtbl, g_fmtargrange, argv[3]);
               return ERROR;

--- a/system/batterydump/Kconfig
+++ b/system/batterydump/Kconfig
@@ -3,26 +3,26 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 #
-config TESTING_BATTERYDUMP
-	tristate "Battery dump for test"
+config SYSTEM_BATTERYDUMP
+	tristate "Battery dump system tool"
 	default n
 	---help---
 		Enable the battery dump
 
-if TESTING_BATTERYDUMP
+if SYSTEM_BATTERYDUMP
 
-config TESTING_BATTERYDUMP_PROGNAME
+config SYSTEM_BATTERYDUMP_PROGNAME
 	string "Program name"
 	default "batterydump"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.
 
-config TESTING_BATTERYDUMP_PRIORITY
+config SYSTEM_BATTERYDUMP_PRIORITY
 	int "Battery dump task priority"
 	default 100
 
-config TESTING_BATTERYDUMP_STACKSIZE
+config SYSTEM_BATTERYDUMP_STACKSIZE
 	int "Battery dump stack size"
 	default DEFAULT_TASK_STACKSIZE
 

--- a/system/batterydump/Make.defs
+++ b/system/batterydump/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/testing/batterydump/Makefile
+# apps/system/batterydump/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,13 +18,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
-PROGNAME  = $(CONFIG_TESTING_BATTERYDUMP_PROGNAME)
-PRIORITY  = $(CONFIG_TESTING_BATTERYDUMP_PRIORITY)
-STACKSIZE = $(CONFIG_TESTING_BATTERYDUMP_STACKSIZE)
-MODULE    = $(CONFIG_TESTING_BATTERYDUMP)
-
-MAINSRC = batterydump.c
-
-include $(APPDIR)/Application.mk
+ifneq ($(CONFIG_SYSTEM_BATTERYDUMP),)
+CONFIGURED_APPS += $(APPDIR)/system/batterydump
+endif

--- a/system/batterydump/Makefile
+++ b/system/batterydump/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/testing/batterydump/Make.defs
+# apps/system/batterydump/Makefile
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,6 +18,13 @@
 #
 ############################################################################
 
-ifneq ($(CONFIG_TESTING_BATTERYDUMP),)
-CONFIGURED_APPS += $(APPDIR)/testing/batterydump
-endif
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_SYSTEM_BATTERYDUMP_PROGNAME)
+PRIORITY  = $(CONFIG_SYSTEM_BATTERYDUMP_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_BATTERYDUMP_STACKSIZE)
+MODULE    = $(CONFIG_SYSTEM_BATTERYDUMP)
+
+MAINSRC = batterydump.c
+
+include $(APPDIR)/Application.mk

--- a/system/batterydump/batterydump.c
+++ b/system/batterydump/batterydump.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/testing/batterydump/batterydump.c
+ * apps/system/batterydump/batterydump.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/system/gcov/Kconfig
+++ b/system/gcov/Kconfig
@@ -5,7 +5,7 @@
 
 config SYSTEM_GCOV
 	tristate "gcov tool"
-	depends on ARCH_COVERAGE
+	depends on SCHED_GCOV
 	---help---
 		Enable support for the 'gcov' command.
 

--- a/system/gcov/gcov.c
+++ b/system/gcov/gcov.c
@@ -76,7 +76,7 @@ static void gcov_dump(FAR const char * path, FAR const char *strip)
 int main(int argc, FAR char *argv[])
 {
   FAR const char *strip = "99";
-  FAR const char *path;
+  FAR const char *path = NULL;
   int option;
 
   if (argc < 2)

--- a/testing/drivertest/drivertest_pm_runtime.c
+++ b/testing/drivertest/drivertest_pm_runtime.c
@@ -28,8 +28,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
 #include <string.h>
-#include <pthread.h>
 #include <cmocka.h>
 #include <nuttx/power/pm_runtime.h>
 

--- a/testing/drivertest/drivertest_regulator.c
+++ b/testing/drivertest/drivertest_regulator.c
@@ -28,8 +28,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
 #include <string.h>
-#include <pthread.h>
 #include <cmocka.h>
 #include <nuttx/power/consumer.h>
 

--- a/testing/drivertest/drivertest_regulator.c
+++ b/testing/drivertest/drivertest_regulator.c
@@ -446,10 +446,8 @@ static void test_regulator_supply_4(FAR void **state)
                                              &g_fake_regulator);
   assert_false(NULL == g_fake_regulator.rdev);
   test = regulator_get(REGULATOR_ID);
-  assert_false(NULL == test);
+  assert_true(NULL == test);
   g_fake_regulator_supply.state = 0;
-  ret = regulator_enable(test);
-  assert_true(ret < 0);
   g_fake_regulator_supply.rdev = regulator_register(
                                              &g_fake_regulator_supply_desc,
                                              &g_fake_regulator_ops,
@@ -457,7 +455,8 @@ static void test_regulator_supply_4(FAR void **state)
   assert_false(NULL == g_fake_regulator_supply.rdev);
   assert_int_equal(g_fake_regulator_supply.state, 0);
   assert_int_equal(g_fake_regulator.state, 0);
-
+  test = regulator_get(REGULATOR_ID);
+  assert_false(NULL == test);
   while (cnt--)
     {
       ret = regulator_enable(test);
@@ -499,6 +498,7 @@ static void test_regulator_mode(FAR void **state)
   int ret = 0;
 
   g_fake_regulator.lpmode = 0;
+  g_fake_regulator_desc.supply_name = NULL;
   g_fake_regulator.rdev = regulator_register(&g_fake_regulator_desc,
                                              &g_fake_regulator_ops,
                                              &g_fake_regulator);


### PR DESCRIPTION
## Summary
fix noteprint compile error
The sched_note_string/bprintf/dump interfaces have been removed and replaced with printf and event

## Impact
RELEASE

## Testing
CI

Note
includes 
https://github.com/apache/nuttx-apps/pull/2596
https://github.com/apache/nuttx-apps/pull/2614
https://github.com/apache/nuttx-apps/pull/2650
https://github.com/apache/nuttx-apps/pull/2677
https://github.com/apache/nuttx-apps/pull/2681
