### PR TITLE
lvgldemo: should use nuttx_deinit to free all resources

### DIFF
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -162,7 +162,7 @@ int main(int argc, FAR char *argv[])
 #endif
 
 demo_end:
-  lv_disp_remove(result.disp);
+  lv_nuttx_deinit(&result);
   lv_deinit();
 
   return 0;


### PR DESCRIPTION


## Summary
Memory leak can be detected when simply change the while(1) loop to break after certain time. The `lv_nuttx_deinit` will free resources including display, input etc.


## Impact

This issue only happen when the while(1) loop exist and need to de-init `lvgl`.
Now no memory leak detected using `lsan` command on sim. This 

## Testing
Tested on sim with ASAN enabled.
```patch
+CONFIG_FRAME_POINTER=y
+CONFIG_MM_CUSTOMIZE_MANAGER=y
+CONFIG_SIM_ASAN=y
-CONFIG_INIT_ARGS="\"widgets\""
-CONFIG_INIT_ENTRYPOINT="lvgldemo_main"
+CONFIG_INIT_ENTRYPOINT="nsh_main"

```

```patch
diff --git a/examples/lvgldemo/lvgldemo.c b/examples/lvgldemo/lvgldemo.c
index 52d48ba7d..f5b42bddb 100644
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -149,7 +149,8 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_LV_USE_NUTTX_LIBUV
   lv_nuttx_uv_loop(&ui_loop, &result);
 #else
-  while (1)
+  int i = 100;
+  while (i--)
     {
       uint32_t idle;
       idle = lv_timer_handler();
```

Run lvgldemo & and wait it to exit, then execute `lsan`

```shell
nsh> lvgldemo sd &
lvgldemo [9:100]
...
nsh> lsan
lsan [10:100]
nsh>

```