### PR TITLE
netutils: fix compile error when not defined CONFIG_NET_ETHERNET

### DIFF
--- a/netutils/netlib/netlib_obtainipv4addr.c
+++ b/netutils/netlib/netlib_obtainipv4addr.c
@@ -112,14 +112,19 @@ static int dhcp_obtain_statefuladdr(FAR const char *ifname)
 {
   struct dhcpc_state ds;
   FAR void *handle;
+  int ret;
   uint8_t mac[IFHWADDRLEN];
 
-  int ret = netlib_getmacaddr(ifname, mac);
+#ifdef CONFIG_NET_ETHERNET
+  ret = netlib_getmacaddr(ifname, mac);
   if (ret < 0)
     {
       nerr("ERROR: get MAC address failed for '%s' : %d\n", ifname, ret);
       return ret;
     }
+#else
+  bzero(mac, sizeof(mac));
+#endif
 
   /* Set up the DHCPC modules */
 


### PR DESCRIPTION
## Summary

netutils/netlib/netlib_obtainipv4addr.c:117: undefined reference to `netlib_getmacaddr'

## Impact

minor

## Testing

ci