### PR TITLE
canutils: change dependency from GPL to BSD

### DIFF
--- a/canutils/candump/Kconfig
+++ b/canutils/candump/Kconfig
@@ -6,8 +6,7 @@
 config CANUTILS_CANDUMP
 	tristate "SocketCAN candump tool"
 	default n
-	depends on NET_CAN
-	select CANUTILS_LIBCANUTILS
+	depends on NET_CAN && CANUTILS_LIBCANUTILS
 	---help---
 		Enable the SocketCAN candump tool ported from
 		https://github.com/linux-can/can-utils

--- a/canutils/cansend/Kconfig
+++ b/canutils/cansend/Kconfig
@@ -6,8 +6,7 @@
 config CANUTILS_CANSEND
 	tristate "SocketCAN cansend tool"
 	default n
-	depends on NET_CAN
-	select CANUTILS_LIBCANUTILS
+	depends on NET_CAN && CANUTILS_LIBCANUTILS
 	---help---
 		Enable the SocketCAN cansend tool ported from
 		https://github.com/linux-can/can-utils

--- a/canutils/libcanutils/Kconfig
+++ b/canutils/libcanutils/Kconfig
@@ -6,7 +6,7 @@
 config CANUTILS_LIBCANUTILS
 	bool "CAN-utils support library"
 	default n
-	depends on NET_CAN && ALLOW_GPL_COMPONENTS
+	depends on NET_CAN && ALLOW_BSD_COMPONENTS
 	---help---
 		Enable the CAN-utils support library ported from
 		https://github.com/linux-can/can-utils


### PR DESCRIPTION
## Summary
canutils: change dependency from GPL to BSD
socketCAN utils are dual licence, there is no point in using GPL licence when we can use BSD.

Also change `select CANUTILS_LIBCANUTILS` to `depends on CANUTILS_LIBCANUTILS`. We can't `select` that option when `ALLOW_BSD_COMPONENTS` is not set.

depends on: https://github.com/apache/nuttx/pull/14520

## Impact
SocketCAN utils depends on BSD now

## Testing
CI
