### PR TITLE
benchmarks: support tinymembench

### DIFF
--- a/benchmarks/tinymembench/0001-tinymembench-fix-compiling-error-for-NuttX.patch
+++ b/benchmarks/tinymembench/0001-tinymembench-fix-compiling-error-for-NuttX.patch
@@ -1,0 +1,28 @@
+From f478ab0f728bea1ed352844339f8bdc87f7792fa Mon Sep 17 00:00:00 2001
+From: ouyangxiangzhen <ouyangxiangzhen@xiaomi.com>
+Date: Fri, 31 May 2024 19:58:48 +0800
+Subject: [PATCH] tinymembench: fix compiling error for NuttX
+
+This patch fix compilation error: Resolve conflict between `util.c` function fmin and math library function fmin
+
+Signed-off-by: ouyangxiangzhen <ouyangxiangzhen@xiaomi.com>
+---
+ util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util.c b/util.c
+index a0d562c..539049f 100644
+--- a/util.c
++++ b/util.c
+@@ -303,7 +303,7 @@ double gettime(void)
+     return (double)((int64_t)tv.tv_sec * 1000000 + tv.tv_usec) / 1000000.;
+ }
+ 
+-double fmin(double a, double b)
++__attribute__((weak)) double fmin(double a, double b)
+ {
+     return a < b ? a : b;
+ }
+-- 
+2.34.1
+

--- a/benchmarks/tinymembench/CMakeLists.txt
+++ b/benchmarks/tinymembench/CMakeLists.txt
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+if(CONFIG_BENCHMARK_TINY_MEMBENCH)
+
+  set(TINYMB_UNPACK ${CMAKE_CURRENT_LIST_DIR}/tinymembench)
+  set(TINYMB_URL https://github.com/ssvb/tinymembench/archive)
+  set(TINYMB_ZIP master.zip)
+
+  if(NOT EXISTS ${TINYMB_UNPACK})
+
+    FetchContent_Declare(
+      tinymb_fetch
+      URL ${TINYMB_URL}/${TINYMB_ZIP} SOURCE_DIR ${TINYMB_UNPACK} BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/benchmarks/tinymembench/tinymembench
+      PATCH_COMMAND
+        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-tinymembench-fix-compiling-error-for-NuttX.patch
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(tinymb_fetch)
+    if(NOT tinymb_fetch_POPULATED)
+      FetchContent_Populate(tinymb_fetch)
+    endif()
+
+  endif()
+
+  list(APPEND CFLAGS -Wno-unused-but-set-variable -Wno-unused-variable
+       -Wno-strict-prototypes)
+
+  set(SRCS tinymembench/main.c)
+
+  list(
+    APPEND
+    SRCS
+    tinymembench/aarch64-asm.S
+    tinymembench/arm-neon.S
+    tinymembench/x86-sse2.S
+    tinymembench/mips-32.S
+    tinymembench/asm-opt.c
+    tinymembench/util.c)
+
+  nuttx_add_application(
+    NAME
+    tinymembench
+    PRIORITY
+    ${CONFIG_BENCHMARK_TINY_MEMBENCH_PRIORITY}
+    STACKSIZE
+    ${CONFIG_BENCHMARK_TINY_MEMBENCH_STACKSIZE}
+    MODULE
+    ${CONFIG_BENCHMARK_TINY_MEMBENCH}
+    COMPILE_FLAGS
+    ${CFLAGS}
+    SRCS
+    ${SRCS})
+endif()

--- a/benchmarks/tinymembench/Kconfig
+++ b/benchmarks/tinymembench/Kconfig
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+config BENCHMARK_TINY_MEMBENCH
+	tristate "TinyMemBench"
+	default n
+	---help---
+		Measure the memory bandwidth and latency
+
+if BENCHMARK_TINY_MEMBENCH
+
+config BENCHMARK_TINY_MEMBENCH_PRIORITY
+	int "TinyMemBench task priority"
+	default 100
+
+config BENCHMARK_TINY_MEMBENCH_STACKSIZE
+	int "TinyMemBench stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/benchmarks/tinymembench/Make.defs
+++ b/benchmarks/tinymembench/Make.defs
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ifneq ($(CONFIG_BENCHMARK_TINY_MEMBENCH),)
+CONFIGURED_APPS += $(APPDIR)/benchmarks/tinymembench
+endif

--- a/benchmarks/tinymembench/Makefile
+++ b/benchmarks/tinymembench/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include $(APPDIR)/Make.defs
+
+PROGNAME    = tinymembench
+PRIORITY    = $(CONFIG_BENCHMARK_TINY_MEMBENCH_PRIORITY)
+STACKSIZE   = $(CONFIG_BENCHMARK_TINY_MEMBENCH_STACKSIZE)
+MODULE      = $(CONFIG_BENCHMARK_TINY_MEMBENCH)
+
+TINYMB_UNPACK   = tinymembench
+TINYMB_GIT      = github.com/ssvb/tinymembench
+TINYMB_URL      = https://github.com/ssvb/tinymembench/archive
+TINYMB_VERSION  = master
+TINYMB_ZIP      = $(TINYMB_UNPACK)-$(TINYMB_VERSION).zip
+UNPACK         ?= unzip -q -o
+
+$(TINYMB_ZIP):
+	@echo "Downloading: $(TINYMB_URL)"
+	$(Q) curl -L $(TINYMB_URL)/$(TINYMB_VERSION).zip -o $(TINYMB_UNPACK)-$(TINYMB_VERSION).zip
+
+$(TINYMB_UNPACK): $(TINYMB_ZIP)
+	@echo "Unpacking: $(TINYMB_ZIP) -> $(TINYMB_UNPACK)"
+	$(Q) $(UNPACK) $(TINYMB_ZIP)
+	$(Q) mv	tinymembench-$(TINYMB_VERSION) $(TINYMB_UNPACK)
+	$(Q) touch $(TINYMB_UNPACK)
+	@echo "Patching: Applying patch"
+	$(Q) cd tinymembench && patch -p1 < ../0001-tinymembench-fix-compiling-error-for-NuttX.patch
+
+ifeq ($(wildcard $(TINYMB_UNPACK)/.git),)
+context:: $(TINYMB_UNPACK)
+
+distclean::
+	$(call DELDIR, $(TINYMB_UNPACK))
+	$(call DELFILE, $(TINYMB_ZIP))
+endif
+
+ASRCS      += $(TINYMB_UNPACK)/aarch64-asm.S
+ASRCS      += $(TINYMB_UNPACK)/arm-neon.S
+ASRCS      += $(TINYMB_UNPACK)/x86-sse2.S
+ASRCS      += $(TINYMB_UNPACK)/mips-32.S
+
+CSRCS      += $(TINYMB_UNPACK)/asm-opt.c
+CSRCS      += $(TINYMB_UNPACK)/util.c
+
+MAINSRC     = $(TINYMB_UNPACK)/main.c
+
+CFLAGS     += -Wno-unused-but-set-variable -Wno-unused-variable
+CFLAGS     += -Wno-strict-prototypes
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
This patch adds `tinymembench` for memory bandwidth and latency measuring.

## Impact
None.

## Testing
Tested on QEMU/x86.
