### PR TITLE
macos:fix sim:module build warning

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -273,7 +273,9 @@ endif
 $(PREFIX).built: $(AROBJS)
 	$(call SPLITVARIABLE,ALL_OBJS,$(AROBJS),100)
 	$(foreach BATCH, $(ALL_OBJS_TOTAL), \
-		$(shell $(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH)))) \
+		$(if $(strip $(ALL_OBJS_$(BATCH))), \
+			$(shell $(call ARLOCK, $(call CONVERT_PATH,$(BIN)), $(ALL_OBJS_$(BATCH)))) \
+		) \
 	)
 	$(Q) touch $@
 


### PR DESCRIPTION
## Summary
build warning fix
## Impact
macos
## Testing
CP:  /Users/vela/ajh/nuttx/include/nuttx/fs/hostfs.h CC:  inode/fs_inodebasename.c ar: no archive members specified usage:  ar -d [-TLsv] archive file ...
        ar -m [-TLsv] archive file ...
        ar -m [-abiTLsv] position archive file ...
        ar -p [-TLsv] archive [file ...]
        ar -q [-cTLsv] archive file ...
        ar -r [-cuTLsv] archive file ...
        ar -r [-abciuTLsv] position archive file ...
        ar -t [-TLsv] archive [file ...]
        ar -x [-ouTLsv] archive [file ...]


add this patch,and build sim:module in macos, no warning output
