### PR TITLE
net/arp: optimize the arp command display result

### DIFF
--- a/netutils/netlib/netlib_getarptab.c
+++ b/netutils/netlib/netlib_getarptab.c
@@ -153,8 +153,12 @@ ssize_t netlib_get_arptable(FAR struct arpreq *arptab,
   if (nsent < 0)
     {
       int errcode = errno;
-      fprintf(stderr, "ERROR: send() failed: %d\n", errcode);
-      ret = -errcode;
+      if (errcode != ENOENT)
+        {
+          fprintf(stderr, "ERROR: send() failed: %d\n", errcode);
+          ret = -errcode;
+        }
+
       goto errout_with_socket;
     }
 

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -1326,7 +1326,7 @@ int cmd_arp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   /* Error exits */
 
 errout_cmdfaild:
-  if (ret == -ENOENT)
+  if (ret == -ENOENT || ret == -ENETUNREACH)
     {
       nsh_error(vtbl, g_fmtnosuch, argv[0], "ARP entry", argv[optind]);
     }


### PR DESCRIPTION
## Summary

* netlib_getarptab.c: improved the display without any arp entry
* nsh_netcmds.c: handle the ENETUNREACH error number

## Impact

* `arp` utility results presentation fix.

## Testing

* sim:local with KASAN

* nsh_netcmds.c: handle the ENETUNREACH error number
  ```
  before:
  server> arp -a 10.0.1.4
  nsh: arp: ioctl failed: 101

  after:
  server> arp -a 10.0.1.4
  nsh: arp: no such ARP entry: 10.0.1.4
  ```

* netlib_getarptab.c: improved the display without any arp entry
  ```
  before:
  server> arp
  ERROR: send() failed: 2
  nsh: arp: S��x�����Ì
   failed: 2
  server>

  after:
  server> arp
  IP Address   Ethernet Address  Interface
  server>
  ```
