### PR TITLE
netpkt_ethercat.c: fix the description of usage

### DIFF
--- a/examples/netpkt/netpkt_ethercat.c
+++ b/examples/netpkt/netpkt_ethercat.c
@@ -40,7 +40,7 @@
 
 static void usage(void)
 {
-  printf("usage: netpkt_ethercat <[ifname] <times>>\n");
+  printf("usage: netpkt_ethercat [<ifname> [times]]\n");
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
the current usage description is incorrect,
ifname must follow ethercat. The number of transfers can be specified only after ifname is specified.

## Impact

## Testing
qemu:local
