### PR TITLE
gcov: modify depends on

### DIFF
--- a/system/gcov/Kconfig
+++ b/system/gcov/Kconfig
@@ -5,7 +5,7 @@
 
 config SYSTEM_GCOV
 	tristate "gcov tool"
-	depends on SCHED_GCOV
+	depends on LIBC_GCOV
 	---help---
 		Enable support for the 'gcov' command.
 


### PR DESCRIPTION
## Summary

* GCOV dependency update.
* Depends on https://github.com/apache/nuttx/pull/14538

## Impact

* GCOV updated dependency from SCHED to LIBC.

## Testing
Enable CONFIG_SYSTEM_GCOV and CONFIG_LIBC_GCOV, CONFIG_GCOV_ALL, nsh run "gcov -d  /data " can generate gcda files for all files, that is, code coverage analysis generates files
