### PR TITLE
nshlib/console: fix compile error when open CONFIG_NSH_ALTCONDEV

### DIFF
--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -45,9 +45,13 @@
 
 struct serialsave_s
 {
+#ifdef CONFIG_NSH_ALTCONDEV
+  int   cn_confd;     /* Console I/O file descriptor */
+#else
+  int   cn_infd;      /* Re-directed input file descriptor */
+#endif
   int   cn_errfd;     /* Re-directed error output file descriptor */
   int   cn_outfd;     /* Re-directed output file descriptor */
-  int   cn_infd;      /* Re-directed input file descriptor */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

nshlib/console: fix compile error when open CONFIG_NSH_ALTCONDEV

CC:  mm_heap/mm_memalign.c misc/rwbuffer.c: In function 'rwb_readbytes': misc/rwbuffer.c:1172:2: warning: #warning Not Implemented [-Wcpp]
 1172 | #warning Not Implemented
      |  ^~~~~~~
CC:  binfmt_unloadmodule.c In file included from nsh_console.c:40: nsh_console.c: In function 'nsh_consoleredirect':
nsh_console.h:85:30: error: 'struct serialsave_s' has no member named 'cn_confd'; did you mean 'cn_infd'?
   85 | #  define INFD(p)      ((p)->cn_confd)
      |                              ^~~~~~~~
nsh_console.c:344:7: note: in expansion of macro 'INFD'
  344 |       INFD(ssave) = INFD(pstate);
      |       ^~~~
nsh_console.c: In function 'nsh_consoleundirect':
nsh_console.h:85:30: error: 'struct serialsave_s' has no member named 'cn_confd'; did you mean 'cn_infd'?
   85 | #  define INFD(p)      ((p)->cn_confd)
      |                              ^~~~~~~~
nsh_console.c:370:18: note: in expansion of macro 'INFD'
  370 |   INFD(pstate) = INFD(ssave);
      |                  ^~~~


## Impact

CI

## Testing

CI
