### PR TITLE
benchmarks: support test-tlb

### DIFF
--- a/benchmarks/test-tlb/0001-test-tlb-port-for-NuttX.patch
+++ b/benchmarks/test-tlb/0001-test-tlb-port-for-NuttX.patch
@@ -1,0 +1,139 @@
+From fe4108f726a0e30d429f031a6006f030c5eda113 Mon Sep 17 00:00:00 2001
+From: ouyangxiangzhen <ouyangxiangzhen@xiaomi.com>
+Date: Thu, 6 Jun 2024 19:53:37 +0800
+Subject: [PATCH] test-tlb: port for NuttX
+
+VELAPLATFO-25227
+
+This commit ports the test-tlb test program to the NuttX. Additionally, it implements dynamic CPU frequency calculation.
+
+Change-Id: If1c15f36742d7ee5a7d13147b41b3372047dad08
+Signed-off-by: ouyangxiangzhen <ouyangxiangzhen@xiaomi.com>
+---
+ test-tlb.c | 68 ++++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 63 insertions(+), 5 deletions(-)
+
+diff --git a/test-tlb.c b/test-tlb.c
+index 5c8aaa5..767794a 100644
+--- a/test-tlb.c
++++ b/test-tlb.c
+@@ -14,13 +14,58 @@
+ #include <math.h>
+ #include <time.h>
+ 
+-#define PAGE_SIZE 4096
+-
+-#define FREQ 3.9
+ 
+ static int test_hugepage = 0;
+ static int random_list = 0;
+ 
++/* Fix definition conflict */
++#ifndef PAGE_SIZE
++#define PAGE_SIZE		4096
++#endif
++
++/* dynamic calculate freq */
++#define MEASURE_GAP		500000
++
++#ifdef __x86_64__
++static inline unsigned long rdcnt_relax(void)
++{
++	unsigned int lo,hi;
++	asm volatile ("rdtsc" : "=a" (lo), "=d" (hi));
++	return ((unsigned long)hi << 32) | (unsigned long)lo;
++}
++#elif defined(__aarch64__)
++static inline unsigned long rdcnt_relax(void)
++{
++	unsigned long time;
++	asm volatile("mrs %0, cntvct_el0" : "=r"(time));
++	return time;
++}
++#else
++#error "Unsupported architecture for dynamic frequencies measuring"
++#endif
++
++static inline unsigned long rdcnt(void)
++{
++	return rdcnt_relax();
++}
++
++static unsigned long measure_freq(void)
++{
++	unsigned long cycles_per_useconds;
++	unsigned long start;
++	unsigned long end;
++
++	start = rdcnt();
++	usleep(MEASURE_GAP);
++	end = rdcnt();
++
++	cycles_per_useconds = (end - start) / MEASURE_GAP;
++
++	printf("cycles_per_microseconds: %lu\n", cycles_per_useconds);
++
++	return cycles_per_useconds;
++}
++
+ static void die(const char *fmt, ...)
+ {
+ 	va_list argp;
+@@ -69,7 +114,7 @@ static unsigned long warmup(void *map)
+ 
+ static double do_test(void *map)
+ {
+-	unsigned long count = 0, offset = 0, usec;
++	unsigned long volatile count = 0, offset = 0, usec;
+ 	struct timeval start, end;
+ 	struct itimerval itval =  {
+ 		.it_interval = { 0, 0 },
+@@ -190,7 +235,14 @@ static void *create_map(void *map, unsigned long size, unsigned long stride)
+ 	if (map) {
+ 		if (test_hugepage)
+ 			return map;
++
++#ifdef __NuttX__
++		if (munmap(map, size) != 0)
++			die("munmap failed\n");
++		map = NULL;
++#else
+ 		flags |= MAP_FIXED;
++#endif
+ 	}
+ 
+ 	mapsize = size;
+@@ -237,9 +289,14 @@ int main(int argc, char **argv)
+ 	const char *arg;
+ 	void *map;
+ 	double cycles;
++	unsigned long freq;
+ 
+ 	srandom(time(NULL));
+ 
++	/* Fix segmentation fault when execution without any arguments in NuttX */
++	if (argc < 3)
++		die("bad arguments: test-tlb [-H] <size> <stride>");
++
+ 	while ((arg = argv[1]) != NULL) {
+ 		if (*arg != '-')
+ 			break;
+@@ -261,6 +318,7 @@ int main(int argc, char **argv)
+ 		argv++;
+ 	}
+ 
++	freq = measure_freq();
+ 	size = get_num(argv[1]);
+ 	stride = get_num(argv[2]);
+ 	if (stride < 4 || size < stride)
+@@ -281,6 +339,6 @@ int main(int argc, char **argv)
+ 	}
+ 
+ 	printf("%6.2fns (~%.1f cycles)\n",
+-		cycles, cycles*FREQ);
++		cycles, cycles * freq);
+ 	return 0;
+ }
+-- 
+2.34.1
+

--- a/benchmarks/test-tlb/CMakeLists.txt
+++ b/benchmarks/test-tlb/CMakeLists.txt
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+if(CONFIG_BENCHMARK_TESTTLB)
+
+  set(SRCS test-tlb/test-tlb.c)
+
+  set(TESTTLB_UNPACK ${CMAKE_CURRENT_LIST_DIR}/test-tlb)
+  set(TESTTLB_URL https://github.com/torvalds/test-tlb/archive)
+  set(TESTTLB_ZIP master.zip)
+
+  if(NOT EXISTS ${TESTTLB_UNPACK})
+
+    FetchContent_Declare(
+      testtlb_fetch
+      URL ${TESTTLB_URL}/${TESTTLB_ZIP} SOURCE_DIR ${TESTTLB_UNPACK} BINARY_DIR
+          ${CMAKE_BINARY_DIR}/apps/benchmarks/test-tlb/test-tlb
+      PATCH_COMMAND patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
+                    ${CMAKE_CURRENT_LIST_DIR}/0001-test-tlb-port-for-NuttX.patch
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(testtlb_fetch)
+    if(NOT testtlb_fetch_POPULATED)
+      FetchContent_Populate(testtlb_fetch)
+    endif()
+
+  endif()
+
+  nuttx_add_application(
+    NAME
+    testtlb
+    PRIORITY
+    ${CONFIG_BENCHMARK_TESTTLB_PRIORITY}
+    STACKSIZE
+    ${CONFIG_BENCHMARK_TESTTLB_STACKSIZE}
+    MODULE
+    ${CONFIG_BENCHMARK_TESTTLB}
+    COMPILE_FLAGS
+    ${CFLAGS}
+    SRCS
+    ${SRCS})
+endif()

--- a/benchmarks/test-tlb/Kconfig
+++ b/benchmarks/test-tlb/Kconfig
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+config BENCHMARK_TESTTLB
+	tristate "Memory Latency profiling"
+	depends on ALLOW_GPL_COMPONENTS
+	default n
+	---help---
+		Measure the memory latency
+
+if BENCHMARK_TESTTLB
+
+config BENCHMARK_TESTTLB_PRIORITY
+	int "TestTLB task priority"
+	default 100
+
+config BENCHMARK_TESTTLB_STACKSIZE
+	int "TestTLB stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/benchmarks/test-tlb/Make.defs
+++ b/benchmarks/test-tlb/Make.defs
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ifneq ($(CONFIG_BENCHMARK_TESTTLB),)
+CONFIGURED_APPS += $(APPDIR)/benchmarks/test-tlb
+endif

--- a/benchmarks/test-tlb/Makefile
+++ b/benchmarks/test-tlb/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = testtlb
+PRIORITY  = $(CONFIG_BENCHMARK_TESTTLB_PRIORITY)
+STACKSIZE = $(CONFIG_BENCHMARK_TESTTLB_STACKSIZE)
+MODULE    = $(CONFIG_BENCHMARK_TESTTLB)
+
+TESTTLB_UNPACK   = test-tlb
+TESTTLB_GIT      = github.com/torvalds/test-tlb
+TESTTLB_URL      = https://github.com/torvalds/test-tlb/archive
+TESTTLB_VERSION  = master
+TESTTLB_ZIP      = $(TESTTLB_UNPACK)-$(TESTTLB_VERSION).zip
+UNPACK         ?= unzip -q -o
+
+$(TESTTLB_ZIP):
+	@echo "Downloading: $(TESTTLB_URL)"
+	$(Q) curl -L $(TESTTLB_URL)/$(TESTTLB_VERSION).zip -o $(TESTTLB_UNPACK)-$(TESTTLB_VERSION).zip
+
+$(TESTTLB_UNPACK): $(TESTTLB_ZIP)
+	@echo "Unpacking: $(TESTTLB_ZIP) -> $(TESTTLB_UNPACK)"
+	$(Q) $(UNPACK) $(TESTTLB_ZIP)
+	$(Q) mv	test-tlb-$(TESTTLB_VERSION) $(TESTTLB_UNPACK)
+	$(Q) touch $(TESTTLB_UNPACK)
+	@echo "Patching: Applying patch"
+	$(Q) cd test-tlb && patch -p1 < ../0001-test-tlb-port-for-NuttX.patch
+
+ifeq ($(wildcard $(TESTTLB_UNPACK)/.git),)
+context:: $(TESTTLB_UNPACK)
+
+distclean::
+	$(call DELDIR, $(TESTTLB_UNPACK))
+	$(call DELFILE, $(TESTTLB_ZIP))
+endif
+
+MAINSRC   = test-tlb/test-tlb.c
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
This commit added support for test-tlb, a memory latency micro-benchmark.

## Impact
None.

## Testing
Tested on QEMU/x86_64 and QEMU/armv8a-virt.
