### PR TITLE
benchmarks: support cyclictest

### DIFF
--- a/benchmarks/rt-tests/0001-rt-tests-cyclictest-Port-for-NuttX.patch
+++ b/benchmarks/rt-tests/0001-rt-tests-cyclictest-Port-for-NuttX.patch
@@ -1,0 +1,43 @@
+From cbd7831e20f387a35e94a50b95e0b8db5c5e63dd Mon Sep 17 00:00:00 2001
+From: ouyangxiangzhen <ouyangxiangzhen@xiaomi.com>
+Date: Mon, 8 Jul 2024 10:43:14 +0800
+Subject: [PATCH] rt-tests/cyclictest: Port for NuttX
+
+VELAPLATFO-37815
+
+This patch ports cyclictest for NuttX.
+
+Change-Id: I918da053887aaba78910e230db0169239dba3b73
+Signed-off-by: ouyangxiangzhen <ouyangxiangzhen@xiaomi.com>
+---
+ src/cyclictest/cyclictest.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/cyclictest/cyclictest.c b/src/cyclictest/cyclictest.c
+index c5c3389..0edb684 100644
+--- a/src/cyclictest/cyclictest.c
++++ b/src/cyclictest/cyclictest.c
+@@ -847,7 +847,11 @@ static void display_help(int error)
+ static int use_nanosleep = MODE_CLOCK_NANOSLEEP;
+ static int timermode = TIMER_ABSTIME;
+ static int use_system;
++#ifdef RTTESTS_PRIORITY
++static int priority = RTTESTS_PRIORITY;
++#else
+ static int priority;
++#endif
+ static int policy = SCHED_OTHER;	/* default policy if not specified */
+ static int num_threads = 1;
+ static int max_cycles;
+@@ -1224,7 +1228,7 @@ static void process_options(int argc, char *argv[], int max_cpus)
+ 	if (distance == -1)
+ 		distance = DEFAULT_DISTANCE;
+ 
+-	if (priority < 0 || priority > 99)
++	if (priority < 0 || priority > 255)
+ 		error = 1;
+ 
+ 	if (num_threads == -1)
+-- 
+2.34.1
+

--- a/benchmarks/rt-tests/CMakeLists.txt
+++ b/benchmarks/rt-tests/CMakeLists.txt
@@ -1,0 +1,80 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+if(CONFIG_BENCHMARK_RTTESTS)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/rt-tests/.git)
+    set(RTTESTS_URL
+        "https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git")
+    set(RTTESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rt-tests)
+
+    execute_process(
+      COMMAND git clone ${RTTESTS_URL} ${RTTESTS_DIR}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      RESULT_VARIABLE GIT_CLONE_RESULT)
+
+    if(NOT ${GIT_CLONE_RESULT} EQUAL 0)
+      message(FATAL_ERROR "Failed to clone rt-tests repository")
+    endif()
+
+    execute_process(
+      COMMAND cd ${RTTESTS_DIR} && git checkout -q ${RTTESTS_VERSION} && patch
+              -p1 < ../0001-rt-tests-cyclictest-Port-for-NuttX.patch
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(distclean COMMAND ${CMAKE_COMMAND} -E remove_directory
+                                        ${RTTESTS_DIR})
+  endif()
+
+  list(
+    APPEND
+    SRCS
+    rt-tests/src/cyclictest/cyclictest.c
+    rt-tests/src/lib/rt-error.c
+    rt-tests/src/lib/histogram.c
+    rt-tests/src/lib/rt-utils.c
+    rt-tests/src/lib/rt-numa.c)
+
+  list(
+    APPEND
+    CFLAGS
+    -Irt-tests/src/include
+    -I.
+    -DVERSION=0.1
+    -DSYS_gettid=0
+    -Dgettid=rttest_gettid
+    -D'syscall
+    (x)
+    =
+    ((pid_t) (x))
+    '
+    -w
+    -DRTTESTS_PRIORITY=${CONFIG_BENCHMARK_RTTESTS_PRIORITY}+1)
+
+  nuttx_add_application(
+    NAME
+    cyclictest
+    PRIORITY
+    ${CONFIG_BENCHMARK_RTTESTS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_BENCHMARK_RTTESTS_STACKSIZE}
+    MODULE
+    ${CONFIG_BENCHMARK_RTTESTS}
+    COMPILE_FLAGS
+    ${CFLAGS}
+    SRCS
+    ${SRCS})
+endif()

--- a/benchmarks/rt-tests/Kconfig
+++ b/benchmarks/rt-tests/Kconfig
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+config BENCHMARK_RTTESTS
+	tristate "RT-Tests"
+	default n
+	depends on PIPES && ALLOW_GPL_COMPONENTS
+	---help---
+		Measure the timer jitter
+
+if BENCHMARK_RTTESTS
+
+config BENCHMARK_RTTESTS_PRIORITY
+	int "RT-Tests task priority"
+	default 200
+
+config BENCHMARK_RTTESTS_STACKSIZE
+	int "RT-Tests stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/benchmarks/rt-tests/Make.defs
+++ b/benchmarks/rt-tests/Make.defs
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ifneq ($(CONFIG_BENCHMARK_RTTESTS),)
+CONFIGURED_APPS += $(APPDIR)/benchmarks/rt-tests
+endif

--- a/benchmarks/rt-tests/Makefile
+++ b/benchmarks/rt-tests/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################################
+# Targets
+############################################################################
+
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = cyclictest
+PRIORITY  = $(CONFIG_BENCHMARK_RTTESTS_PRIORITY)
+STACKSIZE = $(CONFIG_BENCHMARK_RTTESTS_STACKSIZE)
+MODULE    = $(CONFIG_BENCHMARK_RTTESTS)
+
+RTTESTS_PATH    = $(APPDIR)/benchmarks/rt-tests/rt-tests
+RTTESTS_URL     = https://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git
+RTTESTS_VERSION = cadd661f984c0e6717e681fdaca1ce589b0ed964
+RTTESTS_GIT     = rt-tests
+
+ifeq ($(wildcard rt-tests/.git),)
+rt-tests:
+	@echo "Git Cloning: $(RTTESTS_URL)"
+	$(Q) git clone $(RTTESTS_URL)
+	@echo "Checkout commit: $(RTTESTS_VERSION)"
+	$(Q) cd $(RTTESTS_PATH) && \
+	git checkout -q $(RTTESTS_VERSION)
+	@echo "Patching: Applying patch"
+	$(Q) cd $(RTTESTS_PATH) && \
+	patch -p1 < ../0001-rt-tests-cyclictest-Port-for-NuttX.patch
+
+context:: rt-tests
+endif
+
+distclean::
+	$(call DELDIR, $(RTTESTS_GIT))
+
+MAINSRC   = rt-tests/src/cyclictest/cyclictest.c
+CSRCS     = rt-tests/src/lib/rt-error.c rt-tests/src/lib/histogram.c
+CSRCS    += rt-tests/src/lib/rt-utils.c rt-tests/src/lib/rt-numa.c
+
+CFLAGS   += -Irt-tests/src/include -I. -DVERSION=0.1
+CFLAGS   += -DSYS_gettid=0 -Dgettid=rttest_gettid -D'syscall(x)=((pid_t)(x))'
+CFLAGS   += -w -DRTTESTS_PRIORITY=$(CONFIG_BENCHMARK_RTTESTS_PRIORITY)+1
+
+include $(APPDIR)/Application.mk

--- a/benchmarks/rt-tests/numa.h
+++ b/benchmarks/rt-tests/numa.h
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * apps/benchmarks/rt-tests/numa.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __NUMA_H__
+#define __NUMA_H__
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <strings.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CACHE_LINESIZE                (64)
+#define numa_run_on_node(...)         (-1)
+#define numa_node_of_cpu(...)         (-1)
+#define numa_alloc_onnode(size, node) memalign(CACHE_LINESIZE, size)
+#define numa_free(ptr, size)          free(ptr)
+#define numa_available()              (-1)
+
+struct bitmask
+{
+  unsigned long  size; /* number of bits in the map */
+  unsigned long *maskp;
+};
+
+static inline
+struct bitmask *numa_allocate_cpumask(void)
+{
+    return NULL;
+}
+
+static inline void numa_bitmask_free(struct bitmask *mask)
+{
+    return;
+}
+
+static inline int numa_sched_getaffinity(pid_t pid, struct bitmask *mask)
+{
+    return -1;
+}
+
+static inline
+unsigned int numa_bitmask_isbitset(const struct bitmask *mask,
+                                   unsigned int          idx)
+{
+  return mask->maskp[idx / sizeof(unsigned long)] &
+         ((unsigned long)1 << (idx % sizeof(unsigned long)));
+}
+
+static inline
+struct bitmask *numa_bitmask_clearbit(struct bitmask *mask,
+                                      unsigned int idx)
+{
+    mask->maskp[idx / sizeof(unsigned long)] &=
+        ~((unsigned long)1 << (idx % sizeof(unsigned long)));
+    return mask;
+}
+
+static inline
+struct bitmask *numa_parse_cpustring_all(const char *s)
+{
+  return NULL;
+}
+
+static inline
+unsigned int numa_bitmask_weight(const struct bitmask *bitmap)
+{
+  unsigned int idx;
+  unsigned int ret = 0;
+  for (idx = 0; idx < bitmap->size / sizeof(unsigned long); idx++)
+    {
+      ret += popcountl(bitmap->maskp[idx]);
+    }
+  return ret;
+}
+
+#define numa_sched_setaffinity(...) (-1)
+
+#endif


### PR DESCRIPTION
## Summary
This commit supports cyclictest from RT-Tests for the timer jitter profiling.

## Impact
None.

## Testing
Tested on QEMU/x86_64.
