### PR TITLE
gcov: modify depends on

### DIFF
--- a/system/gcov/Kconfig
+++ b/system/gcov/Kconfig
@@ -5,7 +5,7 @@
 
 config SYSTEM_GCOV
 	tristate "gcov tool"
-	depends on SCHED_GCOV
+	depends on LIB_GCOV
 	---help---
 		Enable support for the 'gcov' command.
 


### PR DESCRIPTION
## Summary
gcov: modify depends on
## Impact
Depend on https://github.com/apache/nuttx/pull/14555
## Testing
enable CONFIG_LIB_GCOV,CONFIG_SYSTEM_GCOV, and set the corresponding gcov compilation options and run gcov -d /data/xxx to get the detection data.
