### PR TITLE
Improve nxdiag example for Espressif devices

### DIFF
--- a/system/nxdiag/Kconfig
+++ b/system/nxdiag/Kconfig
@@ -68,4 +68,10 @@ config SYSTEM_NXDIAG_ESPRESSIF
 	---help---
 		Enable Espressif-specific information and checks.
 
+config SYSTEM_NXDIAG_ESPRESSIF_CHIP
+	bool "Espressif Chip"
+	default n
+	---help---
+		Enable Espressif-specific information about chip. Chip must be connected during build process.
+
 endif # SYSTEM_NXDIAG

--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -89,6 +89,10 @@ else
 NXDIAG_FLAGS += --espressif "$(TOPDIR)" "$(HALDIR)"
 endif
 
+ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP),y)
+NXDIAG_FLAGS += --espressif_chip
+endif
+
 endif
 
 # Common build

--- a/system/nxdiag/nxdiag.c
+++ b/system/nxdiag/nxdiag.c
@@ -345,6 +345,16 @@ int main(int argc, char *argv[])
       print_array(ESPRESSIF_TOOLCHAIN, ESPRESSIF_TOOLCHAIN_ARRAY_SIZE);
       printf("Esptool version: %s\n\n", ESPRESSIF_ESPTOOL);
       printf("HAL version: %s\n\n", ESPRESSIF_HAL);
+#ifdef CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP
+      printf("CHIP ID: %s\n\n", ESPRESSIF_CHIP_ID);
+      printf("Flash ID:\n");
+      print_array(ESPRESSIF_FLASH_ID, ESPRESSIF_FLASH_ID_ARRAY_SIZE);
+      printf("Security information:\n");
+      print_array(ESPRESSIF_SECURITY_INFO,
+                  ESPRESSIF_SECURITY_INFO_ARRAY_SIZE);
+      printf("Flash status: %s\n\n", ESPRESSIF_FLASH_STAT);
+      printf("MAC address: %s\n\n", ESPRESSIF_MAC_ADDR);
+#endif
 #endif
     }
 


### PR DESCRIPTION
## Summary
- Improve nxdiag example for Espressif devices

## Impact

All ESP32 devices

## Testing

Tested with `esp32c3-generic:nsh` config with these options enabled:

```
CONFIG_SYSTEM_NXDIAG=y
CONFIG_SYSTEM_NXDIAG_ESPRESSIF=y
CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP=y
```

During build process make sure that chip is connected. Output should be like this:

```
nsh> nxdiag --all
Nxdiag Report:

NuttX RTOS info:
	Hostname: 
	Release: 10.4.0
	Build: 69e813ce78 Oct 31 2024 10:43:05
	Arch: risc-v
	Defconfig: esp32c3-generic:nsh-dirty

Host system OS:
	...
	
Espressif specific information:

Bootloader version:
	esp32: v5.1-dev-3972-g1559b6309f
	esp32s2: v5.1-dev-3972-g1559b6309f
	esp32s3: v5.1-dev-3972-g1559b6309f
	esp32c2: v5.1-dev-3972-g1559b6309f
	esp32c3: v5.1-dev-3972-g1559b6309f
	esp32c6: v5.1-dev-3972-g1559b6309f
	esp32h2: v5.1-dev-3972-g1559b6309f

Toolchain version:
	clang: Not found
	gcc: gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
	xtensa-esp32-elf-gcc: xtensa-esp32-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0
	xtensa-esp32s2-elf-gcc: xtensa-esp32s2-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0
	xtensa-esp32s3-elf-gcc: xtensa-esp32s3-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0
	riscv32-esp-elf-gcc: Not found
	riscv64-unknown-elf-gcc: Not found

Esptool version: 4.8.dev4

HAL version: sync/release_v5.1.c-nuttx-20230814-1573-gca869dd97e

CHIP ID: ESP32-C3 has no Chip ID. Reading MAC instead.

Flash ID:
	Manufacturer: 20
	Device: 4016

Security information:
	Flags: 0x00000000 (0b0)
	Key Purposes: (0, 0, 0, 0, 0, 0, 12)
	Chip ID: 5
	API Version: 3
	Secure Boot: Disabled
	Flash Encryption: Disabled
	SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT): 0x0

Flash status: 0x0000

MAC address: ...

nsh> 
```
