### PR TITLE
system/debugpoint: Fix RO watchpoint test issue for esp devices

### DIFF
--- a/system/debugpoint/debug.c
+++ b/system/debugpoint/debug.c
@@ -38,7 +38,7 @@
  ****************************************************************************/
 
 static uint8_t g_test_data[8];
-static const char g_test_rodata[] = "This is a read-only string";
+static const char g_test_rodata[32] = "This is a read-only string";
 
 /****************************************************************************
  * Name: debug_option


### PR DESCRIPTION
## Summary

Issue is about adress alignment differences between [idf](https://github.com/espressif/esp-idf/blob/master/components/riscv/include/riscv/rv_utils.h) and [nuttx](https://github.com/apache/nuttx/blob/master/arch/risc-v/src/common/riscv_debug.c#L326) implementation. On idf implementation we round the size value if size is greater than one. Due to this difference example is failing because data length was 27 and not rounded. [According to add idf watchpoint description](https://github.com/espressif/esp-idf/blob/master/components/esp_hw_support/include/esp_cpu.h#L493-L497) it has to be power of 2.

- Fix RO watchpoint test issue for esp devices

## Impact

## Testing

`esp32c3-generic:nsh` config used with `CONFIG_SYSTEM_DEBUGPOINT` and `LIB_GDBSTUB` options enabled and `debugpoint` command used