### PR TITLE
CI: Add Python linter to check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Check Pull Request
         run: |
           echo "::add-matcher::nuttx/.github/nxstyle.json"
-          python -m venv .venv
+          python3 -m venv .venv
           source .venv/bin/activate
-          pip install cmake-format
+          pip install cmake-format black isort flake8
           cd apps
           commits="${{ github.event.pull_request.base.sha }}..HEAD"
           git log --oneline $commits


### PR DESCRIPTION
## Summary

This PR syncs https://github.com/apache/nuttx/pull/14323 from `nuttx` repo to `nuttx-apps`.

This will resolve the `checkpatch.sh` failure: https://github.com/apache/nuttx-apps/issues/2812

## Impact

`checkpatch.sh` now runs correctly in the CI Workflow.

## Testing

We synced https://github.com/apache/nuttx/pull/14323 from `nuttx` repo to `nuttx-apps`. `checkpatch.sh` now runs correctly:
https://github.com/nuttxpr/nuttx-apps/actions/runs/11641702799/job/32420488934?pr=4
