### PR TITLE
cmake(bugfix):fix ymodem cmake typo error and sotest build error

### DIFF
--- a/examples/sotest/main/CMakeLists.txt
+++ b/examples/sotest/main/CMakeLists.txt
@@ -19,5 +19,27 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_SOTEST)
-  nuttx_add_application(NAME sotest)
+
+  # FIXME: fix all empty a after the kernel build is implemented
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/sotest_symtab.c
+    COMMAND
+      ${NUTTX_APPS_DIR}/tools/mksymtab.sh ${CMAKE_CURRENT_BINARY_DIR}/empty
+      g_sot > ${CMAKE_CURRENT_BINARY_DIR}/sotest_symtab.c)
+
+  add_custom_target(
+    sotest_romfs
+    COMMAND genromfs -f sotest_romfs.img -d empty
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+  add_custom_command(
+    OUTPUT sotest_romfs.c
+    COMMAND xxd -i sotest_romfs.img > sotest_romfs.c
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS sotest_romfs)
+
+  nuttx_add_application(
+    NAME sotest SRCS sotest_main.c ${CMAKE_CURRENT_BINARY_DIR}/sotest_symtab.c
+    ${CMAKE_CURRENT_BINARY_DIR}/sotest_romfs.c)
+
 endif()

--- a/system/ymodem/CMakeLists.txt
+++ b/system/ymodem/CMakeLists.txt
@@ -19,8 +19,7 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_YMODEM)
-  set(CSRCS ymodem.c)
-
+  target_sources(apps PRIVATE ymodem.c)
   nuttx_add_application(
     MODULE
     ${CONFIG_SYSTEM_YMODEM}
@@ -31,8 +30,7 @@ if(CONFIG_SYSTEM_YMODEM)
     PRIORITY
     ${CONFIG_SYSTEM_YMODEM_PRIORITY}
     SRCS
-    sb_main.c
-    ${CSRCS})
+    sb_main.c)
 
   nuttx_add_application(
     MODULE
@@ -44,6 +42,6 @@ if(CONFIG_SYSTEM_YMODEM)
     PRIORITY
     ${CONFIG_SYSTEM_YMODEM_PRIORITY}
     SRCS
-    rb_main.c
-    ${CSRCS})
+    rb_main.c)
+
 endif()


### PR DESCRIPTION
## Summary
1. fix ymodem typo
2. implement cmake sotest when kernel build does not support yet

## Impact
CMake: ymodem and sotest fixes.

## Testing
CI test

