### PR TITLE
CI: Disable the CI Build on push to master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - 'releases/*'
     tags:
 


### PR DESCRIPTION
## Summary

Due to the [recent cost-cutting](https://github.com/apache/nuttx/issues/14376), we are no longer running PR Merge Jobs in the `nuttx` and `nuttx-apps` repos. For this to happen, I am now running a script on my computer that will cancel any PR Merge Jobs that appear: [kill-push-master.sh](https://github.com/lupyuen/nuttx-release/blob/main/kill-push-master.sh)

This PR disables PR Merge Jobs permanently, so that we no longer need to run the script. This prevents our CI Charges from over-running, in case the script fails to operate properly.

## Impact

Some NuttX Developers may wish to run the PR Merge Jobs in their repos. They will have to re-enable the job in `build.yml`:

```yaml
on: ...
  push: ...
    branches:
      - master
```

Or they may rename the Default Branch from `master` to `releases/master` branch. Which will continue to execute PR Merge Jobs:

![Screenshot 2024-11-04 at 5 36 15 AM](https://github.com/user-attachments/assets/ccd5ba21-7bd7-4c72-87a2-12b257f21425)

__No Impact when Creating / Updating a PR:__ They will still undergo the same CI Checks.

__No Impact to Release Branch:__ Merging a PR to the Release Branch will still run the PR Merge Job (exactly like today). This ensures that the Release Branch will be verified through complete CI Checks.

__No Impact to Docker Builds:__ When the Dockerfile is updated, it will trigger the CI Workflow `docker_linux.yml`. Which is not affected by this PR, and will continue to run (exactly like today).

__No Impact to Documentation:__ When the docs are updated, they are published to NuttX Website via the CI Workflow `main.yml` from the `nuttx-website` repo (scheduled daily). Which is not affected by this PR, and will continue to run (exactly like today).

## Testing

Creating a PR will trigger the CI Checks: (exactly like today)
- https://github.com/lupyuen5/label-nuttx/actions/runs/11652645194?pr=88

Merging a PR will no longer execute the "Merge Pull Request" job:
- https://github.com/lupyuen5/label-nuttx/actions/workflows/build.yml

If we create a branch `releases/master` and merge a PR: CI Checks shall still execute:
- https://github.com/lupyuen5/label-nuttx/actions/runs/11654331888
