### PR TITLE
benchmarks: add .gitignore files

### DIFF
--- a/benchmarks/rt-tests/.gitignore
+++ b/benchmarks/rt-tests/.gitignore
@@ -1,0 +1,2 @@
+/rt-tests
+/*.zip

--- a/benchmarks/tacle-bench/.gitignore
+++ b/benchmarks/tacle-bench/.gitignore
@@ -1,0 +1,2 @@
+/tacle-bench
+/*.zip

--- a/benchmarks/test-tlb/.gitignore
+++ b/benchmarks/test-tlb/.gitignore
@@ -1,0 +1,2 @@
+/test-tlb
+/*.zip

--- a/benchmarks/tinymembench/.gitignore
+++ b/benchmarks/tinymembench/.gitignore
@@ -1,0 +1,2 @@
+/tinymembench
+/*.zip


### PR DESCRIPTION
## Summary

Updated `benchmarks/rt-tests/.gitignore` so local cache and package files are ignored on git repo and not added by mistake.

## Impact

`benchmarks/rt-tests` cache and dist files are ignored on git repo.

## Testing

ci