### PR TITLE
nsh_vars: Remove rogue sched_unlock()

### DIFF
--- a/nshlib/nsh_vars.c
+++ b/nshlib/nsh_vars.c
@@ -346,7 +346,6 @@ int nsh_unsetvar(FAR struct nsh_vtbl_s *vtbl, FAR const char *name)
         }
     }
 
-  sched_unlock();
   return ret;
 }
 #endif


### PR DESCRIPTION

## Summary
There is no corresponding sched_lock() for this and therefore this causes random crashes.

Found when running a long init script which utilizes shell variables in SMP mode.

## Impact
Remove sched_unlock() from a place that does not use sched_lock()
## Testing
Downstream MPFS target which utilizes nsh_vars.
