### PR TITLE
fix compile error

### DIFF
--- a/testing/ostest/smp_call.c
+++ b/testing/ostest/smp_call.c
@@ -29,13 +29,14 @@
 
 #include <nuttx/sched.h>
 
+#if defined(CONFIG_SMP) && defined(CONFIG_BUILD_FLAT)
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
 static struct smp_call_data_s g_call_data;
 
-#if defined(CONFIG_SMP) && defined(CONFIG_BUILD_FLAT)
 /****************************************************************************
  * Private Functions
  ****************************************************************************/


### PR DESCRIPTION


## Summary
fix compile error
Error: smp_call.c:36:31: error: 'g_call_data' defined but not used [-Werror=unused-variable]
   36 | static struct smp_call_data_s g_call_data;
      |                               ^~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [/github/workspace/sources/apps/Application.mk:237: smp_call.c.github.workspace.sources.apps.testing.ostest.o] Error 1
make[2]: Target 'all' not remade because of errors.
make[1]: *** [Makefile:52: /github/workspace/sources/apps/testing/ostest_all] Error 2
make[1]: Target 'all' not remade because of errors.
make: *** [tools/LibTargets.mk:248: /github/workspace/sources/apps/libapps.a] Error 2
make: Target 'all' not remade because of errors.
/github/workspace/sources/nuttx/tools/testbuild.sh: line 385: /github/workspace/sources/nuttx/../nuttx/nuttx.manifest: No such file or directory
## Impact
fix compile error
## Testing
ci
