### PR TITLE
uORB/sensor: Add GNSS firmware version for `sensor_gnss_format`

### DIFF
--- a/system/uorb/sensor/gnss.c
+++ b/system/uorb/sensor/gnss.c
@@ -35,7 +35,7 @@
   "vdop:%hf,ground_speed:%hf,course:%hf,satellites_used:%" PRIu32 ""
 
 static const char sensor_gnss_format[] =
-  UORB_DEBUG_FORMAT_SENSOR_GNSS;
+  UORB_DEBUG_FORMAT_SENSOR_GNSS ",firmware_version:%" PRIu32 "";
 
 static const char sensor_gnss_clock_format[] =
   "flags:%" PRIx32 ",leap_second:%" PRId32 ",time_ns:%" PRId64 ","


### PR DESCRIPTION
## Summary
Update debug format of "sensor_gnss".

## Impact
uorb_listener

## Testing
1. Selftest
```
uorb_listener -n 20 sensor_gnss
```
2. NuttX CI
