### PR TITLE
isrthread: add configuring the stack of an isrthread as static

### DIFF
--- a/testing/ostest/wqueue.c
+++ b/testing/ostest/wqueue.c
@@ -288,7 +288,7 @@ void wqueue_test(void)
   for (i = 1; i < 3; i++)
     {
       printf("wqueue_test: test %d\n", i);
-      wq = work_queue_create("test", 100, 2048, i);
+      wq = work_queue_create("test", 100, NULL, 2048, i);
       DEBUGASSERT(wq != NULL);
       wqueue_priority_test(0, wq, 100);
       work_queue_free(wq);


### PR DESCRIPTION
## Summary
isrthread: add configuring the stack of an isrthread as static

reason:
we configure the isr thread stack as static to allow for more flexible placement of the stack.


## Impact
isrthread


https://github.com/apache/nuttx/pull/14686
https://github.com/apache/nuttx-apps/pull/2828
These two pull requests (PRs) must be merged together.

## Testing
ci ostest
