### PR TITLE
nxaudio: fix audio stop logic to prevent buffer addition after STOP signal

### DIFF
--- a/audioutils/nxaudio/nxaudio.c
+++ b/audioutils/nxaudio/nxaudio.c
@@ -282,11 +282,11 @@ int nxaudio_stop(FAR struct nxaudio_s *nxaudio)
 {
   struct audio_msg_s term_msg;
 
-  ioctl(nxaudio->fd, AUDIOIOC_STOP, 0);
-
   term_msg.msg_id = AUDIO_MSG_STOP;
   term_msg.u.data = 0;
   mq_send(nxaudio->mq, (FAR const char *)&term_msg, sizeof(term_msg), 0);
+
+  ioctl(nxaudio->fd, AUDIOIOC_STOP, 0);
 
   return OK;
 }


### PR DESCRIPTION
## Summary

- Ensure `AUDIO_STOP` via `ioctrl` is followed by `mq_send STOP` without race conditions.
- Modify loop condition to correctly handle `running = false` upon receiving STOP signal.
- Resolve potential issue where `AUDIO_MSG_DEQUEUE` could still accept buffers after STOP signal due to timing.

Before:
- `nxaudio_stop` would call `ioctrl AUDIO_STOP` followed by `mq_send STOP`, which might lead to `AUDIO_MSG_DEQUEUE` accepting buffers after STOP.

After:
- Synchronized the sequence of `ioctrl AUDIO_STOP` and `mq_send STOP` to prevent buffer addition after STOP.
- Enhanced loop condition to accurately reflect the STOP state.

## Impact
N/A

## Testing
N/A
