### PR TITLE
nshlib/nsh_session: Arguments of subcommand was lost

### DIFF
--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -143,7 +143,23 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 
           if (argc > 2)
             {
-              return nsh_parse(vtbl, argv[2]);
+              char cmdline[CONFIG_NSH_LINELEN];
+
+              memset(cmdline, 0, sizeof(cmdline));
+
+              for (ret = 0; ret < argc - 2; ret++)
+                {
+                  if (sizeof(cmdline) - strlen(cmdline) - 1 <
+                      strlen(argv[ret + 2]) + 1)
+                    {
+                      break;
+                    }
+
+                  strcat(cmdline, argv[ret + 2]);
+                  strcat(cmdline, ret == argc - 3 ? "\n" : " ");
+                }
+
+              return nsh_parse(vtbl, cmdline);
             }
           else
             {


### PR DESCRIPTION
## Summary
Fix a bug that arguments of subcommand will be lost.
1. It`s fine if subcommand has no argument sh -c dd
```
sh -c dd
```
2. Argument(s) of subcommand will be lost sh -c dd bs=1
```
sh -c dd bs=1

# Merge to one argument by using quotation is OK
sh -c "dd bs=1"
```
3. Error case
```
nsh> ls | dd bs=1 | cat
```
```C
 argv[0] = "sh";
 argv[1] = "-c";
 argv[2] = "dd";
 argv[3] = "bs=1";

 nsh_execute(..., argv, ...);
```
## Impact
Bugfix of nshlib/nsh_session

## Testing
1. Selftest as commit message show.
2. NuttX CI
