### PR TITLE
stdio.h:Remove unnecessary header file, app header change

### DIFF
--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -36,6 +36,8 @@
 #include <assert.h>
 #include <unistd.h>
 
+#include <nuttx/lib/lib.h>
+
 #include "nsh.h"
 #include "nsh_console.h"
 

--- a/testing/ostest/nxevent.c
+++ b/testing/ostest/nxevent.c
@@ -26,6 +26,7 @@
 #include <nuttx/event.h>
 
 #include <stdio.h>
+#include <sched.h>
 #include <pthread.h>
 
 #include "ostest.h"

--- a/testing/ostest/pthread_exit.c
+++ b/testing/ostest/pthread_exit.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <sys/wait.h>
 #include <stdio.h>
+#include <sched.h>
 #include <stdlib.h>
 #include <pthread.h>
 #include <unistd.h>

--- a/testing/ostest/setjmp.c
+++ b/testing/ostest/setjmp.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 /****************************************************************************
  * Public Functions

--- a/testing/ostest/setvbuf.c
+++ b/testing/ostest/setvbuf.c
@@ -26,6 +26,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
 

--- a/testing/ostest/signest.c
+++ b/testing/ostest/signest.c
@@ -32,6 +32,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <debug.h>


### PR DESCRIPTION
## Summary

Remove stdio.h  unnecessary header file

## Impact

Many compilation configs rely on removing redundant header files in stdio

## Testing

build sim:nsh
