### PR TITLE
build: increase FetchContent timeout to 120 seconds for LVGL

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -43,7 +43,7 @@ if(CONFIG_GRAPHICS_LVGL)
           TEST_COMMAND
           ""
       DOWNLOAD_NO_PROGRESS true
-      TIMEOUT 30)
+      TIMEOUT 120)
 
     FetchContent_GetProperties(lvgl_fetch)
 


### PR DESCRIPTION
## Summary

LVGL 9.2.1 archive is ~70MB. Over poor connections, it may take longer to download it. This renders CMake build unusable in such environments.

## Impact

CMake build for LVGL configurations is now usable over poor network connections.

## Testing

Local CMake configure step for 
```
cmake .. -G Ninja -DBOARD_CONFIG=sim:lvgl_fb
```

