### PR TITLE
nshlib/cmd_dd: Retry if read() was interrupted

### DIFF
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -126,6 +126,11 @@ static int dd_read(FAR struct dd_s *dd)
       nbytes = read(dd->infd, buffer, dd->sectsize - dd->nbytes);
       if (nbytes < 0)
         {
+          if (errno == EINTR)
+            {
+              continue;
+            }
+
           FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
           nsh_error(vtbl, g_fmtcmdfailed, g_dd, "read", NSH_ERRNO);
           return ERROR;
@@ -134,7 +139,7 @@ static int dd_read(FAR struct dd_s *dd)
       dd->nbytes += nbytes;
       buffer     += nbytes;
     }
-  while (dd->nbytes < dd->sectsize && nbytes > 0);
+  while (dd->nbytes < dd->sectsize && nbytes != 0);
 
   dd->eof |= (dd->nbytes == 0);
   return OK;


### PR DESCRIPTION
## Summary
nshlib/cmd_dd: Retry if read() was interrupted

- Without this patch
```bash
nsh> ls /etc/group | dd | dd
sh [13:100]
sh [14:100]
nsh: dd: read failed: 4
nsh>
```
- With this patch
```
nsh> ls | dd | dd | dd | dd | dd
sh [4:100]
sh [5:100]
sh [6:100]
sh [7:100]
sh [8:100]
/:
 bin/
 dev/
 etc/
 proc/
 tmp/
 var/
nsh>
```
Link: https://github.com/apache/nuttx-apps/pull/2833 (same reason), https://github.com/apache/nuttx-apps/pull/2737 (nsh pipeline)
## Impact
nshlib/cmd_dd

## Testing
- nsh:sim with pipeline enabled
- NuttX CI
