### PR TITLE
audioutils/nxaudio: added pause/resume interface in nxaudio.h

### DIFF
--- a/include/audioutils/nxaudio.h
+++ b/include/audioutils/nxaudio.h
@@ -69,6 +69,8 @@ int init_nxaudio_devname(FAR struct nxaudio_s *nxaudio,
 void fin_nxaudio(FAR struct nxaudio_s *nxaudio);
 int nxaudio_enqbuffer(FAR struct nxaudio_s *nxaudio,
                       FAR struct ap_buffer_s *apb);
+int nxaudio_pause(FAR struct nxaudio_s *nxaudio);
+int nxaudio_resume(FAR struct nxaudio_s *nxaudio);
 int nxaudio_setvolume(FAR struct nxaudio_s *nxaudio, uint16_t vol);
 int nxaudio_start(FAR struct nxaudio_s *nxaudio);
 int nxaudio_msgloop(FAR struct nxaudio_s *nxaudio,


### PR DESCRIPTION
## Summary
audioutils/nxaudio: added pause/resume interface in nxaudio.h
## Impact
nxaudio
## Testing
nxaudio
