### PR TITLE
cmake(bugfix):add INCLUDE_DIRECTORIES for nimble

### DIFF
--- a/examples/nimble/CMakeLists.txt
+++ b/examples/nimble/CMakeLists.txt
@@ -20,7 +20,12 @@
 
 if(CONFIG_EXAMPLES_NIMBLE)
   nuttx_add_application(
-    NAME nimble
-    SRCS ${CMAKE_CURRENT_LIST_DIR}/nimble_main.c
-    DEPENDS nimble)
+    NAME
+    nimble
+    SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/nimble_main.c
+    INCLUDE_DIRECTORIES
+    $<GENEX_EVAL:$<TARGET_PROPERTY:nimble,INCLUDE_DIRECTORIES>>
+    DEPENDS
+    nimble)
 endif()


### PR DESCRIPTION
## Summary

/github/workspace/sources/apps/examples/nimble/nimble_main.c:40:10: fatal error: nimble/nimble_npl.h: No such file or directory
   40 | #include "nimble/nimble_npl.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.

## Impact

bugfix

## Testing

cmake -B build -DBOARD_CONFIG=nrf52840-dk/sdc_nimble -GNinja

build pass
