### PR TITLE
nshlib/cmd_wait: Wait failed if `FS_PROCFS` not enabled

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -715,6 +715,7 @@ config NSH_DISABLE_WAIT
 	bool "Disable wait"
 	default DEFAULT_SMALL
 	depends on SCHED_WAITPID
+	depends on FS_PROCFS && !FS_PROCFS_EXCLUDE_PROCESS
 
 config NSH_DISABLE_WATCH
 	bool "Disable watch"

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1238,7 +1238,8 @@ int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
 #if !defined(CONFIG_NSH_DISABLE_WAIT) && defined(CONFIG_SCHED_WAITPID) && \
-    !defined(CONFIG_DISABLE_PTHREAD)
+    !defined(CONFIG_DISABLE_PTHREAD) && defined(CONFIG_FS_PROCFS) && \
+    !defined(CONFIG_FS_PROCFS_EXCLUDE_PROCESS)
 int cmd_wait(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -679,7 +679,8 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("xd",       cmd_xd,       3, 3, "<hex-address> <byte-count>"),
 #endif
 #if !defined(CONFIG_NSH_DISABLE_WAIT) && defined(CONFIG_SCHED_WAITPID) && \
-    !defined(CONFIG_DISABLE_PTHREAD)
+    !defined(CONFIG_DISABLE_PTHREAD) && defined(CONFIG_FS_PROCFS) && \
+    !defined(CONFIG_FS_PROCFS_EXCLUDE_PROCESS)
   CMD_MAP("wait",     cmd_wait,     1, CONFIG_NSH_MAXARGUMENTS,
           "pid1 [pid2 [pid3] ...]"),
 #endif

--- a/nshlib/nsh_wait.c
+++ b/nshlib/nsh_wait.c
@@ -35,7 +35,8 @@
 #include "nsh_console.h"
 
 #if !defined(CONFIG_NSH_DISABLE_WAIT) && defined(CONFIG_SCHED_WAITPID) && \
-    !defined(CONFIG_DISABLE_PTHREAD)
+    !defined(CONFIG_DISABLE_PTHREAD) && defined(CONFIG_FS_PROCFS) && \
+    !defined(CONFIG_FS_PROCFS_EXCLUDE_PROCESS)
 
 static const char g_groupid[] = "Group:";
 


### PR DESCRIPTION
## Summary
Wait failed if `FS_PROCFS` not enabled
#### Env
```diff
# sim:nsh
- CONFIG_FS_PROCFS=y
```
#### Error
```
nsh> sleep 5 &
sh [4:100]
nsh> wait 4
nsh: wait: wait failed: 2
```
#### cmd_wait()
```C
snprintf(path, sizeof(path), "/proc/%d/status", tid);
```

Reported by @XuNeo and @Gary-Hobson, thank you;-)
## Impact
nshlib/cmd_wait

## Testing
1. Selftest: Using `sim:nsh` with `CONFIG_FS_PROCFS` disabled - PASSED
2. NuttX CI
