### PR TITLE
posix_spawn: Move dependencies to Kconfig

### DIFF
--- a/examples/posix_spawn/Kconfig
+++ b/examples/posix_spawn/Kconfig
@@ -6,6 +6,12 @@
 config EXAMPLES_POSIXSPAWN
 	tristate "posix_spawn Unit Test"
 	default n
+	depends on !BINFMT_DISABLE
+	depends on !DISABLE_MOUNTPOINT
+	depends on BOARDCTL
+	depends on BOARDCTL_APP_SYMTAB
+	depends on ELF
+	depends on FS_ROMFS
 	---help---
 		Enable the posix_spawn() unit test
 

--- a/examples/posix_spawn/spawn_main.c
+++ b/examples/posix_spawn/spawn_main.c
@@ -45,38 +45,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Check configuration.  This is not all of the configuration settings that
- * are required -- only the more obvious.
- */
-
-#ifdef CONFIG_BINFMT_DISABLE
-#  error "The binary loader is disabled (CONFIG_BINFMT_DISABLE)!"
-#endif
-
-#ifndef CONFIG_ELF
-#  error "You must select CONFIG_ELF in your configuration file"
-#endif
-
-#ifndef CONFIG_FS_ROMFS
-#  error "You must select CONFIG_FS_ROMFS in your configuration file"
-#endif
-
-#ifdef CONFIG_DISABLE_MOUNTPOINT
-#  error "You must not disable mountpoints via CONFIG_DISABLE_MOUNTPOINT in your configuration file"
-#endif
-
-#ifdef CONFIG_BINFMT_DISABLE
-#  error "You must not disable loadable modules via CONFIG_BINFMT_DISABLE in your configuration file"
-#endif
-
-#ifndef CONFIG_BOARDCTL
-#  error "This configuration requires CONFIG_BOARDCTL"
-#endif
-
-#ifndef CONFIG_BOARDCTL_APP_SYMTAB
-#  error "You must enable the symobol table interface with CONFIG_BOARDCTL_APP_SYMTAB"
-#endif
-
 /* Describe the ROMFS file system */
 
 #define SECTORSIZE   512


### PR DESCRIPTION
## Summary

`posix_spawn` depends on these configurations:
- !BINFMT_DISABLE
- !DISABLE_MOUNTPOINT
- BOARDCTL
- BOARDCTL_APP_SYMTAB
- ELF
- FS_ROMFS

Check them in compile time may waste some time if the dependencies are not met, move them to Kconfig to avoid this.

## Impact

No

## Testing
Local machine
