### PR TITLE
quickjs: fix mp_mul multiple definition

### DIFF
--- a/interpreters/quickjs/CMakeLists.txt
+++ b/interpreters/quickjs/CMakeLists.txt
@@ -78,6 +78,9 @@ if(CONFIG_INTERPRETERS_QUICKJS)
     -include
     alloca.h)
 
+  list(APPEND QUICKJS_FLAGS -Dmp_add=qjs_mp_add -Dmp_sub=qjs_mp_sub
+       -Dmp_mul=qjs_mp_mul)
+
   list(APPEND QUICKJS_INCDIR ${QUICKJS_DIR})
 
   list(


### PR DESCRIPTION
## Summary

in function `mp_mul':
apps/interpreters/quickjs/quickjs/libbf.c:1179: multiple definition of `mp_mul'; nuttx/staging/libapps.a:apps/math/libtommath/libtommath/bn_mp_mul.c:8: first defined here

## Impact

quickjs

## Testing

ci