### PR TITLE
cmake(build):add missing basic and nxlooper cmake script

### DIFF
--- a/interpreters/minibasic/CMakeLists.txt
+++ b/interpreters/minibasic/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ##############################################################################
+# apps/interpreters/minibasic/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_INTERPRETERS_MINIBASIC)
+  nuttx_add_application(
+    NAME
+    basic
+    SRCS
+    script.c
+    basic.c
+    STACKSIZE
+    ${CONFIG_INTERPRETER_MINIBASIC_STACKSIZE}
+    PRIORITY
+    ${CONFIG_INTERPRETER_MINIBASIC_PRIORITY})
+endif()

--- a/system/nxlooper/CMakeLists.txt
+++ b/system/nxlooper/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# apps/system/nxlooper/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_NXLOOPER)
+
+  target_sources(apps PRIVATE nxlooper.c)
+
+  if(CONFIG_NXLOOPER_COMMAND_LINE)
+    nuttx_add_application(NAME nxlooper SRCS nxlooper_main.c STACKSIZE
+                          ${CONFIG_NXLOOPER_MAINTHREAD_STACKSIZE})
+  endif()
+
+endif()


### PR DESCRIPTION
## Summary

add interpreter basic and nxlooper missing CMake build

## Impact

fix ci fail in https://github.com/apache/nuttx/actions/runs/11880169863/job/33103008538?pr=14756

## Testing
```
cmake -B build -DBOARD_CONFIG=sim:minibasic -GNinja
cmake -B build -DBOARD_CONFIG=sim:alsa -GNinja
```
refresh pass
