### PR TITLE
tools: Optimize size by wasm-opt

### DIFF
--- a/tools/Wasm.mk
+++ b/tools/Wasm.mk
@@ -42,7 +42,12 @@ define LINK_WASM
 	    $(if $(RETVAL), \
 	        $(error wasm build failed for $(PROGNAME).wasm) \
 	    ) \
-		$(call WAMR_AOT_COMPILE) \
+	    $(eval RETVAL=$(shell $(WASI_SDK_PATH)/wasm-opt -Oz -o $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm \
+	        $(BINDIR)$(DELIM)wasm$(DELIM)$(PROGNAME).wasm || echo 1;)) \
+	    $(if $(RETVAL), \
+	        $(error wasm build failed for $(PROGNAME).wasm) \
+	    ) \
+	    $(call WAMR_AOT_COMPILE) \
 	   ) \
 	 )
 endef


### PR DESCRIPTION


## Summary
wasm-opt is a tool from binaryen that can do
further optimization for Wasm module, to reduce
the size of bytecode.
## Impact
New experimental feature, for wasm build
## Testing
Local machine
