### PR TITLE
system/adb: Fix log format error

### DIFF
--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -7,6 +7,7 @@ menuconfig SYSTEM_ADBD
 	tristate "ADB daemon application"
 	default n
 	depends on LIBUV
+	select LIBC_PRINT_EXTENSION
 	---help---
 		Enable support for adb daemon.
 


### PR DESCRIPTION
## Summary
The `"%pV"` format depends on libc extension
e.g. Calling `avb_log()` in function `adbd_main()`:
```
  adbd_main (***): 0x3fc9175cV
```
## Impact
system/adb

## Testing
- Selftest (esp32s3-devkit:adb(in process))
- NuttX CI
