### PR TITLE
build.yml: MSYS2 GitHub Action disabled ccache and enabled option -N (CMake+Ninja)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,7 @@ jobs:
         with:
           msystem: MSYS
           update: false
+          cache: false
           install: >-
             base-devel
             gcc
@@ -322,7 +323,7 @@ jobs:
           git config --global --add safe.directory /github/workspace/sources/nuttx
           git config --global --add safe.directory /github/workspace/sources/apps
           cd sources/nuttx/tools/ci
-          ./cibuild.sh -g -i -A -C -R testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -g -i -A -C -N -R testlist/${{matrix.boards}}.dat
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

CMake+Ninja arm-none-eabi-ar: Argument list too long
 has been fixed on the NuttX  https://github.com/apache/nuttx/pull/14892

You need to disable the msys2 cache from the GitHub action because we moved the Scheduled Merge Jobs to a new NuttX Mirror Repo. https://github.com/apache/nuttx/pull/14909

https://github.com/apache/nuttx-apps/actions/caches

## Impact
Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing
Github
local msys2
```
$ cmake -B build -DBOARD_CONFIG=nucleo-l152re:nsh -GNinja
-- Initializing NuttX
  Select HOST_WINDOWS=y
  Select WINDOWS_MSYS=y
--   CMake:  3.28.1
--   Ninja:  1.11.1
--   Board:  nucleo-l152re
--   Config: nsh
--   Appdir: /home/nuttx/nxninja/apps
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: /home/nuttx/nuttxnew/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Configuring done (16.9s)
-- Generating done (8.0s)
-- Build files have been written to: /home/nuttx/nxninja/nuttx/build


$ cmake --build build
[27/1025] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32/stm32_gpio.c.obj
C:/msys64/home/nuttx/nxninja/nuttx/arch/arm/src/stm32/stm32_gpio.c:41:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   41 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1022/1025] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       55500 B       512 KB     10.59%
            sram:        3700 B        80 KB      4.52%
[1025/1025] Generating System.map
```
