### PR TITLE
system/flatbuffers: fix patch flow of flatbuffers

### DIFF
--- a/math/kissfft/CMakeLists.txt
+++ b/math/kissfft/CMakeLists.txt
@@ -33,6 +33,8 @@ if(CONFIG_MATH_KISSFFT)
       kissfft_fetch
       URL ${KISSFFT_URL} SOURCE_DIR ${KISSFFT_DIR} BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/math/kissfft/kissfft
+      PATCH_COMMAND patch -d ${KISSFFT_DIR} -p1 <
+                    ${CMAKE_CURRENT_LIST_DIR}/kissfft.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -40,14 +42,6 @@ if(CONFIG_MATH_KISSFFT)
 
     if(NOT kissfft_fetch_POPULATED)
       FetchContent_Populate(kissfft_fetch)
-
-      # Apply the patch after fetching the content
-      execute_process(
-        COMMAND ${CMAKE_COMMAND} -E echo "Applying patch to kissfft"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-
-      execute_process(COMMAND patch -d ${KISSFFT_DIR} -p1 <
-                              ${CMAKE_CURRENT_LIST_DIR}/kissfft.patch)
     endif()
   endif()
 

--- a/math/ruy/CMakeLists.txt
+++ b/math/ruy/CMakeLists.txt
@@ -44,17 +44,4 @@ if(CONFIG_MATH_RUY)
     endif()
   endif()
 
-  # ############################################################################
-  # Include Directory
-  # ############################################################################
-
-  set(INCDIR ${CMAKE_CURRENT_LIST_DIR}/ruy)
-
-  # ############################################################################
-  # Library Configuration
-  # ############################################################################
-
-  nuttx_add_library(ruy STATIC)
-  target_include_directories(ruy PUBLIC ${INCDIR})
-
 endif()

--- a/mlearning/CMakeLists.txt
+++ b/mlearning/CMakeLists.txt
@@ -18,4 +18,6 @@
 #
 # ##############################################################################
 
+nuttx_add_subdirectory()
+
 nuttx_generate_kconfig(MENUDESC "Machine Learning Support")

--- a/mlearning/tflite-micro/CMakeLists.txt
+++ b/mlearning/tflite-micro/CMakeLists.txt
@@ -59,7 +59,6 @@ if(CONFIG_TFLITEMICRO)
   set(COMMON_FLAGS
       -DTF_LITE_STATIC_MEMORY
       -DTF_LITE_DISABLE_X86_NEON
-      -DTF_LITE_STRIP_ERROR_STRINGS
       -Wno-sign-compare
       -Wno-unused-variable
       -Wno-undef
@@ -68,6 +67,13 @@ if(CONFIG_TFLITEMICRO)
 
   if(CONFIG_MLEARNING_CMSIS_NN)
     list(APPEND COMMON_FLAGS -DCMSIS_NN)
+  endif()
+
+  if(CONFIG_TFLITEMICRO_DEBUG)
+    list(APPEND COMMON_FLAGS -DTF_LITE_SHOW_MEMORY_USE)
+    list(APPEND COMMON_FLAGS -DTF_LITE_USE_CTIME)
+  else()
+    list(APPEND COMMON_FLAGS -DTF_LITE_STRIP_ERROR_STRINGS)
   endif()
 
   # ############################################################################
@@ -155,5 +161,21 @@ if(CONFIG_TFLITEMICRO)
   target_compile_options(tflite_micro PRIVATE ${COMMON_FLAGS})
   target_sources(tflite_micro PRIVATE ${TFLITE_MICRO_SRCS})
   target_include_directories(tflite_micro PUBLIC ${INCDIR})
+
+  if(CONFIG_TFLITEMICRO_TOOL)
+    nuttx_add_application(
+      NAME
+      tflm
+      STACKSIZE
+      ${CONFIG_TFLITEMICRO_TOOL_STACKSIZE}
+      PRIORITY
+      ${CONFIG_TFLITEMICRO_TOOL_PRIORITY}
+      SRCS
+      ${CMAKE_CURRENT_LIST_DIR}/tflm_tool.cc
+      INCLUDE_DIRECTORIES
+      ${INCDIR}
+      COMPILE_FLAGS
+      ${COMMON_FLAGS})
+  endif()
 
 endif()

--- a/mlearning/tflite-micro/CMakeLists.txt
+++ b/mlearning/tflite-micro/CMakeLists.txt
@@ -34,6 +34,14 @@ if(CONFIG_TFLITEMICRO)
       tflite_micro_fetch
       URL ${TFLITE_MICRO_URL} SOURCE_DIR ${TFLITE_MICRO_DIR} BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro
+      PATCH_COMMAND
+        patch -d ${TFLITE_MICRO_DIR} -p1 <
+        ${CMAKE_CURRENT_LIST_DIR}/tflite-micro.patch && patch -d
+        ${TFLITE_MICRO_DIR} -p1 <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-dequantize-int8.patch && patch -d
+        ${TFLITE_MICRO_DIR} -p1 <
+        ${CMAKE_CURRENT_LIST_DIR}/0002-quantize-int8.patch && patch -d
+        ${TFLITE_MICRO_DIR} -p1 < ${CMAKE_CURRENT_LIST_DIR}/0003-mean-int8.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -41,21 +49,6 @@ if(CONFIG_TFLITEMICRO)
 
     if(NOT tflite_micro_fetch_POPULATED)
       FetchContent_Populate(tflite_micro_fetch)
-
-      # Apply the patch after fetching the content
-      execute_process(
-        COMMAND ${CMAKE_COMMAND} -E echo "Applying patch to tflite-micro"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-      execute_process(COMMAND patch -d ${TFLITE_MICRO_DIR} -p1 <
-                              ${CMAKE_CURRENT_LIST_DIR}/tflite-micro.patch)
-      execute_process(
-        COMMAND patch -d ${TFLITE_MICRO_DIR} -p1 <
-                ${CMAKE_CURRENT_LIST_DIR}/0001-dequantize-int8.patch)
-      execute_process(
-        COMMAND patch -d ${TFLITE_MICRO_DIR} -p1 <
-                ${CMAKE_CURRENT_LIST_DIR}/0002-quantize-int8.patch)
-      execute_process(COMMAND patch -d ${TFLITE_MICRO_DIR} -p1 <
-                              ${CMAKE_CURRENT_LIST_DIR}/0003-mean-int8.patch)
     endif()
   endif()
 

--- a/mlearning/tflite-micro/CMakeLists.txt
+++ b/mlearning/tflite-micro/CMakeLists.txt
@@ -136,13 +136,15 @@ if(CONFIG_TFLITEMICRO)
   # ############################################################################
 
   set(INCDIR
-      ${CMAKE_BINARY_DIR}/apps/math/gemmlowp/gemmlowp
-      ${CMAKE_BINARY_DIR}/apps/math/ruy/ruy
-      ${CMAKE_BINARY_DIR}/apps/math/kissfft/kissfft
-      ${CMAKE_BINARY_DIR}/apps/math/tflite-micro/tflite-micro)
+      ${NUTTX_APPS_DIR}/math/gemmlowp/gemmlowp
+      ${NUTTX_APPS_DIR}/math/ruy/ruy
+      ${NUTTX_APPS_DIR}/math/kissfft/kissfft
+      ${NUTTX_APPS_DIR}/math/kissfft/kissfft
+      ${NUTTX_APPS_DIR}/mlearning/tflite-micro/tflite-micro
+      ${NUTTX_APPS_DIR}/system/flatbuffers/flatbuffers/include)
 
   if(CONFIG_MLEARNING_CMSIS_NN)
-    list(APPEND INCDIR ${CMAKE_BINARY_DIR}/apps/mlearning/cmsis-nn/cmsis-nn)
+    list(APPEND INCDIR ${NUTTX_APPS_DIR}/apps/mlearning/cmsis-nn/cmsis-nn)
   endif()
 
   # ############################################################################

--- a/mlearning/tflite-micro/Kconfig
+++ b/mlearning/tflite-micro/Kconfig
@@ -24,7 +24,7 @@ config TFLITEMICRO
 	depends on SYSTEM_FLATBUFFERS && MATH_GEMMLOWP && MATH_KISSFFT && MATH_RUY
 
 if TFLITEMICRO
-	config TFLITEMICRO_DEBUG
+config TFLITEMICRO_DEBUG
 	bool "Print tflite-micro's debug message"
 	default n
 
@@ -33,11 +33,11 @@ config TFLITEMICRO_TOOL
 	default n
 
 if TFLITEMICRO_TOOL
-	config TFLITEMICRO_TOOL_PRIORITY
+config TFLITEMICRO_TOOL_PRIORITY
 	int "tflite-micro tool priority"
 	default 100
 
-	config TFLITEMICRO_TOOL_STACKSIZE
+config TFLITEMICRO_TOOL_STACKSIZE
 	int "tflite-micro tool stacksize"
 	default 4096
 

--- a/system/flatbuffers/CMakeLists.txt
+++ b/system/flatbuffers/CMakeLists.txt
@@ -33,6 +33,8 @@ if(CONFIG_SYSTEM_FLATBUFFERS)
       flatbuffers_fetch
       URL ${FLATBUFFERS_URL} SOURCE_DIR ${FLATBUFFERS_DIR} BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/math/flatbuffers/flatbuffers
+      PATCH_COMMAND patch -d ${FLATBUFFERS_DIR} -p1 <
+                    ${CMAKE_CURRENT_LIST_DIR}/flatbuffers.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -40,14 +42,6 @@ if(CONFIG_SYSTEM_FLATBUFFERS)
 
     if(NOT flatbuffers_fetch_POPULATED)
       FetchContent_Populate(flatbuffers_fetch)
-
-      # Apply the patch after fetching the content
-      execute_process(
-        COMMAND ${CMAKE_COMMAND} -E echo "Applying patch to flatbuffers"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-
-      execute_process(COMMAND patch -d ${FLATBUFFERS_DIR} -p1 <
-                              ${CMAKE_CURRENT_LIST_DIR}/flatbuffers.patch)
     endif()
   endif()
 


### PR DESCRIPTION

## Summary

system/flatbuffers: fix patch flow of flatbuffers

```
Applying patch to flatbuffers
patching file '<'
Hunk #1 FAILED at 1.
1 out of 1 hunk FAILED -- saving rejects to file '<.rej'
patching file '<'
Hunk #1 FAILED at 39.
1 out of 1 hunk FAILED -- saving rejects to file '<.rej'
patching file '<'
Hunk #1 FAILED at 495.
1 out of 1 hunk FAILED -- saving rejects to file '<.rej'
patching file '<'
Hunk #1 FAILED at 23.
1 out of 1 hunk FAILED -- saving rejects to file '<.rej'
patch: **** Can't reopen file '<' : No such file or directory
-- Configuring done (12.8s)
-- Generating done (0.3s)
```

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

sim/nsh and enable CONFIG_SYSTEM_FLATBUFFERS