### PR TITLE
lvgldemo: add LVGL duplicate initialization protection

### DIFF
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -114,6 +114,12 @@ int main(int argc, FAR char *argv[])
   lv_memzero(&ui_loop, sizeof(ui_loop));
 #endif
 
+  if (lv_is_initialized())
+    {
+      LV_LOG_ERROR("LVGL already initialized! aborting.");
+      return -1;
+    }
+
 #ifdef NEED_BOARDINIT
   /* Perform board-specific driver initialization */
 


### PR DESCRIPTION
## Summary

In lvgl singleton mode, it is necessary to prevent users from trying to start multiple lvgl instances, otherwise lvgl data will be accessed by multiple processes, causing a crash.

## Impact

lvgldemo

## Testing

sim lvgl_fb