### PR TITLE
system/usbmsc: Add support for setting paths bind to LUN at runtime

### DIFF
--- a/system/usbmsc/Kconfig
+++ b/system/usbmsc/Kconfig
@@ -18,19 +18,21 @@ if SYSTEM_USBMSC
 
 config SYSTEM_USBMSC_NLUNS
 	int "Number of LUNs"
-	default 1
+	default 8
 	---help---
-		Defines the number of logical units (LUNs) exported by the USB
+		Defines the max number of logical units (LUNs) exported by the USB
 		storage driver.  Each LUN corresponds to one exported block driver
-		(or partition of a block driver).  May be 1, 2, or 3.  Default is 1.
+		(or partition of a block driver).  May be 1, 2, or 3.
 
 config SYSTEM_USBMSC_DEVMINOR1
 	int "LUN1 Minor Device Number"
-	default 0
+	default -1
 	---help---
 		The minor device number of the block driver for the first LUN. For
 		example, N in /dev/mmcsdN.  Used for registering the block driver.
-		Default is zero.
+		Default -1 means the LUN is disabled.
+
+if SYSTEM_USBMSC_DEVMINOR1 > -1
 
 config SYSTEM_USBMSC_DEVPATH1
 	string "LUN1 Device Path"
@@ -46,13 +48,17 @@ config SYSTEM_USBMSC_WRITEPROTECT1
 		Enable this if you want to write-protect the first LUN. Default is
 		off.
 
+endif
+
 config SYSTEM_USBMSC_DEVMINOR2
 	int "LUN2 Minor Device Number"
-	default 1
+	default -1
 	---help---
 		The minor device number of the block driver for the second LUN. For
 		example, N in /dev/mmcsdN.  Used for registering the block driver.
-		Ignored if SYSTEM_USBMSC_NLUNS < 2. Default is one.
+		Default -1 means the LUN is disabled.
+
+if SYSTEM_USBMSC_DEVMINOR2 > -1
 
 config SYSTEM_USBMSC_DEVPATH2
 	string "LUN2 Device Path"
@@ -68,13 +74,17 @@ config SYSTEM_USBMSC_WRITEPROTECT2
 		Enable this if you want to write-protect the second LUN. Ignored if
 		SYSTEM_USBMSC_NLUNS < 2. Default is off.
 
+endif
+
 config SYSTEM_USBMSC_DEVMINOR3
 	int "LUN3 Minor Device Number"
-	default 2
+	default -1
 	---help---
 		The minor device number of the block driver for the third LUN. For
 		example, N in /dev/mmcsdN.  Used for registering the block driver.
-		Ignored if SYSTEM_USBMSC_NLUNS < 3. Default is two.
+		Default -1 means the LUN is disabled.
+
+if SYSTEM_USBMSC_DEVMINOR3 > -1
 
 config SYSTEM_USBMSC_DEVPATH3
 	string "LUN3 Device Path"
@@ -89,6 +99,8 @@ config SYSTEM_USBMSC_WRITEPROTECT3
 	---help---
 		Enable this if you want to write-protect the third LUN. Ignored if
 		SYSTEM_USBMSC_NLUNS < 3. Default is off.
+
+endif
 
 config SYSTEM_USBMSC_DEBUGMM
 	bool "USB MSC MM Debug"

--- a/system/usbmsc/usbmsc.h
+++ b/system/usbmsc/usbmsc.h
@@ -32,48 +32,6 @@
  * Pre-Processor Definitions
  ****************************************************************************/
 
-/* Configuration ************************************************************/
-
-#ifndef CONFIG_SYSTEM_USBMSC_NLUNS
-#  define CONFIG_SYSTEM_USBMSC_NLUNS 1
-#endif
-
-#ifndef CONFIG_SYSTEM_USBMSC_DEVMINOR1
-#  define CONFIG_SYSTEM_USBMSC_DEVMINOR1 0
-#endif
-
-#ifndef CONFIG_SYSTEM_USBMSC_DEVPATH1
-#  define CONFIG_SYSTEM_USBMSC_DEVPATH1 "/dev/mmcsd0"
-#endif
-
-#if CONFIG_SYSTEM_USBMSC_NLUNS > 1
-#  ifndef CONFIG_SYSTEM_USBMSC_DEVMINOR2
-#    error "CONFIG_SYSTEM_USBMSC_DEVMINOR2 for LUN=2"
-#  endif
-#  ifndef CONFIG_SYSTEM_USBMSC_DEVPATH2
-#    error "CONFIG_SYSTEM_USBMSC_DEVPATH2 for LUN=2"
-#  endif
-#  if CONFIG_SYSTEM_USBMSC_NLUNS > 2
-#    ifndef CONFIG_SYSTEM_USBMSC_DEVMINOR3
-#      error "CONFIG_SYSTEM_USBMSC_DEVMINOR2 for LUN=3"
-#    endif
-#    ifndef CONFIG_SYSTEM_USBMSC_DEVPATH3
-#      error "CONFIG_SYSTEM_USBMSC_DEVPATH3 for LUN=3"
-#    endif
-#    if CONFIG_SYSTEM_USBMSC_NLUNS > 3
-#      error "CONFIG_SYSTEM_USBMSC_NLUNS must be {1,2,3}"
-#    endif
-#  else
-#    undef CONFIG_SYSTEM_USBMSC_DEVMINOR3
-#    undef CONFIG_SYSTEM_USBMSC_DEVPATH3
-#  endif
-#else
-#  undef CONFIG_SYSTEM_USBMSC_DEVMINOR2
-#  undef CONFIG_SYSTEM_USBMSC_DEVPATH2
-#  undef CONFIG_SYSTEM_USBMSC_DEVMINOR3
-#  undef CONFIG_SYSTEM_USBMSC_DEVPATH3
-#endif
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Add support for setting paths bind to LUN at runtime.

#### Help
```
nsh> msconn -h
Usage: msconn [-o OPTION]... [-l LUNs]...
Configures the USB mass storage device and exports the LUN(s).

Supported arguments
  -o
      nc: No const LUN
      ro: Readonly
      rw: Read/Write(default)
  -l
      Device path to export

Examples
  1. Export const LUN(s) only
      msconn
  2. Export /dev/ramx and const LUN(s)
      msconn -l /dev/ramx
  3. Export /dev/ramx without const LUN
      msconn -o nc -l /dev/ramx
```
#### Export without const LUN
```
nsh> msconn -o nc -l /dev/esp32s3flash
mcsonn_main: Creating block drivers
mcsonn_main: Configuring with NLUNS=1
mcsonn_main: handle=0x3fc8ec80
mcsonn_main: Bind LUN=0 to /dev/esp32s3flash
mcsonn_main: Connected
nsh> msdis
msdis: Disconnected
```
#### Export with const LUN
```
nsh> mkrd -m 10 -s 512 640
nsh> msconn
mcsonn_main: Creating block drivers
mcsonn_main: Configuring with NLUNS=2
mcsonn_main: handle=0x3fcdecc8
mcsonn_main: Bind LUN=1 to /dev/esp32s3flash
mcsonn_main: Bind LUN=0 to /dev/ram10
mcsonn_main: Connected
nsh> msdis
msdis: Disconnected
```
#### Export without const LUN
```
nsh> msconn -o nc -l /dev/ram10
mcsonn_main: Creating block drivers
mcsonn_main: Configuring with NLUNS=1
mcsonn_main: handle=0x3fcdecc8
mcsonn_main: Bind LUN=0 to /dev/ram10
mcsonn_main: Connected
nsh>
```
## Impact
- system/usbmsc: Compatible with current usage.

## Testing
1. Selftest as above
2. NuttX CI
