### PR TITLE
MbedTLS: patch warning when DTLS is off

### DIFF
--- a/crypto/mbedtls/0003-Fix-MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT-warning.patch
+++ b/crypto/mbedtls/0003-Fix-MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT-warning.patch
@@ -1,0 +1,33 @@
+From 84d6430f412d869a56bbcce070d5b730386e540a Mon Sep 17 00:00:00 2001
+From: George Poulios <gpoulios@census-labs.com>
+Date: Thu, 5 Dec 2024 02:28:19 +0200
+Subject: [PATCH 3/3] Fix MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT warning
+
+When MBEDTLS_SSL_PROTO_DTLS is not defined, config_adjust_ssl.h
+undefines (among others) MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT.
+Then the preprocessor comparison with 0 generates Wundef. Wrap
+the comparison under a defined() check to suppress this. This
+breaks builds on systems with -Werror.
+
+Signed-off-by: George Poulios <gpoulios@census-labs.com>
+---
+ include/mbedtls/ssl.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/mbedtls/ssl.h b/include/mbedtls/ssl.h
+index 42fffbf860..c68be5e30a 100644
+--- a/include/mbedtls/ssl.h
++++ b/include/mbedtls/ssl.h
+@@ -620,7 +620,8 @@
+ #define MBEDTLS_TLS_EXT_SIG_ALG_CERT                50 /* RFC 8446 TLS 1.3 */
+ #define MBEDTLS_TLS_EXT_KEY_SHARE                   51 /* RFC 8446 TLS 1.3 */
+ 
+-#if MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT == 0
++#if !defined(MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT) || \
++    MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT == 0
+ #define MBEDTLS_TLS_EXT_CID                         54 /* RFC 9146 DTLS 1.2 CID */
+ #else
+ #define MBEDTLS_TLS_EXT_CID                        254 /* Pre-RFC 9146 DTLS 1.2 CID */
+-- 
+2.39.5 (Apple Git-154)
+

--- a/crypto/mbedtls/CMakeLists.txt
+++ b/crypto/mbedtls/CMakeLists.txt
@@ -38,6 +38,8 @@ if(CONFIG_CRYPTO_MBEDTLS)
         ${CMAKE_CURRENT_LIST_DIR}/0001-mbedtls-entropy_poll-use-getrandom-to-get-the-system.patch
         && patch -p1 -d ${MBEDTLS_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0002-mbedtls-add-mbedtls-x509-crt-pool.patch
+        && patch -p1 -d ${MBEDTLS_DIR} <
+        ${CMAKE_CURRENT_LIST_DIR}/0003-Fix-MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT-warning.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/crypto/mbedtls/Makefile
+++ b/crypto/mbedtls/Makefile
@@ -68,6 +68,7 @@ $(MBEDTLS_UNPACKNAME): $(MBEDTLS_ZIP)
 	$(Q) mv	mbedtls-$(MBEDTLS_VERSION) $(MBEDTLS_UNPACKNAME)
 	$(Q) patch -p1 -d $(MBEDTLS_UNPACKNAME) < 0001-mbedtls-entropy_poll-use-getrandom-to-get-the-system.patch
 	$(Q) patch -p1 -d $(MBEDTLS_UNPACKNAME) < 0002-mbedtls-add-mbedtls-x509-crt-pool.patch
+	$(Q) patch -p1 -d $(MBEDTLS_UNPACKNAME) < 0003-Fix-MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT-warning.patch
 	$(Q) touch $(MBEDTLS_UNPACKNAME)
 
 # Download and unpack tarball if no git repo found


### PR DESCRIPTION
## Summary

This is to patch upstream MbedTLS issue: https://github.com/Mbed-TLS/mbedtls/issues/9425 that triggers a -`Werror=undef` on `MBEDTLS_SSL_DTLS_CONNECTION_ID_COMPAT` when `MBEDTLS_SSL_PROTO_DTLS` is undefined. There is no other way to silence that warning and it breaks builds in systems with `-Werror`. Once the upstream issue is resolved, this can be reverted.

Given that NuttX might stay with this particular version of MbedTLS for a while (even if upstream fixes the issue and releases it), this patch seems like the best compromise (hopefully acceptable?) until it is resolved.

## Impact

Said warning breaks builds in systems configured with `-Werror` and  `CONFIG_MBEDTLS_SSL_PROTO_DTLS` not set, and there is no way to work around it other than:
 - Not using `-Werror` (might not be an option)
 - Enabling back `MBEDTLS_SSL_PROTO_DTLS` (might not be an option either due to code size)

Other than that, the patch has no impact to functionality or even code (previously undefined macro would be evaluated to 0 anyways). Behaviour remains exactly the same.

## Testing

<details>
  <summary>MbedTLS v3.6.2 self test output (30/30 passed)</summary>

```
NuttShell (NSH) NuttX-12.7.0
nsh> mbedselftest

  CALLOC(0,1): passed (distinct non-null)
  CALLOC(1,0): passed (distinct non-null)
  CALLOC(1): passed
  CALLOC(1 again): passed

  MD5 test #1: passed
  MD5 test #2: passed
  MD5 test #3: passed
  MD5 test #4: passed
  MD5 test #5: passed
  MD5 test #6: passed
  MD5 test #7: passed

  RIPEMD-160 test #1: passed
  RIPEMD-160 test #2: passed
  RIPEMD-160 test #3: passed
  RIPEMD-160 test #4: passed
  RIPEMD-160 test #5: passed
  RIPEMD-160 test #6: passed
  RIPEMD-160 test #7: passed
  RIPEMD-160 test #8: passed

  SHA-1 test #1: passed
  SHA-1 test #2: passed
  SHA-1 test #3: passed

  SHA-224 test #1: passed
  SHA-224 test #2: passed
  SHA-224 test #3: passed

  SHA-256 test #1: passed
  SHA-256 test #2: passed
  SHA-256 test #3: passed

  SHA-384 test #1: passed
  SHA-384 test #2: passed
  SHA-384 test #3: passed

  SHA-512 test #1: passed
  SHA-512 test #2: passed
  SHA-512 test #3: passed

  SHA3-224 test 0 passed
  SHA3-256 test 0 passed
  SHA3-384 test 0 passed
  SHA3-512 test 0 passed
  SHA3-224 test 1 passed
  SHA3-256 test 1 passed
  SHA3-384 test 1 passed
  SHA3-512 test 1 passed
  SHA3-224 long KAT test passed
  SHA3-256 long KAT test passed
  SHA3-384 long KAT test passed
  SHA3-512 long KAT test passed

  DES -ECB- 56 (dec): passed
  DES -ECB- 56 (enc): passed
  DES3-ECB-112 (dec): passed
  DES3-ECB-112 (enc): passed
  DES3-ECB-168 (dec): passed
  DES3-ECB-168 (enc): passed

  DES -CBC- 56 (dec): passed
  DES -CBC- 56 (enc): passed
  DES3-CBC-112 (dec): passed
  DES3-CBC-112 (enc): passed
  DES3-CBC-168 (dec): passed
  DES3-CBC-168 (enc): passed

  AES note: built-in implementation.
  AES-ECB-128 (dec): passed
  AES-ECB-128 (enc): passed
  AES-ECB-192 (dec): passed
  AES-ECB-192 (enc): passed
  AES-ECB-256 (dec): passed
  AES-ECB-256 (enc): passed

  AES-CBC-128 (dec): passed
  AES-CBC-128 (enc): passed
  AES-CBC-192 (dec): passed
  AES-CBC-192 (enc): passed
  AES-CBC-256 (dec): passed
  AES-CBC-256 (enc): passed

  AES-CFB128-128 (dec): passed
  AES-CFB128-128 (enc): passed
  AES-CFB128-192 (dec): passed
  AES-CFB128-192 (enc): passed
  AES-CFB128-256 (dec): passed
  AES-CFB128-256 (enc): passed

  AES-OFB-128 (dec): passed
  AES-OFB-128 (enc): passed
  AES-OFB-192 (dec): passed
  AES-OFB-192 (enc): passed
  AES-OFB-256 (dec): passed
  AES-OFB-256 (enc): passed

  AES-CTR-128 (dec): passed
  AES-CTR-128 (enc): passed
  AES-CTR-128 (dec): passed
  AES-CTR-128 (enc): passed
  AES-CTR-128 (dec): passed
  AES-CTR-128 (enc): passed

  AES-XTS-128 (dec): passed
  AES-XTS-128 (enc): passed
  AES-XTS-128 (dec): passed
  AES-XTS-128 (enc): passed
  AES-XTS-128 (dec): passed
  AES-XTS-128 (enc): passed

  GCM note: built-in implementation.
  AES-GCM-128 #0 (enc): passed
  AES-GCM-128 #0 (dec): passed
  AES-GCM-128 #0 split (enc): passed
  AES-GCM-128 #0 split (dec): passed
  AES-GCM-128 #1 (enc): passed
  AES-GCM-128 #1 (dec): passed
  AES-GCM-128 #1 split (enc): passed
  AES-GCM-128 #1 split (dec): passed
  AES-GCM-128 #2 (enc): passed
  AES-GCM-128 #2 (dec): passed
  AES-GCM-128 #2 split (enc): passed
  AES-GCM-128 #2 split (dec): passed
  AES-GCM-128 #3 (enc): passed
  AES-GCM-128 #3 (dec): passed
  AES-GCM-128 #3 split (enc): passed
  AES-GCM-128 #3 split (dec): passed
  AES-GCM-128 #4 (enc): passed
  AES-GCM-128 #4 (dec): passed
  AES-GCM-128 #4 split (enc): passed
  AES-GCM-128 #4 split (dec): passed
  AES-GCM-128 #5 (enc): passed
  AES-GCM-128 #5 (dec): passed
  AES-GCM-128 #5 split (enc): passed
  AES-GCM-128 #5 split (dec): passed
  AES-GCM-192 #0 (enc): passed
  AES-GCM-192 #0 (dec): passed
  AES-GCM-192 #0 split (enc): passed
  AES-GCM-192 #0 split (dec): passed
  AES-GCM-192 #1 (enc): passed
  AES-GCM-192 #1 (dec): passed
  AES-GCM-192 #1 split (enc): passed
  AES-GCM-192 #1 split (dec): passed
  AES-GCM-192 #2 (enc): passed
  AES-GCM-192 #2 (dec): passed
  AES-GCM-192 #2 split (enc): passed
  AES-GCM-192 #2 split (dec): passed
  AES-GCM-192 #3 (enc): passed
  AES-GCM-192 #3 (dec): passed
  AES-GCM-192 #3 split (enc): passed
  AES-GCM-192 #3 split (dec): passed
  AES-GCM-192 #4 (enc): passed
  AES-GCM-192 #4 (dec): passed
  AES-GCM-192 #4 split (enc): passed
  AES-GCM-192 #4 split (dec): passed
  AES-GCM-192 #5 (enc): passed
  AES-GCM-192 #5 (dec): passed
  AES-GCM-192 #5 split (enc): passed
  AES-GCM-192 #5 split (dec): passed
  AES-GCM-256 #0 (enc): passed
  AES-GCM-256 #0 (dec): passed
  AES-GCM-256 #0 split (enc): passed
  AES-GCM-256 #0 split (dec): passed
  AES-GCM-256 #1 (enc): passed
  AES-GCM-256 #1 (dec): passed
  AES-GCM-256 #1 split (enc): passed
  AES-GCM-256 #1 split (dec): passed
  AES-GCM-256 #2 (enc): passed
  AES-GCM-256 #2 (dec): passed
  AES-GCM-256 #2 split (enc): passed
  AES-GCM-256 #2 split (dec): passed
  AES-GCM-256 #3 (enc): passed
  AES-GCM-256 #3 (dec): passed
  AES-GCM-256 #3 split (enc): passed
  AES-GCM-256 #3 split (dec): passed
  AES-GCM-256 #4 (enc): passed
  AES-GCM-256 #4 (dec): passed
  AES-GCM-256 #4 split (enc): passed
  AES-GCM-256 #4 split (dec): passed
  AES-GCM-256 #5 (enc): passed
  AES-GCM-256 #5 (dec): passed
  AES-GCM-256 #5 split (enc): passed
  AES-GCM-256 #5 split (dec): passed

  CCM-AES #1: passed
  CCM-AES #2: passed
  CCM-AES #3: passed

  KW-AES-128  passed
  KW-AES-192  passed
  KW-AES-256  passed
  KWP-AES-128  passed
  KWP-AES-192  passed
  KWP-AES-256  passed

  AES 128 CMAC subkey #1: passed
  AES 128 CMAC subkey #2: passed
  AES 128 CMAC subkey #3: passed
  AES 128 CMAC subkey #4: passed
  AES 128 CMAC #1: passed
  AES 128 CMAC #2: passed
  AES 128 CMAC #3: passed
  AES 128 CMAC #4: passed
  AES 192 CMAC subkey #1: passed
  AES 192 CMAC subkey #2: passed
  AES 192 CMAC subkey #3: passed
  AES 192 CMAC subkey #4: passed
  AES 192 CMAC #1: passed
  AES 192 CMAC #2: passed
  AES 192 CMAC #3: passed
  AES 192 CMAC #4: passed
  AES 256 CMAC subkey #1: passed
  AES 256 CMAC subkey #2: passed
  AES 256 CMAC subkey #3: passed
  AES 256 CMAC subkey #4: passed
  AES 256 CMAC #1: passed
  AES 256 CMAC #2: passed
  AES 256 CMAC #3: passed
  AES 256 CMAC #4: passed
  3DES 2 key CMAC subkey #1: passed
  3DES 2 key CMAC subkey #2: passed
  3DES 2 key CMAC subkey #3: passed
  3DES 2 key CMAC subkey #4: passed
  3DES 2 key CMAC #1: passed
  3DES 2 key CMAC #2: passed
  3DES 2 key CMAC #3: passed
  3DES 2 key CMAC #4: passed
  3DES 3 key CMAC subkey #1: passed
  3DES 3 key CMAC subkey #2: passed
  3DES 3 key CMAC subkey #3: passed
  3DES 3 key CMAC subkey #4: passed
  3DES 3 key CMAC #1: passed
  3DES 3 key CMAC #2: passed
  3DES 3 key CMAC #3: passed
  3DES 3 key CMAC #4: passed
  AES CMAC 128 PRF #0: passed
  AES CMAC 128 PRF #1: passed
  AES CMAC 128 PRF #2: passed

  ChaCha20 test 0 passed
  ChaCha20 test 1 passed

  Poly1305 test 0 passed
  Poly1305 test 1 passed

  ChaCha20-Poly1305 test 0 passed

  Base64 encoding test: passed
  Base64 decoding test: passed

  MPI test #1 (mul_mpi): passed
  MPI test #2 (div_mpi): passed
  MPI test #3 (exp_mod): passed
  MPI test #4 (inv_mod): passed
  MPI test #5 (simple gcd): passed

  RSA key validation: passed
  PKCS#1 encryption : passed
  PKCS#1 decryption : passed
  PKCS#1 data sign  : passed
  PKCS#1 sig. verify: passed

  CAMELLIA-ECB-128 (dec): passed
  CAMELLIA-ECB-128 (enc): passed
  CAMELLIA-ECB-192 (dec): passed
  CAMELLIA-ECB-192 (enc): passed
  CAMELLIA-ECB-256 (dec): passed
  CAMELLIA-ECB-256 (enc): passed

  CAMELLIA-CBC-128 (dec): passed
  CAMELLIA-CBC-128 (enc): passed
  CAMELLIA-CBC-192 (dec): passed
  CAMELLIA-CBC-192 (enc): passed
  CAMELLIA-CBC-256 (dec): passed
  CAMELLIA-CBC-256 (enc): passed

  CAMELLIA-CTR-128 (dec): passed
  CAMELLIA-CTR-128 (enc): passed
  CAMELLIA-CTR-128 (dec): passed
  CAMELLIA-CTR-128 (enc): passed
  CAMELLIA-CTR-128 (dec): passed
  CAMELLIA-CTR-128 (enc): passed

  ARIA-ECB-128 (enc): passed
  ARIA-ECB-128 (dec): passed
  ARIA-ECB-192 (enc): passed
  ARIA-ECB-192 (dec): passed
  ARIA-ECB-256 (enc): passed
  ARIA-ECB-256 (dec): passed

  ARIA-CBC-128 (enc): passed
  ARIA-CBC-128 (dec): passed
  ARIA-CBC-192 (enc): passed
  ARIA-CBC-192 (dec): passed
  ARIA-CBC-256 (enc): passed
  ARIA-CBC-256 (dec): passed

  ARIA-CFB-128 (enc): passed
  ARIA-CFB-128 (dec): passed
  ARIA-CFB-192 (enc): passed
  ARIA-CFB-192 (dec): passed
  ARIA-CFB-256 (enc): passed
  ARIA-CFB-256 (dec): passed

  ARIA-CTR-128 (enc): passed
  ARIA-CTR-128 (dec): passed
  ARIA-CTR-192 (enc): passed
  ARIA-CTR-192 (dec): passed
  ARIA-CTR-256 (enc): passed
  ARIA-CTR-256 (dec): passed

  CTR_DRBG (PR = TRUE) : passed
  CTR_DRBG (PR = FALSE): passed

  HMAC_DRBG (PR = True) : passed
  HMAC_DRBG (PR = False) : passed

  ECP SW test #1 (constant op_count, base point G): passed
  ECP SW test #2 (constant op_count, other point): passed
  ECP Montgomery test (constant op_count): passed

  ECJPAKE test #0 (setup): passed
  ECJPAKE test #1 (random handshake): passed
  ECJPAKE test #2 (reference handshake): passed

  DHM parameter load: passed

  ENTROPY test: passed

  PBKDF2 (SHA1) #0: passed
  PBKDF2 (SHA1) #1: passed
  PBKDF2 (SHA1) #2: passed
  PBKDF2 (SHA1) #3: passed
  PBKDF2 (SHA1) #4: passed
  PBKDF2 (SHA1) #5: passed

  Executed 30 test suites

  [ All tests PASS ]
```
</details>

