### PR TITLE
system/nxdiag: Change the order to generate the sysinfo.h file

### DIFF
--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -113,7 +113,7 @@ sysinfo.h : checkpython3 $(INFO_DEPS)
 		exit 1; \
 	fi
 
-context:: sysinfo.h
+depend:: sysinfo.h
 
 distclean::
 	$(call DELFILE, sysinfo.h)


### PR DESCRIPTION
## Summary

* system/nxdiag: Change the order for generating the sysinfo.h file

The generation of `sys info.h` depends on evaluating whether Espressif's HAL exists in the arch folder. However, cloning the HAL itself happens in the `context` phase of the build, so it is necessary to wait for it to finish before proceeding to the evaluation in nxdiag. This is done by using the `depend` phase to generate the `sysinfo.h` file.

## Impact

Closes https://github.com/apache/nuttx/issues/15063

## Testing

Internal CI testing + NuttX CI

