### PR TITLE
Feature/nxdiag enchancements

### DIFF
--- a/system/nxdiag/Kconfig
+++ b/system/nxdiag/Kconfig
@@ -74,6 +74,13 @@ config SYSTEM_NXDIAG_ESPRESSIF_CHIP
 	---help---
 		Enable Espressif-specific information about chip. Chip must be connected during build process.
 
+config SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL
+	bool "Espressif Chip info without esptool"
+	depends on SYSTEM_NXDIAG_ESPRESSIF_CHIP
+	default n
+	---help---
+		Enable Espressif-specific information about chip without using esptool.
+
 config SYSTEM_NXDIAG_ESPRESSIF_VERBOSE
 	bool "Espressif Verbose"
 	default n

--- a/system/nxdiag/Kconfig
+++ b/system/nxdiag/Kconfig
@@ -60,6 +60,12 @@ config SYSTEM_NXDIAG_HOST_MODULES
 		modules on the host system. This is useful for debugging the
 		host system. Enables the "-m" and "--host-modules" options.
 
+config SYSTEM_NXDIAG_VERBOSE
+	bool "Verbose"
+	default n
+	---help---
+		Enable printing nxdiag application information during build.
+
 comment "Vendor specific information"
 
 config SYSTEM_NXDIAG_ESPRESSIF
@@ -80,11 +86,5 @@ config SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL
 	default n
 	---help---
 		Enable Espressif-specific information about chip without using esptool.
-
-config SYSTEM_NXDIAG_ESPRESSIF_VERBOSE
-	bool "Espressif Verbose"
-	default n
-	---help---
-		Enable printing Espressif-specific information about chip during build.
 
 endif # SYSTEM_NXDIAG

--- a/system/nxdiag/Kconfig
+++ b/system/nxdiag/Kconfig
@@ -74,4 +74,10 @@ config SYSTEM_NXDIAG_ESPRESSIF_CHIP
 	---help---
 		Enable Espressif-specific information about chip. Chip must be connected during build process.
 
+config SYSTEM_NXDIAG_ESPRESSIF_VERBOSE
+	bool "Espressif Verbose"
+	default n
+	---help---
+		Enable printing Espressif-specific information about chip during build.
+
 endif # SYSTEM_NXDIAG

--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -57,6 +57,10 @@ ifeq ($(CONFIG_SYSTEM_NXDIAG_HOST_PATH),y)
 NXDIAG_FLAGS += --path
 endif
 
+ifeq ($(CONFIG_SYSTEM_NXDIAG_VERBOSE),y)
+NXDIAG_FLAGS += --verbose
+endif
+
 # Vendor-specific checks
 
 # Espressif
@@ -95,10 +99,6 @@ NXDIAG_FLAGS += --espressif_chip
 else
 NXDIAG_FLAGS += --espressif_chip_runtime
 endif
-endif
-
-ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_VERBOSE),y)
-NXDIAG_FLAGS += --espressif_verbose
 endif
 
 endif

--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -93,6 +93,10 @@ ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP),y)
 NXDIAG_FLAGS += --espressif_chip
 endif
 
+ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_VERBOSE),y)
+NXDIAG_FLAGS += --espressif_verbose
+endif
+
 endif
 
 # Common build

--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -90,7 +90,11 @@ NXDIAG_FLAGS += --espressif "$(TOPDIR)" "$(HALDIR)"
 endif
 
 ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP),y)
+ifneq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL),y)
 NXDIAG_FLAGS += --espressif_chip
+else
+NXDIAG_FLAGS += --espressif_chip_runtime
+endif
 endif
 
 ifeq ($(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_VERBOSE),y)

--- a/system/nxdiag/nxdiag.c
+++ b/system/nxdiag/nxdiag.c
@@ -32,6 +32,9 @@
 #include <nuttx/version.h>
 
 #include "sysinfo.h"
+#ifdef CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL
+#include <fcntl.h>
+#endif
 
 /****************************************************************************
  * Private Data
@@ -224,6 +227,11 @@ static void print_usage(char *prg)
 
 int main(int argc, char *argv[])
 {
+#ifdef CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL
+  int fd;
+  int ret;
+#endif
+
   if (argc == 1 || !are_valid_args(argc, argv))
     {
       print_usage(argv[0]);
@@ -346,6 +354,7 @@ int main(int argc, char *argv[])
       printf("Esptool version: %s\n\n", ESPRESSIF_ESPTOOL);
       printf("HAL version: %s\n\n", ESPRESSIF_HAL);
 #ifdef CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP
+#ifndef CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL
       printf("CHIP ID: %s\n\n", ESPRESSIF_CHIP_ID);
       printf("Flash ID:\n");
       print_array(ESPRESSIF_FLASH_ID, ESPRESSIF_FLASH_ID_ARRAY_SIZE);
@@ -354,8 +363,26 @@ int main(int argc, char *argv[])
                   ESPRESSIF_SECURITY_INFO_ARRAY_SIZE);
       printf("Flash status: %s\n\n", ESPRESSIF_FLASH_STAT);
       printf("MAC address: %s\n\n", ESPRESSIF_MAC_ADDR);
-#endif
-#endif
+#else
+      fd = open("/dev/nxdiag", O_RDONLY);
+      if (fd < 0)
+        {
+          printf("Failed to open device\n");
+          return ERROR;
+        }
+
+      ret = read(fd, ESPRESSIF_INFO, ESPRESSIF_INFO_SIZE);
+      if (ret <= 0)
+        {
+          printf("Failed to read device\n");
+          return ERROR;
+        }
+
+      printf("%s\n\n", ESPRESSIF_INFO);
+
+#endif /* CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL */
+#endif /* CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP */
+#endif /* CONFIG_SYSTEM_NXDIAG_ESPRESSIF */
     }
 
   return 0;

--- a/tools/host_sysinfo.py
+++ b/tools/host_sysinfo.py
@@ -736,8 +736,13 @@ def generate_header(args):
             )
             build_output += "MAC address:  {}\n\n".format(info["ESPRESSIF_MAC_ADDR"])
 
+        elif args.espressif_chip_runtime:
+            output += "#define ESPRESSIF_INFO_SIZE 384\n"
+            output += 'static char ESPRESSIF_INFO[ESPRESSIF_TOOLCHAIN_ARRAY_SIZE] =\n{\n  0\n};\n\n'
+
         if args.espressif_verbose:
             espressif_verbose(info, build_output)
+
 
     output += "#endif /* __SYSTEM_INFO_H */\n"
 
@@ -774,6 +779,10 @@ if __name__ == "__main__":
                         Requires the path to the bootloader binary directory.
             --espressif_chip:
                         Get Espressif specific information about chip.
+                        Requires device connection during build.
+            --espressif_chip_runtime:
+                        Get Espressif specific information about chip
+                        on runtime.
                         Requires device connection during build.
             --espressif_verbose:
                         Enable printing Espressif-specific information about
@@ -839,6 +848,12 @@ if __name__ == "__main__":
         "--espressif_chip",
         action="store_true",
         help="Get Espressif specific information about chip. Requires device connection during build.",
+    )
+
+    parser.add_argument(
+        "--espressif_chip_runtime",
+        action="store_true",
+        help="Get Espressif specific information about chip on runtime. Requires device connection during build.",
     )
 
     parser.add_argument(

--- a/tools/host_sysinfo.py
+++ b/tools/host_sysinfo.py
@@ -234,6 +234,56 @@ def get_espressif_hal_version(hal_dir):
     return hal_version
 
 
+def espressif_verbose(info, esp_logs):
+    """
+    Prepare and print information on build screen.
+
+    Args:
+        info (dict): Information dictionary of build system.
+        esp_logs (str): Information string of espressif specific features.
+
+    Returns:
+        None.
+    """
+    esp_verbose = "=" * 79 + "\n"
+
+    esp_verbose += "NuttX RTOS info: {}\n\n".format(info["OS_VERSION"])
+    if args.flags:
+        esp_verbose += "NuttX CFLAGS: {}\n\n".format(info["NUTTX_CFLAGS"])
+        esp_verbose += "NuttX CXXFLAGS: {}\n\n".format(info["NUTTX_CXXFLAGS"])
+        esp_verbose += "NuttX LDFLAGS: {}\n\n".format(info["NUTTX_LDFLAGS"])
+
+    if args.config:
+        esp_verbose += "NuttX configuration options: \n"
+        for i in range(len(info["NUTTX_CONFIG"])):
+            esp_verbose += "  " + info["NUTTX_CONFIG"][i].replace('"', '\\"') + "\n"
+        esp_verbose += "\n\n"
+
+    if args.path:
+        esp_verbose += "Host system PATH: \n"
+        for i in range(len(info["SYSTEM_PATH"])):
+            esp_verbose += "  " + info["SYSTEM_PATH"][i] + "\n"
+        esp_verbose += "\n\n"
+
+    if args.packages:
+        esp_verbose += "Host system installed packages: \n"
+        for i in range(len(info["INSTALLED_PACKAGES"])):
+            esp_verbose += "  " + info["INSTALLED_PACKAGES"][i] + "\n"
+        esp_verbose += "\n\n"
+
+    if args.modules:
+        esp_verbose += "Host system installed python modules: \n"
+        for i in range(len(info["PYTHON_MODULES"])):
+            esp_verbose += "  " + info["PYTHON_MODULES"][i] + "\n"
+        esp_verbose += "\n\n"
+
+    esp_verbose += "Espressif specific information: \n\n"
+    esp_verbose += esp_logs
+    esp_verbose += "=" * 79 + "\n"
+
+    eprint(esp_verbose)
+
+
 # Common functions #
 
 
@@ -602,9 +652,12 @@ def generate_header(args):
             len(info["ESPRESSIF_BOOTLOADER"])
         )
         output += "static const char *ESPRESSIF_BOOTLOADER[ESPRESSIF_BOOTLOADER_ARRAY_SIZE] =\n{\n"
+        build_output = "Bootloader version:\n"
         for key, value in info["ESPRESSIF_BOOTLOADER"].items():
             output += '  "{}: {}",\n'.format(key, value)
+            build_output += "  {}: {},\n".format(key, value)
         output += "};\n\n"
+        build_output += "\n\n"
 
         # Espressif toolchain version
 
@@ -613,9 +666,12 @@ def generate_header(args):
             len(info["ESPRESSIF_TOOLCHAIN"])
         )
         output += "static const char *ESPRESSIF_TOOLCHAIN[ESPRESSIF_TOOLCHAIN_ARRAY_SIZE] =\n{\n"
+        build_output += "Toolchain version:\n"
         for key, value in info["ESPRESSIF_TOOLCHAIN"].items():
             output += '  "{}: {}",\n'.format(key, value)
+            build_output += "  {}: {},\n".format(key, value)
         output += "};\n\n"
+        build_output += "\n\n"
 
         # Espressif esptool version
 
@@ -625,6 +681,9 @@ def generate_header(args):
         output += 'static const char ESPRESSIF_ESPTOOL[] = "{}";\n\n'.format(
             info["ESPRESSIF_ESPTOOL"].split("-")[1]
         )
+        build_output += "Esptool version: {}\n\n".format(
+            info["ESPRESSIF_ESPTOOL"].split("-")[1]
+        )
 
         # Espressif HAL version
 
@@ -632,40 +691,53 @@ def generate_header(args):
         output += 'static const char ESPRESSIF_HAL[] = "{}";\n\n'.format(
             info["ESPRESSIF_HAL"]
         )
+        build_output += "HAL version: {}\n\n".format(info["ESPRESSIF_HAL"])
 
         if args.espressif_chip and info["ESPRESSIF_ESPTOOL"] not in "Not found":
             info["ESPRESSIF_CHIP_ID"] = get_espressif_chip_id()
             output += 'static const char ESPRESSIF_CHIP_ID[] = "{}";\n\n'.format(
                 info["ESPRESSIF_CHIP_ID"]
             )
+            build_output += "CHIP ID: = {}\n\n".format(info["ESPRESSIF_CHIP_ID"])
 
             info["ESPRESSIF_FLASH_ID"] = get_espressif_flash_id()
             output += "#define ESPRESSIF_FLASH_ID_ARRAY_SIZE {}\n".format(
                 len(info["ESPRESSIF_FLASH_ID"])
             )
             output += "static const char *ESPRESSIF_FLASH_ID[ESPRESSIF_FLASH_ID_ARRAY_SIZE] =\n{\n"
+            build_output += "Flash ID:\n"
             for each_item in info["ESPRESSIF_FLASH_ID"]:
                 output += '  "{}",\n'.format(each_item)
+                build_output += "  {}\n".format(each_item)
             output += "};\n\n"
+            build_output += "\n\n"
 
             info["ESPRESSIF_SECURITY_INFO"] = get_espressif_security_info()
             output += "#define ESPRESSIF_SECURITY_INFO_ARRAY_SIZE {}\n".format(
                 len(info["ESPRESSIF_SECURITY_INFO"])
             )
             output += "static const char *ESPRESSIF_SECURITY_INFO[ESPRESSIF_SECURITY_INFO_ARRAY_SIZE] =\n{\n"
+            build_output += "Security information: \n"
             for each_item in info["ESPRESSIF_SECURITY_INFO"]:
                 output += '  "{}",\n'.format(each_item)
+                build_output += "  {}\n".format(each_item)
             output += "};\n\n"
+            build_output += "\n\n"
 
             info["ESPRESSIF_FLASH_STAT"] = get_espressif_flash_status()
             output += 'static const char ESPRESSIF_FLASH_STAT[] = "{}";\n\n'.format(
                 info["ESPRESSIF_FLASH_STAT"]
             )
+            build_output += "Flash status: {}\n\n".format(info["ESPRESSIF_FLASH_STAT"])
 
             info["ESPRESSIF_MAC_ADDR"] = get_espressif_mac_address()
             output += 'static const char ESPRESSIF_MAC_ADDR[] = "{}";\n\n'.format(
                 info["ESPRESSIF_MAC_ADDR"]
             )
+            build_output += "MAC address:  {}\n\n".format(info["ESPRESSIF_MAC_ADDR"])
+
+        if args.espressif_verbose:
+            espressif_verbose(info, build_output)
 
     output += "#endif /* __SYSTEM_INFO_H */\n"
 
@@ -703,6 +775,9 @@ if __name__ == "__main__":
             --espressif_chip:
                         Get Espressif specific information about chip.
                         Requires device connection during build.
+            --espressif_verbose:
+                        Enable printing Espressif-specific information about
+                        chip during build.
     """
 
     # Generic arguments
@@ -764,6 +839,12 @@ if __name__ == "__main__":
         "--espressif_chip",
         action="store_true",
         help="Get Espressif specific information about chip. Requires device connection during build.",
+    )
+
+    parser.add_argument(
+        "--espressif_verbose",
+        action="store_true",
+        help="Enable printing Espressif-specific information about chip during build",
     )
 
     # Parse arguments


### PR DESCRIPTION
## Summary

New features added on nxdiag tool to diagnostic issues better and fetch diagnostic data in different ways (e.g get diag data without using esptool).

- apps/nxdiag: Add dignostic info logging support during build on nxdiag example for Espressif devices
- apps/nxdiag: Add dignostic info without esptool support for Espressif devices
- Move verbose option to common use

## Impact

Common and Espressif devices

## Testing
esp32c6-devkitc:nsh with `NXDIAG` tests options enabled.
