### PR TITLE
mlearning: fix build break if enable cmsis-nn

### DIFF
--- a/mlearning/cmsis-nn/CMakeLists.txt
+++ b/mlearning/cmsis-nn/CMakeLists.txt
@@ -69,6 +69,8 @@ if(CONFIG_MLEARNING_CMSIS_NN)
     ${CMSIS_NN_DIR}/Source/LSTMFunctions/*.c
     ${CMSIS_NN_DIR}/Source/ReshapeFunctions/*.c)
 
+  set(CMSIS_NN_INCDIR ${CMAKE_CURRENT_LIST_DIR}/cmsis-nn/Include)
+
   if(CONFIG_ARM_NEON)
     list(
       REMOVE_ITEM
@@ -86,5 +88,6 @@ if(CONFIG_MLEARNING_CMSIS_NN)
   nuttx_add_library(cmsis_nn STATIC)
   target_compile_options(cmsis_nn PRIVATE ${CFLAGS})
   target_sources(cmsis_nn PRIVATE ${CMSIS_NN_SRCS})
+  target_include_directories(cmsis_nn PUBLIC ${CMSIS_NN_INCDIR})
 
 endif()

--- a/mlearning/tflite-micro/CMakeLists.txt
+++ b/mlearning/tflite-micro/CMakeLists.txt
@@ -152,7 +152,7 @@ if(CONFIG_TFLITEMICRO)
       ${NUTTX_APPS_DIR}/system/flatbuffers/flatbuffers/include)
 
   if(CONFIG_MLEARNING_CMSIS_NN)
-    list(APPEND INCDIR ${NUTTX_APPS_DIR}/apps/mlearning/cmsis-nn/cmsis-nn)
+    list(APPEND INCDIR ${NUTTX_APPS_DIR}/mlearning/cmsis-nn/cmsis-nn)
   endif()
 
   # ############################################################################


### PR DESCRIPTION
## Summary

mlearning: fix build break if enable cmsis-nn

apps/mlearning/tflite-micro/tflite-micro/tensorflow/lite/micro/kernels/cmsis_nn/conv.cc:18:10:
  fatal error: Include/arm_nnfunctions.h: No such file or directory
   18 | #include "Include/arm_nnfunctions.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

cmake -B build -DBOARD_CONFIG=fvp-armv8r-aarch32/nsh -GNinja