### PR TITLE
testing/ltp: Increase Stack Size

### DIFF
--- a/testing/ltp/Kconfig
+++ b/testing/ltp/Kconfig
@@ -13,6 +13,6 @@ if TESTING_LTP
 
 config TESTING_LTP_STACKSIZE
 	int "Linux Test Project stack size"
-	default 4096
+	default 8192
 
 endif #TESTING_LTP


### PR DESCRIPTION
## Summary

Inside CI Build risc-v-05: `rv-virt:citest` fails with a Stack Overflow at ltp_interfaces_pthread_barrierattr_init_2_1:
- https://github.com/apache/nuttx/issues/15170

This PR doubles the Stack Size for `testing/ltp` (from 4096 bytes to 8192), so that `rv-virt:citest` completes successfully.

## Impact

With this PR, `rv-virt:citest` will complete successfully.

## Testing

We tested `rv-virt:citest` on Docker:

https://gist.github.com/lupyuen/3688826ed676971536249509ceefe834

```text
sudo docker run \
  -it \
  ghcr.io/apache/nuttx/apache-nuttx-ci-linux:latest \
  /bin/bash
cd
git clone https://github.com/apache/nuttx
git clone https://github.com/lupyuen2/wip-nuttx-apps --branch ltp-stack apps
pushd nuttx ; echo NuttX Source: https://github.com/apache/nuttx/tree/$(git rev-parse HEAD) ; popd
pushd apps  ; echo NuttX Apps: https://github.com/apache/nuttx-apps/tree/$(git rev-parse HEAD) ; popd
cd nuttx/tools/ci
./cibuild.sh -c -A -N -R testlist/risc-v-05.dat 

NuttX Source: https://github.com/apache/nuttx/tree/0913fa4b7343686c76affdfa177aed73917963ad
NuttX Apps: https://github.com/apache/nuttx-apps/tree/887729409fb64d4c54b18d247e37029b78d90107
Configuration/Tool: rv-virt/citest
test_open_posix/test_openposix_.py::test_ltp_interfaces_pthread_barrierattr_init_2_1 PASSED                  [ 17%]
test_os/test_os.py::test_ostest PASSED                                                                       [ 99%]
=========================== 990 passed, 11 skipped, 67 deselected in 1849.40s (0:30:49) ============================
```
