### PR TITLE
drivertest_uart: The string was not truncated because one more charac…

### DIFF
--- a/testing/drivertest/drivertest_uart.c
+++ b/testing/drivertest/drivertest_uart.c
@@ -226,7 +226,7 @@ static void read_default(FAR void **state)
 
   while (cnt < sizeof(DEFAULT_CONTENT) - 1)
     {
-      ssize_t n = read(test_state->fd, buffer + cnt, buffer_size - cnt);
+      ssize_t n = read(test_state->fd, buffer + cnt, buffer_size - cnt - 1);
 
       assert_true(n >= 0);
       if (n == 0)


### PR DESCRIPTION
…ter was read

    #0 0x43c7443a in strnlen nuttx/libs/libc/string/lib_strnlen.c:42
    #1 0x43c698aa in vsprintf_internal nuttx/libs/libc/stdio/lib_libvsprintf.c:933
    #2 0x43c6ca80 in lib_vsprintf nuttx/libs/libc/stdio/lib_libvsprintf.c:1383
    #3 0x4409c0bd in vsnprintf nuttx/libs/libc/stdio/lib_vsnprintf.c:72
    #4 0x47137cd0 in vcmocka_print_error apps/testing/cmocka/cmocka/src/cmocka.c:2097
    #5 0x47139573 in cmocka_print_error apps/testing/cmocka/cmocka/src/cmocka.c:2422
    #6 0x471376ff in string_equal_display_error apps/testing/cmocka/cmocka/src/cmocka.c:1410
    #7 0x471379a0 in _assert_string_equal apps/testing/cmocka/cmocka/src/cmocka.c:1952
    #8 0x4433d972 in read_default apps/testing/drivertest/drivertest_uart.c:242
    #9 0x4713c6cd in cmocka_run_one_test_or_fixture apps/testing/cmocka/cmocka/src/cmocka.c:3029
    #10 0x4713d487 in cmocka_run_one_tests apps/testing/cmocka/cmocka/src/cmocka.c:3143
    #11 0x4713f2ca in _cmocka_run_group_tests apps/testing/cmocka/cmocka/src/cmocka.c:3294
    #12 0x443444c6 in cmocka_driver_uart_main apps/testing/drivertest/drivertest_uart.c:358
    #13 0x4409a472 in nxtask_startup nuttx/libs/libc/sched/task_startup.c:72
    #14 0x43dc92e7 in nxtask_start nuttx/sched/task/task_start.c:116
    #15 0x43e31f00 in pre_start nuttx/arch/sim/src/sim/sim_initialstate.c:52

## Summary
drivertest_uart
## Impact

## Testing
+CONFIG_TESTING_CMOCKA=y
+CONFIG_TESTING_CMOCKA_STACKSIZE=8192
+CONFIG_TESTING_DRIVER_TEST=y
+CONFIG_TESTING_DRIVER_TEST_STACKSIZE=8192

cmocka_driver_uart -d /dev/console
put: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,./<>?;':"[]{}\|!@#$%^&*()-+_=
put:0 
put:#

