### PR TITLE
test:add mutex socket syscall directory

### DIFF
--- a/testing/testsuites/Kconfig
+++ b/testing/testsuites/Kconfig
@@ -49,4 +49,19 @@ config CM_PTHREAD_TEST
 	default n
 	depends on TESTS_TESTSUITES
 
+config CM_SOCKET_TEST
+    bool "enbale socket test"
+    default n
+    depends on TESTS_TESTSUITES
+
+config CM_SYSCALL_TEST
+    bool "enbale syscall test"
+    default n
+    depends on TESTS_TESTSUITES
+
+config CM_MUTEX_TEST
+    bool "enbale mutex test"
+    default n
+    depends on TESTS_TESTSUITES
+
 endif # TESTS_TESTSUITES

--- a/testing/testsuites/Makefile
+++ b/testing/testsuites/Makefile
@@ -69,4 +69,28 @@ PROGNAME += cmocka_pthread_test
 MAINSRC += $(CURDIR)/kernel/pthread/cmocka_pthread_test.c
 endif
 
+ifneq ($(CONFIG_CM_MUTEX_TEST),)
+CFLAGS += -I$(CURDIR)/kernel/mutex/include
+CSRCS += $(wildcard kernel/mutex/cases/*.c)
+CSRCS += $(wildcard kernel/mutex/common/*.c)
+PROGNAME += cmocka_mutex_test
+MAINSRC += $(CURDIR)/kernel/mutex/cmocka_mutex_test.c
+endif
+
+ifneq ($(CONFIG_CM_SOCKET_TEST),)
+CFLAGS += -I$(CURDIR)/kernel/socket/include
+CSRCS += $(wildcard kernel/socket/cases/*.c)
+PROGNAME += cmocka_socket_test
+MAINSRC += $(CURDIR)/kernel/socket/cmocka_socket_test.c
+endif
+
+ifneq ($(CONFIG_CM_SYSCALL_TEST),)
+CFLAGS += -I$(CURDIR)/kernel/syscall/include
+CFLAGS += -I$(APPDIR)/nshlib
+CSRCS += $(wildcard kernel/syscall/cases/*.c)
+CSRCS += $(wildcard kernel/syscall/common/*.c)
+PROGNAME += cmocka_syscall_test
+MAINSRC += $(CURDIR)/kernel/syscall/cmocka_syscall_test.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/testing/testsuites/kernel/fs/cases/fs_append_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_append_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_append_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -39,17 +41,17 @@
 #define TESTFILENAME "stream01Testfile"
 
 /****************************************************************************
- * Public Functions
+ * Name: stream
+ * Example description:
+ *    1. open a file with "a+".
+ *    2. Write some strings to the file.
+ *    3. Check if the file pointer is offset.
+ * Test item: fopen() fseek() ftell()
+ * Expect results: TEST PASSED
  ****************************************************************************/
 
 /****************************************************************************
- * Name: stream
- * Example description:
- *   1. open a file with "a+".
- *   2. Write some strings to the file.
- *   3. Check if the file pointer is offset.
- * Test item: fopen() fseek() ftell()
- * Expect results: TEST PASSED
+ * Public Functions
  ****************************************************************************/
 
 void test_nuttx_fs_append01(FAR void **state)
@@ -61,8 +63,8 @@ void test_nuttx_fs_append01(FAR void **state)
   fd = fopen(TESTFILENAME, "a+");
   if (fd == NULL)
     {
-      syslog(LOG_ERR, "Unable to open file %s, errno %d\n",
-             TESTFILENAME, errno);
+      syslog(LOG_ERR, "Unable to open file %s, errno %d\n", TESTFILENAME,
+             errno);
       assert_true(1 == 0);
     }
 

--- a/testing/testsuites/kernel/fs/cases/fs_creat_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_creat_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_creat_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -53,9 +55,10 @@ void test_nuttx_fs_creat01(FAR void **state)
 {
   int fd;
   int ret;
-  char buf[20] = {
-      0
-    };
+  char buf[20] =
+  {
+    0
+  };
 
   struct fs_testsuites_state_s *test_state;
 

--- a/testing/testsuites/kernel/fs/cases/fs_dup2_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_dup2_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_dup2_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,9 +52,10 @@
 
 void test_nuttx_fs_dup201(FAR void **state)
 {
-  char buf[16] = {
-      0
-    };
+  char buf[16] =
+  {
+    0
+  };
 
   off_t currpos;
   struct fs_testsuites_state_s *test_state;

--- a/testing/testsuites/kernel/fs/cases/fs_dup_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_dup_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_dup_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,9 +55,9 @@ void test_nuttx_fs_dup01(FAR void **state)
   int fd;
   int newfd;
   int rval;
-  char buf_fd[5] = "hello";
-  char buf_new_fd[8] = "littleFS";
-  char read_buf[20] = "";
+  char buffd[5] = "hello";
+  char bufnewfd[8] = "littleFS";
+  char readbuf[20] = "";
   struct fs_testsuites_state_s *test_state;
 
   test_state = (struct fs_testsuites_state_s *)*state;
@@ -68,7 +70,7 @@ void test_nuttx_fs_dup01(FAR void **state)
 
   /* do write */
 
-  assert_int_in_range(write(fd, buf_fd, sizeof(buf_fd)), 1, sizeof(buf_fd));
+  assert_int_in_range(write(fd, buffd, sizeof(buffd)), 1, sizeof(buffd));
 
   /* refresh to storage */
 
@@ -88,8 +90,8 @@ void test_nuttx_fs_dup01(FAR void **state)
 
   /* write newfd after dup */
 
-  rval = write(newfd, buf_new_fd, sizeof(buf_new_fd));
-  assert_int_in_range(rval, 1, sizeof(buf_new_fd));
+  rval = write(newfd, bufnewfd, sizeof(bufnewfd));
+  assert_int_in_range(rval, 1, sizeof(bufnewfd));
 
   /* refresh to storage */
 
@@ -102,10 +104,10 @@ void test_nuttx_fs_dup01(FAR void **state)
 
   /* do double check */
 
-  rval = read(newfd, read_buf, 20);
+  rval = read(newfd, readbuf, 20);
   assert_int_in_range(rval, 1, 20);
 
-  /* check read_buf */
+  /* check readbuf */
 
-  assert_int_equal(strncmp(read_buf, "hellolittleFS", 13), 0);
+  assert_int_equal(strncmp(readbuf, "hellolittleFS", 13), 0);
 }

--- a/testing/testsuites/kernel/fs/cases/fs_eventfd_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_eventfd_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_eventfd_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,15 +41,17 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: thread_func
+ * Name: threadfunc
  ****************************************************************************/
 
-__attribute__((unused)) static void *thread_func(void *args)
+__attribute__((unused)) static void *threadfunc(void *args)
 {
   eventfd_t eventfd01_buffer;
+  int fd = *(int *)args;
+
   for (int i = 1; i < 6; i++)
     {
-      read(*(int *)args, &eventfd01_buffer, sizeof(eventfd_t));
+      read(fd, &eventfd01_buffer, sizeof(eventfd_t));
       sleep(1);
     }
 
@@ -75,13 +79,13 @@ void test_nuttx_fs_eventfd(FAR void **state)
   eventfd01_efd = eventfd(0, 0);
   assert_int_not_equal(eventfd01_efd, -1);
   test_state->fd1 = eventfd01_efd;
-  assert_true(pthread_create(&eventfd01_tid, NULL,
-                             thread_func, &eventfd01_efd) >= 0);
+  assert_true(pthread_create(&eventfd01_tid, NULL, threadfunc,
+                             &eventfd01_efd) >= 0);
 
   for (int i = 1; i < 5; i++)
     {
-      eventfd01_ret = write(eventfd01_efd, &eventfd01_buf,
-                            sizeof(eventfd_t));
+      eventfd01_ret =
+          write(eventfd01_efd, &eventfd01_buf, sizeof(eventfd_t));
       assert_int_equal(eventfd01_ret, sizeof(eventfd_t));
       eventfd01_buf++;
       sleep(1);

--- a/testing/testsuites/kernel/fs/cases/fs_fcntl_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_fcntl_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_fcntl_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -33,7 +35,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
 #define BUFSIZE 512
 #define TEST_FILE_1 "fcntl01_testfile"
 
@@ -109,7 +110,7 @@ void test_nuttx_fs_fcntl02(FAR void **state)
   /* open file */
 
   fd = open(TEST_FILE_2, O_RDWR | O_CREAT, 0700);
-  assert_int_in_range(fd, 0, 255);
+  assert_true(fd > 0);
 
   /* do fcntl */
 
@@ -133,10 +134,10 @@ void test_nuttx_fs_fcntl02(FAR void **state)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: fs_fcntl_set_lile_status
+ * Name: fsfcntlsetlilestatus
  ****************************************************************************/
 
-static int fs_fcntl_set_lile_status(int mode, int fd)
+static int fsfcntlsetlilestatus(int mode, int fd)
 {
   int flags;
   int ret;
@@ -177,12 +178,14 @@ void test_nuttx_fs_fcntl03(FAR void **state)
   int ret;
   int size;
   int ret2;
-  char path[32] = {
-     0
+  char path[32] =
+  {
+    0
   };
 
-  char buf[10] = {
-     0
+  char buf[10] =
+  {
+    0
   };
 
   getcwd(path, sizeof(path));
@@ -214,7 +217,7 @@ void test_nuttx_fs_fcntl03(FAR void **state)
 
   /* F_SETFL */
 
-  ret = fs_fcntl_set_lile_status(O_APPEND, fd);
+  ret = fsfcntlsetlilestatus(O_APPEND, fd);
   assert_int_equal(ret, 0);
 
   /* set memory */

--- a/testing/testsuites/kernel/fs/cases/fs_fstat_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_fstat_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_fstat_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -127,4 +129,18 @@ void test_nuttx_fs_fstat02(FAR void **state)
   /* close file */
 
   assert_int_equal(close(fd), 0);
+
+  /* #if defined(CONFIG_NET)
+   *    // creat socket
+   *    fd = socket(AF_INET, SOCK_STREAM, 0);
+   *    assert_int_not_equal(fd, -1);
+
+   *    // get file size again
+   *    ret = fstat(fd, &file_s);
+   *    assert_int_equal(ret, 0);
+
+   *    assert_true(S_ISSOCK(file_s.st_mode));
+   *    assert_int_equal(close(fd), 0);
+   * #endif
+   */
 }

--- a/testing/testsuites/kernel/fs/cases/fs_fstatfs_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_fstatfs_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_fstatfs_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
@@ -44,23 +46,26 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_print_statfs
+ * Name: test_nuttx_fs_printstatfs
  ****************************************************************************/
 
-__attribute__((unused)) static void test_nuttx_fs_print_statfs
-                                                        (struct statfs *buf)
+__attribute__((unused)) static void
+test_nuttx_fs_printstatfs(struct statfs *buf)
 {
   syslog(LOG_INFO, "statfs buffer:\n");
   syslog(LOG_INFO, "  f_type:     %lu\n", (unsigned long)buf->f_type);
   syslog(LOG_INFO, "  f_namelen:  %lu\n", (unsigned long)buf->f_namelen);
   syslog(LOG_INFO, "  f_bsize:    %lu\n", (unsigned long)buf->f_bsize);
   syslog(LOG_INFO, "  f_blocks:   %llu\n",
-                      (unsigned long long)buf->f_blocks);
-  syslog(LOG_INFO, "  f_bfree:    %llu\n", (unsigned long long)buf->f_bfree);
+         (unsigned long long)buf->f_blocks);
+  syslog(LOG_INFO, "  f_bfree:    %llu\n",
+         (unsigned long long)buf->f_bfree);
   syslog(LOG_INFO, "  f_bavail:   %llu\n",
-                      (unsigned long long)buf->f_bavail);
-  syslog(LOG_INFO, "  f_files:    %llu\n", (unsigned long long)buf->f_files);
-  syslog(LOG_INFO, "  f_ffree:    %llu\n", (unsigned long long)buf->f_ffree);
+         (unsigned long long)buf->f_bavail);
+  syslog(LOG_INFO, "  f_files:    %llu\n",
+         (unsigned long long)buf->f_files);
+  syslog(LOG_INFO, "  f_ffree:    %llu\n",
+         (unsigned long long)buf->f_ffree);
 }
 
 /****************************************************************************

--- a/testing/testsuites/kernel/fs/cases/fs_fsync_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_fsync_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_fsync_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,8 +42,10 @@
  ****************************************************************************/
 
 #define TESTFILE "FsyncTestFile"
-#define BUF "testData123#$%*-=/ sdafasd37575sasdfasdf3563456345" \
-            "63456ADSFASDFASDFQWREdf4as5df4as5dfsd ###"
+#define BUF                                                             \
+  "testData123#$%*-=/ "                                                 \
+  "sdafasd37575sasdfasdf356345634563456ADSFASDFASDFQWREdf4as5df4as5dfs" \
+  "d ###"
 
 /****************************************************************************
  * Public Functions
@@ -53,6 +57,8 @@
 
 void test_nuttx_fs_fsync01(FAR void **state)
 {
+  /* clock_t start, finish; */
+
   int fd;
   int rval;
   int ret;
@@ -97,7 +103,9 @@ void test_nuttx_fs_fsync02(FAR void **state)
   ssize_t writen = 0;
   struct statfs statfsbuf;
   struct fs_testsuites_state_s *test_state;
+  struct mallinfo mem_info;
 
+  memset(&mem_info, 0, sizeof(mem_info));
   test_state = (struct fs_testsuites_state_s *)*state;
 
   /* delete test file */
@@ -114,10 +122,23 @@ void test_nuttx_fs_fsync02(FAR void **state)
 
   ret = fstatfs(fd, &statfsbuf);
   assert_int_equal(ret, 0);
-
+#ifdef CONFIG_ARCH_SIM
   bufsize = statfsbuf.f_bsize;
+#else
+  get_mem_info(&mem_info);
+  if (mem_info.mxordblk < statfsbuf.f_bsize)
+    {
+      bufsize = mem_info.mxordblk - 16;
+    }
 
-  syslog(LOG_INFO, "the bsize = %" PRIdPTR "\n", statfsbuf.f_bsize);
+  else
+    {
+      bufsize = statfsbuf.f_bsize;
+    }
+
+#endif
+  syslog(LOG_INFO, "the fbsize = %"PRIu64",buffer size=%d\n",
+        statfsbuf.f_bsize, bufsize);
 
   /* malloc memory */
 

--- a/testing/testsuites/kernel/fs/cases/fs_getfilep_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_getfilep_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_getfilep_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -27,9 +29,6 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
-
-#include <nuttx/fs/fs.h>
-
 #include "fstest.h"
 
 /****************************************************************************
@@ -97,6 +96,10 @@ void test_nuttx_fs_getfilep01(FAR void **state)
 
   fsync(fileno(fp));
 
+  /* put filep */
+
+  fs_putfilep(filep);
+
   /* get struct file again */
 
   ret = fs_getfilep(fileno(fp), &filep);
@@ -105,5 +108,10 @@ void test_nuttx_fs_getfilep01(FAR void **state)
   assert_int_equal(filep->f_pos, BUF_SIZE);
 
   test_state->fd2 = fileno(fp);
+
+  /* put filep */
+
+  fs_putfilep(filep);
+
   assert_int_equal(fclose(fp), 0);
 }

--- a/testing/testsuites/kernel/fs/cases/fs_mkdir_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_mkdir_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_mkdir_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/testing/testsuites/kernel/fs/cases/fs_open_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_open_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_open_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -38,6 +40,7 @@
  ****************************************************************************/
 
 #define TESTFILE "testOpenFile"
+#define TESTDIR "testOpenDir"
 
 /****************************************************************************
  * Public Functions
@@ -52,9 +55,10 @@ void test_nuttx_fs_open01(FAR void **state)
   int fd;
   int ret;
   char s[] = "test data!";
-  char buffer[50] = {
-      0
-    };
+  char buffer[50] =
+  {
+    0
+  };
 
   struct fs_testsuites_state_s *test_state;
 
@@ -81,4 +85,36 @@ void test_nuttx_fs_open01(FAR void **state)
 
   ret = read(fd, buffer, sizeof(buffer));
   assert_true(ret > 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_fs_open02
+ ****************************************************************************/
+
+void test_nuttx_fs_open02(FAR void **state)
+{
+  int fd = -1;
+  int ret = 0;
+
+  /* create a dir for test */
+
+  ret = mkdir(TESTDIR, 0777);
+  assert_int_equal(ret, 0);
+
+  /* open file with RDONLY：fatfs will fail,so skip currently 2024-9-25
+   */
+
+#if 0
+    fd = open(TESTDIR, O_RDONLY);
+    assert_true(fd > 0);
+    close(fd);
+#endif
+  /* open file with RDWR */
+
+  fd = open(TESTDIR, O_RDWR);
+  assert_true(fd < 0);
+
+  /* do rmdir */
+
+  assert_int_equal(rmdir(TESTDIR), 0);
 }

--- a/testing/testsuites/kernel/fs/cases/fs_opendir_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_opendir_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_opendir_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/testing/testsuites/kernel/fs/cases/fs_poll_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_poll_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_poll_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +42,6 @@
 
 #define I_FILE1 "poll_test1"
 #define I_FILE2 "poll_test2"
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/testing/testsuites/kernel/fs/cases/fs_pread_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_pread_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_pread_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <errno.h>
 #include <string.h>

--- a/testing/testsuites/kernel/fs/cases/fs_pwrite_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_pwrite_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_pwrite_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <errno.h>
 #include <string.h>

--- a/testing/testsuites/kernel/fs/cases/fs_read_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_read_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_read_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <errno.h>
 #include <string.h>
@@ -60,7 +62,7 @@ void test_nuttx_fs_read01(FAR void **state)
   test_state = (struct fs_testsuites_state_s *)*state;
 
   fd = open(TESTFILE, O_WRONLY | O_CREAT, 0777);
-  assert_int_in_range(fd, 0, 255);
+  assert_true(fd > 0);
   test_state->fd1 = fd;
 
   size = write(fd, s, sizeof(s));
@@ -68,7 +70,7 @@ void test_nuttx_fs_read01(FAR void **state)
 
   close(fd);
   fd = open(TESTFILE, O_RDONLY, 0777);
-  assert_int_in_range(fd, 0, 255);
+  assert_true(fd > 0);
   test_state->fd1 = fd;
   size = read(fd, buffer, sizeof(buffer));
   assert_int_equal(size, sizeof(s));

--- a/testing/testsuites/kernel/fs/cases/fs_readdir_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_readdir_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_readdir_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,19 +50,16 @@ void test_nuttx_fs_readdir01(FAR void **state)
 {
   int fd;
   int ret;
-  char buf[20] = {
-      0
-    };
+  char buf[20] =
+  {
+    0
+  };
 
-  char *filename[] = {
-      "testFile1",
-      "testFile2",
-      "testFile3",
-      "testFile4",
-      "testFile5",
-      "testFile6",
-      "testFile7"
-    };
+  char *filename[] =
+  {
+    "testfile1", "testfile2", "testfile3", "testfile4",
+                      "testfile5", "testfile6", "testfile7"
+  };
 
   DIR *test_dir;
   struct dirent *dptr;

--- a/testing/testsuites/kernel/fs/cases/fs_readlink_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_readlink_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_readlink_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <errno.h>
 #include <string.h>
@@ -58,13 +60,15 @@ void test_nuttx_fs_readlink01(FAR void **state)
 
   /* test symlink */
 
-  char path[PATH_MAX_SIZE] = {
-      0
-    };
+  char path[PATH_MAX_SIZE] =
+  {
+    0
+  };
 
-  char buf[PATH_MAX_SIZE] = {
-      0
-    };
+  char buf[PATH_MAX_SIZE] =
+  {
+    0
+  };
 
   struct fs_testsuites_state_s *test_state;
 

--- a/testing/testsuites/kernel/fs/cases/fs_rename_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_rename_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_rename_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,15 +50,11 @@ void test_nuttx_fs_rename01(FAR void **state)
   int ret;
   char buffer[50];
   char filename1[] = "testRenameFile1";
-  struct fs_testsuites_state_s *test_state;
-
-  test_state = (struct fs_testsuites_state_s *)*state;
 
   /* open file */
 
   fd = open(filename1, O_WRONLY | O_CREAT, 0700);
   assert_true(fd > 0);
-  test_state->fd1 = fd;
 
   /* set memory */
 
@@ -66,6 +64,10 @@ void test_nuttx_fs_rename01(FAR void **state)
 
   ret = write(fd, buffer, 50);
   assert_int_in_range(ret, 1, 50);
+
+  /* close file befor rename */
+
+  close(fd);
 
   /* do rename */
 

--- a/testing/testsuites/kernel/fs/cases/fs_rewinddir_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_rewinddir_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_rewinddir_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -58,15 +60,16 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_cteat_file
+ * Name: test_nuttx_fs_cteatfile
  ****************************************************************************/
 
-static void test_nuttx_fs_cteat_file(char *filename, size_t write_size)
+static void test_nuttx_fs_cteatfile(char *filename, size_t write_size)
 {
   int fd;
-  char w_buffer[WRITE_BUF_SIZE] = {
-      0
-    };
+  char w_buffer[WRITE_BUF_SIZE] =
+  {
+    0
+  };
 
   ssize_t size = 0;
 
@@ -126,13 +129,16 @@ void test_nuttx_fs_rewinddir01(FAR void **state)
       fail_msg("Failed to obtain partition information !\n");
     }
 
-  /* Stop the test if the available space of the partition is less than 50K */
+  /* Stop the test if the available space of the partition is less than
+   * 50K
+   */
 
   if (size < 51200)
     {
       syslog(LOG_WARNING, "Partitioned free space not enough !\n");
       syslog(LOG_WARNING, "Test case (%s) exits early !\n", __func__);
     }
+
   else
     {
       /* make directory */
@@ -146,9 +152,9 @@ void test_nuttx_fs_rewinddir01(FAR void **state)
 
       /* create */
 
-      test_nuttx_fs_cteat_file(TEST_CHILD_FILE1, 10);
-      test_nuttx_fs_cteat_file(TEST_CHILD_FILE2, 10);
-      test_nuttx_fs_cteat_file(TEST_CHILD_FILE3, 10);
+      test_nuttx_fs_cteatfile(TEST_CHILD_FILE1, 10);
+      test_nuttx_fs_cteatfile(TEST_CHILD_FILE2, 10);
+      test_nuttx_fs_cteatfile(TEST_CHILD_FILE3, 10);
 
       /* open directory */
 

--- a/testing/testsuites/kernel/fs/cases/fs_rmdir_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_rmdir_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_rmdir_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -46,31 +48,36 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_fmdir01
+ * Name: test_nuttx_fs_rmdir01
  ****************************************************************************/
 
-void test_nuttx_fs_fmdir01(FAR void **state)
+void test_nuttx_fs_rmdir01(FAR void **state)
 {
   int status;
   int fd;
   char str[5];
-  char test_file_name[20] = {
+  char testfilename[20] =
+  {
     0
   };
 
-  char test_dir_name[20] = {
+  char testdirname[20] =
+  {
     0
   };
 
-  char absolute_directory[100] = {
+  char absolutedirectory[100] =
+  {
     0
   };
 
-  char current_path[100] = {
+  char currentpath[100] =
+  {
     0
   };
 
-  char parent_directory[PATH_MAX] = {
+  char parentdirectory[PATH_MAX] =
+  {
     0
   };
 
@@ -81,8 +88,8 @@ void test_nuttx_fs_fmdir01(FAR void **state)
       fail_msg("Failed to obtain partition information !\n");
     }
 
-  /* Stop the test if the available space of
-   * the partition is less than 160K
+  /* Stop the test if the available space of the partition is less than
+   * 160K
    */
 
   if (size < 163840)
@@ -99,19 +106,19 @@ void test_nuttx_fs_fmdir01(FAR void **state)
 
       /* get test path */
 
-      getcwd(current_path, sizeof(current_path));
+      getcwd(currentpath, sizeof(currentpath));
 
-      strcpy(absolute_directory, current_path);
-      strcat(current_path, "/");
-      strcat(current_path, PARENTDIR1);
+      strcpy(absolutedirectory, currentpath);
+      strcat(currentpath, "/");
+      strcat(currentpath, PARENTDIR1);
 
-      strcpy(parent_directory, current_path);
+      strcpy(parentdirectory, currentpath);
 
-      chdir(current_path);
+      chdir(currentpath);
 
       /* get test path */
 
-      getcwd(current_path, sizeof(current_path));
+      getcwd(currentpath, sizeof(currentpath));
 
       /* create 10 2-level subfolders */
 
@@ -128,13 +135,13 @@ void test_nuttx_fs_fmdir01(FAR void **state)
 
       /* enter sub-directory */
 
-      strcat(current_path, "/");
-      strcat(current_path, str);
-      chdir(current_path);
+      strcat(currentpath, "/");
+      strcat(currentpath, str);
+      chdir(currentpath);
 
       /* get test path */
 
-      getcwd(current_path, sizeof(current_path));
+      getcwd(currentpath, sizeof(currentpath));
 
       /* make directory */
 
@@ -152,29 +159,29 @@ void test_nuttx_fs_fmdir01(FAR void **state)
 
       /* enter sub-directory */
 
-      memset(current_path, 0, sizeof(current_path));
-      strcpy(current_path, parent_directory);
-      strcat(current_path, "/");
-      strcat(current_path, str);
-      chdir(current_path);
+      memset(currentpath, 0, sizeof(currentpath));
+      strcpy(currentpath, parentdirectory);
+      strcat(currentpath, "/");
+      strcat(currentpath, str);
+      chdir(currentpath);
 
       /* get test path */
 
-      getcwd(current_path, sizeof(current_path));
+      getcwd(currentpath, sizeof(currentpath));
 
       for (int j = 1; j <= 10; j++)
         {
-          sprintf(test_file_name, "test_3_file_%d", j);
+          sprintf(testfilename, "test_3_file_%d", j);
 
           /* creat a test file */
 
-          fd = creat(test_file_name, 0700);
+          fd = creat(testfilename, 0700);
           assert_true(fd > 0);
           close(fd);
 
           /* set memory */
 
-          memset(test_file_name, 0, sizeof(test_file_name));
+          memset(testfilename, 0, sizeof(testfilename));
         }
 
       /* switch to directory 2 */
@@ -183,45 +190,45 @@ void test_nuttx_fs_fmdir01(FAR void **state)
 
       /* enter sub-directory */
 
-      memset(current_path, 0, sizeof(current_path));
-      strcpy(current_path, parent_directory);
-      strcat(current_path, "/");
-      strcat(current_path, str);
-      chdir(current_path);
+      memset(currentpath, 0, sizeof(currentpath));
+      strcpy(currentpath, parentdirectory);
+      strcat(currentpath, "/");
+      strcat(currentpath, str);
+      chdir(currentpath);
 
       /* get test path */
 
-      getcwd(current_path, sizeof(current_path));
+      getcwd(currentpath, sizeof(currentpath));
 
       for (int k = 1; k <= 5; k++)
         {
-          sprintf(test_file_name, "test_3_file_%d", k);
-          sprintf(test_dir_name, "test_3_dir_%d", k);
+          sprintf(testfilename, "test_3_file_%d", k);
+          sprintf(testdirname, "test_3_dir_%d", k);
 
           /* create a test file */
 
-          fd = creat(test_file_name, 0700);
+          fd = creat(testfilename, 0700);
           assert_true(fd > 0);
           close(fd);
 
           /* make  directory */
 
-          status = mkdir(test_dir_name, 0700);
+          status = mkdir(testdirname, 0700);
           assert_int_equal(status, 0);
 
           /* set memory */
 
-          memset(test_file_name, 0, sizeof(test_file_name));
-          memset(test_dir_name, 0, sizeof(test_dir_name));
+          memset(testfilename, 0, sizeof(testfilename));
+          memset(testdirname, 0, sizeof(testdirname));
         }
 
       /* wwitch to the test absolute directory */
 
-      chdir(absolute_directory);
+      chdir(absolutedirectory);
 
       /* call the recursive delete interface */
 
-      cm_unlink_recursive(parent_directory);
+      cm_unlink_recursive(parentdirectory);
     }
 }
 
@@ -243,19 +250,23 @@ void test_nuttx_fs_rmdir02(FAR void **state)
 {
   int status;
   int ret;
-  char str[20] = {
+  char str[20] =
+  {
     0
   };
 
-  char absolute_directory[20] = {
+  char absolutedirectory[20] =
+  {
     0
   };
 
-  char parent_directory[PATH_MAX] = {
+  char parentdirectory[PATH_MAX] =
+  {
     0
   };
 
-  char temporary_path[300] = {
+  char temporarypath[300] =
+  {
     0
   };
 
@@ -267,7 +278,9 @@ void test_nuttx_fs_rmdir02(FAR void **state)
       fail_msg("Failed to obtain partition information !\n");
     }
 
-  /* Stop the test if the available space of the partition is less than 98K */
+  /* Stop the test if the available space of the partition is less than
+   * 98K
+   */
 
   if (size < 98304)
     {
@@ -276,20 +289,20 @@ void test_nuttx_fs_rmdir02(FAR void **state)
     }
   else
     {
-      getcwd(absolute_directory, sizeof(absolute_directory));
+      getcwd(absolutedirectory, sizeof(absolutedirectory));
 
       /* create directory */
 
       status = mkdir(PARENTDIR2, 0700);
       assert_int_equal(status, 0);
 
-      strcpy(parent_directory, absolute_directory);
-      strcat(parent_directory, "/");
-      strcat(parent_directory, PARENTDIR2);
+      strcpy(parentdirectory, absolutedirectory);
+      strcat(parentdirectory, "/");
+      strcat(parentdirectory, PARENTDIR2);
 
       /* switch to test PARENTDIR */
 
-      chdir(parent_directory);
+      chdir(parentdirectory);
 
       /* create a 6-level directory in a loop */
 
@@ -297,36 +310,36 @@ void test_nuttx_fs_rmdir02(FAR void **state)
         {
           /* get current path */
 
-          getcwd(temporary_path, sizeof(temporary_path));
-          strcat(temporary_path, "/");
+          getcwd(temporarypath, sizeof(temporarypath));
+          strcat(temporarypath, "/");
 
           /* do snprintf */
 
           ret = snprintf(str, 20, "test_dir_%d", i);
           assert_true(ret > 0);
 
-          strcat(temporary_path, str);
+          strcat(temporarypath, str);
 
           /* make directory */
 
-          status = mkdir(temporary_path, 0700);
+          status = mkdir(temporarypath, 0700);
           assert_int_equal(status, 0);
 
-          chdir(temporary_path);
+          chdir(temporarypath);
 
           /* set memory */
 
-          memset(temporary_path, 0, sizeof(temporary_path));
+          memset(temporarypath, 0, sizeof(temporarypath));
           memset(str, 0, sizeof(str));
         }
 
       /* wwitch to the test absolute directory */
 
-      chdir(absolute_directory);
+      chdir(absolutedirectory);
 
       /* call the recursive delete interface */
 
-      cm_unlink_recursive(parent_directory);
+      cm_unlink_recursive(parentdirectory);
     }
 }
 
@@ -343,7 +356,8 @@ void test_nuttx_fs_rmdir03(FAR void **state)
   int status;
   DIR *dir = NULL;
   char str[5];
-  char buf[20] = {
+  char buf[20] =
+  {
     0
   };
 
@@ -356,7 +370,9 @@ void test_nuttx_fs_rmdir03(FAR void **state)
       fail_msg("Failed to obtain partition information !\n");
     }
 
-  /* Stop the test if the available space of the partition is less than 80K */
+  /* Stop the test if the available space of the partition is less than
+   * 80K
+   */
 
   if (size < 81920)
     {

--- a/testing/testsuites/kernel/fs/cases/fs_seek_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_seek_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_seek_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -148,10 +150,10 @@ tcases[] =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_verify_lseek
+ * Name: test_nuttx_fs_verifylseek
  ****************************************************************************/
 
-static int test_nuttx_fs_verify_lseek(unsigned int n)
+static int test_nuttx_fs_verifylseek(unsigned int n)
 {
   char read_buf[64];
   struct tcase *tc = &tcases[n];
@@ -182,7 +184,8 @@ static int test_nuttx_fs_verify_lseek(unsigned int n)
   if (ret != tc->exp_off)
     {
       syslog(LOG_ERR, "lseek(%s, %lld, %s) returned %d, expected %lld\n",
-          TFILE, (long long)tc->off, tc->wname, ret, (long long)tc->exp_off);
+             TFILE, (long long)tc->off, tc->wname, ret,
+             (long long)tc->exp_off);
       return -1;
     }
 
@@ -196,8 +199,8 @@ static int test_nuttx_fs_verify_lseek(unsigned int n)
 
   if (tc->exp_data && strcmp(read_buf, tc->exp_data))
     {
-      syslog(LOG_ERR, "lseek(%s, %lld, %s) read incorrect data\n",
-             TFILE, (long long)tc->off, tc->wname);
+      syslog(LOG_ERR, "lseek(%s, %lld, %s) read incorrect data\n", TFILE,
+             (long long)tc->off, tc->wname);
       return -1;
     }
   else
@@ -254,22 +257,22 @@ void test_nuttx_fs_seek02(FAR void **state)
 
   /* do verify lseek */
 
-  ret = test_nuttx_fs_verify_lseek(0);
+  ret = test_nuttx_fs_verifylseek(0);
   assert_int_equal(ret, 0);
 
   /* do verify lseek */
 
-  ret = test_nuttx_fs_verify_lseek(1);
+  ret = test_nuttx_fs_verifylseek(1);
   assert_int_equal(ret, 0);
 
   /* do verify lseek */
 
-  ret = test_nuttx_fs_verify_lseek(2);
+  ret = test_nuttx_fs_verifylseek(2);
   assert_int_equal(ret, 0);
 
   /* do verify lseek */
 
-  ret = test_nuttx_fs_verify_lseek(3);
+  ret = test_nuttx_fs_verifylseek(3);
   assert_int_equal(ret, 0);
 
   /* do clean */

--- a/testing/testsuites/kernel/fs/cases/fs_sendfile_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_sendfile_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_sendfile_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/types.h>
 #include <sys/sendfile.h>
@@ -41,33 +43,29 @@
 #define I_FILE1 "inputFile1"
 #define I_FILE2 "inputFile2"
 
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
 static void set_test(void)
 {
   int fd;
   fd = open(O_FILE, O_CREAT | O_RDWR, 0777);
   if (fd == -1)
     {
-      syslog(LOG_ERR, "Unable to open file %s, errno %d\n", O_FILE, errno);
+      syslog(LOG_ERR, "Unable to open file %s, errno %d\n", O_FILE,
+             errno);
       assert_true(1 == 0);
     }
-
   write(fd, "ABCDEFGHIJ", 10);
   close(fd);
 }
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
 
 /****************************************************************************
  * Name: sendfile
  * Example description:
  *  1.Test copy the entire file
  * Expect results: TEST PASSED
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
  ****************************************************************************/
 
 void test_nuttx_fs_sendfile01(FAR void **state)
@@ -195,7 +193,8 @@ void test_nuttx_fs_sendfile02(FAR void **state)
   close(fd_o);
   close(fd_i);
 
-  /* Checks whether the file pointer is offset to the specified position */
+  /* Checks whether the file pointer is offset to the specified position
+   */
 
   assert_int_equal(offset, f_stat.st_size);
 }

--- a/testing/testsuites/kernel/fs/cases/fs_stat_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_stat_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_stat_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <string.h>
@@ -51,10 +53,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_print_time
+ * Name: test_nuttx_fs_printtime
  ****************************************************************************/
 
-__attribute__((unused)) static void test_nuttx_fs_print_time(struct tm *TM)
+__attribute__((unused)) static void test_nuttx_fs_printtime(struct tm *TM)
 {
   syslog(LOG_INFO, "    tm_year: %d\n", TM->tm_year + 1900);
   syslog(LOG_INFO, "    tm_mon: %d\n", TM->tm_mon);
@@ -78,7 +80,8 @@ void test_nuttx_fs_stat01(FAR void **state)
   int ret;
   int ret2;
   struct stat file_s;
-  char buf[BUF_SIZE] = {
+  char buf[BUF_SIZE] =
+  {
     0
   };
 

--- a/testing/testsuites/kernel/fs/cases/fs_statfs_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_statfs_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_statfs_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,11 +50,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_print_statfs
+ * Name: test_nuttx_fs_printstatfs
  ****************************************************************************/
 
-__attribute__((unused)) static void test_nuttx_fs_print_statfs
-                                                    (struct statfs *buf)
+__attribute__((unused)) static void
+test_nuttx_fs_printstatfs(struct statfs *buf)
 {
   syslog(LOG_INFO, "statfs buffer:\n");
   syslog(LOG_INFO, "  f_type:     %u \n", (unsigned)buf->f_type);
@@ -80,12 +82,12 @@ __attribute__((unused)) static void test_nuttx_fs_print_statfs
 
 void test_nuttx_fs_statfs01(FAR void **state)
 {
-  struct statfs disk_info;
+  struct statfs diskinfo;
 
   /* call statfs() */
 
   char *buf = getcwd(NULL, 0);
-  int ret = statfs(buf, &disk_info);
+  int ret = statfs(buf, &diskinfo);
   free(buf);
   assert_int_equal(ret, 0);
 }

--- a/testing/testsuites/kernel/fs/cases/fs_stream_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_stream_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_stream_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -38,10 +40,6 @@
 #define TESTFILENAME "streamTestfile"
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: stream
  * Example description:
  *   1. open a file with "a+".
@@ -50,6 +48,10 @@
  *   4. Check the returned results.
  * Test item: fopen() fwrite() freopen()
  * Expect results: TEST PASSED
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
  ****************************************************************************/
 
 void test_nuttx_fs_stream01(FAR void **state)
@@ -100,9 +102,9 @@ void test_nuttx_fs_stream01(FAR void **state)
  * Name: stream
  * Example description:
  *   1. open a file with "a+".
- *   2. Write the file multiple times.
- *   3. Check that the file pointer is in the correct
- *      position after each write.
+ *    2. Write the file multiple times.
+ *    3. Check that the file pointer is in the correct position after
+ *each write.
  *   4. Reset the file pointer position. Repeat step 2-3
  *   4. Check the returned results.
  * Test item: fopen() fwrite() rewind() ftell() fseek() fgets()
@@ -127,7 +129,8 @@ void test_nuttx_fs_stream02(FAR void **state)
       pos = ftell(stream);
       if (pos != 0)
         {
-          syslog(LOG_ERR, "file pointer descrepancy 1, errno %d\n", errno);
+          syslog(LOG_ERR, "file pointer descrepancy 1, errno %d\n",
+                 errno);
           fclose(stream);
           assert_true(1 == 0);
         }
@@ -142,13 +145,15 @@ void test_nuttx_fs_stream02(FAR void **state)
       pos = ftell(stream);
       if (pos != strlen(junk))
         {
-          syslog(LOG_ERR,
-                 "strlen(junk)=%zi: file pointer descrepancy 2 (pos=%li)",
-                 strlen(junk), pos);
+          syslog(
+              LOG_ERR,
+              "strlen(junk)=%zi: file pointer descrepancy 2 (pos=%li)",
+              strlen(junk), pos);
           fclose(stream);
           assert_true(1 == 0);
         }
 
+      usleep(1000);
       rewind(stream);
       pos = ftell(stream);
       if (pos != 0)
@@ -171,9 +176,10 @@ void test_nuttx_fs_stream02(FAR void **state)
       if (pos != strlen(junk))
         {
           fclose(stream);
-          syslog(LOG_ERR,
-                 "strlen(junk)=%zi: file pointer descrepancy 4 (pos=%li)",
-                 strlen(junk), pos);
+          syslog(
+              LOG_ERR,
+              "strlen(junk)=%zi: file pointer descrepancy 4 (pos=%li)",
+              strlen(junk), pos);
           assert_true(1 == 0);
         }
 
@@ -188,9 +194,10 @@ void test_nuttx_fs_stream02(FAR void **state)
       if (pos != strlen(junk))
         {
           fclose(stream);
-          syslog(LOG_ERR,
-                 "strlen(junk)=%zi: file pointer descrepancy 5 (pos=%li)",
-                 strlen(junk), pos);
+          syslog(
+              LOG_ERR,
+              "strlen(junk)=%zi: file pointer descrepancy 5 (pos=%li)",
+              strlen(junk), pos);
           assert_true(1 == 0);
         }
 
@@ -206,7 +213,8 @@ void test_nuttx_fs_stream02(FAR void **state)
         {
           fclose(stream);
           syslog(LOG_ERR,
-                 "file pointer descrepancy 6 (pos=%li, wanted pos=0)", pos);
+                 "file pointer descrepancy 6 (pos=%li, wanted pos=0)",
+                 pos);
           assert_true(1 == 0);
         }
 
@@ -215,28 +223,30 @@ void test_nuttx_fs_stream02(FAR void **state)
       pos = ftell(stream);
       if (pos != strlen(junk))
         {
-          syslog(LOG_ERR,
-                 "strlen(junk)=%zi: file pointer descrepancy 7 (pos=%li)",
-                 strlen(junk), pos);
+          syslog(
+              LOG_ERR,
+              "strlen(junk)=%zi: file pointer descrepancy 7 (pos=%li)",
+              strlen(junk), pos);
           assert_true(1 == 0);
         }
 
       fclose(stream);
       unlink(TESTFILENAME);
+      usleep(40000);
     }
 }
 
 /****************************************************************************
  * Name: stream
  * Example description:
- *  1. open a file with "a+".
- *  2. Write the file multiple times.
- *  3. close the file.
- *  4. open the file again with "r+"
- *  5. Request a piece of memory and read the contents of the file.
- *  6. Check that the read file class is correct.
- *  7. repeat step 2-3-4-5-6 for 10 times.
- *  8. Check that the test returns results.
+ *   1. open a file with "a+".
+ *   2. Write the file multiple times.
+ *   3. close the file.
+ *   4. open the file again with "r+"
+ *   5. Request a piece of memory and read the contents of the file.
+ *   6. Check that the read file class is correct.
+ *   7. repeat step 2-3-4-5-6 for 10 times.
+ *   8. Check that the test returns results.
  * Test item: fopen() fwrite() fread() malloc()
  * Expect results: TEST PASSED
  ****************************************************************************/
@@ -266,8 +276,7 @@ void test_nuttx_fs_stream03(FAR void **state)
 
       if ((size_t)ret != len)
         {
-          syslog(LOG_ERR,
-                 "len = %zi != return value from fwrite = %i",
+          syslog(LOG_ERR, "len = %zu != return value from fwrite = %d",
                  len, ret);
           fclose(stream);
           assert_true(1 == 0);
@@ -299,8 +308,7 @@ void test_nuttx_fs_stream03(FAR void **state)
 
       if ((size_t)ret != len)
         {
-          syslog(LOG_ERR,
-                 "len = %zi != return value from fread = %i",
+          syslog(LOG_ERR, "len = %zu != return value from fread = %d",
                  len, ret);
           free(inbuf);
           fclose(stream);
@@ -351,8 +359,7 @@ void test_nuttx_fs_stream04(FAR void **state)
 
       if (ferror(stream) != 0)
         {
-          syslog(LOG_ERR,
-                 "ferror did not return zero, return %d\n",
+          syslog(LOG_ERR, "ferror did not return zero, return %d\n",
                  ferror(stream));
           fclose(stream);
           assert_true(1 == 0);
@@ -386,14 +393,15 @@ void test_nuttx_fs_stream04(FAR void **state)
 
       if ((stream = fopen(TESTFILENAME, "r+")) == NULL)
         {
-          syslog(LOG_ERR,
-                 "fopen(%s) r+ failed, errno %d\n", TESTFILENAME, errno);
+          syslog(LOG_ERR, "fopen(%s) r+ failed, errno %d\n",
+                 TESTFILENAME, errno);
           assert_true(1 == 0);
         }
 
       if (feof(stream) != 0)
         {
-          syslog(LOG_ERR, "feof returned non-zero when it should not \n");
+          syslog(LOG_ERR,
+                 "feof returned non-zero when it should not \n");
           fclose(stream);
           assert_true(1 == 0);
         }

--- a/testing/testsuites/kernel/fs/cases/fs_symlink_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_symlink_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_symlink_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <errno.h>
 #include <string.h>
@@ -54,28 +56,34 @@ static char *path;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_run_test
+ * Name: test_nuttx_fs_runtest
  ****************************************************************************/
 
-static int test_nuttx_fs_run_test(void)
+static int test_nuttx_fs_runtest(void)
 {
   int ret;
 
   /* test symlink */
 
-  char buf[64] = {
+  char buf[64] =
+  {
     0
   };
 
   ret = symlink(path, "/file_link");
+
+  /* syslog(LOG_INFO, "the symlink return : %d\n", ret); */
+
   if (ret != 0)
     {
       return ERROR;
     }
-
   else
     {
       ret = readlink("/file_link", buf, PATH_MAX_SIZE);
+
+      /* syslog(LOG_INFO, "buf = %s\n", buf); */
+
       unlink("/file_link");
     }
 
@@ -116,11 +124,14 @@ void test_nuttx_fs_symlink01(FAR void **state)
 
   fd = open(path, O_WRONLY | O_CREAT, 0700);
   assert_true(fd > 0);
-  test_state->fd1 = fd;
 
   /* do run test */
 
-  ret = test_nuttx_fs_run_test();
+  ret = test_nuttx_fs_runtest();
+
+  /* close file */
+
+  close(fd);
 
   /* do remove */
 

--- a/testing/testsuites/kernel/fs/cases/fs_truncate_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_truncate_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_truncate_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/testing/testsuites/kernel/fs/cases/fs_unlink_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_unlink_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_unlink_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,7 +66,8 @@ void test_nuttx_fs_unlink01(FAR void **state)
   assert_true(fd > 0);
   test_state->fd1 = fd;
 
-  char buf[MAXSIZE] = {
+  char buf[MAXSIZE] =
+  {
     0
   };
 

--- a/testing/testsuites/kernel/fs/cases/fs_write_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_write_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cases/fs_write_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/testing/testsuites/kernel/fs/cmocka_fs_test.c
+++ b/testing/testsuites/kernel/fs/cmocka_fs_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/cmocka_fs_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -29,161 +31,169 @@
 #include "fstest.h"
 
 /****************************************************************************
- * Public Functions
+ * Name: cmocka_fs_test_main
  ****************************************************************************/
 
 /****************************************************************************
- * Name: cmocka_fs_test_main
+ * Public Functions
  ****************************************************************************/
 
 int main(int argc, char *argv[])
 {
   /* Add Test Cases */
 
-  const struct CMUnitTest nuttx_fs_test_suites[] = {
+  const struct CMUnitTest nuttx_fs_test_suites[] =
+  {
       cmocka_unit_test_setup_teardown(test_nuttx_fs_creat01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_dup01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
+      /* cmocka_unit_test_setup_teardown(test_nuttx_fs_dup201,
+       * test_nuttx_fs_test_group_setup, test_nuttx_fs_test_group_teardown),
+       */
+
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fcntl01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #ifndef CONFIG_ARCH_SIM
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fcntl02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fcntl03,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #endif
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fstat01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #ifndef CONFIG_ARCH_SIM
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fstat02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #endif
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fstatfs01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fsync01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fsync02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_getfilep01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_mkdir01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_open01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_fs_open02,
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_opendir01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_opendir02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_pread01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_pwrite01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #ifndef CONFIG_ARCH_SIM
       cmocka_unit_test_setup_teardown(test_nuttx_fs_read01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #endif
       cmocka_unit_test_setup_teardown(test_nuttx_fs_readdir01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_readlink01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_rename01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_rename02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_rewinddir01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
-      cmocka_unit_test_setup_teardown(test_nuttx_fs_fmdir01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_fs_rmdir01,
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_rmdir02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_rmdir03,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_seek01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_seek02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #ifndef CONFIG_ARCH_SIM
       cmocka_unit_test_setup_teardown(test_nuttx_fs_stat01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
 #endif
       cmocka_unit_test_setup_teardown(test_nuttx_fs_statfs01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_symlink01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_truncate01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_unlink01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_write01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_write02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_write03,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_append01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_sendfile01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_sendfile02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_stream01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_stream02,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_stream03,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_stream04,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_eventfd,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_poll01,
-                                      test_nuttx_fs_fest_group_set_up,
-                                      test_nuttx_fs_test_group_tear_down),
+                                      test_nuttx_fs_test_group_setup,
+                                      test_nuttx_fs_test_group_teardown),
   };
 
   /* Run Test cases */

--- a/testing/testsuites/kernel/fs/common/test_fs_common.c
+++ b/testing/testsuites/kernel/fs/common/test_fs_common.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/common/test_fs_common.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -46,21 +48,27 @@ unsigned long long cm_get_partition_available_size(void)
 {
   unsigned long long size = 0;
   int ret;
-  struct statfs stat_info;
+  struct statfs statinfo;
 
   /* call statfs() */
 
-  ret = statfs(MOUNT_DIR, &stat_info);
+  ret = statfs(MOUNT_DIR, &statinfo);
   if (ret == 0)
     {
-      size = (unsigned long long)stat_info.f_bsize
-             * (unsigned long long)stat_info.f_bfree;
+      size = (unsigned long long)statinfo.f_bsize *
+             (unsigned long long)statinfo.f_bfree;
     }
   else
     {
       size = (unsigned long long)-1;
     }
   return size;
+}
+
+int get_mem_info(struct mallinfo *mem_info)
+{
+  *mem_info = mallinfo();
+  return 0;
 }
 
 int cm_unlink_recursive(FAR char *path)
@@ -112,10 +120,10 @@ int cm_unlink_recursive(FAR char *path)
 
   ret = closedir(dp);
   if (ret >= 0)
-  {
-    path[len] = '\0';
-    ret = rmdir(path);
-  }
+    {
+      path[len] = '\0';
+      ret = rmdir(path);
+    }
 
   return ret;
 }
@@ -125,10 +133,10 @@ int cm_unlink_recursive(FAR char *path)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_fest_group_set_up
+ * Name: test_nuttx_fs_test_group_setup
  ****************************************************************************/
 
-int test_nuttx_fs_fest_group_set_up(void **state)
+int test_nuttx_fs_test_group_setup(void **state)
 {
   int res;
   struct stat buf;
@@ -148,9 +156,10 @@ int test_nuttx_fs_fest_group_set_up(void **state)
     }
   else
     {
-      char testdir[PATH_MAX] = {
-          0
-        };
+      char testdir[PATH_MAX] =
+      {
+        0
+      };
 
       sprintf(testdir, "%s/%s", MOUNT_DIR, CM_FSTESTDIR);
 
@@ -160,7 +169,8 @@ int test_nuttx_fs_fest_group_set_up(void **state)
       res = mkdir(CM_FSTESTDIR, 0777);
       if (res != 0)
         {
-          syslog(LOG_INFO, "ERROR: Failed to creat the test directory\n");
+          syslog(LOG_INFO,
+                 "ERROR: Failed to creat the test directory\n");
           exit(1);
         }
 
@@ -178,15 +188,16 @@ int test_nuttx_fs_fest_group_set_up(void **state)
 }
 
 /****************************************************************************
- * Name: test_nuttx_fs_test_group_tear_down
+ * Name: test_nuttx_fs_testgroupteardown
  ****************************************************************************/
 
-int test_nuttx_fs_test_group_tear_down(void **state)
+int test_nuttx_fs_test_group_teardown(void **state)
 {
   int res;
-  char testdir[PATH_MAX] = {
-      0
-    };
+  char testdir[PATH_MAX] =
+  {
+    0
+  };
 
   struct fs_testsuites_state_s *test_state;
 

--- a/testing/testsuites/kernel/fs/include/fstest.h
+++ b/testing/testsuites/kernel/fs/include/fstest.h
@@ -1,27 +1,29 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/fs/include/fstest.h
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/****************************************************************************
- * Included Files
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
  ****************************************************************************/
 
 #ifndef __TEST_H
 #define __TEST_H
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
 #include <nuttx/config.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -36,14 +38,13 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
 #define TEST_PASS 0
 #define TEST_FAIL -1
 
 #define MAX_PATH 300
 
-/* The test files generated during the 'fs-test'
- * are stored in this directory
+/* The test files generated during the 'fs-test' are stored in this
+ * directory
  */
 
 #define FS_TEST_DIR "fs_test_dir"
@@ -65,145 +66,178 @@ struct fs_testsuites_state_s
 
 unsigned long long cm_get_partition_available_size(void);
 int cm_unlink_recursive(FAR char *path);
-int test_nuttx_fs_fest_group_set_up(FAR void **state);
-int test_nuttx_fs_test_group_tear_down(FAR void **state);
+int test_nuttx_fs_test_group_setup(FAR void **state);
+int test_nuttx_fs_test_group_teardown(FAR void **state);
+int get_mem_info(struct mallinfo *mem_info);
 
-/* cases/fs_creat_test.c ****************************************************/
+/* cases/fs_creat_test.c
+ * ************************************************/
 
 void test_nuttx_fs_creat01(FAR void **state);
 
-/* cases/fs_dup_test.c ******************************************************/
+/* cases/fs_dup_test.c
+ * ************************************************/
 
 void test_nuttx_fs_dup01(FAR void **state);
 
-/* cases/fs_dup2_test.c *****************************************************/
+/* cases/fs_dup2_test.c
+ * ************************************************/
 
 void test_nuttx_fs_dup201(FAR void **state);
 
-/* cases/fs_fcntl_test.c ****************************************************/
+/* cases/fs_fcntl_test.c
+ * ************************************************/
 
 void test_nuttx_fs_fcntl01(FAR void **state);
 void test_nuttx_fs_fcntl02(FAR void **state);
 void test_nuttx_fs_fcntl03(FAR void **state);
 
-/* cases/fs_fstat_test.c ****************************************************/
+/* cases/fs_fstat_test.c
+ * ************************************************/
 
 void test_nuttx_fs_fstat01(FAR void **state);
 void test_nuttx_fs_fstat02(FAR void **state);
 
-/* cases/fs_fstatfs_test.c **************************************************/
+/* cases/fs_fstatfs_test.c
+ * ************************************************/
 
 void test_nuttx_fs_fstatfs01(FAR void **state);
 
-/* cases/fs_fsync_test.c ****************************************************/
+/* cases/fs_fsync_test.c
+ * ************************************************/
 
 void test_nuttx_fs_fsync01(FAR void **state);
 void test_nuttx_fs_fsync02(FAR void **state);
 
-/* cases/fs_getfilep_test.c *************************************************/
+/* cases/fs_getfilep_test.c
+ * ************************************************/
 
 void test_nuttx_fs_getfilep01(FAR void **state);
 
-/* cases/fs_mkdir_test.c ****************************************************/
+/* cases/fs_mkdir_test.c
+ * ************************************************/
 
 void test_nuttx_fs_mkdir01(FAR void **state);
 
-/* cases/fs_open_test.c *****************************************************/
+/* cases/fs_open_test.c
+ * ************************************************/
 
 void test_nuttx_fs_open01(FAR void **state);
+void test_nuttx_fs_open02(FAR void **state);
 
-/* cases/fs_opendir_test.c **************************************************/
+/* cases/fs_opendir_test.c
+ * ************************************************/
 
 void test_nuttx_fs_opendir01(FAR void **state);
 void test_nuttx_fs_opendir02(FAR void **state);
 
-/* cases/fs_pread_test.c ****************************************************/
+/* cases/fs_pread_test.c
+ * ************************************************/
 
 void test_nuttx_fs_pread01(FAR void **state);
 
-/* cases/fs_pwrite_test.c ***************************************************/
+/* cases/fs_pwrite_test.c
+ * ************************************************/
 
 void test_nuttx_fs_pwrite01(FAR void **state);
 
-/* cases/fs_read_test.c *****************************************************/
+/* cases/fs_read_test.c
+ * ************************************************/
 
 void test_nuttx_fs_read01(FAR void **state);
 
-/* cases/fs_readdir_test.c **************************************************/
+/* cases/fs_readdir_test.c
+ * ************************************************/
 
 void test_nuttx_fs_readdir01(FAR void **state);
 
-/* cases/fs_readlink_test.c *************************************************/
+/* cases/fs_readlink_test.c
+ * ************************************************/
 
 void test_nuttx_fs_readlink01(FAR void **state);
 
-/* cases/fs_rename_test.c ***************************************************/
+/* cases/fs_rename_test.c
+ * ************************************************/
 
 void test_nuttx_fs_rename01(FAR void **state);
 void test_nuttx_fs_rename02(FAR void **state);
 
-/* cases/fs_rewinddir_test.c ************************************************/
+/* cases/fs_rewinddir_test.c
+ * ************************************************/
 
 void test_nuttx_fs_rewinddir01(FAR void **state);
 
-/* cases/fs_rmdir_test.c ****************************************************/
+/* cases/fs_rmdir_test.c
+ * ************************************************/
 
-void test_nuttx_fs_fmdir01(FAR void **state);
+void test_nuttx_fs_rmdir01(FAR void **state);
 void test_nuttx_fs_rmdir02(FAR void **state);
 void test_nuttx_fs_rmdir03(FAR void **state);
 
-/* cases/fs_seek_test.c *****************************************************/
+/* cases/fs_seek_test.c
+ * ************************************************/
 
 void test_nuttx_fs_seek01(FAR void **state);
 void test_nuttx_fs_seek02(FAR void **state);
 
-/* cases/fs_stat_test.c *****************************************************/
+/* cases/fs_stat_test.c
+ * ************************************************/
 
 void test_nuttx_fs_stat01(FAR void **state);
 
-/* cases/fs_statfs_test.c ***************************************************/
+/* cases/fs_statfs_test.c
+ * ************************************************/
 
 void test_nuttx_fs_statfs01(FAR void **state);
 
-/* cases/fs_symlink_test.c **************************************************/
+/* cases/fs_symlink_test.c
+ * ************************************************/
 
 void test_nuttx_fs_symlink01(FAR void **state);
 
-/* cases/fs_truncate_test.c *************************************************/
+/* cases/fs_truncate_test.c
+ * ************************************************/
 
 void test_nuttx_fs_truncate01(FAR void **state);
 
-/* cases/fs_unlink_test.c ***************************************************/
+/* cases/fs_unlink_test.c
+ * ************************************************/
 
 void test_nuttx_fs_unlink01(FAR void **state);
 
-/* cases/fs_write_test.c ****************************************************/
+/* cases/fs_write_test.c
+ * ************************************************/
 
 void test_nuttx_fs_write01(FAR void **state);
 void test_nuttx_fs_write02(FAR void **state);
 void test_nuttx_fs_write03(FAR void **state);
 
-/* cases/fs_append_test.c ***************************************************/
+/* cases/fs_append_test.c
+ * ************************************************/
 
 void test_nuttx_fs_append01(FAR void **state);
 
-/* cases/fs_sendfile_test.c *************************************************/
+/* cases/fs_sendfile_test.c
+ * ************************************************/
 
 void test_nuttx_fs_sendfile01(FAR void **state);
 void test_nuttx_fs_sendfile02(FAR void **state);
 
-/* cases/fs_stream_test.c ***************************************************/
+/* cases/fs_stream_test.c
+ * ************************************************/
 
 void test_nuttx_fs_stream01(FAR void **state);
 void test_nuttx_fs_stream02(FAR void **state);
 void test_nuttx_fs_stream03(FAR void **state);
 void test_nuttx_fs_stream04(FAR void **state);
 
-/* cases/fs_eventfd_test.c **************************************************/
+/* cases/fs_eventfd_test.c
+ * ************************************************/
 
 void test_nuttx_fs_eventfd(FAR void **state);
 
-/* fs_poll_test.c ***********************************************************/
+/* fs_poll_test.c
+ * ************************************************/
 
 void test_nuttx_fs_poll01(FAR void **state);
 

--- a/testing/testsuites/kernel/mm/cases/mm_test_001.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_001.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -38,12 +37,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm01
+ * Name: test_nuttx_mm01
  ****************************************************************************/
 
 void test_nuttx_mm01(FAR void **state)
 {
-  int i = 0;
+  int i;
   int flag = 0;
   char *pm1;
   char *pm2;

--- a/testing/testsuites/kernel/mm/cases/mm_test_002.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_002.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -38,12 +37,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm02
+ * Name: test_nuttx_mm02
  ****************************************************************************/
 
 void test_nuttx_mm02(FAR void **state)
 {
-  int i = 0;
+  int i;
   int flag = 0;
   char *pm1;
   char *pm2;
@@ -63,7 +62,7 @@ void test_nuttx_mm02(FAR void **state)
 
   pm2 = pm1;
   for (i = 0; i < memsize; i++)
-      *pm2++ = 'X';
+    *pm2++ = 'X';
   pm2 = pm1;
   for (i = 0; i < memsize; i++)
     {

--- a/testing/testsuites/kernel/mm/cases/mm_test_003.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_003.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -38,7 +37,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm03
+ * Name: test_nuttx_mm03
  ****************************************************************************/
 
 void test_nuttx_mm03(FAR void **state)

--- a/testing/testsuites/kernel/mm/cases/mm_test_004.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_004.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -39,7 +38,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm04
+ * Name: test_nuttx_mm04
  ****************************************************************************/
 
 void test_nuttx_mm04(FAR void **state)

--- a/testing/testsuites/kernel/mm/cases/mm_test_005.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_005.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -43,14 +42,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm05
+ * Name: test_nuttx_mm05
  ****************************************************************************/
 
 void test_nuttx_mm05(FAR void **state)
 {
-  int i = 0;
+  int i;
   int flag = 0;
-  char *ptr = NULL;
+  char *ptr;
   char *temp_ptr = NULL;
 
   ptr = temp_ptr = zalloc(1024 * sizeof(char));

--- a/testing/testsuites/kernel/mm/cases/mm_test_006.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_006.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -52,7 +51,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm06
+ * Name: test_nuttx_mm06
  ****************************************************************************/
 
 void test_nuttx_mm06(FAR void **state)
@@ -68,7 +67,8 @@ void test_nuttx_mm06(FAR void **state)
 
       /* Produces a random size */
 
-      malloc_size = mmtest_get_rand_size(MALLOC_MIN_SIZE, MALLOC_MAX_SIZE);
+      malloc_size =
+          mmtest_get_rand_size(MALLOC_MIN_SIZE, MALLOC_MAX_SIZE);
       address_ptr = (char *)malloc(malloc_size * sizeof(char));
       assert_non_null(address_ptr);
       memset(address_ptr, check_character, malloc_size);

--- a/testing/testsuites/kernel/mm/cases/mm_test_007.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_007.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -55,7 +54,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm07
+ * Name: test_nuttx_mm07
  ****************************************************************************/
 
 void test_nuttx_mm07(FAR void **state)
@@ -69,7 +68,8 @@ void test_nuttx_mm07(FAR void **state)
   struct mallinfo test_befor_info;
   struct mallinfo test_during_info;
   struct mallinfo test_after_info;
-
+  struct mallinfo mem_info;
+  memset(&mem_info, 0, sizeof(mem_info));
   for (int i = 0; i < MEMORY_LIST_LENGTH; i++)
     {
       mem_list[i] = NULL;
@@ -79,13 +79,30 @@ void test_nuttx_mm07(FAR void **state)
 
   /* get a random size */
 
-  malloc_size = mmtest_get_rand_size(MALLOC_MIN_SIZE, MALLOC_MAX_SIZE);
   for (int k = 0; k < MEMORY_LIST_LENGTH; k++)
     {
+      get_mem_info(&mem_info);
+      malloc_size =
+          mmtest_get_rand_size(MALLOC_MIN_SIZE, MALLOC_MAX_SIZE);
+      if (mem_info.mxordblk - 16 < 0)
+        {
+          syslog(LOG_INFO,
+                 "TEST END because of the mem_info.mxordblk is:%d",
+                 mem_info.mxordblk);
+          break;
+        }
+
+      if (malloc_size > mem_info.mxordblk - 16)
+        {
+          syslog(LOG_INFO, "SET memsize to:%d", mem_info.mxordblk - 16);
+          malloc_size = mem_info.mxordblk - 16;
+        }
+
       if (malloc_size > 0)
         {
           tmp_str = (char *)malloc(malloc_size * sizeof(char));
         }
+
       else
         {
           malloc_size = 512;

--- a/testing/testsuites/kernel/mm/cases/mm_test_008.c
+++ b/testing/testsuites/kernel/mm/cases/mm_test_008.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -39,9 +38,6 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <malloc.h>
-
-#include <nuttx/sched.h>
-
 #include "MmTest.h"
 
 /****************************************************************************
@@ -55,11 +51,7 @@
 #define MALLOC_MIN_SIZE 32
 #define MALLOC_MAX_SIZE 2048
 
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-static int test_nuttx08_routine_1(int argc, char *argv[])
+static int test_nuttx_08_routine_1(int argc, char *argv[])
 {
   char *ptr = NULL;
   char *tmp_ptr = NULL;
@@ -94,7 +86,7 @@ static int test_nuttx08_routine_1(int argc, char *argv[])
   return 0;
 }
 
-static int test_nuttx08_routine_2(int argc, char *argv[])
+static int test_nuttx_08_routine_2(int argc, char *argv[])
 {
   char *temp_ptr = NULL;
   int flag = 0;
@@ -118,15 +110,32 @@ static int test_nuttx08_routine_2(int argc, char *argv[])
   return 0;
 }
 
-static int test_nuttx08_routine_3(int argc, char *argv[])
+static int test_nuttx_08_routine_3(int argc, char *argv[])
 {
   char *pm;
   unsigned long memsize;
+  struct mallinfo mem_info;
+  memset(&mem_info, 0, sizeof(mem_info));
   for (int i = 0; i < 500; i++)
     {
       /* Apply for as much memory as a system allows */
 
+      get_mem_info(&mem_info);
       memsize = mmtest_get_rand_size(1024, 2048);
+      if (mem_info.mxordblk - 16 < 0)
+        {
+          syslog(LOG_INFO,
+                 "TEST END because of the mem_info.mxordblk is:%d",
+                 mem_info.mxordblk);
+          break;
+        }
+
+      if (memsize > mem_info.mxordblk - 16)
+        {
+          syslog(LOG_INFO, "SET memsize to:%d", mem_info.mxordblk - 16);
+          memsize = mem_info.mxordblk - 16;
+        }
+
       pm = malloc(memsize);
       assert_non_null(pm);
       free(pm);
@@ -140,7 +149,7 @@ static int test_nuttx08_routine_3(int argc, char *argv[])
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMm08
+ * Name: test_nuttx_mm08
  ****************************************************************************/
 
 void test_nuttx_mm08(FAR void **state)
@@ -148,14 +157,14 @@ void test_nuttx_mm08(FAR void **state)
   pid_t pid;
   int status;
 
-  pid = task_create("TestNuttx08_routine_1",
-             TASK_PRIORITY, DEFAULT_STACKSIZE, test_nuttx08_routine_1, NULL);
+  pid = task_create("test_nuttx_08_routine_1", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, test_nuttx_08_routine_1, NULL);
   assert_true(pid > 0);
-  pid = task_create("TestNuttx08_routine_2",
-             TASK_PRIORITY, DEFAULT_STACKSIZE, test_nuttx08_routine_2, NULL);
+  pid = task_create("test_nuttx_08_routine_2", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, test_nuttx_08_routine_2, NULL);
   assert_true(pid > 0);
-  pid = task_create("TestNuttx08_routine_3",
-             TASK_PRIORITY, DEFAULT_STACKSIZE, test_nuttx08_routine_3, NULL);
+  pid = task_create("test_nuttx_08_routine_3", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, test_nuttx_08_routine_3, NULL);
   assert_true(pid > 0);
   waitpid(pid, &status, 0);
 }

--- a/testing/testsuites/kernel/mm/cmocka_mm_test.c
+++ b/testing/testsuites/kernel/mm/cmocka_mm_test.c
@@ -1,19 +1,22 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/mm/cmocka_mm_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
@@ -31,7 +34,7 @@
 #include <cmocka.h>
 
 /****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
@@ -42,31 +45,24 @@ int main(int argc, char *argv[])
 {
   /* Add Test Cases */
 
-  const struct CMUnitTest nuttx_mm_test_suites[] = {
-      cmocka_unit_test_setup_teardown(test_nuttx_mm01,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm02,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm03,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm04,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm05,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm06,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm07,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_mm08,
-                                      test_nuttx_mmsetup,
-                                      test_nuttx_mmteardown),
+  const struct CMUnitTest nuttx_mm_test_suites[] =
+  {
+      cmocka_unit_test_setup_teardown(test_nuttx_mm01, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm02, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm03, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm04, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm05, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm06, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm07, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
+      cmocka_unit_test_setup_teardown(test_nuttx_mm08, test_nuttx_mm_setup,
+                                      test_nuttx_mm_teardown),
   };
 
   /* Run Test cases */

--- a/testing/testsuites/kernel/mm/common/test_mm_common.c
+++ b/testing/testsuites/kernel/mm/common/test_mm_common.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/mm/common/test_mm_common.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <malloc.h>
@@ -45,7 +47,7 @@ int mmtest_get_rand_size(int min, int max)
   int rval = 1;
   if (min > 0 && max > 0 && (max - min) > 0)
     {
-    rval = rand() % (max - min) + min;
+      rval = rand() % (max - min) + min;
     }
 
   return rval;
@@ -61,15 +63,15 @@ void mmtest_showmallinfo(void)
   alloc_info = mallinfo();
   syslog(LOG_INFO, "     mallinfo:\n");
   syslog(LOG_INFO, "       Total space allocated from system = %lu\n",
-        (unsigned long)alloc_info.arena);
+         (unsigned long)alloc_info.arena);
   syslog(LOG_INFO, "       Number of non-inuse chunks        = %lu\n",
-        (unsigned long)alloc_info.ordblks);
+         (unsigned long)alloc_info.ordblks);
   syslog(LOG_INFO, "       Largest non-inuse chunk           = %lu\n",
-        (unsigned long)alloc_info.mxordblk);
+         (unsigned long)alloc_info.mxordblk);
   syslog(LOG_INFO, "       Total allocated space             = %lu\n",
-        (unsigned long)alloc_info.uordblks);
+         (unsigned long)alloc_info.uordblks);
   syslog(LOG_INFO, "       Total non-inuse space             = %lu\n",
-        (unsigned long)alloc_info.fordblks);
+         (unsigned long)alloc_info.fordblks);
 }
 
 /****************************************************************************
@@ -93,7 +95,7 @@ unsigned long mmtest_get_memsize(void)
 
   if (memsize > 1024 * 1024 * 2)
     {
-        memsize = 1024 * 1024 * 2;
+      memsize = 1024 * 1024 * 2;
     }
 
   return memsize;
@@ -105,19 +107,19 @@ unsigned long mmtest_get_memsize(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxMmsetup
+ * Name: test_nuttx_mm_setup
  ****************************************************************************/
 
-int test_nuttx_mmsetup(void **state)
+int test_nuttx_mm_setup(void **state)
 {
   return 0;
 }
 
 /****************************************************************************
- * Name: TestNuttxMmteardown
+ * Name: test_nuttx_mm_teardown
  ****************************************************************************/
 
-int test_nuttx_mmteardown(void **state)
+int test_nuttx_mm_teardown(void **state)
 {
   return 0;
 }

--- a/testing/testsuites/kernel/mm/include/MmTest.h
+++ b/testing/testsuites/kernel/mm/include/MmTest.h
@@ -1,19 +1,22 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/mm/include/MmTest.h
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 #ifndef __SYSCALLTEST_H
 #define __SYSCALLTEST_H
@@ -21,15 +24,14 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <malloc.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
 #define PTHREAD_STACK_SIZE CONFIG_DEFAULT_TASK_STACKSIZE
 #define DEFAULT_STACKSIZE CONFIG_DEFAULT_TASK_STACKSIZE
 #define TASK_PRIORITY SCHED_PRIORITY_DEFAULT
@@ -41,41 +43,55 @@
 int mmtest_get_rand_size(int min, int max);
 void mmtest_showmallinfo(void);
 unsigned long mmtest_get_memsize(void);
+static int __attribute__((unused))
+get_mem_info(struct mallinfo *mem_info)
+{
+  *mem_info = mallinfo();
+  return 0;
+}
 
-int test_nuttx_mmsetup(void **state);
-int test_nuttx_mmteardown(void **state);
+int test_nuttx_mm_setup(void **state);
+int test_nuttx_mm_teardown(void **state);
 
 /* test case function */
 
-/* cases/mm_test_001.c ******************************************************/
+/* cases/mm_test_001.c
+ * *****************************************************/
 
 void test_nuttx_mm01(FAR void **state);
 
-/* cases/mm_test_002.c ******************************************************/
+/* cases/mm_test_002.c
+ * *****************************************************/
 
 void test_nuttx_mm02(FAR void **state);
 
-/* cases/mm_test_003.c ******************************************************/
+/* cases/mm_test_003.c
+ * *****************************************************/
 
 void test_nuttx_mm03(FAR void **state);
 
-/* cases/mm_test_004.c ******************************************************/
+/* cases/mm_test_004.c
+ * *****************************************************/
 
 void test_nuttx_mm04(FAR void **state);
 
-/* cases/mm_test_005.c ******************************************************/
+/* cases/mm_test_005.c
+ * *****************************************************/
 
 void test_nuttx_mm05(FAR void **state);
 
-/* cases/mm_test_006.c ******************************************************/
+/* cases/mm_test_006.c
+ * *****************************************************/
 
 void test_nuttx_mm06(FAR void **state);
 
-/* cases/mm_test_007.c ******************************************************/
+/* cases/mm_test_007.c
+ * *****************************************************/
 
 void test_nuttx_mm07(FAR void **state);
 
-/* cases/mm_test_008.c ******************************************************/
+/* cases/mm_test_008.c
+ * *****************************************************/
 
 void test_nuttx_mm08(FAR void **state);
 

--- a/testing/testsuites/kernel/mm/tool/mem_batch_opt_perf_test.c
+++ b/testing/testsuites/kernel/mm/tool/mem_batch_opt_perf_test.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -42,8 +41,9 @@
 
 static void show_usage(void)
 {
-  printf("\nUsage: mm_stress_test  <min_size> \
-         <max_size>  <list_length> <test_num>\n");
+  printf(
+      "\nUsage: mm_stress_test  <min_size>  <max_size>  <list_length> "
+      "<test_num>\n");
   printf("\nWhere:\n");
   printf("  <min_size>    Minimum number of memory requests.\n");
   printf("  <max_size>    Maximum number of memory requests.\n");
@@ -52,18 +52,16 @@ static void show_usage(void)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: main
  ****************************************************************************/
 
 int main(int argc, FAR char *argv[])
 {
   int malloc_size = 0;
-  int mallc_min_size; /* The minimum memory length requested in the test */
-  int mallc_max_size; /* The maximum memory length requested in the test */
+  int mallc_min_size; /* The minimum memory length requested in the test
+                       */
+  int mallc_max_size; /* The maximum memory length requested in the test
+                       */
   int list_length;
   int test_num = 1;
   struct timespec t_start;
@@ -96,29 +94,32 @@ int main(int argc, FAR char *argv[])
       for (int i = 0; i < list_length; i++)
         {
           srand(i + gettid());
-          malloc_size = mmtest_get_rand_size(mallc_min_size, mallc_max_size);
+          malloc_size =
+              mmtest_get_rand_size(mallc_min_size, mallc_max_size);
 
           clock_gettime(CLOCK_MONOTONIC, &t_start);
           address_ptr = (char *)malloc(malloc_size * sizeof(char));
           clock_gettime(CLOCK_MONOTONIC, &t_end);
-          timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec)
-                     + (t_end.tv_nsec - t_start.tv_nsec) / 1000;
+          timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec) +
+                    (t_end.tv_nsec - t_start.tv_nsec) / 1000;
           if (address_ptr != NULL)
             {
               syslog(LOG_INFO,
-                     "[Test %d Round] Allocate success -> mem_list[%d]"
-                     " (address:%p size:%d) takes:%ld microseconds\n",
-              n, i, address_ptr, malloc_size, timedif);
+                     "[Test %d Round] Allocate success -> mem_list[%d] "
+                     "(address:%p size:%d) takes:%ld microseconds\n",
+                     n, i, address_ptr, malloc_size, timedif);
               memset(address_ptr, 0x67, malloc_size);
 
               /* Add to list */
 
               mem_list[i] = address_ptr;
             }
+
           else
             {
               syslog(LOG_ERR,
-              "Malloc failed ! The remaining memory may be insufficient\n");
+                     "Malloc failed ! The remaining memory may be "
+                     "insufficient\n");
               syslog(LOG_ERR, "Continue to test !!\n");
 
               /* Memory allocation failure */
@@ -136,11 +137,11 @@ int main(int argc, FAR char *argv[])
               clock_gettime(CLOCK_MONOTONIC, &t_start);
               free(address_ptr);
               clock_gettime(CLOCK_MONOTONIC, &t_end);
-              timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec)
-                        + (t_end.tv_nsec - t_start.tv_nsec) / 1000;
+              timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec) +
+                        (t_end.tv_nsec - t_start.tv_nsec) / 1000;
               syslog(LOG_INFO,
-                     "[Test %d Round] Free -> mem_list[%d] (size:%d)"
-                     " takes:%ld microseconds\n",
+                     "[Test %d Round] Free -> mem_list[%d] (size:%d) "
+                     "takes:%ld microseconds\n",
                      n, k, malloc_size, timedif);
               mem_list[k] = NULL;
             }

--- a/testing/testsuites/kernel/mm/tool/mem_cycle_opt_perf_test.c
+++ b/testing/testsuites/kernel/mm/tool/mem_cycle_opt_perf_test.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -42,8 +41,9 @@
 
 static void show_usage(void)
 {
-  printf("\nUsage: mm_stress_test  <min_size>  \
-          <max_size>  <test_num> <delay_time>\n");
+  printf(
+      "\nUsage: mm_stress_test  <min_size>  <max_size>  <test_num> "
+      "<delay_time>\n");
   printf("\nWhere:\n");
   printf("  <min_size>    Minimum number of memory requests.\n");
   printf("  <max_size>    Maximum number of memory requests.\n");
@@ -52,21 +52,22 @@ static void show_usage(void)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: main
  ****************************************************************************/
 
 int main(int argc, FAR char *argv[])
 {
   int malloc_size;
-  int mallc_min_size; /* The minimum memory length requested in the test */
-  int mallc_max_size; /* The maximum memory length requested in the test */
+  int mallc_min_size; /* The minimum memory length requested in the test
+                       */
+  int mallc_max_size; /* The maximum memory length requested in the test
+                       */
   int test_num;
   int application_delay_time = 1; /* Delay in test */
-  char check_character;           /* Memory write content check character */
+
+  /* Memory write content check character */
+
+  char check_character;
   char *address_ptr = NULL;
   struct timespec t_start;
   struct timespec t_end;
@@ -92,19 +93,22 @@ int main(int argc, FAR char *argv[])
       clock_gettime(CLOCK_MONOTONIC, &t_start);
       address_ptr = (char *)malloc(malloc_size * sizeof(char));
       clock_gettime(CLOCK_MONOTONIC, &t_end);
-      timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec)
-                + (t_end.tv_nsec - t_start.tv_nsec) / 1000;
+      timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec) +
+                (t_end.tv_nsec - t_start.tv_nsec) / 1000;
       if (address_ptr != NULL)
         {
           syslog(LOG_INFO,
-          "[Test malloc] (address:%p size:%d) takes:%ld microseconds\n",
-          address_ptr, malloc_size, timedif);
+                 "[Test malloc] (address:%p size:%d) takes:%ld "
+                 "microseconds\n",
+                 address_ptr, malloc_size, timedif);
           memset(address_ptr, check_character, malloc_size);
         }
+
       else
         {
           syslog(LOG_ERR,
-          "Malloc failed ! The remaining memory may be insufficient\n");
+                 "Malloc failed ! The remaining memory may be "
+                 "insufficient\n");
           syslog(LOG_ERR, "Continue to test !!\n");
           continue;
         }
@@ -126,11 +130,12 @@ int main(int argc, FAR char *argv[])
       /* Free test memory */
 
       clock_gettime(CLOCK_MONOTONIC, &t_end);
-      timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec)
-                + (t_end.tv_nsec - t_start.tv_nsec) / 1000;
-      syslog(LOG_INFO,
-             "[Test free] (address:%p size:%d) takes:%ld microseconds\n\n",
-             address_ptr, malloc_size, timedif);
+      timedif = 1000000 * (t_end.tv_sec - t_start.tv_sec) +
+                (t_end.tv_nsec - t_start.tv_nsec) / 1000;
+      syslog(
+          LOG_INFO,
+          "[Test free] (address:%p size:%d) takes:%ld microseconds\n\n",
+          address_ptr, malloc_size, timedif);
       free(address_ptr);
       usleep(application_delay_time);
     }

--- a/testing/testsuites/kernel/mutex/cases/posix_mutex_test_001.c
+++ b/testing/testsuites/kernel/mutex/cases/posix_mutex_test_001.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/mutex/cases/posix_mutex_test_001.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "MutexTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_mutex_test01
+ ****************************************************************************/
+
+void test_nuttx_mutex_test01(FAR void **state)
+{
+  pthread_mutexattr_t mta;
+  int rc;
+
+  /* Initialize a mutex attributes object */
+
+  rc = pthread_mutexattr_init(&mta);
+  syslog(LOG_INFO, "rc : %d\n", rc);
+  assert_int_equal(rc, 0);
+
+  rc = pthread_mutexattr_destroy(&mta);
+  syslog(LOG_INFO, "rc : %d\n", rc);
+  assert_int_equal(rc, 0);
+}

--- a/testing/testsuites/kernel/mutex/cases/posix_mutex_test_019.c
+++ b/testing/testsuites/kernel/mutex/cases/posix_mutex_test_019.c
@@ -1,0 +1,276 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/mutex/cases/posix_mutex_test_019.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "MutexTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+static pthread_mutex_t *g_mtx;
+static sem_t g_sema;
+static sem_t g_semb;
+static pthread_mutex_t g_mtxnull;
+static pthread_mutex_t g_mtxdef;
+static int g_testmutexretval;
+static UINT32 g_testmutexcount;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+static void *taskf01(void *arg)
+{
+  int ret;
+
+  /* testbusytaskdelay(20); */
+
+  usleep(50000);
+  g_testmutexcount++;
+
+  if ((ret = pthread_mutex_lock(g_mtx)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      goto EXIT;
+    }
+
+  if ((ret = sem_post(&g_sema)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      goto EXIT;
+    }
+
+  if ((ret = sem_wait(&g_semb)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      goto EXIT;
+    }
+
+  if (g_testmutexretval != 0)
+    {
+      /* parent thread failed to unlock the mutex) */
+
+      if ((ret = pthread_mutex_unlock(g_mtx)))
+        {
+          syslog(LOG_INFO, "ret: %d \n", ret);
+          goto EXIT;
+        }
+    }
+
+  g_testmutexcount++;
+  return NULL;
+
+EXIT:
+  assert_int_equal(1, 0);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: test_nuttx_mutex_test19
+ ****************************************************************************/
+
+void test_nuttx_mutex_test19(FAR void **state)
+{
+  pthread_mutexattr_t mattr;
+  pthread_t thr;
+
+  pthread_mutex_t *tabmutex[2];
+  int tabres[2][3] =
+  {
+    {
+      0, 0, 0
+    },
+    {
+      0, 0, 0
+    }
+  };
+
+  int ret;
+  void *thret = NULL;
+  int i;
+  g_testmutexretval = 0;
+  g_testmutexcount = 0;
+
+  /* We first initialize the two mutexes. */
+
+  if ((ret = pthread_mutex_init(&g_mtxnull, NULL)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      assert_int_equal(1, 0);
+    }
+
+  if ((ret = pthread_mutexattr_init(&mattr)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      assert_int_equal(1, 0);
+    }
+
+  if ((ret = pthread_mutex_init(&g_mtxdef, &mattr)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      assert_int_equal(1, 0);
+    }
+
+  if ((ret = pthread_mutexattr_destroy(&mattr)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      assert_int_equal(1, 0);
+    }
+
+  tabmutex[0] = &g_mtxnull;
+  tabmutex[1] = &g_mtxdef;
+
+  if ((ret = sem_init(&g_sema, 0, 0)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      assert_int_equal(1, 0);
+    }
+
+  if ((ret = sem_init(&g_semb, 0, 0)))
+    {
+      syslog(LOG_INFO, "ret: %d \n", ret);
+      assert_int_equal(1, 0);
+    }
+
+  /* OK let's go for the first part of the test : abnormals unlocking */
+
+  /* We first check if unlocking an unlocked mutex returns an uwErr. */
+
+  ret = pthread_mutex_unlock(tabmutex[0]);
+  syslog(LOG_INFO, "ret: %d \n", ret);
+  assert_int_not_equal(ret, ENOERR);
+
+  ret = pthread_mutex_unlock(tabmutex[1]);
+  syslog(LOG_INFO, "ret: %d \n", ret);
+  assert_int_not_equal(ret, ENOERR);
+
+  /* Now we focus on unlocking a mutex lock by another thread */
+
+  for (i = 0; i < 2; i++)
+    {
+      /* 2, Set the timeout of runtime */
+
+      g_mtx = tabmutex[i];
+      tabres[i][0] = 0;
+      tabres[i][1] = 0;
+      tabres[i][2] = 0; /* 2, buffer index. */
+
+      if ((ret = pthread_create(&thr, NULL, taskf01, NULL)))
+        {
+          syslog(LOG_INFO, "ret: %d \n", ret);
+          assert_int_equal(1, 0);
+        }
+
+      if (i == 0)
+        {
+          syslog(LOG_INFO, "g_testmutexcount: %d \n", g_testmutexcount);
+          assert_int_equal(g_testmutexcount, 0);
+        }
+
+      if (i == 1)
+        {
+          syslog(LOG_INFO, "g_testmutexcount: %d \n", g_testmutexcount);
+          assert_int_equal(g_testmutexcount,
+                           2); /* 2, Here, assert the g_testmutexcount. */
+        }
+
+      if ((ret = sem_wait(&g_sema)))
+        {
+          syslog(LOG_INFO, "ret: %d \n", ret);
+          assert_int_equal(1, 0);
+        }
+
+      g_testmutexretval = pthread_mutex_unlock(g_mtx);
+      syslog(LOG_INFO, "g_testmutexretval: %d \n", g_testmutexretval);
+      assert_int_equal(g_testmutexretval, EPERM);
+
+      if (i == 0)
+        {
+          syslog(LOG_INFO, "g_testmutexcount: %d \n", g_testmutexcount);
+          assert_int_equal(g_testmutexcount, 1);
+        }
+
+      if (i == 1)
+        {
+          syslog(LOG_INFO, "g_testmutexcount: %d \n", g_testmutexcount);
+          assert_int_equal(g_testmutexcount,
+                           3); /* 3, Here, assert the g_testmutexcount. */
+        }
+
+      if ((ret = sem_post(&g_semb)))
+        {
+          syslog(LOG_INFO, "ret: %d \n", ret);
+          assert_int_equal(1, 0);
+        }
+
+      if ((ret = pthread_join(thr, &thret)))
+        {
+          syslog(LOG_INFO, "ret: %d \n", ret);
+          assert_int_equal(1, 0);
+        }
+
+      if (i == 0)
+        {
+          syslog(LOG_INFO, "g_testmutexcount: %d \n", g_testmutexcount);
+          assert_int_equal(g_testmutexcount,
+                           2); /* 2, Here, assert the g_testmutexcount. */
+        }
+
+      if (i == 1)
+        {
+          syslog(LOG_INFO, "g_testmutexcount: %d \n", g_testmutexcount);
+          assert_int_equal(g_testmutexcount,
+                           4); /* 4, Here, assert the g_testmutexcount. */
+        }
+
+      tabres[i][0] = g_testmutexretval;
+    }
+
+  if (tabres[0][0] != tabres[1][0])
+    {
+      assert_int_equal(1, 0);
+    }
+
+  /* We start with testing the NULL mutex features */
+
+  (void)pthread_mutexattr_destroy(&mattr);
+  ret = pthread_mutex_destroy(&g_mtxnull);
+  syslog(LOG_INFO, "ret: %d \n", ret);
+  assert_int_equal(ret, 0);
+
+  ret = pthread_mutex_destroy(&g_mtxdef);
+  syslog(LOG_INFO, "ret: %d \n", ret);
+  assert_int_equal(ret, 0);
+
+  ret = sem_destroy(&g_sema);
+  syslog(LOG_INFO, "ret: %d \n", ret);
+  assert_int_equal(ret, 0);
+
+  ret = sem_destroy(&g_semb);
+  syslog(LOG_INFO, "ret: %d \n", ret);
+  assert_int_equal(ret, 0);
+}

--- a/testing/testsuites/kernel/mutex/cases/posix_mutex_test_020.c
+++ b/testing/testsuites/kernel/mutex/cases/posix_mutex_test_020.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/mutex/cases/posix_mutex_test_020.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "MutexTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_mutex_test20
+ ****************************************************************************/
+
+void test_nuttx_mutex_test20(FAR void **state)
+{
+  pthread_mutex_t mutex;
+  int rc;
+
+  /* Initialize a mutex object */
+
+  rc = pthread_mutex_init(&mutex, NULL);
+  syslog(LOG_INFO, "rc : %d\n", rc);
+  assert_int_equal(rc, ENOERR);
+
+  /* Acquire the mutex object using pthread_mutex_lock */
+
+  if ((rc = pthread_mutex_lock(&mutex)))
+    {
+      syslog(LOG_INFO, "rc: %d \n", rc);
+      goto EXIT1;
+    }
+
+  sleep(1);
+
+  /* Release the mutex object using pthread_mutex_unlock */
+
+  if ((rc = pthread_mutex_unlock(&mutex)))
+    {
+      syslog(LOG_INFO, "rc: %d \n", rc);
+      goto EXIT2;
+    }
+
+  /* Destroy the mutex object */
+
+  if ((rc = pthread_mutex_destroy(&mutex)))
+    {
+      syslog(LOG_INFO, "rc: %d \n", rc);
+      goto EXIT1;
+    }
+
+  return;
+
+EXIT2:
+  pthread_mutex_unlock(&mutex);
+  assert_int_equal(1, 0);
+
+EXIT1:
+  pthread_mutex_destroy(&mutex);
+  assert_int_equal(1, 0);
+  return;
+}

--- a/testing/testsuites/kernel/mutex/cmocka_mutex_test.c
+++ b/testing/testsuites/kernel/mutex/cmocka_mutex_test.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/mutex/cmocka_mutex_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "MutexTest.h"
+#include <cmocka.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cmocka_sched_test_main
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+  /* Add Test Cases */
+
+  const struct CMUnitTest nuttx_mutex_test_suites[] =
+  {
+      cmocka_unit_test_setup_teardown(test_nuttx_mutex_test01, NULL, NULL),
+#ifdef CONFIG_PTHREAD_MUTEX_ROBUST
+      cmocka_unit_test_setup_teardown(test_nuttx_mutex_test19, NULL, NULL),
+#endif
+      cmocka_unit_test_setup_teardown(test_nuttx_mutex_test20, NULL, NULL),
+  };
+
+  /* Run Test cases */
+
+  cmocka_run_group_tests(nuttx_mutex_test_suites, NULL, NULL);
+
+  return 0;
+}

--- a/testing/testsuites/kernel/mutex/include/MutexTest.h
+++ b/testing/testsuites/kernel/mutex/include/MutexTest.h
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/mutex/include/MutexTest.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+#ifndef PTHREAD_TEST_H
+#define PTHREAD_TEST_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <syslog.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "sched.h"
+#include "semaphore.h"
+#include "unistd.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define MUTEX_TEST_NUM 100
+#define ENOERR 0
+typedef unsigned int UINT32;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* test case function */
+
+/* cases/posix_mutex_test_001.c
+ * ************************************************/
+
+void test_nuttx_mutex_test01(FAR void **state);
+
+/* cases/posix_mutex_test_019.c
+ * ************************************************/
+
+void test_nuttx_mutex_test19(FAR void **state);
+
+/* cases/posix_mutex_test_020.c
+ * ************************************************/
+
+void test_nuttx_mutex_test20(FAR void **state);
+#endif

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_003.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_003.c
@@ -3,30 +3,28 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <stdint.h>
-
 #include "PthreadTest.h"
 
 /****************************************************************************
@@ -37,19 +35,19 @@
  * Public Functions
  ****************************************************************************/
 
-static void *thread_f01(void *arg)
+static void *threadf01(void *arg)
 {
   pthread_exit(NULL);
   return NULL;
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest03
+ * Name: test_nuttx_pthread_test03
  ****************************************************************************/
 
 void test_nuttx_pthread_test03(FAR void **state)
 {
-  pthread_t a_thread;
+  pthread_t athread;
   pthread_t ptid;
   pthread_t a = 0;
   pthread_t b = 0;
@@ -65,7 +63,7 @@ void test_nuttx_pthread_test03(FAR void **state)
   ptid = pthread_self();
   syslog(LOG_INFO, "ptid: %d \n", ptid);
   assert_int_not_equal(ptid, 0);
-  pthread_create(&a_thread, NULL, thread_f01, NULL);
+  pthread_create(&athread, NULL, threadf01, NULL);
 
   tmp = pthread_equal(a, b);
   syslog(LOG_INFO, "ret: %d\n", tmp);
@@ -83,7 +81,7 @@ void test_nuttx_pthread_test03(FAR void **state)
 
   pthread_attr_destroy(&aa);
 
-  ret = pthread_join(a_thread, NULL);
+  ret = pthread_join(athread, NULL);
   syslog(LOG_INFO, "ret of pthread_join: %d\n", ret);
   assert_int_equal(ret, 0);
 }

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_004.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_004.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -37,24 +36,24 @@
  * Public Functions
  ****************************************************************************/
 
-static void *thread_f01(void *arg)
+static void *threadf01(void *arg)
 {
   pthread_exit((void *)2); /* 2, here set value of the exit status. */
   return NULL;
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest04
+ * Name: test_nuttx_pthread_test04
  ****************************************************************************/
 
 void test_nuttx_pthread_test04(FAR void **state)
 {
-  pthread_t main_th;
-  pthread_t new_th;
+  pthread_t mainth;
+  pthread_t newth;
   UINT32 ret;
   UINTPTR temp;
 
-  if (pthread_create(&new_th, NULL, thread_f01, NULL) != 0)
+  if (pthread_create(&newth, NULL, threadf01, NULL) != 0)
     {
       printf("Error creating thread\n");
       assert_int_equal(1, 0);
@@ -62,17 +61,17 @@ void test_nuttx_pthread_test04(FAR void **state)
 
   usleep(1000);
 
-  /* LOS_TaskDelay(1);
-   * Obtain the thread ID of this main function
-   */
+  /* los_taskdelay(1); */
 
-  main_th = test_pthread_self();
+  /* Obtain the thread ID of this main function */
+
+  mainth = testpthreadself();
 
   /* Compare the thread ID of the new thread to the main thread.
    * They should be different.  If not, the test fails.
    */
 
-  if (pthread_equal(new_th, main_th) != 0)
+  if (pthread_equal(newth, mainth) != 0)
     {
       printf("Test FAILED: A new thread wasn't created\n");
       assert_int_equal(1, 0);
@@ -80,9 +79,9 @@ void test_nuttx_pthread_test04(FAR void **state)
 
   usleep(1000);
 
-  /* TestExtraTaskDelay(1); */
+  /* testextrataskdelay(1); */
 
-  ret = pthread_join(new_th, (void *)&temp);
+  ret = pthread_join(newth, (void *)&temp);
   syslog(LOG_INFO, "ret: %d \n", ret);
   syslog(LOG_INFO, "temp: %ld \n", temp);
   assert_int_equal(ret, 0);

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_005.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_005.c
@@ -3,30 +3,29 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <stdint.h>
-#include <time.h>
+#include<time.h>
 #include "PthreadTest.h"
 
 /****************************************************************************
@@ -37,7 +36,7 @@
  * Public Functions
  ****************************************************************************/
 
-static void *thread_f01(void *arg)
+static void *threadf01(void *arg)
 {
   sleep(500);
 
@@ -50,20 +49,19 @@ static void *thread_f01(void *arg)
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest05
+ * Name: test_nuttx_pthread_test05
  ****************************************************************************/
 
 void test_nuttx_pthread_test05(FAR void **state)
 {
-  pthread_t new_th;
+  pthread_t newth;
   UINT32 ret;
   UINTPTR temp;
-  clock_t start;
-  clock_t finish;
+  clock_t start, finish;
   double duration;
 
   start = clock();
-  if (pthread_create(&new_th, NULL, thread_f01, NULL) < 0)
+  if (pthread_create(&newth, NULL, threadf01, NULL) < 0)
     {
       syslog(LOG_INFO, "Error creating thread\n");
       assert_int_equal(1, 0);
@@ -71,18 +69,19 @@ void test_nuttx_pthread_test05(FAR void **state)
 
   usleep(1000);
 
-  /* LOS_TaskDelay(1);
-   * Try to cancel the newly created thread.  If an error is returned,
+  /* los_taskdelay(1); */
+
+  /* Try to cancel the newly created thread.  If an error is returned,
    * then the thread wasn't created successfully.
    */
 
-  if (pthread_cancel(new_th) != 0)
+  if (pthread_cancel(newth) != 0)
     {
       syslog(LOG_INFO, "Test FAILED: A new thread wasn't created\n");
       assert_int_equal(1, 0);
     }
 
-  ret = pthread_join(new_th, (void *)&temp);
+  ret = pthread_join(newth, (void *)&temp);
   finish = clock();
   duration = (double)(finish - start) / CLOCKS_PER_SEC * 1000;
   syslog(LOG_INFO, "duration: %f \n", duration);

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_006.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_006.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -37,7 +36,7 @@
  * Public Functions
  ****************************************************************************/
 
-static void *thread_f01(void *arg)
+static void *threadf01(void *arg)
 {
   pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
@@ -48,7 +47,7 @@ static void *thread_f01(void *arg)
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest06
+ * Name: test_nuttx_pthread_test06
  ****************************************************************************/
 
 void test_nuttx_pthread_test06(FAR void **state)
@@ -61,7 +60,7 @@ void test_nuttx_pthread_test06(FAR void **state)
 
   /* Create a new thread. */
 
-  if (pthread_create(&a, NULL, thread_f01, NULL) != 0)
+  if (pthread_create(&a, NULL, threadf01, NULL) != 0)
     {
       printf("Error creating thread\n");
       assert_int_equal(1, 0);
@@ -69,7 +68,7 @@ void test_nuttx_pthread_test06(FAR void **state)
 
   usleep(1000);
 
-  /* LOS_TaskDelay(1); */
+  /* los_taskdelay(1); */
 
   pthread_cancel(a);
 

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_009.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_009.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -37,9 +36,9 @@
  * Public Functions
  ****************************************************************************/
 
-static void *pthread_f01(void *arg)
+static void *pthreadf01(void *arg)
 {
-  g_test_pthread_count++;
+  g_testpthreadcount++;
 
   pthread_exit(NULL);
 
@@ -47,31 +46,31 @@ static void *pthread_f01(void *arg)
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest09
+ * Name: test_nuttx_pthread_test09
  ****************************************************************************/
 
 void test_nuttx_pthread_test09(FAR void **state)
 {
-  pthread_t new_th;
+  pthread_t newth;
   UINT32 ret;
   UINTPTR temp = 1;
 
   /* _pthread_data *joinee = NULL; */
 
-  g_test_pthread_count = 0;
-  g_test_pthread_task_max_num = 128;
+  g_testpthreadcount = 0;
+  g_testpthreadtaskmaxnum = 128;
 
-  ret = pthread_create(&new_th, NULL, pthread_f01, NULL);
+  ret = pthread_create(&newth, NULL, pthreadf01, NULL);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
   usleep(1000);
 
-  /* LOS_TaskDelay(1); */
+  /* los_taskdelay(1); */
 
-  syslog(LOG_INFO, "g_testPthreadCount: %d \n", g_test_pthread_count);
-  assert_int_equal(g_test_pthread_count, 1);
+  syslog(LOG_INFO, "g_testpthreadcount: %d \n", g_testpthreadcount);
+  assert_int_equal(g_testpthreadcount, 1);
 
-  ret = pthread_join(g_test_pthread_task_max_num, (void *)&temp);
+  ret = pthread_join(g_testpthreadtaskmaxnum, (void *)&temp);
   syslog(LOG_INFO, "ret: %d \n", ret);
   syslog(LOG_INFO, "temp: %ld \n", temp);
   assert_int_equal(ret, ESRCH);
@@ -83,20 +82,20 @@ void test_nuttx_pthread_test09(FAR void **state)
   syslog(LOG_INFO, "temp: %ld \n", temp);
   assert_int_equal(temp, 1);
 
-  ret = pthread_detach(g_test_pthread_task_max_num);
+  ret = pthread_detach(g_testpthreadtaskmaxnum);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, ESRCH);
 
-  ret = pthread_join(new_th, NULL);
+  ret = pthread_join(newth, NULL);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
 
   sleep(1);
-  ret = pthread_detach(new_th);
+  ret = pthread_detach(newth);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, ESRCH);
 
-  ret = pthread_join(new_th, NULL);
+  ret = pthread_join(newth, NULL);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, ESRCH);
 }

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_018.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_018.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -33,40 +32,40 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-static sem_t re_pthread_f01;
+static sem_t re_pthreadf01;
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-static void *pthread_f01(void *argument)
+static void *pthreadf01(void *argument)
 {
-  g_test_pthread_count++;
-  sem_wait(&re_pthread_f01);
+  g_testpthreadcount++;
+  sem_wait(&re_pthreadf01);
 
   return argument;
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest18
+ * Name: test_nuttx_pthread_test18
  ****************************************************************************/
 
 void test_nuttx_pthread_test18(FAR void **state)
 {
   pthread_attr_t attr;
-  pthread_t new_th;
+  pthread_t newth;
   UINT32 ret;
   UINTPTR temp;
   int policy;
   struct sched_param param;
   struct sched_param param2 =
-    {
-      2
-    }; /* 2, init */
+  {
+    2
+  }; /* 2, init */
 
-  g_test_pthread_count = 0;
+  g_testpthreadcount = 0;
 
-  ret = sem_init(&re_pthread_f01, 0, 0);
+  ret = sem_init(&re_pthreadf01, 0, 0);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
 
@@ -74,65 +73,73 @@ void test_nuttx_pthread_test18(FAR void **state)
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
 
-  ret = pthread_create(&new_th, NULL, pthread_f01, (void *)9); /* 9, test param of the function. */
+  ret = pthread_create(&newth, NULL, pthreadf01,
+                       (void *)9); /* 9, test param of the function. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
   usleep(1000);
 
-  /* LOS_TaskDelay(1); */
+  /* los_taskdelay(1); */
 
-  syslog(LOG_INFO, "g_testPthreadCount: %d \n", g_test_pthread_count);
-  assert_int_equal(g_test_pthread_count, 1);
+  syslog(LOG_INFO, "g_testpthreadcount: %d \n", g_testpthreadcount);
+  assert_int_equal(g_testpthreadcount, 1);
 
-  ret = pthread_setschedparam(new_th, -1, &param);
+  ret = pthread_setschedparam(newth, -1, &param);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
-  ret = pthread_setschedparam(new_th, 100, &param); /* 4, test for invalid param. */
+  ret = pthread_setschedparam(newth, 100,
+                              &param); /* 4, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
 #if CONFIG_RR_INTERVAL > 0
   param.sched_priority = 31; /* 31, init */
-  ret = pthread_setschedparam(new_th, SCHED_RR, &param);
+  ret = pthread_setschedparam(newth, SCHED_RR, &param);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
 #endif
 
-  ret = pthread_getschedparam(new_th, NULL, &param2);
+  ret = pthread_getschedparam(newth, NULL, &param2);
   syslog(LOG_INFO, "ret: %d \n", ret);
-  syslog(LOG_INFO, "param2.sched_priority: %d \n", param2.sched_priority);
+  syslog(LOG_INFO, "param2.sched_priority: %d \n",
+         param2.sched_priority);
   assert_int_equal(ret, EINVAL);
-  assert_int_equal(param2.sched_priority, 2); /* 2, here assert the result. */
+  assert_int_equal(param2.sched_priority,
+                   2); /* 2, here assert the result. */
 
-  ret = pthread_getschedparam(new_th, &policy, NULL);
+  ret = pthread_getschedparam(newth, &policy, NULL);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
-  ret = pthread_getschedparam(new_th, &policy, &param2);
+  ret = pthread_getschedparam(newth, &policy, &param2);
   syslog(LOG_INFO, "ret: %d \n", ret);
-  syslog(LOG_INFO, "param2.sched_priority: %d \n", param2.sched_priority);
+  syslog(LOG_INFO, "param2.sched_priority: %d \n",
+         param2.sched_priority);
   assert_int_equal(ret, 0);
 #if CONFIG_RR_INTERVAL > 0
-  assert_int_equal(param2.sched_priority, 31); /* 31, here assert the result. */
+  assert_int_equal(param2.sched_priority,
+                   31); /* 31, here assert the result. */
 #endif
 
-  ret = sem_post(&re_pthread_f01);
+  ret = sem_post(&re_pthreadf01);
   syslog(LOG_INFO, "ret of sem_post: %d \n", ret);
   assert_int_equal(ret, 0);
-  ret = pthread_join(new_th, (void *)&temp);
+  ret = pthread_join(newth, (void *)&temp);
   syslog(LOG_INFO, "ret: %d \n", ret);
   syslog(LOG_INFO, "temp: %ld \n", temp);
   assert_int_equal(ret, 0);
   assert_int_equal(temp, 9); /* 9, here assert the result. */
 
 #if CONFIG_RR_INTERVAL > 0
-  ret = pthread_setschedparam(new_th + 9, SCHED_RR, &param); /* 9, test for invalid param. */
+  ret = pthread_setschedparam(newth + 9, SCHED_RR,
+                              &param); /* 9, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, ESRCH);
 #endif
 
-  ret = pthread_getschedparam(new_th + 8, &policy, &param2); /* 8, test for invalid param. */
+  ret = pthread_getschedparam(newth + 8, &policy,
+                              &param2); /* 8, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, ESRCH);
 
@@ -140,7 +147,7 @@ void test_nuttx_pthread_test18(FAR void **state)
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
 
-  ret = sem_destroy(&re_pthread_f01);
+  ret = sem_destroy(&re_pthreadf01);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
 }

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_019.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_019.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -37,39 +36,39 @@
  * Public Functions
  ****************************************************************************/
 
-static void pthread_once_f01(void)
+static void pthreadoncef01(void)
 {
-  g_test_pthread_count++;
+  g_testpthreadcount++;
 }
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest19
+ * Name: test_nuttx_pthread_test19
  ****************************************************************************/
 
 void test_nuttx_pthread_test19(FAR void **state)
 {
   UINT32 ret;
-  pthread_once_t once_block = PTHREAD_ONCE_INIT;
+  pthread_once_t onceblock = PTHREAD_ONCE_INIT;
 
-  g_test_pthread_count = 0;
+  g_testpthreadcount = 0;
 
-  ret = pthread_once(NULL, pthread_once_f01);
+  ret = pthread_once(NULL, pthreadoncef01);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
-  ret = pthread_once(&once_block, NULL);
+  ret = pthread_once(&onceblock, NULL);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
-  ret = pthread_once(&once_block, pthread_once_f01);
+  ret = pthread_once(&onceblock, pthreadoncef01);
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, 0);
-  syslog(LOG_INFO, "g_testPthreadCount: %d \n", g_test_pthread_count);
-  assert_int_equal(g_test_pthread_count, 1);
+  syslog(LOG_INFO, "g_testpthreadcount: %d \n", g_testpthreadcount);
+  assert_int_equal(g_testpthreadcount, 1);
 
-  ret = pthread_once(&once_block, pthread_once_f01);
+  ret = pthread_once(&onceblock, pthreadoncef01);
   syslog(LOG_INFO, "ret: %d \n", ret);
-  syslog(LOG_INFO, "g_testPthreadCount: %d \n", g_test_pthread_count);
+  syslog(LOG_INFO, "g_testpthreadcount: %d \n", g_testpthreadcount);
   assert_int_equal(ret, 0);
-  assert_int_equal(g_test_pthread_count, 1);
+  assert_int_equal(g_testpthreadcount, 1);
 }

--- a/testing/testsuites/kernel/pthread/cases/posix_pthread_test_021.c
+++ b/testing/testsuites/kernel/pthread/cases/posix_pthread_test_021.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -38,7 +37,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestNuttxPthreadTest21
+ * Name: test_nuttx_pthread_test21
  ****************************************************************************/
 
 void test_nuttx_pthread_test21(FAR void **state)
@@ -47,11 +46,13 @@ void test_nuttx_pthread_test21(FAR void **state)
   int oldstate;
   int oldstype;
 
-  ret = pthread_setcancelstate(2, &oldstate); /* 2, test for invalid param. */
+  ret =
+      pthread_setcancelstate(2, &oldstate); /* 2, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
-  ret = pthread_setcancelstate(3, &oldstate); /* 3, test for invalid param. */
+  ret =
+      pthread_setcancelstate(3, &oldstate); /* 3, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
@@ -65,11 +66,13 @@ void test_nuttx_pthread_test21(FAR void **state)
   syslog(LOG_INFO, "oldstate: %d \n", oldstate);
   assert_int_equal(oldstate, PTHREAD_CANCEL_ENABLE);
 
-  ret = pthread_setcanceltype(2, &oldstype); /* 2, test for invalid param. */
+  ret =
+      pthread_setcanceltype(2, &oldstype); /* 2, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 
-  ret = pthread_setcanceltype(3, &oldstype); /* 3, test for invalid param. */
+  ret =
+      pthread_setcanceltype(3, &oldstype); /* 3, test for invalid param. */
   syslog(LOG_INFO, "ret: %d \n", ret);
   assert_int_equal(ret, EINVAL);
 

--- a/testing/testsuites/kernel/pthread/cmocka_pthread_test.c
+++ b/testing/testsuites/kernel/pthread/cmocka_pthread_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/pthread/cmocka_pthread_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -43,15 +45,24 @@ int main(int argc, char *argv[])
 {
   /* Add Test Cases */
 
-  const struct CMUnitTest nuttx_pthread_test_suites[] = {
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test03, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test04, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test05, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test06, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test09, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test18, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test19, NULL, NULL),
-      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test21, NULL, NULL),
+  const struct CMUnitTest nuttx_pthread_test_suites[] =
+  {
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test03, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test04, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test05, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test06, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test09, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test18, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test19, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_pthread_test21, NULL,
+                                      NULL),
   };
 
   /* Run Test cases */

--- a/testing/testsuites/kernel/pthread/common/test_pthread_common.c
+++ b/testing/testsuites/kernel/pthread/common/test_pthread_common.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -38,9 +37,8 @@
 #include <stdlib.h>
 #include "PthreadTest.h"
 
-UINT32 g_test_pthread_count;
-UINT32 g_test_pthread_task_max_num = 128;
-
+UINT32 g_testpthreadcount;
+UINT32 g_testpthreadtaskmaxnum = 128;
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -50,10 +48,10 @@ UINT32 g_test_pthread_task_max_num = 128;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: TestPthreadSelf
+ * Name: testpthreadself
  ****************************************************************************/
 
-pthread_t test_pthread_self(void)
+pthread_t testpthreadself(void)
 {
   pthread_t tid = pthread_self();
   return tid;

--- a/testing/testsuites/kernel/pthread/include/PthreadTest.h
+++ b/testing/testsuites/kernel/pthread/include/PthreadTest.h
@@ -3,28 +3,26 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
+#ifndef PTHREAD_TEST_H
+#define PTHREAD_TEST_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
-#ifndef PTHREAD_TEST_H
-#define PTHREAD_TEST_H
-
 #include <nuttx/config.h>
 #include <errno.h>
 #include <syslog.h>
@@ -59,7 +57,10 @@ typedef unsigned long UINTPTR;
 #define THREAD_NUM 3
 #define PTHREAD_TIMEOUT (THREAD_NUM * 2)
 #define PTHREAD_INTHREAD_TEST 0 /* Control going to or is already for Thread */
-#define PTHREAD_INMAIN_TEST 1   /* Control going to or is already for Main */
+
+/* Control going to or is already for Main */
+
+#define PTHREAD_INMAIN_TEST 1
 #define INVALID_PSHARED_VALUE (-100)
 #define NUM_OF_CONDATTR 10
 #define RUNTIME 5
@@ -75,52 +76,63 @@ typedef unsigned long UINTPTR;
 
 /* We are testing conformance to IEEE Std 1003.1, 2003 Edition */
 
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
+
 #define PRIORITY_OTHER (-1)
 #define PRIORITY_FIFO 20
 #define PRIORITY_RR 20
 #define LOSCFG_BASE_CORE_TSK_CONFIG 1024
 
-extern UINT32 g_test_pthread_count;
-extern UINT32 g_test_pthread_task_max_num;
+extern UINT32 g_testpthreadcount;
+extern UINT32 g_testpthreadtaskmaxnum;
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-pthread_t test_pthread_self(void);
+pthread_t testpthreadself(void);
 
 /* test case function */
 
-/* cases/posix_pthread_test_003.c *******************************************/
+/* cases/posix_pthread_test_003.c
+ * ************************************************/
 
 void test_nuttx_pthread_test03(FAR void **state);
 
-/* cases/posix_pthread_test_004.c *******************************************/
+/* cases/posix_pthread_test_004.c
+ * ************************************************/
 
 void test_nuttx_pthread_test04(FAR void **state);
 
-/* cases/posix_pthread_test_005.c *******************************************/
+/* cases/posix_pthread_test_005.c
+ * ************************************************/
 
 void test_nuttx_pthread_test05(FAR void **state);
 
-/* cases/posix_pthread_test_006.c *******************************************/
+/* cases/posix_pthread_test_006.c
+ * ************************************************/
 
 void test_nuttx_pthread_test06(FAR void **state);
 
-/* cases/posix_pthread_test_009.c *******************************************/
+/* cases/posix_pthread_test_009.c
+ * ************************************************/
 
 void test_nuttx_pthread_test09(FAR void **state);
 
-/* cases/posix_pthread_test_018.c *******************************************/
+/* cases/posix_pthread_test_018.c
+ * ************************************************/
 
 void test_nuttx_pthread_test18(FAR void **state);
 
-/* cases/posix_pthread_test_019.c *******************************************/
+/* cases/posix_pthread_test_019.c
+ * ************************************************/
 
 void test_nuttx_pthread_test19(FAR void **state);
 
-/* cases/posix_pthread_test_021.c *******************************************/
+/* cases/posix_pthread_test_021.c
+ * ************************************************/
 
 void test_nuttx_pthread_test21(FAR void **state);
 #endif

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_001.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_001.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,10 +43,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread01_threadroutine
+ * Name: schedpthread01threadroutine
  ****************************************************************************/
 
-static void *sched_pthread01_threadroutine(void *arg)
+static void *schedpthread01threadroutine(void *arg)
 {
   int flag;
   flag = 1;
@@ -70,7 +69,7 @@ void test_nuttx_sched_pthread01(FAR void **state)
 
   /* create thread */
 
-  pthread_create(&p_t, NULL, sched_pthread01_threadroutine, &run_flag);
+  pthread_create(&p_t, NULL, schedpthread01threadroutine, &run_flag);
 
   /* pthread_join Wait for the thread to end */
 

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_002.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_002.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,10 +43,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread02_threadroutine
+ * Name: schedpthread02threadroutine
  ****************************************************************************/
 
-static void *sched_pthread02_threadroutine(void *arg)
+static void *schedpthread02threadroutine(void *arg)
 {
   return NULL;
 }
@@ -87,7 +86,7 @@ void test_nuttx_sched_pthread02(FAR void **state)
 
   /* create thread */
 
-  pthread_create(&p_t, &attr, sched_pthread02_threadroutine, NULL);
+  pthread_create(&p_t, &attr, schedpthread02threadroutine, NULL);
 
   /* Wait for the child thread finish */
 

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_003.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_003.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,10 +43,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread03_threadroutine
+ * Name: schedpthread03threadroutine
  ****************************************************************************/
 
-static void *sched_pthread03_threadroutine(void *arg)
+static void *schedpthread03threadroutine(void *arg)
 {
   int i = 0;
   for (i = 0; i <= 5; i++)
@@ -80,8 +79,8 @@ void test_nuttx_sched_pthread03(FAR void **state)
 
   /* create test thread */
 
-  ret = pthread_create(&pid_1, NULL,
-                       (void *)sched_pthread03_threadroutine, &run_flag);
+  ret = pthread_create(&pid_1, NULL, (void *)schedpthread03threadroutine,
+                       &run_flag);
   assert_int_equal(ret, 0);
 
   pthread_join(pid_1, NULL);

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_004.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_004.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,10 +43,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread04_threadroutine
+ * Name: schedpthread04threadroutine
  ****************************************************************************/
 
-static void *sched_pthread04_threadroutine(void *arg)
+static void *schedpthread04threadroutine(void *arg)
 {
   /* set enable */
 
@@ -82,13 +81,12 @@ void test_nuttx_sched_pthread04(FAR void **state)
 
   /* int flag */
 
-  int sched_pthread_test04_run_flag = 0;
+  int schedpthreadtest04_run_flag = 0;
 
   /* create thread_1 */
 
-  res = pthread_create(&p_t_1, NULL,
-                       sched_pthread04_threadroutine,
-                       &sched_pthread_test04_run_flag);
+  res = pthread_create(&p_t_1, NULL, schedpthread04threadroutine,
+                       &schedpthreadtest04_run_flag);
   assert_int_equal(res, OK);
 
   res = pthread_cancel(p_t_1);
@@ -97,5 +95,5 @@ void test_nuttx_sched_pthread04(FAR void **state)
   /* join thread_1 */
 
   pthread_join(p_t_1, NULL);
-  assert_int_equal(sched_pthread_test04_run_flag, 0);
+  assert_int_equal(schedpthreadtest04_run_flag, 0);
 }

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_005.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_005.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,10 +43,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread05_threadroutine
+ * Name: schedpthread05threadroutine
  ****************************************************************************/
 
-static void *sched_pthread05_threadroutine(void *arg)
+static void *schedpthread05threadroutine(void *arg)
 {
   int i;
   for (i = 0; i <= 5; i++)
@@ -76,7 +75,7 @@ void test_nuttx_sched_pthread05(FAR void **state)
 
   /* create thread */
 
-  res = pthread_create(&p_t, NULL, sched_pthread05_threadroutine, NULL);
+  res = pthread_create(&p_t, NULL, schedpthread05threadroutine, NULL);
 
   assert_int_equal(res, 0);
 

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_006.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_006.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,10 +43,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread06_threadroutine
+ * Name: schedpthread06threadroutine
  ****************************************************************************/
 
-static void *sched_pthread06_threadroutine(void *arg)
+static void *schedpthread06threadroutine(void *arg)
 {
   int pid;
 
@@ -59,6 +58,7 @@ static void *sched_pthread06_threadroutine(void *arg)
     {
       *((int *)arg) = 0;
     }
+
   else
     {
       *((int *)arg) = 1;
@@ -83,7 +83,8 @@ void test_nuttx_sched_pthread06(FAR void **state)
 
   /* create thread */
 
-  res = pthread_create(&p_t, NULL, sched_pthread06_threadroutine, &run_flag);
+  res =
+      pthread_create(&p_t, NULL, schedpthread06threadroutine, &run_flag);
   assert_int_equal(res, OK);
 
   pthread_join(p_t, NULL);

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_007.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_007.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -44,18 +43,18 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread07_threadroutine
+ * Name: schedpthread07threadroutine
  ****************************************************************************/
 
-static void *sched_pthread07_threadroutine(void *arg)
+static void *schedpthread07threadroutine(void *arg)
 {
   int i;
-  pthread_mutex_t sched_pthread_test07_mutex = PTHREAD_MUTEX_INITIALIZER;
+  pthread_mutex_t schedpthreadtest07_mutex = PTHREAD_MUTEX_INITIALIZER;
   for (i = 0; i < 100; i++)
     {
-      pthread_mutex_lock(&sched_pthread_test07_mutex);
+      pthread_mutex_lock(&schedpthreadtest07_mutex);
       (*((int *)arg))++;
-      pthread_mutex_unlock(&sched_pthread_test07_mutex);
+      pthread_mutex_unlock(&schedpthreadtest07_mutex);
     }
 
   return NULL;
@@ -75,14 +74,14 @@ void test_nuttx_sched_pthread07(FAR void **state)
   pthread_t pt_1, pt_2, pt_3;
   int run_flag = 0;
 
-  res = pthread_create(&pt_1, NULL,
-                       (void *)sched_pthread07_threadroutine, &run_flag);
+  res = pthread_create(&pt_1, NULL, (void *)schedpthread07threadroutine,
+                       &run_flag);
   assert_int_equal(res, OK);
-  res = pthread_create(&pt_2, NULL,
-                       (void *)sched_pthread07_threadroutine, &run_flag);
+  res = pthread_create(&pt_2, NULL, (void *)schedpthread07threadroutine,
+                       &run_flag);
   assert_int_equal(res, OK);
-  res = pthread_create(&pt_3, NULL,
-                       (void *)sched_pthread07_threadroutine, &run_flag);
+  res = pthread_create(&pt_3, NULL, (void *)schedpthread07threadroutine,
+                       &run_flag);
   assert_int_equal(res, OK);
 
   pthread_join(pt_1, NULL);

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_008.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_008.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -43,22 +42,22 @@
  * Private Data
  ****************************************************************************/
 
-static sem_t sched_task08_sem;
+static sem_t schedtask08_sem;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread08_threadroutine
+ * Name: schedpthread08threadroutine
  ****************************************************************************/
 
-static void *sched_pthread08_threadroutine(void *arg)
+static void *schedpthread08threadroutine(void *arg)
 {
   int i;
   for (i = 0; i < 5; i++)
     {
-      sem_wait(&sched_task08_sem);
+      sem_wait(&schedtask08_sem);
       (*((int *)arg))++;
     }
 
@@ -79,25 +78,25 @@ void test_nuttx_sched_pthread08(FAR void **state)
   pthread_t pthread_id;
   int run_flag = 0;
 
-  res = sem_init(&sched_task08_sem, 0, 0);
+  res = sem_init(&schedtask08_sem, 0, 0);
   assert_int_equal(res, OK);
 
   /* create pthread */
 
   res = pthread_create(&pthread_id, NULL,
-                       (void *)sched_pthread08_threadroutine, &run_flag);
+                       (void *)schedpthread08threadroutine, &run_flag);
   assert_int_equal(res, OK);
 
   while (1)
     {
       sleep(2);
-      res = sem_post(&sched_task08_sem);
+      res = sem_post(&schedtask08_sem);
       assert_int_equal(res, OK);
       if (run_flag == 5)
         break;
     }
 
-  res = sem_destroy(&sched_task08_sem);
+  res = sem_destroy(&schedtask08_sem);
   assert_int_equal(res, OK);
   assert_int_equal(run_flag, 5);
 }

--- a/testing/testsuites/kernel/sched/cases/api_pthread_test_009.c
+++ b/testing/testsuites/kernel/sched/cases/api_pthread_test_009.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -43,26 +42,26 @@
  * Private Data
  ****************************************************************************/
 
-static sem_t sched_task09_sem;
+static sem_t schedtask09_sem;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_pthread09_threadroutine
+ * Name: schedpthread09threadroutine
  ****************************************************************************/
 
-static void *sched_pthread09_threadroutine(void *arg)
+static void *schedpthread09threadroutine(void *arg)
 {
   int i;
   int res;
   for (i = 0; i < 10; i++)
     {
-      res = sem_wait(&sched_task09_sem);
+      res = sem_wait(&schedtask09_sem);
       assert_int_equal(res, OK);
       (*((int *)arg))++;
-      res = sem_post(&sched_task09_sem);
+      res = sem_post(&schedtask09_sem);
       assert_int_equal(res, OK);
     }
 
@@ -83,14 +82,15 @@ void test_nuttx_sched_pthread09(FAR void **state)
   pthread_t pthread_id[10];
   int run_flag = 0;
 
-  res = sem_init(&sched_task09_sem, 0, 1);
+  res = sem_init(&schedtask09_sem, 0, 1);
   assert_int_equal(res, OK);
 
   int i;
   for (i = 0; i < 10; i++)
     {
-      res = pthread_create(&pthread_id[i], NULL,
-                           (void *)sched_pthread09_threadroutine, &run_flag);
+      res =
+          pthread_create(&pthread_id[i], NULL,
+                         (void *)schedpthread09threadroutine, &run_flag);
       assert_int_equal(res, OK);
     }
 
@@ -98,7 +98,7 @@ void test_nuttx_sched_pthread09(FAR void **state)
   for (j = 0; j < 10; j++)
     pthread_join(pthread_id[j], NULL);
 
-  res = sem_destroy(&sched_task09_sem);
+  res = sem_destroy(&schedtask09_sem);
   assert_int_equal(res, OK);
 
   assert_int_equal(run_flag, 100);

--- a/testing/testsuites/kernel/sched/cases/api_task_test_001.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_001.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -47,10 +46,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task01_routine
+ * Name: schedtask01routine
  ****************************************************************************/
 
-static int sched_task01_routine(int argc, char *argv[])
+static int schedtask01routine(int argc, char *argv[])
 {
   char *str = NULL;
   str = (char *)malloc(sizeof(char) * 1024);
@@ -73,8 +72,8 @@ void test_nuttx_sched_task01(FAR void **state)
   pid_t pid;
   int status;
 
-  pid = task_create("sched_task01_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task01_routine, NULL);
+  pid = task_create("schedtask01routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask01routine, NULL);
   assert_true(pid > 0);
   waitpid(pid, &status, 0);
 }

--- a/testing/testsuites/kernel/sched/cases/api_task_test_002.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_002.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -47,10 +46,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task02_routine
+ * Name: schedtask02routine
  ****************************************************************************/
 
-static int sched_task02_routine(int argc, char *argv[])
+static int schedtask02routine(int argc, char *argv[])
 {
   int i;
   for (i = 0; i < 10; i++)
@@ -75,8 +74,8 @@ void test_nuttx_sched_task02(FAR void **state)
   int status;
   int res;
 
-  pid = task_create("sched_task02_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task02_routine, NULL);
+  pid = task_create("schedtask02routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask02routine, NULL);
   assert_true(pid > 0);
   for (int i = 0; i < 2; i++)
     {

--- a/testing/testsuites/kernel/sched/cases/api_task_test_003.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_003.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -47,10 +46,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task03_routine
+ * Name: schedtask03routine
  ****************************************************************************/
 
-static int sched_task03_routine(int argc, char *argv[])
+static int schedtask03routine(int argc, char *argv[])
 {
   int i;
   for (i = 0; i < 100; ++i)
@@ -75,8 +74,8 @@ void test_nuttx_sched_task03(FAR void **state)
 {
   pid_t pid;
   int res;
-  pid = task_create("sched_task03_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task03_routine, NULL);
+  pid = task_create("schedtask03routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask03routine, NULL);
   assert_true(pid > 0);
 
   int i;

--- a/testing/testsuites/kernel/sched/cases/api_task_test_004.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_004.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -47,10 +46,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task04_routine
+ * Name: schedtask04routine
  ****************************************************************************/
 
-static int sched_task04_routine(int argc, char *argv[])
+static int schedtask04routine(int argc, char *argv[])
 {
   for (int i = 0; i < 5; i++)
     {
@@ -75,13 +74,12 @@ void test_nuttx_sched_task04(FAR void **state)
   pid_t pid;
   int status;
   int ret;
-
   struct sched_param task_entry_param;
 
   /* create a test task */
 
-  pid = task_create("sched_task04_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task04_routine, NULL);
+  pid = task_create("schedtask04routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask04routine, NULL);
   assert_true(pid > 0);
   ret = sched_getparam(pid, &task_entry_param);
   assert_int_equal(ret, 0);

--- a/testing/testsuites/kernel/sched/cases/api_task_test_005.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_005.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -47,10 +46,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task05_routine
+ * Name: schedtask05routine
  ****************************************************************************/
 
-static int sched_task05_routine(int argc, char *argv[])
+static int schedtask05routine(int argc, char *argv[])
 {
   int ret;
   int i;
@@ -79,8 +78,8 @@ void test_nuttx_sched_task05(FAR void **state)
   pid_t pid;
   int status;
 
-  pid = task_create("sched_task05_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task05_routine, NULL);
+  pid = task_create("schedtask05routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask05routine, NULL);
   assert_true(pid > 0);
   waitpid(pid, &status, 0);
 }

--- a/testing/testsuites/kernel/sched/cases/api_task_test_006.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_006.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -48,10 +47,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task06_routine
+ * Name: schedtask06routine
  ****************************************************************************/
 
-static int sched_task06_routine(int argc, char *argv[])
+static int schedtask06routine(int argc, char *argv[])
 {
   return 0;
 }
@@ -73,8 +72,8 @@ void test_nuttx_sched_task06(FAR void **state)
 
   /* struct sched_param task_entry_param */
 
-  pid = task_create("sched_task06_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task06_routine, NULL);
+  pid = task_create("schedtask06routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask06routine, NULL);
   assert_true(pid > 0);
   priority_max = sched_get_priority_max(SCHED_FIFO);
   priority_min = sched_get_priority_min(SCHED_FIFO);

--- a/testing/testsuites/kernel/sched/cases/api_task_test_007.c
+++ b/testing/testsuites/kernel/sched/cases/api_task_test_007.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -48,10 +47,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sched_task07_routine
+ * Name: schedtask07routine
  ****************************************************************************/
 
-static int sched_task07_routine(int argc, char *argv[])
+static int schedtask07routine(int argc, char *argv[])
 {
   /* lock */
 
@@ -89,8 +88,8 @@ void test_nuttx_sched_task07(FAR void **state)
   pid_t pid;
   int status;
 
-  pid = task_create("sched_task07_routine", TASK_PRIORITY,
-                    DEFAULT_STACKSIZE, sched_task07_routine, NULL);
+  pid = task_create("schedtask07routine", TASK_PRIORITY,
+                    DEFAULT_STACKSIZE, schedtask07routine, NULL);
   assert_true(pid > 0);
 
   waitpid(pid, &status, 0);

--- a/testing/testsuites/kernel/sched/cmocka_sched_test.c
+++ b/testing/testsuites/kernel/sched/cmocka_sched_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/sched/cmocka_sched_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -40,7 +42,8 @@ int main(int argc, char *argv[])
 {
   /* Add Test Cases */
 
-  const struct CMUnitTest nuttx_sched_testsuites[] = {
+  const struct CMUnitTest nuttx_sched_test_suites[] =
+  {
       cmocka_unit_test(test_nuttx_sched_pthread01),
       cmocka_unit_test(test_nuttx_sched_pthread02),
       cmocka_unit_test(test_nuttx_sched_pthread03),
@@ -61,8 +64,8 @@ int main(int argc, char *argv[])
 
   /* Run Test cases */
 
-  cmocka_run_group_tests(nuttx_sched_testsuites,
-                         test_nuttx_schedtest_group_setup,
-                         test_nuttx_schedtest_group_teardown);
+  cmocka_run_group_tests(nuttx_sched_test_suites,
+                         test_nuttx_sched_test_group_setup,
+                         test_nuttx_sched_test_group_teardown);
   return 0;
 }

--- a/testing/testsuites/kernel/sched/common/test_sched_common.c
+++ b/testing/testsuites/kernel/sched/common/test_sched_common.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -37,10 +36,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_schedtest_group_setup
+ * Name: test_nuttx_sched_test_group_setup
  ****************************************************************************/
 
-int test_nuttx_schedtest_group_setup(void **state)
+int test_nuttx_sched_test_group_setup(void **state)
 {
   /* syslog(LOG_INFO, "This is goup setup !\n"); */
 
@@ -48,10 +47,10 @@ int test_nuttx_schedtest_group_setup(void **state)
 }
 
 /****************************************************************************
- * Name: test_nuttx_schedtest_group_teardown
+ * Name: test_nuttx_sched_test_group_teardown
  ****************************************************************************/
 
-int test_nuttx_schedtest_group_teardown(void **state)
+int test_nuttx_sched_test_group_teardown(void **state)
 {
   /* syslog(LOG_INFO, "This is goup tearDown !\n"); */
 

--- a/testing/testsuites/kernel/sched/include/SchedTest.h
+++ b/testing/testsuites/kernel/sched/include/SchedTest.h
@@ -1,19 +1,22 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/sched/include/SchedTest.h
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 #ifndef __SCHEDTEST_H
 #define __SCHEDTEST_H
@@ -21,15 +24,12 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <setjmp.h>
 #include <cmocka.h>
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
 #define PTHREAD_STACK_SIZE CONFIG_DEFAULT_TASK_STACKSIZE
 #define DEFAULT_STACKSIZE CONFIG_DEFAULT_TASK_STACKSIZE
 #define TASK_PRIORITY SCHED_PRIORITY_DEFAULT
@@ -38,74 +38,91 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-/* common/common_test.c *****************************************************/
+/* common/common_test.c
+ * *****************************************************/
 
-int test_nuttx_schedtest_group_setup(void **state);
-int test_nuttx_schedtest_group_teardown(void **state);
+int test_nuttx_sched_test_group_setup(void **state);
+int test_nuttx_sched_test_group_teardown(void **state);
 
 /* testcase function */
 
-/* cases/api_pthread_test_001.c *********************************************/
+/* cases/api_pthread_test_001.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread01(FAR void **state);
 
-/* cases/api_pthread_test_002.c *********************************************/
+/* cases/api_pthread_test_002.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread02(FAR void **state);
 
-/* cases/api_pthread_test_003.c *********************************************/
+/* cases/api_pthread_test_003.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread03(FAR void **state);
 
-/* cases/api_pthread_test_004.c *********************************************/
+/* cases/api_pthread_test_004.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread04(FAR void **state);
 
-/* cases/api_pthread_test_005.c *********************************************/
+/* cases/api_pthread_test_005.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread05(FAR void **state);
 
-/* cases/api_pthread_test_006.c *********************************************/
+/* cases/api_pthread_test_006.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread06(FAR void **state);
 
-/* cases/api_pthread_test_007.c *********************************************/
+/* cases/api_pthread_test_007.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread07(FAR void **state);
 
-/* cases/api_pthread_test_008.c *********************************************/
+/* cases/api_pthread_test_008.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread08(FAR void **state);
 
-/* cases/api_pthread_test_009.c *********************************************/
+/* cases/api_pthread_test_009.c
+ * *********************************************/
 
 void test_nuttx_sched_pthread09(FAR void **state);
 
-/* cases/api_task_test_001.c ************************************************/
+/* cases/api_task_test_001.c
+ * ************************************************/
 
 void test_nuttx_sched_task01(FAR void **state);
 
-/* cases/api_task_test_002.c ************************************************/
+/* cases/api_task_test_002.c
+ * ************************************************/
 
 void test_nuttx_sched_task02(FAR void **state);
 
-/* cases/api_task_test_003.c ************************************************/
+/* cases/api_task_test_003.c
+ * ************************************************/
 
 void test_nuttx_sched_task03(FAR void **state);
 
-/* cases/api_task_test_004.c ************************************************/
+/* cases/api_task_test_004.c
+ * ************************************************/
 
 void test_nuttx_sched_task04(FAR void **state);
 
-/* cases/api_task_test_005.c ************************************************/
+/* cases/api_task_test_005.c
+ * ************************************************/
 
 void test_nuttx_sched_task05(FAR void **state);
 
-/* cases/api_task_test_006.c ************************************************/
+/* cases/api_task_test_006.c
+ * ************************************************/
 
 void test_nuttx_sched_task06(FAR void **state);
 
-/* cases/api_task_test_007.c ************************************************/
+/* cases/api_task_test_007.c
+ * ************************************************/
 
 void test_nuttx_sched_task07(FAR void **state);
 

--- a/testing/testsuites/kernel/socket/cases/net_socket_test_005.c
+++ b/testing/testsuites/kernel/socket/cases/net_socket_test_005.c
@@ -1,0 +1,81 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cases/net_socket_test_005.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <inttypes.h>
+
+#include "SocketTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_net_socket_test05
+ ****************************************************************************/
+
+void test_nuttx_net_socket_test05(FAR void **state)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  uint32_t hl = ntohl(0x12345678);
+  syslog(LOG_INFO, "hl %#" PRIx32, hl);
+  assert_int_equal(hl, 0x78563412);
+
+  uint32_t nl = htonl(0x12345678);
+  syslog(LOG_INFO, "nl %#" PRIx32, nl);
+  assert_int_equal(nl, 0x78563412);
+
+  uint16_t hs = ntohs(0x1234);
+  syslog(LOG_INFO, "hs %#" PRIx16, hs);
+  assert_int_equal(hs, 0x3412);
+
+  uint16_t ns = htons(0x1234);
+  syslog(LOG_INFO, "ns %#" PRIx16, ns);
+  assert_int_equal(ns, 0x3412);
+#else
+  uint32_t hl = ntohl(0x12345678);
+  syslog(LOG_INFO, "hl %#" PRIx32, hl);
+  assert_int_equal(hl, 0x12345678);
+
+  uint32_t nl = htonl(0x12345678);
+  syslog(LOG_INFO, "nl %#" PRIx32, nl);
+  assert_int_equal(nl, 0x12345678);
+
+  uint16_t hs = ntohs(0x1234);
+  syslog(LOG_INFO, "hs %#" PRIx16, hs);
+  assert_int_equal(hs, 0x1234);
+
+  uint16_t ns = htons(0x1234);
+  syslog(LOG_INFO, "ns %#" PRIx16, ns);
+  assert_int_equal(ns, 0x1234);
+#endif
+}

--- a/testing/testsuites/kernel/socket/cases/net_socket_test_006.c
+++ b/testing/testsuites/kernel/socket/cases/net_socket_test_006.c
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cases/net_socket_test_006.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <inttypes.h>
+
+#include "SocketTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_net_socket_test06
+ ****************************************************************************/
+
+void test_nuttx_net_socket_test06(FAR void **state)
+{
+  struct in_addr in;
+  int ret = inet_pton(AF_INET, "300.10.10.10", &in);
+  syslog(LOG_INFO, "ret: %d", ret);
+  assert_int_equal(ret, 0);
+
+  ret = inet_pton(AF_INET, "10.11.12.13", &in);
+  syslog(LOG_INFO, "ret: %d", ret);
+  assert_int_equal(ret, 1);
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  syslog(LOG_INFO, "in.s_addr: %#" PRIx32, in.s_addr);
+  assert_int_equal(in.s_addr, 0x0d0c0b0a);
+#else
+  syslog(LOG_INFO, "in.s_addr: %#" PRIx32, in.s_addr);
+  assert_int_equal(in.s_addr, 0x0a0b0c0d);
+#endif
+  /* Currently nuttx does not support the following interfaces inet_lnaof,
+   * inet_netof, inet_makeaddr
+   */
+
+  /* host order */
+
+  /* in_addr_t lna = inet_lnaof(in);
+   * syslog(LOG_INFO, "lna: %#"PRIx32, lna);
+   * assert_int_equal(lna, 0x000b0c0d);
+   */
+
+  /* host order */
+
+  /* in_addr_t net = inet_netof(in);
+   * syslog(LOG_INFO, "net: %#"PRIx32, net);
+   * assert_int_equal(net, 0x0000000a);
+
+   * in = inet_makeaddr(net, lna);
+   * #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+   *   syslog(LOG_INFO, "in.s_addr: %#"PRIx32, in.s_addr);
+   *   assert_int_equal(in.s_addr, 0x0d0c0b0a);
+   * #else
+   *   syslog(LOG_INFO, "in.s_addr: %#"PRIx32, in.s_addr);
+   *   assert_int_equal(in.s_addr, 0x0a0b0c0d);
+   * #endif
+   */
+
+  in_addr_t net = inet_network("300.10.10.10");
+  syslog(LOG_INFO, "net: %#" PRIx32, net);
+  assert_int_equal((int32_t)net, -1);
+
+  /* host order */
+
+  net = inet_network("10.11.12.13");
+  syslog(LOG_INFO, "host order net: %#" PRIx32, net);
+  assert_int_equal(net, 0x0a0b0c0d);
+
+  const char *p = inet_ntoa(in);
+  syslog(LOG_INFO, "inet_ntoa p: %s", p);
+  assert_int_equal(strcmp(p, "10.11.12.13"), 0);
+
+  char buf[32];
+  p = inet_ntop(AF_INET, &in, buf, sizeof(buf));
+  syslog(LOG_INFO, "inet_ntop p: %s", p);
+  assert_string_equal(p, buf);
+  assert_int_equal(strcmp(p, "10.11.12.13"), 0);
+}

--- a/testing/testsuites/kernel/socket/cases/net_socket_test_008.c
+++ b/testing/testsuites/kernel/socket/cases/net_socket_test_008.c
@@ -1,0 +1,339 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cases/net_socket_test_008.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "SocketTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SERVER_PORT 9001  //
+#define INVALID_SOCKET -1 //
+#define BACKLOG CLIENT_NUM
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+static int gfds[FD_SETSIZE];
+static int gbye;
+
+static void initfds(void)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      gfds[i] = INVALID_SOCKET;
+    }
+}
+
+static void getreadfds(fd_set *fds, int *nfd)
+{
+  for (int i = 0; i < FD_SETSIZE; i++)
+    {
+      if (gfds[i] == INVALID_SOCKET)
+        {
+          continue;
+        }
+
+      FD_SET(gfds[i], fds);
+      if (*nfd < gfds[i])
+        {
+          *nfd = gfds[i];
+        }
+    }
+}
+
+static int addfd(int fd)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == INVALID_SOCKET)
+        {
+          gfds[i] = fd;
+          return 0;
+        }
+    }
+
+  return -1;
+}
+
+static void delfd(int fd)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == fd)
+        {
+          gfds[i] = INVALID_SOCKET;
+        }
+    }
+
+  (void)close(fd);
+}
+
+static int closeallfd(void)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] != INVALID_SOCKET)
+        {
+          (void)close(gfds[i]);
+          gfds[i] = INVALID_SOCKET;
+        }
+    }
+
+  return 0;
+}
+
+static int handlerecv(int fd)
+{
+  char buf[256];
+  int ret = recv(fd, buf, sizeof(buf) - 1, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_INFO, "[%d]Error: %s", fd, strerror(errno));
+      delfd(fd);
+    }
+
+  else if (ret == 0)
+    {
+      syslog(LOG_INFO, "[%d]Closed", fd);
+      delfd(fd);
+    }
+
+  else
+    {
+      buf[ret] = 0;
+      syslog(LOG_INFO, "[%d]Received: %s", fd, buf);
+      if (strstr(buf, "Bye") != NULL)
+        {
+          delfd(fd);
+          gbye++;
+        }
+    }
+
+  return -(ret < 0);
+}
+
+static int handleaccept(int lsfd)
+{
+  struct sockaddr_in sa;
+  socklen_t salen = sizeof(sa);
+  int fd = accept(lsfd, (struct sockaddr *)&sa, &salen);
+  if (fd == INVALID_SOCKET)
+    {
+      perror("accept");
+      return -1;
+    }
+
+  if (addfd(fd) == -1)
+    {
+      syslog(LOG_INFO, "Too many clients, refuse %s:%d",
+             inet_ntoa(sa.sin_addr), ntohs(sa.sin_port));
+      close(fd);
+      return -1;
+    }
+
+  syslog(LOG_INFO, "New client %d: %s:%d", fd, inet_ntoa(sa.sin_addr),
+         ntohs(sa.sin_port));
+  return 0;
+}
+
+static int handlereadfds(fd_set *fds, int lsfd)
+{
+  int ret = 0;
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == INVALID_SOCKET || !FD_ISSET(gfds[i], fds))
+        {
+          continue;
+        }
+
+      if (gfds[i] == lsfd)
+        {
+          ret += handleaccept(lsfd);
+        }
+
+      else
+        {
+          ret += handlerecv(gfds[i]);
+        }
+    }
+
+  return ret;
+}
+
+static void *clientsthread(void *param)
+{
+  int fd;
+  int thrno = (int)(intptr_t)param;
+
+  syslog(LOG_INFO, "<%d>socket client thread started", thrno);
+  fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (fd == INVALID_SOCKET)
+    {
+      perror("socket");
+      return NULL;
+    }
+
+  struct sockaddr_in sa;
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  sa.sin_port = htons(SERVER_PORT);
+  if (connect(fd, (struct sockaddr *)(&sa), sizeof(sa)) == -1)
+    {
+      perror("connect");
+      return NULL;
+    }
+
+  syslog(LOG_INFO, "[%d]<%d>connected to %s:%d successful", fd, thrno,
+         inet_ntoa(sa.sin_addr), SERVER_PORT);
+
+  const char *msg[] =
+  {
+    "hello, ", "ohos, ",
+    "my name is net_socket_test_008, ",
+    "see u next time, ", "Bye!"
+  };
+
+  for (int i = 0; i < sizeof(msg) / sizeof(msg[0]); ++i)
+    {
+      if (send(fd, msg[i], strlen(msg[i]), 0) < 0)
+        {
+          syslog(LOG_INFO, "[%d]<%d>send msg [%s] fail", fd, thrno,
+                 msg[i]);
+        }
+    }
+
+  (void)shutdown(fd, SHUT_RDWR);
+  (void)close(fd);
+  return param;
+}
+
+static int startclients(pthread_t *cli, int clinum)
+{
+  int ret;
+  pthread_attr_t attr;
+
+  for (int i = 0; i < clinum; ++i)
+    {
+      ret = pthread_attr_init(&attr);
+      assert_int_equal(ret, 0);
+
+      ret = pthread_create(&cli[i], &attr, clientsthread,
+                           (void *)(intptr_t)i);
+      assert_int_equal(ret, 0);
+
+      ret = pthread_attr_destroy(&attr);
+      assert_int_equal(ret, 0);
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: test_nuttx_net_socket_test08
+ ****************************************************************************/
+
+void test_nuttx_net_socket_test08(FAR void **state)
+{
+  struct sockaddr_in sa =
+  {
+    0
+  };
+
+  int lsfd;
+  int ret;
+
+  lsfd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  assert_int_not_equal(lsfd, -1);
+
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_ANY);
+  sa.sin_port = htons(SERVER_PORT);
+  ret = bind(lsfd, (struct sockaddr *)(&sa), sizeof(sa));
+  assert_int_not_equal(ret, -1);
+
+  ret = listen(lsfd, BACKLOG);
+  assert_int_not_equal(ret, -1);
+
+  initfds();
+  addfd(lsfd);
+  syslog(LOG_INFO, "[%d]Waiting for client to connect on port %d", lsfd,
+         SERVER_PORT);
+
+  pthread_t clients[CLIENT_NUM];
+
+  ret = startclients(clients, CLIENT_NUM);
+  assert_int_equal(ret, 0);
+
+  for (; ; )
+    {
+      int nfd;
+      fd_set readfds;
+      struct timeval timeout;
+
+      timeout.tv_sec = 3;
+      timeout.tv_usec = 0;
+
+      nfd = 0;
+      FD_ZERO(&readfds);
+
+      getreadfds(&readfds, &nfd);
+
+      ret = select(nfd + 1, &readfds, NULL, NULL, &timeout);
+      syslog(LOG_INFO, "select %d", ret);
+      if (ret == -1)
+        {
+          perror("select");
+          break; /* error occurred */
+        }
+
+      else if (ret == 0)
+        {
+          break; /* timed out */
+        }
+
+      if (handlereadfds(&readfds, lsfd) < 0)
+        {
+          break;
+        }
+    }
+
+  for (int i = 0; i < CLIENT_NUM; ++i)
+    {
+      ret = pthread_join(clients[i], NULL);
+      assert_int_equal(ret, 0);
+    }
+
+  assert_int_equal(gbye, CLIENT_NUM);
+  (void)closeallfd();
+}

--- a/testing/testsuites/kernel/socket/cases/net_socket_test_009.c
+++ b/testing/testsuites/kernel/socket/cases/net_socket_test_009.c
@@ -1,0 +1,337 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cases/net_socket_test_009.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/poll.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <inttypes.h>
+
+#include "SocketTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SERVER_PORT 8888
+#define INVALID_SOCKET -1
+#define BACKLOG CLIENT_NUM
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+static int gfds[FD_SETSIZE];
+static int gbye;
+
+static void initfds(void)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      gfds[i] = INVALID_SOCKET;
+    }
+}
+
+static void getreadfds(struct pollfd *fds, int *nfd)
+{
+  for (int i = 0; i < FD_SETSIZE; i++)
+    {
+      if (gfds[i] == INVALID_SOCKET)
+        {
+          continue;
+        }
+
+      fds[*nfd].fd = gfds[i];
+      fds[*nfd].events = POLLIN;
+      (*nfd)++;
+    }
+}
+
+static int addfd(int fd)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == INVALID_SOCKET)
+        {
+          gfds[i] = fd;
+          return 0;
+        }
+    }
+
+  return -1;
+}
+
+static void delfd(int fd)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == fd)
+        {
+          gfds[i] = INVALID_SOCKET;
+        }
+    }
+
+  (void)close(fd);
+}
+
+static int closeallfd(void)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] != INVALID_SOCKET)
+        {
+          (void)close(gfds[i]);
+          gfds[i] = INVALID_SOCKET;
+        }
+    }
+
+  return 0;
+}
+
+static int handlerecv(int fd)
+{
+  char buf[256];
+  int ret = recv(fd, buf, sizeof(buf) - 1, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_INFO, "[%d]Error: %s", fd, strerror(errno));
+      delfd(fd);
+    }
+
+  else if (ret == 0)
+    {
+      syslog(LOG_INFO, "[%d]Closed", fd);
+      delfd(fd);
+    }
+
+  else
+    {
+      buf[ret] = 0;
+      syslog(LOG_INFO, "[%d]Received: %s", fd, buf);
+      if (strstr(buf, "Bye") != NULL)
+        {
+          delfd(fd);
+          gbye++;
+        }
+    }
+
+  return -(ret < 0);
+}
+
+static int handleaccept(int lsfd)
+{
+  struct sockaddr_in sa;
+  int salen = sizeof(sa);
+  int fd = accept(lsfd, (struct sockaddr *)&sa, (socklen_t *)&salen);
+  if (fd == INVALID_SOCKET)
+    {
+      perror("accept");
+      return -1;
+    }
+
+  if (addfd(fd) == -1)
+    {
+      syslog(LOG_INFO, "Too many clients, refuse %s:%d",
+             inet_ntoa(sa.sin_addr), ntohs(sa.sin_port));
+      close(fd);
+      return -1;
+    }
+
+  syslog(LOG_INFO, "New client %d: %s:%d", fd, inet_ntoa(sa.sin_addr),
+         ntohs(sa.sin_port));
+  return 0;
+}
+
+static int handlereadfds(struct pollfd *fds, int nfds, int lsfd)
+{
+  int ret = 0;
+  for (int i = 0; i < nfds; ++i)
+    {
+      if (fds[i].revents == 0)
+        {
+          continue;
+        }
+
+      syslog(LOG_INFO, "[%d]revents: %04" PRIx32, fds[i].fd,
+             fds[i].revents);
+      if (fds[i].fd == lsfd)
+        {
+          ret += handleaccept(lsfd);
+        }
+
+      else
+        {
+          ret += handlerecv(fds[i].fd);
+        }
+    }
+
+  return ret;
+}
+
+static void *clientsthread(void *param)
+{
+  int fd;
+  int thrno = (int)(intptr_t)param;
+
+  syslog(LOG_INFO, "<%d>socket client thread started", thrno);
+  fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (fd == INVALID_SOCKET)
+    {
+      perror("socket");
+      return NULL;
+    }
+
+  struct sockaddr_in sa;
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  sa.sin_port = htons(SERVER_PORT);
+  if (connect(fd, (struct sockaddr *)&sa, sizeof(sa)) == -1)
+    {
+      perror("connect");
+      return NULL;
+    }
+
+  syslog(LOG_INFO, "[%d]<%d>connected to %s:%d successful", fd, thrno,
+         inet_ntoa(sa.sin_addr), SERVER_PORT);
+
+  const char *msg[] =
+  {
+    "hello, ", "ohos, ",
+    "my name is net_socket_test_009, ",
+    "see u next time, ", "Bye!"
+  };
+
+  for (int i = 0; i < sizeof(msg) / sizeof(msg[0]); ++i)
+    {
+      if (send(fd, msg[i], strlen(msg[i]), 0) < 0)
+        {
+          syslog(LOG_INFO, "[%d]<%d>send msg [%s] fail", fd, thrno,
+                 msg[i]);
+        }
+    }
+
+  (void)shutdown(fd, SHUT_RDWR);
+  (void)close(fd);
+  return param;
+}
+
+static int startclients(pthread_t *cli, int clinum)
+{
+  int ret;
+  pthread_attr_t attr;
+
+  for (int i = 0; i < clinum; ++i)
+    {
+      ret = pthread_attr_init(&attr);
+      assert_int_equal(ret, 0);
+
+      ret = pthread_create(&cli[i], &attr, clientsthread,
+                           (void *)(intptr_t)i);
+      assert_int_equal(ret, 0);
+
+      ret = pthread_attr_destroy(&attr);
+      assert_int_equal(ret, 0);
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: test_nuttx_net_socket_test09
+ ****************************************************************************/
+
+void test_nuttx_net_socket_test09(FAR void **state)
+{
+  struct sockaddr_in sa =
+  {
+    0
+  };
+
+  int lsfd;
+  int ret;
+
+  lsfd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  assert_int_not_equal(lsfd, -1);
+
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_ANY);
+  sa.sin_port = htons(SERVER_PORT);
+  ret = bind(lsfd, (struct sockaddr *)&sa, sizeof(sa));
+  assert_int_not_equal(ret, -1);
+
+  ret = listen(lsfd, BACKLOG);
+  assert_int_not_equal(ret, -1);
+
+  initfds();
+  addfd(lsfd);
+  syslog(LOG_INFO, "[%d]Waiting for client to connect on port %d", lsfd,
+         SERVER_PORT);
+
+  pthread_t clients[CLIENT_NUM];
+
+  ret = startclients(clients, CLIENT_NUM);
+  assert_int_equal(ret, 0);
+
+  for (; ; )
+    {
+      int nfd;
+      struct pollfd readfds[FD_SETSIZE];
+      int timeoutms;
+
+      timeoutms = 3000;
+      nfd = 0;
+      getreadfds(readfds, &nfd);
+
+      ret = poll(readfds, nfd, timeoutms);
+      syslog(LOG_INFO, "poll %d", ret);
+      if (ret == -1)
+        {
+          perror("poll");
+          break; /* error occurred */
+        }
+
+      else if (ret == 0)
+        {
+          break; /* timed out */
+        }
+
+      if (handlereadfds(readfds, nfd, lsfd) < 0)
+        {
+          break;
+        }
+    }
+
+  for (int i = 0; i < CLIENT_NUM; ++i)
+    {
+      ret = pthread_join(clients[i], NULL);
+      assert_int_equal(ret, 0);
+    }
+
+  assert_int_equal(gbye, CLIENT_NUM);
+  (void)closeallfd();
+}

--- a/testing/testsuites/kernel/socket/cases/net_socket_test_010.c
+++ b/testing/testsuites/kernel/socket/cases/net_socket_test_010.c
@@ -1,0 +1,259 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cases/net_socket_test_010.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <inttypes.h>
+#include <fcntl.h>
+
+#include "SocketTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IFF_PROMISC 0x100
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static char gdefaultnetif[IFNAMSIZ] = "eth0";
+
+static void initifreq(struct ifreq *ifr)
+{
+  *ifr = (struct ifreq)
+    {
+        {
+          0
+        }
+    };
+
+  /* (void)strncpy_s(ifr->ifr_name, sizeof(ifr->ifr_name) - 1, */
+
+  /* gdefaultnetif, sizeof(ifr->ifr_name) - 1); */
+
+  (void)strlcpy(ifr->ifr_name, gdefaultnetif, sizeof(ifr->ifr_name));
+  ifr->ifr_name[sizeof(ifr->ifr_name) - 1] = '\0';
+}
+
+static char *ifindex2name(int fd, unsigned index, char *name)
+{
+#ifdef CONFIG_NETDEV_IFINDEX
+  return if_indextoname(index, name);
+#else
+  struct ifreq ifr;
+  int ret;
+
+  ifr.ifr_ifindex = index;
+  ret = ioctl(fd, siocgifname, &ifr);
+  if (ret < 0)
+    {
+      return NULL;
+    }
+
+  /* ret = strncpy_s(name, IF_NAMESIZE - 1, ifr.ifr_name, IF_NAMESIZE -
+   * 1);
+   */
+
+  strncpy(name, ifr.ifr_name, IF_NAMESIZE - 1);
+  name[IF_NAMESIZE - 1] = '\0';
+  return name;
+#endif
+}
+
+static unsigned ifname2index(int fd, const char *name)
+{
+#ifdef CONFIG_NETDEV_IFINDEX
+  return if_nametoindex(name);
+#else
+  struct ifreq ifr;
+  int ret;
+
+  /* (void)strncpy_s(ifr.ifr_name, sizeof(ifr.ifr_name) - 1, name,
+   * sizeof(ifr.ifr_name) - 1);
+   */
+
+  (void)strncpy(ifr.ifr_name, name, sizeof(ifr.ifr_name) - 1);
+  ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+  ret = ioctl(fd, SIOCGIFINDEX, &ifr);
+  return ret < 0 ? 0 : ifr.ifr_ifindex;
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_net_socket_test10
+ ****************************************************************************/
+
+static int ioctltestinternal(int sfd)
+{
+  struct ifreq ifr =
+  {
+    {
+      0
+    }
+  };
+
+  char ifname[IFNAMSIZ] =
+  {
+    0
+  };
+
+  char *p = NULL;
+  unsigned int loindex = 0;
+  unsigned int lanindex = 0;
+  char lanname[IFNAMSIZ];
+  int maxindex = 256;
+  int ret;
+  char *ret_s = NULL;
+
+  for (int i = 0; i < maxindex; ++i)
+    {
+      p = ifindex2name(sfd, i, ifname);
+      if (p)
+        {
+          if (strcmp(p, "lo") == 0)
+            {
+              loindex = i;
+            }
+
+          else
+            {
+              lanindex = i;
+              strcpy(lanname, p);
+              syslog(LOG_INFO, "name of lan:  %s", lanname);
+            }
+        }
+    }
+
+  syslog(LOG_INFO, "ifindex of lo: %u, ifindex of lan: %u", loindex,
+         lanindex);
+  assert_int_not_equal(loindex, 0);
+  assert_int_not_equal(lanindex, 0);
+
+  p = ifindex2name(sfd, loindex, ifname);
+  syslog(LOG_INFO, "ifindex %u: %s", loindex, p);
+  assert_non_null(p);
+  assert_string_equal(p, "lo");
+
+  p = ifindex2name(sfd, lanindex, ifname);
+  syslog(LOG_INFO, "ifindex %u: %s", lanindex, p);
+  assert_non_null(p);
+  assert_string_equal(p, lanname);
+
+  /* ret = strncpy_s(gdefaultnetif, sizeof(gdefaultnetif) -1, p,
+   * sizeof(gdefaultnetif) - 1);
+   */
+
+  ret_s = strncpy(gdefaultnetif, p, sizeof(gdefaultnetif) - 1);
+  assert_non_null(ret_s);
+  gdefaultnetif[sizeof(gdefaultnetif) - 1] = '\0';
+
+  ret = (int)ifname2index(sfd, p);
+  syslog(LOG_INFO, "index of %s: %d", p, ret);
+  assert_int_not_equal(ret, 0);
+  assert_int_equal(ret, lanindex);
+
+  ifr.ifr_ifindex = lanindex;
+  ret = ioctl(sfd, siocgifname, &ifr);
+  assert_int_equal(ret, 0);
+  syslog(LOG_INFO, "name of ifindex %u: %s", lanindex, ifr.ifr_name);
+  assert_string_equal(ifr.ifr_name, lanname);
+
+  initifreq(&ifr);
+  ret = ioctl(sfd, SIOCGIFINDEX, &ifr);
+  assert_int_equal(ret, 0);
+  syslog(LOG_INFO, "index of ifname %s: %d", ifr.ifr_name,
+         ifr.ifr_ifindex);
+  assert_int_equal(ifr.ifr_ifindex, lanindex);
+
+  initifreq(&ifr);
+  ret = ioctl(sfd, SIOCGIFHWADDR, &ifr);
+  assert_int_equal(ret, 0);
+  syslog(LOG_INFO, "hwaddr: %02hhX:%02hhX:%02hhX:XX:XX:XX",
+         ifr.ifr_hwaddr.sa_data[0], ifr.ifr_hwaddr.sa_data[1],
+         ifr.ifr_hwaddr.sa_data[2]);
+
+  initifreq(&ifr);
+  ret = ioctl(sfd, SIOCGIFFLAGS, &ifr);
+  assert_int_equal(ret, 0);
+  syslog(LOG_INFO, "FLAGS of ifname %s: %#" PRIx32 ", IFF_PROMISC: %d",
+         ifr.ifr_name, ifr.ifr_flags, !!(ifr.ifr_flags & IFF_PROMISC));
+
+  if (ifr.ifr_flags & IFF_PROMISC)
+    {
+      ifr.ifr_flags &= ~(IFF_PROMISC);
+    }
+
+  else
+    {
+      ifr.ifr_flags |= IFF_PROMISC;
+    }
+
+  syslog(LOG_INFO, "SIOCSIFFLAGS FLAGS: %#" PRIx32, ifr.ifr_flags);
+  ret = ioctl(sfd, SIOCSIFFLAGS, &ifr);
+  if (ret == -1)
+    {
+      assert_int_equal(errno, EPERM);
+    }
+
+  else
+    {
+      assert_int_equal(ret, 0);
+    }
+
+  initifreq(&ifr);
+  ret = ioctl(sfd, SIOCGIFFLAGS, &ifr);
+  assert_int_equal(ret, 0);
+  syslog(LOG_INFO, "FLAGS of ifname %s: %#" PRIx32 ", IFF_PROMISC: %d",
+         ifr.ifr_name, ifr.ifr_flags, !!(ifr.ifr_flags & IFF_PROMISC));
+
+  ret = fcntl(sfd, F_GETFL, 0);
+  assert_int_equal(ret < 0, 0);
+
+  ret = fcntl(sfd, F_SETFL, ret | O_NONBLOCK);
+  assert_int_equal(ret < 0, 0);
+
+  return 0;
+}
+
+void test_nuttx_net_socket_test10(FAR void **state)
+{
+  int sfd;
+
+  sfd = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+  syslog(LOG_INFO, "socket(PF_INET, SOCK_STREAM, IPPROTO_TCP): %d", sfd);
+  assert_int_not_equal(sfd, -1);
+
+  (void)ioctltestinternal(sfd);
+
+  (void)close(sfd);
+}

--- a/testing/testsuites/kernel/socket/cases/net_socket_test_011.c
+++ b/testing/testsuites/kernel/socket/cases/net_socket_test_011.c
@@ -1,0 +1,319 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cases/net_socket_test_011.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "SocketTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SERVER_PORT 7777
+#define INVALID_SOCKET -1
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+static int gfds[FD_SETSIZE];
+static int gbye;
+
+static void initfds(void)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      gfds[i] = INVALID_SOCKET;
+    }
+}
+
+static void getreadfds(fd_set *fds, int *nfd)
+{
+  for (int i = 0; i < FD_SETSIZE; i++)
+    {
+      if (gfds[i] == INVALID_SOCKET)
+        {
+          continue;
+        }
+
+      FD_SET(gfds[i], fds);
+      if (*nfd < gfds[i])
+        {
+          *nfd = gfds[i];
+        }
+    }
+}
+
+static int addfd(int fd)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == INVALID_SOCKET)
+        {
+          gfds[i] = fd;
+          return 0;
+        }
+    }
+
+  return -1;
+}
+
+static void delfd(int fd)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == fd)
+        {
+          gfds[i] = INVALID_SOCKET;
+        }
+    }
+
+  (void)close(fd);
+}
+
+static int closeallfd(void)
+{
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] != INVALID_SOCKET)
+        {
+          (void)close(gfds[i]);
+          gfds[i] = INVALID_SOCKET;
+        }
+    }
+
+  return 0;
+}
+
+static int handlerecv(int fd)
+{
+  char buf[128];
+  int ret = recv(fd, buf, sizeof(buf) - 1, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_INFO, "[%d]Error: %s", fd, strerror(errno));
+      delfd(fd);
+    }
+
+  else if (ret == 0)
+    {
+      syslog(LOG_INFO, "[%d]Closed", fd);
+      delfd(fd);
+    }
+
+  else
+    {
+      buf[ret] = 0;
+      syslog(LOG_INFO, "[%d]Received: %s", fd, buf);
+      if (strstr(buf, "Bye") != NULL)
+        {
+          gbye++;
+        }
+    }
+
+  return -(ret < 0);
+}
+
+static int handlereadfds(fd_set *fds, int lsfd)
+{
+  int ret = 0;
+  for (int i = 0; i < FD_SETSIZE; ++i)
+    {
+      if (gfds[i] == INVALID_SOCKET || !FD_ISSET(gfds[i], fds))
+        {
+          continue;
+        }
+
+      ret += handlerecv(gfds[i]);
+    }
+
+  return ret;
+}
+
+static void *clientsthread(void *param)
+{
+  int fd;
+  int thrno = (int)(intptr_t)param;
+
+  syslog(LOG_INFO, "<%d>socket client thread started", thrno);
+  fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (fd == INVALID_SOCKET)
+    {
+      perror("socket");
+      return NULL;
+    }
+
+  struct sockaddr_in sa;
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  sa.sin_port = htons(SERVER_PORT);
+  if (connect(fd, (struct sockaddr *)(&sa), sizeof(sa)) == -1)
+    {
+      perror("connect");
+      return NULL;
+    }
+
+  syslog(LOG_INFO, "[%d]<%d>connected to udp://%s:%d successful", fd,
+         thrno, inet_ntoa(sa.sin_addr), SERVER_PORT);
+
+  const char *msg[] =
+  {
+      "ohos, ",
+      "hello, ",
+      "my name is net_socket_test_011, ",
+      "see u next time, ",
+      "Bye!",
+  };
+
+  for (int i = 0; i < sizeof(msg) / sizeof(msg[0]); ++i)
+    {
+      if (send(fd, msg[i], strlen(msg[i]), 0) < 0)
+        {
+          syslog(LOG_INFO, "[%d]<%d>send msg [%s] fail", fd, thrno,
+                 msg[i]);
+        }
+    }
+
+  (void)shutdown(fd, SHUT_RDWR);
+  (void)close(fd);
+  return param;
+}
+
+static int startclients(pthread_t *cli, int clinum)
+{
+  int ret;
+  pthread_attr_t attr =
+    {
+      0
+    };
+
+  struct sched_param param =
+  {
+    0
+  };
+
+  int policy;
+  ret = pthread_getschedparam(pthread_self(), &policy, &param);
+  assert_int_equal(ret, 0);
+
+  for (int i = 0; i < clinum; ++i)
+    {
+      ret = pthread_attr_init(&attr);
+      param.sched_priority = param.sched_priority + 1;
+      pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+      pthread_attr_setschedparam(&attr, &param);
+
+      ret = pthread_create(&cli[i], &attr, clientsthread,
+                           (void *)(intptr_t)i);
+      assert_int_equal(ret, 0);
+      ret = pthread_attr_destroy(&attr);
+      assert_int_equal(ret, 0);
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: test_nuttx_net_socket_test11
+ ****************************************************************************/
+
+void test_nuttx_net_socket_test11(FAR void **state)
+{
+  struct sockaddr_in sa =
+  {
+    0
+  };
+
+  int lsfd;
+  int ret;
+
+  lsfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  assert_int_not_equal(lsfd, -1);
+
+  sa.sin_family = AF_INET;
+  sa.sin_addr.s_addr = htonl(INADDR_ANY);
+  sa.sin_port = htons(SERVER_PORT);
+  ret = bind(lsfd, (struct sockaddr *)(&sa), sizeof(sa));
+  assert_int_not_equal(ret, -1);
+
+  initfds();
+  addfd(lsfd);
+  syslog(LOG_INFO, "[%d]Waiting for client to connect on UDP port %d",
+         lsfd, SERVER_PORT);
+
+  pthread_t clients[CLIENT_NUM];
+
+  ret = startclients(clients, CLIENT_NUM);
+  assert_int_equal(ret, 0);
+
+  for (; ; )
+    {
+      int nfd;
+      fd_set readfds;
+      struct timeval timeout;
+
+      timeout.tv_sec = 3;
+      timeout.tv_usec = 0;
+
+      nfd = 0;
+      FD_ZERO(&readfds);
+
+      getreadfds(&readfds, &nfd);
+
+      ret = select(nfd + 1, &readfds, NULL, NULL, &timeout);
+      syslog(LOG_INFO, "select %d", ret);
+      if (ret == -1)
+        {
+          perror("select");
+          break; /* error occurred */
+        }
+
+      else if (ret == 0)
+        {
+          break; /* timed out */
+        }
+
+      if (handlereadfds(&readfds, lsfd) < 0)
+        {
+          break;
+        }
+    }
+
+  for (int i = 0; i < CLIENT_NUM; ++i)
+    {
+      ret = pthread_join(clients[i], NULL);
+      assert_int_equal(ret, 0);
+    }
+
+#ifdef CONFIG_NET_UDP_NOTIFIER
+  assert_int_equal(gbye, CLIENT_NUM);
+#endif
+  (void)closeallfd();
+}

--- a/testing/testsuites/kernel/socket/cmocka_socket_test.c
+++ b/testing/testsuites/kernel/socket/cmocka_socket_test.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/cmocka_socket_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "SocketTest.h"
+#include <cmocka.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cmocka_sched_test_main
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+  /* Add Test Cases */
+
+  const struct CMUnitTest nuttx_socket_test_suites[] =
+  {
+      cmocka_unit_test_setup_teardown(test_nuttx_net_socket_test05, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_net_socket_test06, NULL,
+                                      NULL),
+#if defined(CONFIG_NET_LOOPBACK) || defined(CONFIG_NET_USRSOCK)
+      cmocka_unit_test_setup_teardown(test_nuttx_net_socket_test08, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_net_socket_test09, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_net_socket_test10, NULL,
+                                      NULL),
+      cmocka_unit_test_setup_teardown(test_nuttx_net_socket_test11, NULL,
+                                      NULL),
+#endif
+  };
+
+  /* Run Test cases */
+
+  cmocka_run_group_tests(nuttx_socket_test_suites, NULL, NULL);
+
+  return 0;
+}

--- a/testing/testsuites/kernel/socket/include/SocketTest.h
+++ b/testing/testsuites/kernel/socket/include/SocketTest.h
@@ -1,0 +1,80 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/socket/include/SocketTest.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __TEST_H
+#define __TEST_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <syslog.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define CLIENT_NUM 8
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* test case function */
+
+/* cases/net_socket_test_005.c
+ * ***********************************************/
+
+void test_nuttx_net_socket_test05(FAR void **state);
+
+/* cases/net_socket_test_006.c
+ * ************************************************/
+
+void test_nuttx_net_socket_test06(FAR void **state);
+
+/* cases/net_socket_test_008.c
+ * ************************************************/
+
+void test_nuttx_net_socket_test08(FAR void **state);
+
+/* cases/net_socket_test_009.c
+ * ************************************************/
+
+void test_nuttx_net_socket_test09(FAR void **state);
+
+/* cases/net_socket_test_010.c
+ * ************************************************/
+
+void test_nuttx_net_socket_test10(FAR void **state);
+
+/* cases/net_socket_test_011.c
+ * ************************************************/
+
+void test_nuttx_net_socket_test11(FAR void **state);
+
+#endif

--- a/testing/testsuites/kernel/syscall/cases/Fstatfs_test.c
+++ b/testing/testsuites/kernel/syscall/cases/Fstatfs_test.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/Fstatfs_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <errno.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fstatfs01
+ ****************************************************************************/
+
+void test_nuttx_syscall_fstatfs01(FAR void **state)
+{
+  int file_fd;
+  int pipe_fd;
+  int lc;
+  int i;
+  int ret;
+  int p[2];
+  struct statfs stats;
+  char fname[256] = "";
+
+  struct tcase
+  {
+    int *fd;
+    const char *msg;
+  }
+
+  tcases[2] =
+    {
+        {
+          NULL, "fstatfs() on a file"
+        },
+
+        {
+          NULL, "fstatfs() on a pipe"
+        },
+    };
+
+  tcases[0].fd = &file_fd;
+  tcases[1].fd = &pipe_fd;
+
+  sprintf(fname, "Fstatfs01_%d", gettid());
+
+  file_fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(file_fd > 0);
+
+  assert_int_equal(pipe(p), 0);
+  pipe_fd = p[0];
+  assert_int_equal(close(p[1]), 0);
+
+  for (lc = 0; lc < 2; lc++)
+    {
+      for (i = 0; i < 1; i++)
+        {
+          ret = fstatfs(*(tcases[i].fd), &stats);
+          assert_int_equal(ret, 0);
+        }
+    }
+
+  if (file_fd > 0)
+    assert_int_equal(close(file_fd), 0);
+
+  if (pipe_fd > 0)
+    assert_int_equal(close(pipe_fd), 0);
+
+  assert_int_equal(unlink(fname), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/accept_test.c
+++ b/testing/testsuites/kernel/syscall/cases/accept_test.c
@@ -1,0 +1,154 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/accept_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_verityaccept01
+ ****************************************************************************/
+
+__attribute__((unused)) void test_nuttx_syscall_verityaccept01(
+    int testno, int domain, int type, int proto, int fd,
+    struct sockaddr *sockaddr, unsigned int *salen, int experrno)
+{
+#ifdef CONFIG_NET_TCP
+  int ret;
+  errno = 0;
+  ret = accept(fd, sockaddr, salen);
+  close(fd);
+  assert_int_equal(ret, -1);
+
+  /* syslog(LOG_INFO, "ret=%d   errnor=%d\n experrno=%d", ret,
+   * errno,experrno);
+   */
+
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_accept01
+ ****************************************************************************/
+
+void test_nuttx_syscall_accept01(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  struct sockaddr_in sin0;
+  struct sockaddr_in sin1;
+  struct sockaddr_in fsin1;
+  int invalid_socketfd = -400;
+  int devnull_fd;
+  int socket_fd;
+  int udp_fd;
+
+  sin0.sin_family = AF_INET;
+  sin0.sin_port = 0;
+  sin0.sin_addr.s_addr = INADDR_ANY;
+
+  devnull_fd = open("/dev/null", O_WRONLY);
+
+  socket_fd = socket(PF_INET, SOCK_STREAM, 0);
+  assert_int_not_equal(socket_fd, -1);
+  bind(socket_fd, (struct sockaddr *)&sin0, sizeof(sin0));
+
+  sin1.sin_family = AF_INET;
+  sin1.sin_port = 0;
+  sin1.sin_addr.s_addr = INADDR_ANY;
+  udp_fd = socket(PF_INET, SOCK_DGRAM, 0);
+  assert_int_not_equal(udp_fd, -1);
+  bind(udp_fd, (struct sockaddr *)&sin1, sizeof(sin1));
+
+  struct test_case
+  {
+    int domain;
+    int type;
+    int proto;
+    int *fd;
+    struct sockaddr *sockaddr;
+    socklen_t salen;
+    int experrno;
+  }
+
+  tcases[] =
+    {
+        {
+          PF_INET, SOCK_STREAM, 0, &invalid_socketfd,
+          (struct sockaddr *)&fsin1, sizeof(fsin1), EBADF
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, &devnull_fd, (struct sockaddr *)&fsin1,
+          sizeof(fsin1), ENOTSOCK
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, &socket_fd, (struct sockaddr *)3,
+          sizeof(fsin1), EINVAL
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, &socket_fd, (struct sockaddr *)&fsin1, 1,
+          EINVAL
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, &socket_fd, (struct sockaddr *)&fsin1,
+          sizeof(fsin1), EINVAL
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, &udp_fd, (struct sockaddr *)&fsin1,
+          sizeof(fsin1), EOPNOTSUPP
+        },
+    };
+
+  for (int i = 0; i < 6; i++)
+    {
+      test_nuttx_syscall_verityaccept01(
+          i, tcases[i].domain, tcases[i].type, tcases[i].proto,
+          *tcases[i].fd, tcases[i].sockaddr, &tcases[i].salen,
+          tcases[i].experrno);
+    }
+#endif
+}

--- a/testing/testsuites/kernel/syscall/cases/bind_test.c
+++ b/testing/testsuites/kernel/syscall/cases/bind_test.c
@@ -1,0 +1,137 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/bind_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <grp.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <syslog.h>
+#include <errno.h>
+#include <pthread.h>
+#include <netinet/in.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_bind01
+ ****************************************************************************/
+
+void test_nuttx_syscall_bind01(FAR void **state)
+{
+  int inet_socket;
+  int dev_null;
+
+  struct sockaddr_in sin1;
+  struct sockaddr_in sin2;
+  struct sockaddr_un sun;
+  struct test_case
+  {
+    int *socket_fd;
+    struct sockaddr *sockaddr;
+    socklen_t salen;
+    int retval;
+    int experrno;
+    char *desc;
+  }
+
+  tcases[] =
+    {
+        {
+          &inet_socket, (struct sockaddr *)&sin1, 3, -1, EINVAL,
+          "invalid salen"
+        },
+
+        {
+          &dev_null, (struct sockaddr *)&sin1, sizeof(sin1), -1, ENOTSOCK,
+          "invalid socket"
+        },
+
+        {
+          &inet_socket, (struct sockaddr *)&sin2, sizeof(sin2), 0, 0,
+          "INADDR_ANYPORT"
+        },
+
+        {
+          &inet_socket, (struct sockaddr *)&sun, sizeof(sun), -1,
+          EAFNOSUPPORT, "UNIX-domain of current directory"
+        },
+    };
+
+  /* initialize sockaddr's */
+
+  sin1.sin_family = AF_INET;
+  sin1.sin_port = 25197;
+  sin1.sin_addr.s_addr = INADDR_ANY;
+  sin2.sin_family = AF_INET;
+  sin2.sin_port = 0;
+  sin2.sin_addr.s_addr = INADDR_ANY;
+
+  sun.sun_family = AF_UNIX;
+  strncpy(sun.sun_path, ".", sizeof(sun.sun_path));
+  inet_socket = socket(PF_INET, SOCK_STREAM, 0);
+  dev_null = open("/dev/null", O_WRONLY);
+
+  int test_ret;
+  int test_err;
+  int i;
+  for (i = 0; i < 4; i++)
+    {
+      inet_socket = socket(PF_INET, SOCK_STREAM, 0);
+      dev_null = open("/dev/null", O_WRONLY);
+      if (tcases[i].experrno)
+        {
+          test_ret = bind(*tcases[i].socket_fd, tcases[i].sockaddr,
+                          tcases[i].salen);
+          test_err = errno;
+          close(inet_socket);
+          close(dev_null);
+          assert_int_not_equal(test_ret, 0);
+          assert_int_equal(test_ret, -1);
+          assert_int_equal(test_err, tcases[i].experrno);
+        }
+
+      else
+        {
+          test_ret = bind(*tcases[i].socket_fd, tcases[i].sockaddr,
+                          tcases[i].salen);
+          close(inet_socket);
+          close(dev_null);
+          assert_int_not_equal(test_ret, -1);
+          assert_int_equal(test_ret, 0);
+        }
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/chdir_test.c
+++ b/testing/testsuites/kernel/syscall/cases/chdir_test.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/chdir_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_chdir01
+ ****************************************************************************/
+
+void test_nuttx_syscall_chdir01(FAR void **state)
+{
+  char testdir[64] =
+  {
+    0
+  };
+
+  int ret;
+
+  sprintf(testdir, "%s_dir", __func__);
+  rmdir(testdir);
+  assert_int_equal(mkdir(testdir, S_IRWXU), 0);
+
+  ret = chdir(testdir);
+  assert_int_equal(ret, 0);
+  rmdir(testdir);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_chdir02
+ ****************************************************************************/
+
+void test_nuttx_syscall_chdir02(FAR void **state)
+{
+  int ret;
+  char dirs[64] =
+  {
+    0
+  };
+
+  getcwd(dirs, sizeof(dirs));
+
+  /* Switch the directory 100 times */
+
+  for (int lc = 0; lc < 100; lc++)
+    {
+      if (lc % 2 == 0)
+        {
+          ret = chdir("/");
+          assert_int_equal(ret, 0);
+        }
+
+      else
+        {
+          ret = chdir(dirs);
+          assert_int_equal(ret, 0);
+        }
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/clock_gettime_test.c
+++ b/testing/testsuites/kernel/syscall/cases/clock_gettime_test.c
@@ -1,0 +1,106 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/clock_gettime_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_clockgettime01
+ ****************************************************************************/
+
+void test_nuttx_syscall_clockgettime01(FAR void **state)
+{
+  int ret;
+  clockid_t type;
+  struct test_case
+  {
+    clockid_t clktype;
+    int allow_inval;
+  }
+
+  tc[] =
+    {
+        {
+            CLOCK_REALTIME,
+        },
+
+        {
+            CLOCK_MONOTONIC,
+        },
+
+        {
+          CLOCK_BOOTTIME, 1
+        },
+    };
+
+  struct timespec spec;
+
+  for (int i = 0; i < 3; i++)
+    {
+      type = tc[i].clktype;
+      switch (type)
+        {
+        case CLOCK_REALTIME:
+
+          /* syslog(LOG_INFO, "clock_gettime test CLOCK_REALTIME\n"); */
+
+          break;
+        case CLOCK_MONOTONIC:
+
+          /* syslog(LOG_INFO, "clock_gettime test CLOCK_MONOTONIC\n"); */
+
+          break;
+        case CLOCK_BOOTTIME:
+
+          /* syslog(LOG_INFO, "clock_gettime test CLOCK_BOOTTIME\n"); */
+
+          break;
+        default:
+          break;
+        }
+
+      ret = clock_gettime(type, &spec);
+      assert_int_equal(ret, 0);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/clock_nanosleep_test.c
+++ b/testing/testsuites/kernel/syscall/cases/clock_nanosleep_test.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/clock_nanosleep_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <errno.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_clocknanosleep01
+ ****************************************************************************/
+
+void test_nuttx_syscall_clocknanosleep01(FAR void **state)
+{
+  int ret;
+  clockid_t type = CLOCK_REALTIME;
+  struct timespec t;
+  clock_t start_time, end_time;
+  t.tv_sec = 2;
+  t.tv_nsec = 0;
+  start_time = clock();
+  ret = clock_nanosleep(type, 0, &t, NULL);
+  assert_int_equal(ret, 0);
+  end_time = clock();
+  assert_int_equal((time_t)(end_time - start_time) / CLOCKS_PER_SEC,
+                   t.tv_sec);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_clocknanosleep02
+ ****************************************************************************/
+
+void test_nuttx_syscall_clocknanosleep02(FAR void **state)
+{
+  int ret;
+  struct timespec ts;
+  clockid_t tcase[] =
+    {
+        CLOCK_MONOTONIC,
+        CLOCK_REALTIME,
+    };
+
+  ret = clock_gettime(tcase[0], &ts);
+  assert_int_equal(ret, 0);
+
+  ts.tv_sec = 4;
+  ts.tv_nsec = 1000;
+
+  ret = clock_nanosleep(tcase[0], TIMER_ABSTIME, &ts, NULL);
+  assert_int_equal(ret, 0);
+
+  ret = clock_gettime(tcase[1], &ts);
+  assert_int_equal(ret, 0);
+
+  ts.tv_sec = 4;
+  ts.tv_nsec = 1000;
+
+  ret = clock_nanosleep(tcase[1], TIMER_ABSTIME, &ts, NULL);
+  assert_int_equal(ret, 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/clock_settime_test.c
+++ b/testing/testsuites/kernel/syscall/cases/clock_settime_test.c
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/clock_settime_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <time.h>
+#include <syslog.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_clocksettime01
+ ****************************************************************************/
+
+void test_nuttx_syscall_clocksettime01(FAR void **state)
+{
+  int ret;
+  struct timespec ts;
+  time_t begin_time;
+  time_t end_time;
+
+  /* do clock_gettime */
+
+  ret = clock_gettime(CLOCK_REALTIME, &ts);
+  assert_int_equal(ret, 0);
+
+  begin_time = ts.tv_sec;
+  ts.tv_sec = ts.tv_sec + 10;
+  ret = clock_settime(CLOCK_REALTIME, &ts);
+  assert_int_equal(ret, 0);
+
+  ret = clock_gettime(CLOCK_REALTIME, &ts);
+  assert_int_equal(ret, 0);
+
+  end_time = ts.tv_sec;
+  assert_true((end_time - begin_time) >= 10);
+}

--- a/testing/testsuites/kernel/syscall/cases/close_test.c
+++ b/testing/testsuites/kernel/syscall/cases/close_test.c
@@ -1,0 +1,150 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/close_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <syslog.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_close01
+ ****************************************************************************/
+
+void test_nuttx_syscall_close01(FAR void **state)
+{
+  int fd;
+  int newfd;
+  int pipefd[2] =
+  {
+    0
+  };
+
+  char filename[128] =
+  {
+    0
+  };
+
+  int ret;
+
+  sprintf(filename, "%s_dir", __func__);
+
+  fd = creat(filename, 0777);
+
+  newfd = dup(fd);
+
+  ret = pipe(pipefd);
+  assert_int_equal(ret, 0);
+
+  for (int i = 0; i < 2; i++)
+    {
+      if (pipefd[i] > 0)
+        {
+          ret = close(pipefd[i]);
+          assert_int_equal(ret, 0);
+        }
+    }
+
+  if (fd > 0)
+    close(fd);
+  if (newfd > 0)
+    close(newfd);
+  remove(filename);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_close02
+ ****************************************************************************/
+
+void test_nuttx_syscall_close02(FAR void **state)
+{
+#ifndef CONFIG_FDSAN
+  int ret;
+  int badfd1 = -1;
+  int badfd2 = 99999999;
+
+  ret = close(badfd1);
+  assert_int_equal(ret, ERROR);
+
+  /* Check that an invalid file descriptor returns EBADF
+   */
+
+  assert_int_equal(errno, EBADF);
+
+  ret = close(badfd2);
+  assert_int_equal(ret, ERROR);
+
+  /* Check that an invalid file descriptor returns EBADF
+   */
+
+  assert_int_equal(errno, EBADF);
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_close03
+ ****************************************************************************/
+
+void test_nuttx_syscall_close03(FAR void **state)
+{
+  char filename[128] =
+  {
+    0
+  };
+
+  int fd;
+  int ret;
+
+  for (int i = 0; i < 100; i++)
+    {
+      memset(filename, 0, sizeof(filename));
+      sprintf(filename, "%s_dir%d", __func__, i + 1);
+
+      fd = open(filename, O_RDWR | O_CREAT, 0700);
+      if (fd < 0)
+        {
+          fail_msg("open test file fail !\n");
+        }
+
+      ret = close(fd);
+      assert_int_equal(ret, 0);
+
+      unlink(filename);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/connect_test.c
+++ b/testing/testsuites/kernel/syscall/cases/connect_test.c
@@ -1,0 +1,372 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/connect_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#ifndef UCLINUX
+#define UCLINUX
+#include <nuttx/config.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <pthread.h>
+#include <errno.h>
+#include <sys/un.h>
+#include <sys/select.h>
+#include <sys/syscall.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#ifdef CONFIG_FDCHECK
+#include <nuttx/fdcheck.h>
+#endif
+#include "SyscallTest.h"
+
+__attribute__((unused)) static int s; /* socket descriptor */
+__attribute__((unused)) static int testno;
+__attribute__((unused)) static struct sockaddr_in sin1, sin2, sin4;
+__attribute__((unused)) static pthread_t thread;
+__attribute__((unused)) static int
+    sfd; /* shared between start_server and do_child */
+__attribute__((unused)) static int setup(void), setup0(void),
+    setup1(void), setup2(void), cleanup(void), cleanup0(void),
+    cleanup1(void);
+__attribute__((unused)) static void do_child(void);
+
+__attribute__((unused)) static void *start_server(void *);
+
+__attribute__((unused)) static struct test_case_t
+{
+  int domain;                /* PF_INET, PF_UNIX, ... */
+  int type;                  /* SOCK_STREAM, SOCK_DGRAM ... */
+  int proto;                 /* protocol number (usually 0 = default) */
+  struct sockaddr *sockaddr; /* socket address buffer */
+  int salen;                 /* connect's 3rd argument */
+  int retval;                /* syscall return value */
+  int experrno;              /* expected errno */
+  int (*setup)(void);
+  int (*cleanup)(void);
+  char *desc;
+}
+
+tdat[] =
+    {
+        {
+          PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&sin1,
+        sizeof(struct sockaddr_in), -1, EBADF, setup0, cleanup0,
+        "bad file descriptor"
+        },
+    #ifndef UCLINUX
+
+        /* Skip since uClinux does not implement memory protection */
+
+        {
+          PF_INET, SOCK_STREAM, 0, (struct sockaddr *)-1,
+        sizeof(struct sockaddr_in), -1, EFAULT, setup1, cleanup1,
+        "invalid socket buffer"
+        },
+
+    #endif
+        {
+          PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&sin1, 3, -1, EINVAL,
+        setup1, cleanup1, "invalid salen"
+        },
+
+        {
+          0, 0, 0, (struct sockaddr *)&sin1, sizeof(sin1), -1, ENOTSOCK,
+        setup0, cleanup0, "invalid socket"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&sin1,
+          sizeof(sin1), -1, EISCONN, setup2, cleanup1,
+          "already connected"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&sin2,
+          sizeof(sin2), -1, ECONNREFUSED, setup1, cleanup1,
+          "connection refused"
+        },
+
+  /* if CONFIG_DEBUG_ASSERTIONS is set,
+   * the connect operation will be crash
+   */
+
+    #ifndef CONFIG_DEBUG_ASSERTIONS
+        {
+          PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&sin4,
+          sizeof(sin4), -1, EAFNOSUPPORT, setup1, cleanup1,
+          "invalid address family"
+        },
+    #endif
+    };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_connect01
+ ****************************************************************************/
+
+void test_nuttx_syscall_connect01(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  int ret;
+  int flag = 1;
+  setup();
+
+  for (testno = 0; testno < sizeof(tdat) / sizeof((tdat)[0]); ++testno)
+    {
+      usleep(100000);
+      if (tdat[testno].setup() < 0)
+        {
+          tdat[testno].cleanup();
+          continue;
+        }
+
+      ret = connect(s, tdat[testno].sockaddr, tdat[testno].salen);
+
+      if (ret != tdat[testno].retval ||
+          (ret < 0 && errno != tdat[testno].experrno))
+        {
+          syslog(LOG_ERR,
+                 "test connect %s failed; "
+                 "returned %d (expected %d), errno %d "
+                 "(expected %d)\n",
+                 tdat[testno].desc, ret, tdat[testno].retval, errno,
+                 tdat[testno].experrno);
+
+          /* fail_msg("test fail !"); */
+
+          flag = 1;
+        }
+
+      tdat[testno].cleanup();
+    }
+
+  cleanup();
+  assert_true(flag);
+#endif
+}
+
+__attribute__((unused)) static int setup(void)
+{
+  int r = pthread_create(&thread, NULL, start_server, (void *)&sin1);
+  if (r < 0)
+      return -1;
+
+  sin2.sin_family = AF_INET;
+
+  /* this port must be unused! */
+
+  sin2.sin_port = get_unused_port(NULL, AF_INET, SOCK_STREAM);
+  if (sin2.sin_port < 0)
+      return -1;
+  sin2.sin_addr.s_addr = INADDR_ANY;
+
+  sin4.sin_family = 47; /* bogus address family */
+  sin4.sin_port = 0;
+  sin4.sin_addr.s_addr = htonl(0x0afffefd);
+  return 0;
+}
+
+__attribute__((unused)) static int cleanup(void)
+{
+  assert_true(pthread_cancel(thread) == 0);
+  assert_true(pthread_join(thread, NULL) == 0);
+  return 0;
+}
+
+__attribute__((unused)) static int setup0(void)
+{
+  if (tdat[testno].experrno == EBADF)
+    s = -400; /* anything not an open file */
+  else if ((s = open("/dev/null", O_WRONLY)) == -1)
+    {
+      syslog(LOG_ERR, "open /dev/null fail, errno %d\n", errno);
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  return 0;
+}
+
+__attribute__((unused)) static int cleanup0(void)
+{
+  close(s);
+  s = -1;
+  return 0;
+}
+
+__attribute__((unused)) static int setup1(void)
+{
+  s = safe_socket(tdat[testno].domain, tdat[testno].type,
+                  tdat[testno].proto);
+  return s;
+}
+
+__attribute__((unused)) static int cleanup1(void)
+{
+  (void)close(s);
+  s = -1;
+  return 0;
+}
+
+__attribute__((unused)) static int setup2(void)
+{
+  if (setup1() < 0) /* get a socket in s */
+      return -1;
+  return safe_connect(s, (const struct sockaddr *)&sin1, sizeof(sin1));
+}
+
+__attribute__((unused)) static void *start_server(void *arg)
+{
+  /* 设置取消状态为启用 */
+
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+
+  /* 设置取消类型为异步取消 */
+
+  pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+
+  struct sockaddr_in *sin0 = (struct sockaddr_in *)arg;
+  socklen_t slen = sizeof(*sin0);
+
+  sin0->sin_family = AF_INET;
+  sin0->sin_port = 0; /* pick random free port */
+  sin0->sin_addr.s_addr = INADDR_ANY;
+
+  sfd = socket(PF_INET, SOCK_STREAM, 0);
+  if (sfd < 0)
+    {
+      syslog(LOG_ERR, "server socket failed\n");
+      fail_msg("test fail !");
+      return NULL;
+    }
+
+  if (bind(sfd, (struct sockaddr *)sin0, sizeof(*sin0)) < 0)
+    {
+      syslog(LOG_ERR, "server bind failed\n");
+      close(sfd);
+      fail_msg("test fail !");
+      return NULL;
+    }
+
+  if (listen(sfd, 10) < 0)
+    {
+      syslog(LOG_ERR, "server listen failed\n");
+      close(sfd);
+      fail_msg("test fail !");
+      return NULL;
+    }
+
+  safe_getsockname(sfd, (struct sockaddr *)sin0, &slen);
+  do_child();
+  return NULL;
+}
+
+__attribute__((unused)) static void do_child(void)
+{
+  struct sockaddr_in fsin;
+  fd_set afds;
+  fd_set rfds;
+  int nfds;
+  int cc;
+  int fd;
+#ifdef CONFIG_FDCHECK
+  int fd_tmp = 0;
+#endif
+  char c;
+
+  FD_ZERO(&afds);
+  FD_SET(sfd, &afds);
+
+  nfds = sfd + 1;
+
+  /* accept connections until killed */
+
+  while (1)
+    {
+      socklen_t fromlen;
+
+      memcpy(&rfds, &afds, sizeof(rfds));
+
+      if (select(nfds, &rfds, NULL, NULL, NULL) < 0)
+          if (errno != EINTR)
+            {
+              syslog(LOG_ERR, "select exit fail\n");
+              fail_msg("test fail !");
+              return;
+            }
+
+      if (FD_ISSET(sfd, &rfds))
+        {
+          int newfd;
+
+          fromlen = sizeof(fsin);
+          newfd = accept(sfd, (struct sockaddr *)&fsin, &fromlen);
+          if (newfd >= 0)
+            {
+              FD_SET(newfd, &afds);
+              nfds = (nfds > newfd + 1) ? (nfds) : (newfd + 1);
+            }
+        }
+
+#ifdef CONFIG_FDCHECK
+      for (fd = 0; fd < fdcheck_restore(nfds - 1) + 1; ++fd)
+        {
+          fd_tmp = fdcheck_protect(fd);
+          if (fd_tmp != sfd && FD_ISSET(fd_tmp, &rfds))
+            {
+              if ((cc = read(fd_tmp, &c, 1)) == 0)
+                {
+                  (void)close(fd_tmp);
+                  FD_CLR(fd_tmp, &afds);
+                }
+            }
+        }
+
+#else
+      for (fd = 0; fd < nfds; ++fd)
+          if (fd != sfd && FD_ISSET(fd, &rfds))
+            {
+              if ((cc = read(fd, &c, 1)) == 0)
+                {
+                  (void)close(fd);
+                  FD_CLR(fd, &afds);
+                }
+            }
+
+#endif
+      pthread_testcancel();
+    }
+}
+
+#undef UCLINUX
+#endif

--- a/testing/testsuites/kernel/syscall/cases/creat_test.c
+++ b/testing/testsuites/kernel/syscall/cases/creat_test.c
@@ -1,0 +1,123 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/creat_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <syslog.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_creat01
+ ****************************************************************************/
+
+void test_nuttx_syscall_creat01(FAR void **state)
+{
+  char filename[50] = "";
+  int fd;
+  int res;
+  struct tcase
+  {
+    int mode;
+  }
+
+  tcases[] =
+    {
+        {
+          0644
+        },
+
+        {
+          0444
+        },
+    };
+
+  sprintf(filename, "Creat01%d", gettid());
+
+  struct stat buf;
+  char c;
+  char w_buf[2] = "A";
+
+  for (int i = 0; i < 2; i++)
+    {
+      fd = creat(filename, tcases[0].mode);
+      if (fd > 0)
+        {
+          res = stat(filename, &buf);
+          assert_int_equal(res, 0);
+          assert_int_equal(buf.st_size, 0);
+          assert_int_equal(write(fd, w_buf, 1), 1);
+          assert_int_equal(read(fd, &c, 1), -1);
+          close(fd);
+        }
+    }
+
+  res = unlink(filename);
+  assert_int_equal(res, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_creat02
+ ****************************************************************************/
+
+void test_nuttx_syscall_creat02(FAR void **state)
+{
+  char filename[50] = "";
+  int fd;
+  int res;
+  struct stat statbuf;
+
+  sprintf(filename, "Creat02%d", gettid());
+
+  fd = creat(filename, 444);
+  if (fd > 0)
+    {
+      res = fstat(fd, &statbuf);
+      assert_int_equal(res, 0);
+      assert_int_equal((statbuf.st_mode & S_ISVTX), 0);
+
+      close(fd);
+      res = unlink(filename);
+      assert_int_equal(res, 0);
+    }
+  else
+    {
+      fail_msg("open test file fail !\n");
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/dup2_test.c
+++ b/testing/testsuites/kernel/syscall/cases/dup2_test.c
@@ -1,0 +1,157 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/dup2_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <stdio.h>
+#include <errno.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <sys/stat.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup201
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup201(FAR void **state)
+{
+#ifndef CONFIG_FDSAN
+  int ret;
+  int goodfd = 5;
+  int badfd = -1;
+  int mystdout = 0;
+
+  struct test_case_t
+  {
+    int *ofd;
+    int *nfd;
+    int error;
+  }
+
+  TC[] =
+    {
+      /* First fd argument is less than 0 - EBADF */
+
+        {
+          NULL, NULL, EBADF
+        },
+
+      /* Second fd argument is less than 0 - EBADF */
+
+        {
+          NULL, NULL, EBADF
+        },
+    };
+
+  TC[0].ofd = &badfd;
+  TC[0].nfd = &goodfd;
+
+  TC[1].ofd = &mystdout;
+  TC[1].nfd = &badfd;
+
+  for (int i = 0; i < 2; i++)
+    {
+      ret = dup2(*TC[i].ofd, *TC[i].nfd);
+      assert_int_equal(ret, -1);
+      assert_int_equal(errno, TC[i].error);
+    }
+
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup202
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup202(FAR void **state)
+{
+  char testfile[64] = "";
+  int ret;
+  int i;
+  int ofd;
+  int duprdo = 10;
+  int dupwro = 20;
+  int duprdwr = 30;
+  struct stat oldbuf;
+  struct stat newbuf;
+
+  struct test_case_t
+  {
+    int *nfd;
+    mode_t mode;
+  }
+
+  TC[] =
+    {
+        {
+          NULL, (S_IRUSR | S_IRGRP | S_IROTH)
+        },
+
+        {
+          NULL, (S_IWUSR | S_IWGRP | S_IWOTH)
+        },
+
+        {
+          NULL, (S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR | S_IWGRP | S_IWOTH)
+        },
+    };
+
+  TC[0].nfd = &duprdo;
+  TC[1].nfd = &dupwro;
+  TC[2].nfd = &duprdwr;
+
+  sprintf(testfile, "%s_file", __func__);
+
+  for (i = 0; i < 3; i++)
+    {
+      ofd = creat(testfile, TC[i].mode);
+      assert_true(ofd > 0);
+
+      ret = dup2(ofd, *TC[i].nfd);
+      assert_int_not_equal(ret, -1);
+      if (ret == -1)
+        {
+          continue;
+        }
+
+      assert_int_equal(fstat(ofd, &oldbuf), 0);
+      assert_int_equal(fstat(*(TC[i].nfd), &newbuf), 0);
+      assert_int_equal(oldbuf.st_mode, newbuf.st_mode);
+
+      close(*TC[i].nfd);
+      close(ofd);
+      close(ret);
+
+      assert_int_equal(unlink(testfile), 0);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/dup_test.c
+++ b/testing/testsuites/kernel/syscall/cases/dup_test.c
@@ -1,0 +1,244 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/dup_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <stdio.h>
+#include <errno.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup01
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup01(FAR void **state)
+{
+  char filename[64];
+  int fd = -1;
+  int ret;
+
+  sprintf(filename, "%s_file", __func__);
+
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  if (fd < 0)
+    {
+      fail_msg("open test file fail !\n");
+    }
+
+  ret = dup(fd);
+
+  assert_true(ret > 0);
+  if (fd > 0)
+    {
+      close(fd);
+    }
+
+  if (ret > 0)
+    close(ret);
+
+  assert_int_equal(unlink(filename), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup02
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup02(FAR void **state)
+{
+#ifndef CONFIG_FDSAN
+  int fds[] =
+  {
+    -1, 1500
+  };
+
+  int ret;
+  int nfds;
+  int ind;
+
+  nfds = sizeof(fds) / sizeof(int);
+
+  for (ind = 0; ind < nfds; ind++)
+    {
+      ret = dup(fds[ind]);
+      assert_int_equal(ret, -1);
+      if (ret == -1)
+        {
+          assert_int_equal(errno, EBADF);
+        }
+    }
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup03
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup03(FAR void **state)
+{
+  int fd[2];
+  int ret;
+
+  fd[0] = -1;
+  pipe(fd);
+
+  ret = dup(fd[0]);
+  assert_true(ret > 0);
+  if (ret > 0)
+    close(ret);
+
+  ret = dup(fd[1]);
+  assert_true(ret > 0);
+  if (ret > 0)
+    close(ret);
+
+  if (fd[0] > 0)
+    close(fd[0]);
+  if (fd[1] > 0)
+    close(fd[1]);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup04
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup04(FAR void **state)
+{
+  char fname[64];
+  int fd = -1;
+  int ret;
+
+  sprintf(fname, "%s_file", __func__);
+
+  fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  ret = dup(fd);
+  assert_true(ret > 0);
+
+  if (fd > 0)
+    {
+      close(fd);
+    }
+
+  if (ret > 0)
+    close(ret);
+
+  assert_int_equal(unlink(fname), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_dup05
+ ****************************************************************************/
+
+void test_nuttx_syscall_dup05(FAR void **state)
+{
+  struct stat retbuf;
+  struct stat dupbuf;
+  int rdoret;
+  int wroret;
+  int rdwret;
+  int duprdo;
+  int dupwro;
+  int duprdwr;
+  char testfile[64] = "";
+
+  sprintf(testfile, "%s_file", __func__);
+
+  rdoret = creat(testfile, 0444);
+  if (rdoret > 0)
+    {
+      duprdo = dup(rdoret);
+      if (duprdo > 0)
+        {
+          assert_int_equal(fstat(rdoret, &retbuf), 0);
+          assert_int_equal(fstat(duprdo, &dupbuf), 0);
+          assert_int_equal(retbuf.st_mode, dupbuf.st_mode);
+
+          assert_int_equal(close(duprdo), 0);
+          assert_int_equal(close(rdoret), 0);
+        }
+    }
+
+  else
+    {
+      fail_msg("create test fail fail !\n");
+    }
+
+  assert_int_equal(unlink(testfile), 0);
+
+  wroret = creat(testfile, 0222);
+  if (wroret > 0)
+    {
+      dupwro = dup(wroret);
+      if (dupwro)
+        {
+          assert_int_equal(fstat(wroret, &retbuf), 0);
+          assert_int_equal(fstat(dupwro, &dupbuf), 0);
+          assert_int_equal(retbuf.st_mode, dupbuf.st_mode);
+
+          assert_int_equal(close(dupwro), 0);
+          assert_int_equal(close(wroret), 0);
+        }
+    }
+
+  else
+    {
+      fail_msg("create test fail fail !\n");
+    }
+
+  assert_int_equal(unlink(testfile), 0);
+
+  rdwret = creat(testfile, 0666);
+  if (rdwret > 0)
+    {
+      duprdwr = dup(rdwret);
+      if (duprdwr > 0)
+        {
+          assert_int_equal(fstat(rdwret, &retbuf), 0);
+          assert_int_equal(fstat(duprdwr, &dupbuf), 0);
+          assert_int_equal(retbuf.st_mode, dupbuf.st_mode);
+
+          assert_int_equal(close(duprdwr), 0);
+          assert_int_equal(close(rdwret), 0);
+        }
+    }
+
+  else
+    {
+      fail_msg("create test fail fail !\n");
+    }
+
+  assert_int_equal(unlink(testfile), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/fcntl_test.c
+++ b/testing/testsuites/kernel/syscall/cases/fcntl_test.c
@@ -1,0 +1,318 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/fcntl_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fcntl01
+ ****************************************************************************/
+
+void test_nuttx_syscall_fcntl01(FAR void **state)
+{
+  int flags;
+  int is_pass = 0;
+  int ret;
+  char fname[40] = "";
+  int fd[10];
+  int fd2[10];
+
+  for (int i = 0; i < 8; i++)
+    {
+      sprintf(fname, "Fcntl01%d-%d", gettid(), i);
+      fd[i] = open(fname, O_WRONLY | O_CREAT, 0666);
+      if (fd[i] < 0)
+        {
+          syslog(LOG_ERR, "open test file fail !\n");
+          is_pass = -1;
+          break;
+        }
+
+      fd2[i] = fd[i];
+    }
+
+  assert_int_equal(is_pass, 0);
+  close(fd[2]);
+  close(fd[3]);
+  close(fd[4]);
+  close(fd[5]);
+
+  assert_false((fd[2] = fcntl(fd[1], F_DUPFD, 1)) == -1);
+
+  assert_false(fd[2] < fd2[2]);
+
+  assert_false((fd[4] = fcntl(fd[1], F_DUPFD, fd2[3])) < 0);
+
+  assert_false(fd[4] < fd2[3]);
+
+  assert_false((fd[8] = fcntl(fd[1], F_DUPFD, fd2[5])) < 0);
+
+  assert_false(fd[8] != fd2[5]);
+
+  /* //block1: */
+
+  flags = fcntl(fd[2], F_GETFL, 0);
+  assert_false((flags & O_WRONLY) == 0);
+
+  /* Check setting of no_delay flag */
+
+  assert_false(fcntl(fd[2], F_SETFL, O_NDELAY) == -1);
+
+  flags = fcntl(fd[2], F_GETFL, 0);
+  assert_false((flags & (O_NDELAY | O_WRONLY)) == 0);
+
+  /* Check of setting append flag */
+
+  assert_false(fcntl(fd[2], F_SETFL, O_APPEND) == -1);
+
+  flags = fcntl(fd[2], F_GETFL, 0);
+  assert_false((flags & (O_APPEND | O_WRONLY)) == 0);
+
+  /* Check setting flags together */
+
+  assert_false(fcntl(fd[2], F_SETFL, O_NDELAY | O_APPEND) < 0);
+
+  flags = fcntl(fd[2], F_GETFL, 0);
+  assert_false((flags & (O_NDELAY | O_APPEND | O_WRONLY)) == 0);
+
+  /* Check that flags are not cummulative */
+
+  assert_false(fcntl(fd[2], F_SETFL, 0) == -1);
+
+  flags = fcntl(fd[2], F_GETFL, 0);
+  assert_false((flags & O_WRONLY) == 0);
+  assert_false((flags = fcntl(fd[2], F_GETFD, 0)) < 0);
+  assert_false(flags != 0);
+  assert_false((flags = fcntl(fd[2], F_SETFD, 1)) == -1);
+  assert_false((flags = fcntl(fd[2], F_GETFD, 0)) == -1);
+  assert_false(flags != 1);
+
+  for (int j = 0; j < 10; j++)
+    close(fd[j]);
+  for (int k = 0; k < 8; k++)
+    {
+      sprintf(fname, "Fcntl01%d-%d", gettid(), k);
+      ret = unlink(fname);
+      if (ret != 0)
+        {
+          syslog(LOG_ERR, "unlink test file(%s) fail !\n", fname);
+          is_pass = -1;
+        }
+    }
+
+  assert_int_equal(is_pass, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fcntl02
+ ****************************************************************************/
+
+void test_nuttx_syscall_fcntl02(FAR void **state)
+{
+  char fname[256] = "";
+  int fd;
+  int min_fd;
+  int ret = 0;
+  int min_fds[] =
+  {
+    0, 1, 2, 3, 10, 100
+  };
+
+  sprintf(fname, "Fcntl02_%d", gettid());
+  fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  if (fd > 0)
+    {
+      min_fd = min_fds[0];
+      ret = fcntl(fd, F_DUPFD, min_fd);
+      assert_true(ret > min_fd);
+    }
+
+  if (ret > 0)
+    close(ret);
+  if (fd > 0)
+    close(fd);
+  ret = unlink(fname);
+  assert_int_equal(ret, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fcntl03
+ ****************************************************************************/
+
+void test_nuttx_syscall_fcntl03(FAR void **state)
+{
+  int fd;
+  int ret;
+  char fname[256] = "";
+  sprintf(fname, "fcntl03_%d", gettid());
+  fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  ret = fcntl(fd, F_GETFD, 0);
+  assert_true(ret != -1);
+
+  close(fd);
+  ret = unlink(fname);
+  assert_int_equal(ret, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fcntl04
+ ****************************************************************************/
+
+void test_nuttx_syscall_fcntl04(FAR void **state)
+{
+  int fd;
+  int ret;
+  char fname[256] = "";
+  sprintf(fname, "fcntl04_%d", gettid());
+
+  fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  ret = fcntl(fd, F_GETFL, 0);
+  assert_int_equal(ret & O_ACCMODE, O_RDWR);
+
+  close(fd);
+  ret = unlink(fname);
+  assert_int_equal(ret, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fcntl05
+ ****************************************************************************/
+
+void test_nuttx_syscall_fcntl05(FAR void **state)
+{
+  int file_fd;
+  int fifo_fd;
+  int lc;
+  int ret;
+  int pipe_fds[2];
+  char fname[256] = "";
+  struct tcase
+  {
+    int *fd;
+    const char *msg;
+  }
+
+  tcases[] =
+    {
+        {
+          NULL, "regular file"
+        },
+
+        {
+          NULL, "pipe (write end)"
+        },
+
+        {
+          NULL, "pipe (read end)"
+        },
+
+        {
+          NULL, "fifo"
+        },
+    };
+
+  sprintf(fname, "fcntl05_%d", gettid());
+
+  file_fd = open(fname, O_CREAT | O_RDWR, 0666);
+  assert_true(file_fd > 0);
+  assert_int_equal(pipe(pipe_fds), 0);
+  unlink("/fcntl05_fifo");
+  assert_int_equal(mkfifo("/fcntl05_fifo", 0777), 0);
+
+  fifo_fd = open("/fcntl05_fifo", O_RDWR);
+  assert_true(fifo_fd > 0);
+
+  tcases[0].fd = &file_fd;
+  tcases[1].fd = pipe_fds;
+  tcases[2].fd = pipe_fds + 1;
+  tcases[3].fd = &fifo_fd;
+
+  for (lc = 0; lc < 1; lc++)
+    {
+      for (int i = 0; i < 4; i++)
+        {
+          ret = fcntl(*((tcases + i)->fd), F_SETFD, FD_CLOEXEC);
+          assert_int_equal(ret, 0);
+        }
+    }
+
+  if (file_fd > 0)
+    assert_int_equal(close(file_fd), 0);
+  if (pipe_fds[0] > 0)
+    assert_int_equal(close(pipe_fds[0]), 0);
+  if (pipe_fds[1] > 0)
+    assert_int_equal(close(pipe_fds[1]), 0);
+  if (fifo_fd > 0)
+    assert_int_equal(close(fifo_fd), 0);
+
+  assert_int_equal(unlink(fname), 0);
+  assert_int_equal(unlink("/fcntl05_fifo"), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fcntl06
+ ****************************************************************************/
+
+void test_nuttx_syscall_fcntl06(FAR void **state)
+{
+  int fd;
+  int ret;
+  int lc;
+  char fname[256] = "";
+
+  sprintf(fname, "fcntl06_%d", gettid());
+
+  fd = open(fname, O_RDWR | O_CREAT);
+  assert_true(fd > 0);
+
+  for (lc = 0; lc < 10; lc++)
+    {
+      ret = fcntl(fd, F_SETFL, O_NDELAY | O_APPEND | O_NONBLOCK);
+      assert_true(ret != -1);
+    }
+
+  assert_int_equal(close(fd), 0);
+  assert_int_equal(unlink(fname), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/fpathconf_test.c
+++ b/testing/testsuites/kernel/syscall/cases/fpathconf_test.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/fpathconf_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fpathconf01
+ ****************************************************************************/
+
+void test_nuttx_syscall_fpathconf01(FAR void **state)
+{
+  int fd;
+  int i;
+  int ret;
+  char filename[64] = "";
+
+  struct pathconf_args
+  {
+    char name[16];
+    int value;
+  }
+
+  test_cases[] =
+    {
+        {
+          "_PC_MAX_CANON", _PC_MAX_CANON
+        },
+
+        {
+          "_PC_MAX_INPUT", _PC_MAX_INPUT
+        },
+
+        {
+          "_PC_LINK_MAX", _PC_LINK_MAX
+        },
+
+        {
+          "_PC_NAME_MAX", _PC_NAME_MAX
+        },
+
+        {
+          "_PC_PATH_MAX", _PC_PATH_MAX
+        },
+
+        {
+          "_PC_PIPE_BUF", _PC_PIPE_BUF
+        },
+    };
+
+  /* setup */
+
+  sprintf(filename, "%s_file", __func__);
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  for (i = 0; i < 6; i++)
+    {
+      ret = fpathconf(fd, test_cases[i].value);
+      assert_int_not_equal(ret, -1);
+    }
+
+  if (fd > 0)
+    {
+      assert_int_equal(close(fd), 0);
+    }
+
+  assert_int_equal(unlink(filename), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/fsync_test.c
+++ b/testing/testsuites/kernel/syscall/cases/fsync_test.c
@@ -1,0 +1,253 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/fsync_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/statvfs.h>
+#include <sys/resource.h>
+#include <time.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/statfs.h>
+#include <sys/types.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fsync01
+ ****************************************************************************/
+
+void test_nuttx_syscall_fsync01(FAR void **state)
+{
+  char fname[255];
+  char buf[8] = "davef";
+  int fd;
+  int ret;
+  ssize_t w_size;
+
+  sprintf(fname, "Fsync01_%d", gettid());
+
+  /* creat a test file */
+
+  fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  for (int i = 0; i < 10; i++)
+    {
+      /* write file */
+
+      w_size = write(fd, buf, sizeof(buf));
+      assert_true(w_size != -1);
+
+      /* do sync */
+
+      ret = fsync(fd);
+      assert_int_equal(ret, 0);
+    }
+
+  assert_int_equal(close(fd), 0);
+  assert_int_equal(unlink(fname), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fsync02
+ ****************************************************************************/
+
+void test_nuttx_syscall_fsync02(FAR void **state)
+{
+  int fifo_rfd;
+  int fifo_wfd;
+  int pipe_fd[2];
+#ifndef CONFIG_FDSAN
+  int bad_fd = -1;
+#endif
+  int ret;
+  int test_flag = 0;
+
+  struct tcase
+  {
+    int *fd;
+    int error;
+  }
+
+  tcases[] =
+    {
+      /* EINVAL - fsync() on pipe should not succeed. */
+
+        {
+          &pipe_fd[1], EINVAL
+        },
+
+      /* EBADF - fd is closed */
+
+        {
+          &pipe_fd[0], EBADF
+        },
+
+      /* EBADF - fd is invalid (-1) */
+
+  #ifndef CONFIG_FDSAN
+        {
+          &bad_fd, EBADF
+        },
+  #endif
+
+      /* EINVAL - fsync() on fifo should not succeed. */
+
+        {
+          &fifo_wfd, EINVAL
+        },
+    };
+
+  ret = mkfifo("/var/Test_Fifo_SyscallFsync02", 0666);
+  assert_int_equal(ret, 0);
+
+  ret = pipe(pipe_fd);
+  assert_int_not_equal(ret, -1);
+
+  fifo_rfd =
+      open("/var/Test_Fifo_SyscallFsync02", O_RDONLY | O_NONBLOCK);
+  fifo_wfd = open("/var/Test_Fifo_SyscallFsync02", O_WRONLY);
+
+  close(pipe_fd[0]);
+
+  for (int i = 0; i < sizeof(tcases) / sizeof(tcases[0]); i++)
+    {
+      ret = fsync(*(tcases[i].fd));
+      if (ret != -1)
+        {
+          syslog(LOG_ERR, "fsync() returned unexpected value %d", ret);
+          test_flag = -1;
+        }
+      else if (errno != tcases[i].error)
+        {
+          syslog(LOG_ERR, "fsync(): unexpected error. exp=%d   errno=%d",
+                 tcases[i].error, errno);
+        }
+      else
+        {
+          /* test PASS */
+
+          test_flag = 0;
+        }
+    }
+
+  close(fifo_wfd);
+  close(fifo_rfd);
+  close(pipe_fd[1]);
+  unlink("/var/Test_Fifo_SyscallFsync02");
+
+  assert_int_equal(test_flag, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fsync03
+ ****************************************************************************/
+
+void test_nuttx_syscall_fsync03(FAR void **state)
+{
+  int fd;
+  int BLOCKSIZE = 8192;
+  unsigned long MAXBLKS = 65536;
+  int TIME_LIMIT = 120;
+  int BUF_SIZE = 2048;
+  char fname[255];
+  struct statvfs stat_buf;
+  unsigned long f_bavail;
+  char pbuf[2048];
+
+  off_t max_blks = 65536;
+
+  sprintf(fname, "Fsync03_%d", getpid());
+  fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, 0777);
+
+  if (fstatvfs(fd, &stat_buf) != 0)
+    {
+      syslog(LOG_ERR, "FAIL, fstatvfs failed\n");
+    }
+
+  f_bavail = (stat_buf.f_bavail * stat_buf.f_bsize) / BLOCKSIZE;
+  if (f_bavail && (f_bavail < MAXBLKS))
+    {
+      max_blks = f_bavail;
+    }
+
+  off_t offset;
+  int i;
+  int ret;
+  int max_block = 0;
+  int data_blocks = 0;
+  time_t time_start;
+  time_t time_end;
+  double time_delta;
+  long int random_number;
+
+  random_number = rand();
+  max_block = random_number % max_blks + 1;
+  data_blocks = random_number % max_block;
+
+  for (i = 1; i <= data_blocks; i++)
+    {
+      offset = i * ((BLOCKSIZE * max_block) / data_blocks);
+      offset -= BUF_SIZE;
+      lseek(fd, offset, SEEK_SET);
+      write(fd, pbuf, BUF_SIZE);
+    }
+
+  time_start = time(0);
+
+  ret = fsync(fd);
+
+  time_end = time(0);
+  assert_true(time_end != (time_t)-1);
+  assert_int_not_equal(ret, -1);
+  assert_int_equal(ret, 0);
+  assert_false(time_end < time_start);
+  assert_false((time_delta = difftime(time_end, time_start)) >
+               TIME_LIMIT);
+
+  /* SAFE_FTRUNCATE(fd, 0); */
+
+  ret = ftruncate(fd, 0);
+  assert_int_equal(ret, 0);
+
+  close(fd);
+  unlink(fname);
+}

--- a/testing/testsuites/kernel/syscall/cases/ftruncate_test.c
+++ b/testing/testsuites/kernel/syscall/cases/ftruncate_test.c
@@ -1,0 +1,126 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/ftruncate_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: checkandreportftruncatetest
+ ****************************************************************************/
+
+static int checkandreportftruncatetest(int fd, off_t offset, char data,
+                                       off_t trunc_len)
+{
+  int i;
+  int file_length;
+  int ret;
+  char buf[1024];
+  struct stat stat_buf;
+  off_t ret_offset;
+  ssize_t rval;
+
+  memset(buf, '*', sizeof(buf));
+  ret = fstat(fd, &stat_buf);
+  assert_int_equal(ret, 0);
+  file_length = stat_buf.st_size;
+  if (file_length != trunc_len)
+    {
+      syslog(LOG_ERR, "FAIL, ftruncate() got incorrected size: %d\n",
+             file_length);
+      return -1;
+    }
+
+  ret_offset = lseek(fd, offset, SEEK_SET);
+  assert_int_in_range(ret_offset, 0, offset);
+  rval = read(fd, buf, sizeof(buf));
+  assert_int_in_range(rval, 0, 1024);
+
+  for (i = 0; i < 256; i++)
+    {
+      if (buf[i] != data)
+        {
+          syslog(
+              LOG_ERR,
+              "FAIL, ftruncate() got incorrect data %d, expected %d\n",
+              buf[i], data);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_ftruncate01
+ ****************************************************************************/
+
+void test_nuttx_syscall_ftruncate01(FAR void **state)
+{
+  int fd;
+  int ret;
+  char fname[256] = "";
+
+  sprintf(fname, "Ftruncate01_%d", gettid());
+
+  assert_int_equal(cmtestfillfile(fname, 'a', 1024, 1), 0);
+
+  fd = open(fname, O_RDWR);
+
+  /* ftruncate to 256 */
+
+  ret = ftruncate(fd, 256);
+  assert_int_equal(ret, 0);
+
+  ret = checkandreportftruncatetest(fd, 0, 'a', 256);
+  assert_int_equal(ret, 0);
+
+  ret = ftruncate(fd, 512);
+  assert_int_equal(ret, 0);
+
+  ret = checkandreportftruncatetest(fd, 256, 0, 512);
+  assert_int_equal(ret, 0);
+
+  assert_int_equal(close(fd), 0);
+  assert_int_equal(unlink(fname), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/getTimeofday_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getTimeofday_test.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getTimeofday_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static int done;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: breakout
+ ****************************************************************************/
+
+static void breakout(int sig)
+{
+  done = sig;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_gettimeofday01
+ ****************************************************************************/
+
+void test_nuttx_syscall_gettimeofday01(FAR void **state)
+{
+  int rtime = 3;
+  struct timeval tv1;
+  struct timeval tv2;
+  unsigned long long cnt = 0;
+
+  signal(SIGALRM, breakout);
+
+  done = 0;
+
+  alarm(rtime);
+
+  if (gettimeofday(&tv1, NULL))
+    fail_msg("FAIL, gettimeofday() failed\n");
+
+  while (!done)
+    {
+      if (gettimeofday(&tv2, NULL))
+        fail_msg("FAIL, gettimeofday() failed\n");
+
+      if (tv2.tv_sec < tv1.tv_sec ||
+          (tv2.tv_sec == tv1.tv_sec && tv2.tv_usec < tv1.tv_usec))
+        {
+          fail_msg("test fail !");
+        }
+
+      sleep(1);
+      tv1 = tv2;
+      cnt++;
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/getcwd_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getcwd_test.c
@@ -1,0 +1,133 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getcwd_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getcwd01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getcwd01(FAR void **state)
+{
+  char buffer[5] = "/";
+  char *res;
+  int ret;
+  struct t_case
+  {
+    char *buf;
+    size_t size;
+    int exp_err;
+  }
+
+  tcases[] =
+    {
+        {
+          buffer, 0, EINVAL
+        },
+
+        {
+          buffer, 1, ERANGE
+        },
+
+        {
+          NULL, 1, ERANGE
+        },
+    };
+
+  for (int i = 0; i < 3; i++)
+    {
+      errno = 0;
+      res = getcwd(tcases[i].buf, tcases[i].size);
+      assert_null(res);
+      ret = errno;
+      assert_int_equal(ret, tcases[i].exp_err);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getcwd02
+ ****************************************************************************/
+
+void test_nuttx_syscall_getcwd02(FAR void **state)
+{
+  char *datadir = MOUNT_DIR;
+  char exp_buf[PATH_MAX] = "";
+  char buffer[PATH_MAX] = "";
+  char *res = NULL;
+
+  struct t_case
+  {
+    char *buf;
+    size_t size;
+  }
+
+  tcases[] =
+    {
+        {
+          NULL, 0
+        },
+
+        {
+          NULL, 0
+        },
+
+        {
+          NULL, PATH_MAX
+        },
+    };
+
+  tcases[0].buf = buffer;
+  tcases[0].size = sizeof(buffer);
+
+  assert_int_equal(chdir(datadir), 0);
+  assert_non_null(realpath(datadir, exp_buf));
+
+  for (int i = 0; i < 3; i++)
+    {
+      errno = 0;
+      res = getcwd(tcases[i].buf, tcases[i].size);
+
+      assert_non_null(res);
+      assert_string_equal(exp_buf, res);
+
+      if (!tcases[i].buf)
+        free(res);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/getegid_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getegid_test.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getegid_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getegid01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getegid01(FAR void **state)
+{
+  int ret;
+  for (int lc = 0; lc < 5; lc++)
+    {
+      ret = getegid();
+      assert_int_not_equal(ret, -1);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getegid02
+ ****************************************************************************/
+
+void test_nuttx_syscall_getegid02(FAR void **state)
+{
+  int lc;
+  int ret;
+  uid_t euid;
+  struct passwd *pwent;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getegid();
+      euid = geteuid();
+      pwent = getpwuid(euid);
+      assert_non_null(pwent);
+      assert_int_equal(pwent->pw_gid, ret);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/geteuid_test.c
+++ b/testing/testsuites/kernel/syscall/cases/geteuid_test.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/geteuid_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_geteuid01
+ ****************************************************************************/
+
+void test_nuttx_syscall_geteuid01(FAR void **state)
+{
+  int ret;
+  for (int lc = 0; lc < 5; lc++)
+    {
+      ret = geteuid();
+      assert_int_not_equal(ret, -1);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_geteuid02
+ ****************************************************************************/
+
+void test_nuttx_syscall_geteuid02(FAR void **state)
+{
+  int lc;
+  int ret;
+  uid_t euid;
+  struct passwd *pwent;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getegid();
+      assert_true(ret > 0);
+      euid = geteuid();
+      pwent = getpwuid(euid);
+      assert_non_null(pwent);
+      assert_int_equal(pwent->pw_gid, ret);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/getgid_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getgid_test.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getgid_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getgid01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getgid01(FAR void **state)
+{
+  int lc;
+  int ret;
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getgid();
+      assert_int_not_equal(ret, -1);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getgid02
+ ****************************************************************************/
+
+void test_nuttx_syscall_getgid02(FAR void **state)
+{
+  int lc;
+  int ret;
+  uid_t uid;
+  struct passwd *pwent;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getgid();
+      uid = getuid();
+      pwent = getpwuid(uid);
+      assert_non_null(pwent);
+      assert_int_equal(pwent->pw_gid, ret);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/gethostname_test.c
+++ b/testing/testsuites/kernel/syscall/cases/gethostname_test.c
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/gethostname_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <netdb.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_gethostname01
+ ****************************************************************************/
+
+void test_nuttx_syscall_gethostname01(FAR void **state)
+{
+  int lc;
+  int ret;
+  char hname[100]; /* host name */
+
+  for (lc = 0; lc < 10; lc++)
+    {
+      ret = gethostname(hname, sizeof(hname));
+      assert_int_equal(ret, 0);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/getitimer_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getitimer_test.c
@@ -1,0 +1,139 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getitimer_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <nuttx/clock.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <sys/time.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#define ITIMER_REAL 0
+#define ITIMER_VIRTUAL 1
+#define ITIMER_PROF 2
+#define CLOCK_MONOTONIC_COARSE 6
+#define SEC 100
+#define USEC 10000
+struct timeval tv;
+struct itimerval value;
+struct timespec time_res;
+long jiffy;
+
+/****************************************************************************
+ * Name: TestNuttxAccept01
+ ****************************************************************************/
+
+void set_settitimer_value(int sec, int usec)
+{
+  value.it_value.tv_sec = sec;
+  value.it_value.tv_usec = usec;
+  value.it_interval.tv_sec = sec;
+  value.it_interval.tv_usec = usec;
+}
+
+void test_nuttx_syscall_veritygetitimer(int which, char *dec)
+{
+  if (which == ITIMER_REAL)
+    {
+      assert_int_not_equal(gettimeofday(&tv, NULL), -1);
+    }
+
+  int ret = getitimer(which, &value);
+  assert_int_equal(ret, 0);
+  assert_int_equal(value.it_value.tv_sec, 0);
+  assert_int_equal(value.it_value.tv_usec, 0);
+  assert_int_equal(value.it_interval.tv_sec, 0);
+  assert_int_equal(value.it_interval.tv_usec, 0);
+  set_settitimer_value(SEC, USEC);
+  int ret2 = setitimer(which, &value, NULL);
+  assert_int_equal(ret2, 0);
+  set_settitimer_value(0, 0);
+  int ret3 = getitimer(which, &value);
+  assert_int_equal(ret3, 0);
+
+  assert_int_equal(value.it_interval.tv_sec, SEC);
+  assert_int_equal(value.it_interval.tv_usec, USEC);
+
+  /* syslog(LOG_INFO,"value.it_value.tv_sec=%lld,
+   * value.it_value.tv_usec=%ld", value.it_value.tv_sec,
+   * value.it_value.tv_usec);
+   */
+
+  long margin = (which == ITIMER_REAL) ? (2 * USEC_PER_TICK) : jiffy;
+  if (value.it_value.tv_sec == SEC)
+    {
+      assert_in_range(value.it_value.tv_usec, 0, USEC + margin);
+    }
+
+  else
+    {
+      assert_in_range(value.it_value.tv_sec, 0, SEC);
+    }
+
+  /* syslog(LOG_INFO,"timer value is within the expected range"); */
+
+  if (which == ITIMER_REAL)
+    {
+      assert_int_not_equal(gettimeofday(&tv, NULL), -1);
+    }
+
+  set_settitimer_value(0, 0);
+  int ret4 = setitimer(which, &value, NULL);
+  assert_int_equal(ret4, 0);
+}
+
+void test_nuttx_syscall_getitimer01(FAR void **state)
+{
+  struct tcase
+  {
+    int which;
+    char *des;
+  }
+
+  tcases[] =
+    {
+        {
+          ITIMER_REAL, "ITIMER_REAL"
+        },
+
+      /* {ITIMER_VIRTUAL, "ITIMER_VIRTUAL"},
+       * {ITIMER_PROF,    "ITIMER_PROF"},
+       */
+    };
+
+  clock_getres(CLOCK_MONOTONIC_COARSE, &time_res);
+  jiffy = (time_res.tv_nsec + 999) / 1000;
+
+  test_nuttx_syscall_veritygetitimer(tcases[0].which, tcases[0].des);
+}

--- a/testing/testsuites/kernel/syscall/cases/getpeername_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getpeername_test.c
@@ -1,0 +1,197 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getpeername_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#ifndef UCLINUX
+#define UCLINUX
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+__attribute__((unused)) static struct sockaddr_in server_addr;
+__attribute__((unused)) static struct sockaddr_in fsin1;
+__attribute__((unused)) static socklen_t sinlen;
+
+/* static socklen_t invalid_sinlen = -1; */
+
+__attribute__((unused)) static void setup(void);
+__attribute__((unused)) static void setup2(int);
+__attribute__((unused)) static void setup3(int);
+
+/* static void setup4(int); */
+
+__attribute__((unused)) static void cleanup2(int);
+
+/* static void cleanup4(int); */
+
+__attribute__((unused)) static struct test_case_t
+{
+  int sockfd;
+  struct sockaddr *sockaddr;
+  socklen_t *addrlen;
+  int expretval;
+  int experrno;
+  void (*setup)(int);
+  void (*cleanup)(int);
+  char *name;
+}
+
+test_cases[] =
+{
+    {
+      -1, (struct sockaddr *)&fsin1, &sinlen, -1, EBADF, NULL, NULL,
+     "EBADF"
+    },
+
+    {
+      -1, (struct sockaddr *)&fsin1, &sinlen, -1, ENOTSOCK, setup2,
+     cleanup2, "ENOTSOCK"
+    },
+
+    {
+      -1, (struct sockaddr *)&fsin1, &sinlen, -1, ENOTCONN, setup3,
+     cleanup2, "ENOTCONN"
+    },
+
+  /* {
+   * -1, (struct sockaddr *)&fsin1, &invalid_sinlen, -1, EINVAL, setup4,
+   *  cleanup4, "EINVAL"
+   * },
+   */
+#if 0
+#ifndef UCLINUX
+    {
+    -1, (struct sockaddr *)-1, &sinlen, -1, EFAULT, setup4, cleanup4,
+     "EFAULT"
+    },
+
+    {
+    -1, (struct sockaddr *)&fsin1, NULL, -1, EFAULT, setup4,
+     cleanup4, "EFAULT"
+    },
+
+    {
+    -1, (struct sockaddr *)&fsin1, (socklen_t *)1, -1, EFAULT, setup4,
+     cleanup4, "EFAULT"
+    },
+#endif
+#endif
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getpeername01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getpeername01(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  int total = sizeof(test_cases) / sizeof(test_cases[0]);
+  int ret;
+  setup();
+  for (int i = 0; i < total; ++i)
+    {
+      if (test_cases[i].setup != NULL)
+        test_cases[i].setup(i);
+
+      assert_false(test_cases[i].setup != NULL &&
+                   test_cases[i].sockfd <= 0);
+      ret = getpeername(test_cases[i].sockfd, test_cases[i].sockaddr,
+                        test_cases[i].addrlen);
+
+      assert_false(ret != test_cases[i].expretval ||
+                   errno != test_cases[i].experrno);
+      if (test_cases[i].cleanup != NULL)
+        test_cases[i].cleanup(i);
+    }
+#endif
+}
+
+__attribute__((unused)) static void setup(void)
+{
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = 0;
+  server_addr.sin_addr.s_addr = INADDR_ANY;
+  sinlen = sizeof(fsin1);
+}
+
+__attribute__((unused)) static void setup2(int i)
+{
+  int ret;
+  ret = open("/dev/null", O_WRONLY, 0666);
+  assert_true(ret >= 0);
+  test_cases[i].sockfd = ret;
+}
+
+__attribute__((unused)) static void setup3(int i)
+{
+  test_cases[i].sockfd = socket(PF_INET, SOCK_STREAM, 0);
+  if (test_cases[i].sockfd < 0)
+    {
+      return;
+    }
+
+  if (safe_bind(test_cases[i].sockfd, (struct sockaddr *)&server_addr,
+                sizeof(server_addr)) < 0)
+    {
+      fail_msg("test fail !");
+    }
+}
+
+/* static void setup4(int i)
+ * {
+ *   if (socketpair(PF_UNIX, SOCK_STREAM, 0, sv) < 0)
+ *     {
+ *         syslog(LOG_ERR, "socketpair failed for getpeername test %d",
+ *         i); faiL_msg("test fail !"); return;
+ *     }
+ *   test_cases[i].sockfd = sv[0];
+ * }
+ */
+
+__attribute__((unused)) static void cleanup2(int i)
+{
+  if (safe_close(test_cases[i].sockfd) < 0)
+    {
+      fail_msg("test fail !");
+    }
+}
+
+#undef UCLINUX
+#endif

--- a/testing/testsuites/kernel/syscall/cases/getpid_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getpid_test.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getpid_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getpid01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getpid01(FAR void **state)
+{
+  int lc;
+  int ret;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getpid();
+      assert_true(ret > 0);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/getppid_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getppid_test.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getppid_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getppid01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getppid01(FAR void **state)
+{
+  int lc;
+  int ret;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getppid();
+      assert_true(ret > 0);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/getsocketopt_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getsocketopt_test.c
@@ -1,0 +1,214 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getsocketopt_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifndef UCLINUX
+#define UCLINUX
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <syslog.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <fcntl.h>
+#include "SyscallTest.h"
+
+__attribute__((unused)) static int testno;
+__attribute__((unused)) static int s; /* socket descriptor */
+__attribute__((unused)) static struct sockaddr_in sin0, fsin1;
+__attribute__((unused)) static int sinlen;
+__attribute__((unused)) static int optval;
+__attribute__((unused)) static socklen_t optlen;
+
+__attribute__((unused)) static void setup(void);
+__attribute__((unused)) static void setup0(void);
+__attribute__((unused)) static void setup1(void);
+__attribute__((unused)) static void cleanup0(void);
+__attribute__((unused)) static void cleanup1(void);
+
+__attribute__((unused)) static struct test_case_t
+{
+  int domain; /* PF_INET, PF_UNIX, ... */
+  int type;   /* SOCK_STREAM, SOCK_DGRAM ... */
+  int proto;  /* protocol number (usually 0 = default) */
+  int level;  /* IPPROTO_* */
+  int optname;
+  void *optval;
+  socklen_t *optlen;
+  struct sockaddr *sin;
+  int salen;
+  int retval;   /* syscall return value */
+  int experrno; /* expected errno */
+  void (*setup)(void);
+  void (*cleanup)(void);
+  char *desc;
+}
+
+tdat[] =
+{
+    {
+      PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, &optlen,
+     (struct sockaddr *)&fsin1, sizeof(fsin1), -1, EBADF, setup0,
+     cleanup0, "bad file descriptor"
+    },
+
+    {
+      PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, &optlen,
+     (struct sockaddr *)&fsin1, sizeof(fsin1), -1, ENOTSOCK, setup0,
+     cleanup0, "bad file descriptor"
+    },
+#ifndef UCLINUX
+    {
+      PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0, &optlen,
+     (struct sockaddr *)&fsin1, sizeof(fsin1), -1, EFAULT, setup1,
+     cleanup1, "invalid option buffer"
+    },
+
+    {
+      PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
+     (struct sockaddr *)&fsin1, sizeof(fsin1), -1, EFAULT, setup1,
+     cleanup1, "invalid optlen"
+    },
+#endif /* UCLINUX */
+    /* {PF_INET, SOCK_STREAM, 0, 500, SO_OOBINLINE, &optval, &optlen,
+     * (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+     * EOPNOTSUPP, setup1, cleanup1, "invalid level"},
+     * {PF_INET, SOCK_STREAM, 0, IPPROTO_UDP, SO_OOBINLINE, &optval,
+     * &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
+     * -1, EOPNOTSUPP, setup1, cleanup1, "invalid option name"},
+     * {PF_INET, SOCK_STREAM, 0, IPPROTO_UDP, SO_OOBINLINE, &optval,
+     * &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
+     * -1, EOPNOTSUPP, setup1, cleanup1,
+     * "invalid option name (UDP)"},
+     */
+
+    {
+      PF_INET, SOCK_STREAM, 0, IPPROTO_IP, -1, &optval, &optlen,
+     (struct sockaddr *)&fsin1, sizeof(fsin1), -1, ENOPROTOOPT, setup1,
+     cleanup1, "invalid option name (IP)"
+    },
+
+    {
+      PF_INET, SOCK_STREAM, 0, IPPROTO_TCP, -1, &optval, &optlen,
+     (struct sockaddr *)&fsin1, sizeof(fsin1), -1, ENOPROTOOPT, setup1,
+     cleanup1, "invalid option name (TCP)"
+    },
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getsockopt01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getsockopt01(FAR void **state)
+{
+#if defined(CONFIG_NET) && defined(CONFIG_NET_SOCKOPTS)
+  int ret;
+  int flag = 1;
+  setup();
+  for (testno = 0; testno < sizeof(tdat) / sizeof(tdat[0]); ++testno)
+    {
+      tdat[testno].setup();
+      if (s < 0)
+        continue;
+      ret = getsockopt(s, tdat[testno].level, tdat[testno].optname,
+                       tdat[testno].optval, tdat[testno].optlen);
+      if (ret != tdat[testno].retval || errno != tdat[testno].experrno)
+        {
+          syslog(LOG_ERR,
+                 "%s ; returned"
+                 " %d (expected %d), errno %d (expected"
+                 " %d)\n",
+                 tdat[testno].desc, ret, tdat[testno].retval, errno,
+                 tdat[testno].experrno);
+          flag = 0;
+        }
+
+      tdat[testno].cleanup();
+    }
+
+  assert_true(flag);
+#endif
+}
+
+__attribute__((unused)) static void setup(void)
+{
+  /* initialize local sockaddr */
+
+  sin0.sin_family = AF_INET;
+  sin0.sin_port = 0;
+  sin0.sin_addr.s_addr = INADDR_ANY;
+}
+
+__attribute__((unused)) static void setup0(void)
+{
+  if (tdat[testno].experrno == EBADF)
+    s = -400; /* anything not an open file */
+  else if ((s = open("/dev/null", O_WRONLY)) == -1)
+    {
+      syslog(LOG_ERR,
+             "error opening /dev/null - "
+             "errno: %s",
+             strerror(errno));
+      fail_msg("test fail !");
+    }
+}
+
+__attribute__((unused)) static void cleanup0(void)
+{
+  if (tdat[testno].experrno != EBADF && s > 0)
+    (void)close(s);
+  s = -1;
+}
+
+__attribute__((unused)) static void setup1(void)
+{
+  s = safe_socket(tdat[testno].domain, tdat[testno].type,
+                  tdat[testno].proto);
+  if (s < 0)
+    fail_msg("setup1 fail");
+  int ret = safe_bind(s, (struct sockaddr *)&sin0, sizeof(sin0));
+  assert_int_not_equal(ret, -1);
+  sinlen = sizeof(fsin1);
+  optlen = sizeof(optval);
+}
+
+__attribute__((unused)) static void cleanup1(void)
+{
+  (void)close(s);
+  s = -1;
+}
+
+#undef UCLINUX
+#endif

--- a/testing/testsuites/kernel/syscall/cases/getuid_test.c
+++ b/testing/testsuites/kernel/syscall/cases/getuid_test.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/getuid_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <pwd.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getuid01
+ ****************************************************************************/
+
+void test_nuttx_syscall_getuid01(FAR void **state)
+{
+  int ret;
+  for (int lc = 0; lc < 5; lc++)
+    {
+      ret = getuid();
+      assert_int_not_equal(ret, -1);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_getuid02
+ ****************************************************************************/
+
+void test_nuttx_syscall_getuid02(FAR void **state)
+{
+  int lc;
+  int ret;
+  uid_t uid;
+  struct passwd *pwent;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      ret = getuid();
+      assert_true(ret > 0);
+      uid = getuid();
+      pwent = getpwuid(uid);
+      assert_non_null(pwent);
+      assert_int_equal(pwent->pw_uid, ret);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/listen_test.c
+++ b/testing/testsuites/kernel/syscall/cases/listen_test.c
@@ -1,0 +1,145 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/listen_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_listen01
+ ****************************************************************************/
+
+void test_nuttx_syscall_listen01(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  int testno;
+  int flag = 1;
+  int s; /* socket descriptor */
+  struct test_case_t
+  {               /* test case structure */
+    int domain;   /* PF_INET, PF_UNIX, ... */
+    int type;     /* SOCK_STREAM, SOCK_DGRAM ... */
+    int proto;    /* protocol number (usually 0 = default) */
+    int backlog;  /* connect's 3rd argument */
+    int retval;   /* syscall return value */
+    int experrno; /* expected errno */
+    const char setup[10];
+    const char cleanup[10];
+    char desc[20];
+  }
+
+  tdat[] =
+    {
+        {
+          0, 0, 0, 0, -1, EBADF, "setup0", "cleanup0",
+        "bad file descriptor"
+        },
+
+        {
+          0, 0, 0, 0, -1, ENOTSOCK, "setup0", "cleanup0", "not a socket"
+        },
+
+        {
+          PF_INET, SOCK_DGRAM, 0, 0, -1, EOPNOTSUPP, "setup1", "cleanup1",
+        "UDP listen"
+        },
+    };
+
+  const char set[] = "setup0";
+  const char clean[] = "cleanup0";
+
+  for (testno = 0; testno < sizeof(tdat) / sizeof(tdat[0]); ++testno)
+    {
+      /* setup0(void) */
+
+      if (!strcmp(tdat[testno].setup, set))
+        {
+          if (tdat[testno].experrno == EBADF)
+            s = -400; /* anything not an open file */
+          else if ((s = open("/dev/null", O_WRONLY)) == -1)
+            syslog(LOG_ERR, "error opening /dev/null - errno: %s\n",
+                   strerror(errno));
+        }
+
+      else
+        {
+          /* setup1(void) */
+
+          s = safe_socket(tdat[testno].domain, tdat[testno].type,
+                          tdat[testno].proto);
+        }
+
+      int rec = safe_listen(s, tdat[testno].backlog);
+
+      if (rec != tdat[testno].retval ||
+          (rec < 0 && errno != tdat[testno].experrno))
+        {
+          syslog(LOG_ERR,
+                 "%s ; returned"
+                 " %d (expected %d), errno %d (expected"
+                 " %d)\n",
+                 tdat[testno].desc, rec, tdat[testno].retval, errno,
+                 tdat[testno].experrno);
+          flag = 0;
+        }
+
+      else
+        {
+          syslog(LOG_INFO, "%s successful\n", tdat[testno].desc);
+        }
+
+      if (!strcmp(tdat[testno].cleanup, clean))
+        {
+          /* cleanup0(void) */
+
+          s = -1;
+        }
+
+      else
+        {
+          /* cleanup1(void) */
+
+          (void)close(s);
+          s = -1;
+        }
+    }
+
+  assert_true(flag);
+#endif
+}

--- a/testing/testsuites/kernel/syscall/cases/lseek_test.c
+++ b/testing/testsuites/kernel/syscall/cases/lseek_test.c
@@ -1,0 +1,230 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/lseek_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_lseek01
+ ****************************************************************************/
+
+void test_nuttx_syscall_lseek01(FAR void **state)
+{
+  int fd;
+  char filename[32] =
+  {
+    0
+  };
+
+  ssize_t rval;
+  char read_buf[64] =
+  {
+    0
+  };
+
+  off_t test_ret;
+  struct tcase
+  {
+    off_t off;
+    int whence;
+    char wname[64];
+    off_t exp_off;
+    ssize_t exp_size;
+    char *exp_data;
+  }
+
+  tcases[] =
+    {
+        {
+          4, SEEK_SET, "SEEK_SET", 4, 3, "efg"
+        },
+
+        {
+          -2, SEEK_CUR, "SEEK_CUR", 5, 2, "fg"
+        },
+
+        {
+          -4, SEEK_END, "SEEK_END", 3, 4, "defg"
+        },
+
+        {
+          0, SEEK_END, "SEEK_END", 7, 0, NULL
+        },
+    };
+
+  snprintf(filename, sizeof(filename), "%s_file", __func__);
+
+  fd = open(filename, O_RDWR | O_CREAT);
+
+  if (fd > 0)
+    {
+      rval = write(fd, "abcdefg", 7);
+      assert_int_in_range(rval, 0, 7);
+    }
+
+  else
+    {
+      fail_msg("creat test file fail !\n");
+    }
+
+  for (int i = 0; i < 4; i++)
+    {
+      /* reset the offset to end of file */
+
+      rval = read(fd, read_buf, sizeof(read_buf));
+      assert_int_in_range(rval, 0, 64);
+      memset(read_buf, 0, sizeof(read_buf));
+      test_ret = lseek(fd, tcases[i].off, tcases[i].whence);
+      if (test_ret == (off_t)-1)
+        {
+          syslog(LOG_ERR, "lseek() failed");
+          fail_msg("test fail !\n");
+        }
+
+      if (test_ret != tcases[i].exp_off)
+        {
+          syslog(LOG_ERR, "lseek() returned not expected\n");
+          fail_msg("test fail !\n");
+        }
+
+      rval = read(fd, read_buf, tcases[i].exp_size);
+      assert_int_in_range(rval, 0, 64);
+
+      if (tcases[i].exp_data && strcmp(read_buf, tcases[i].exp_data))
+        {
+          syslog(LOG_ERR, "lseek() read incorrect data\n");
+          fail_msg("test fail !\n");
+        }
+    }
+
+  if (fd > 0)
+    {
+      close(fd);
+    }
+
+  unlink(filename);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_lseek07
+ ****************************************************************************/
+
+void test_nuttx_syscall_lseek07(FAR void **state)
+{
+  int fd1;
+  int fd2;
+  int flag = 1;
+  int ret;
+  char read_buf[64] =
+  {
+    0
+  };
+
+  struct tcase
+  {
+    int *fd;
+    char fname[32];
+    off_t off;
+    off_t exp_off;
+    int exp_size;
+    char exp_data[16];
+  }
+
+  tcases[] =
+    {
+        {
+          NULL, "", 7, 7, 10, "abcdefgijk"
+        },
+
+        {
+          NULL, "", 2, 2, 7, "abijkfg"
+        },
+    };
+
+  tcases[0].fd = &fd1;
+  tcases[1].fd = &fd2;
+  snprintf(tcases[0].fname, sizeof(tcases[0].fname), "%s_file",
+           __func__);
+  snprintf(tcases[1].fname, sizeof(tcases[1].fname), "%s_file",
+           __func__);
+
+  fd1 = open(tcases[0].fname, O_RDWR | O_CREAT, 0644);
+  fd2 = open(tcases[1].fname, O_RDWR | O_CREAT, 0644);
+
+  write(fd1, "abcdefg", sizeof("abcdefg") - 1);
+  write(fd2, "abcdefg", sizeof("abcdefg") - 1);
+
+  for (int i = 0; i < 2; i++)
+    {
+      memset(read_buf, 0, sizeof(read_buf));
+
+      ret = lseek(*(tcases[i].fd), tcases[i].off, SEEK_SET);
+      if (ret == (off_t)-1)
+        flag = 0;
+
+      if (ret != tcases[i].exp_off)
+        flag = 0;
+
+      write(*(tcases[i].fd), "ijk", sizeof("ijk") - 1);
+
+      close(*(tcases[i].fd));
+
+      *(tcases[i].fd) = open(tcases[i].fname, O_RDWR);
+
+      read(*(tcases[i].fd), read_buf, tcases[i].exp_size);
+
+      if (strcmp(read_buf, tcases[i].exp_data))
+        {
+          flag = 0;
+          syslog(LOG_ERR, "FAIL, lseek() wrote incorrect data\n");
+        }
+    }
+
+  if (fd1 > 0)
+    close(fd1);
+
+  if (fd2 > 0)
+    close(fd2);
+  unlink(tcases[0].fname);
+  unlink(tcases[1].fname);
+  assert_true(flag);
+}

--- a/testing/testsuites/kernel/syscall/cases/lstat_test.c
+++ b/testing/testsuites/kernel/syscall/cases/lstat_test.c
@@ -1,0 +1,80 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/lstat_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_lstat01
+ ****************************************************************************/
+
+void test_nuttx_syscall_lstat01(FAR void **state)
+{
+  uid_t user_id;
+  gid_t group_id;
+  struct stat stat_buf;
+  int ret;
+
+  char filename[64] = "";
+  char symlink_path[64] = "/Lstat01_tst_syml";
+
+  sprintf(filename, "%s_file", __func__);
+  user_id = getuid();
+  group_id = getgid();
+
+  ret = open(filename, O_CREAT | O_WRONLY, 0644);
+  assert_true(ret > 0);
+
+  ret = close(ret);
+  assert_int_equal(ret, 0);
+
+  ret = symlink(filename, symlink_path);
+  assert_int_equal(ret, 0);
+
+  memset(&stat_buf, 0, sizeof(stat_buf));
+
+  ret = lstat(symlink_path, &stat_buf);
+  assert_int_equal(ret, 0);
+
+  assert_true(stat_buf.st_gid == group_id);
+  assert_true(stat_buf.st_uid == user_id);
+  assert_true((stat_buf.st_mode & S_IFMT) == S_IFLNK);
+  assert_int_equal(unlink(symlink_path), 0);
+  assert_int_equal(unlink(filename), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/memcmp_test.c
+++ b/testing/testsuites/kernel/syscall/cases/memcmp_test.c
@@ -1,0 +1,130 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/memcmp_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define BSIZE 4096
+#define LEN 100
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: TestNuttxSyscallFill
+ ****************************************************************************/
+
+static void test_nuttx_syscall_lfill(char *str, int len)
+{
+  int i;
+  for (i = 0; i < len; i++)
+    *str++ = 'a';
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_setup
+ ****************************************************************************/
+
+static void test_nuttx_syscall_setup(char *buf)
+{
+  int i;
+  for (i = 0; i < BSIZE; i++)
+    buf[i] = 0;
+  return;
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_verifymemcmp
+ ****************************************************************************/
+
+static void test_nuttx_syscall_verifymemcmp(char *p, char *q, int len)
+{
+  test_nuttx_syscall_lfill(p, len);
+  test_nuttx_syscall_lfill(q, len);
+
+  assert_int_equal(memcmp(p, q, len), 0);
+
+  p[len - 1] = 0;
+  assert_true(memcmp(p, q, len) < 0);
+
+  p[len - 1] = 'a';
+  p[0] = 0;
+  assert_true(memcmp(p, q, len) < 0);
+
+  p[0] = 'a';
+  q[len - 1] = 0;
+  assert_true(memcmp(p, q, len) > 0);
+
+  q[len - 1] = 'a';
+  q[0] = 0;
+  assert_true(memcmp(p, q, len) > 0);
+
+  q[0] = 'a';
+  assert_int_equal(memcmp(p, q, len), 0);
+}
+
+/****************************************************************************
+ * Pubilc Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_memcmptest01
+ ****************************************************************************/
+
+void test_nuttx_syscall_memcmptest01(FAR void **state)
+{
+  char *buf = NULL;
+  buf = malloc(BSIZE);
+  assert_non_null(buf);
+  test_nuttx_syscall_setup(buf);
+
+  test_nuttx_syscall_verifymemcmp(&buf[100], &buf[800], LEN);
+  test_nuttx_syscall_verifymemcmp(&buf[800], &buf[100], LEN);
+
+  free(buf);
+}

--- a/testing/testsuites/kernel/syscall/cases/memcpy_test.c
+++ b/testing/testsuites/kernel/syscall/cases/memcpy_test.c
@@ -1,0 +1,135 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/memcpy_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <errno.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define BSIZE 4096
+#define LEN 100
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fill
+ ****************************************************************************/
+
+static void test_nuttx_syscall_fill(char *str, int len)
+{
+  int i;
+  for (i = 0; i < len; i++)
+    *str++ = 'a';
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_check
+ ****************************************************************************/
+
+static int test_nuttx_syscall_check(char *str, int len)
+{
+  int i;
+  for (i = 0; i < len; i++)
+      if (*str++ != 'a')
+          return (-1);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_setup
+ ****************************************************************************/
+
+static void test_nuttx_syscall_setup(char *buf)
+{
+  int i;
+  for (i = 0; i < BSIZE; i++)
+    buf[i] = 0;
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_verifymemcpy
+ ****************************************************************************/
+
+static void test_nuttx_syscall_verifymemcpy(char *p, char *q, int len)
+{
+  test_nuttx_syscall_fill(p, len);
+  memcpy(q, p, LEN);
+
+  assert_int_equal(test_nuttx_syscall_check(q, len), 0);
+
+  assert_true(*(p - 1) == '\0');
+  assert_true(p[LEN] == '\0');
+
+  assert_true(*(q - 1) == '\0');
+  assert_true(q[LEN] == '\0');
+}
+
+/****************************************************************************
+ * Pubilc Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_memcpytest01
+ ****************************************************************************/
+
+void test_nuttx_syscall_memcpytest01(FAR void **state)
+{
+  char *buf = NULL;
+  buf = malloc(BSIZE);
+  assert_non_null(buf);
+  test_nuttx_syscall_setup(buf);
+
+  test_nuttx_syscall_verifymemcpy(&buf[100], &buf[800], LEN);
+  test_nuttx_syscall_verifymemcpy(&buf[800], &buf[100], LEN);
+  free(buf);
+}

--- a/testing/testsuites/kernel/syscall/cases/memset_test.c
+++ b/testing/testsuites/kernel/syscall/cases/memset_test.c
@@ -1,0 +1,108 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/memset_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <errno.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+#define BSIZE 4096
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_fill
+ ****************************************************************************/
+
+static void test_nuttx_syscall_fill(char *buf)
+{
+  int i;
+  for (i = 0; i < BSIZE; i++)
+    buf[i] = 'a';
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_check
+ ****************************************************************************/
+
+static int test_nuttx_syscall_check(char *str)
+{
+  int i = 0;
+  while (!*str++)
+    i++;
+  return i;
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_memsettest01
+ ****************************************************************************/
+
+void test_nuttx_syscall_memsettest01(FAR void **state)
+{
+  char *buf = NULL;
+  buf = malloc(BSIZE);
+  assert_non_null(buf);
+  test_nuttx_syscall_fill(buf);
+
+  int i;
+  int j;
+  char *p = &buf[400];
+
+  for (i = 0; i < 200; i++)
+    {
+      test_nuttx_syscall_fill(buf);
+      memset(p, 0, i);
+      j = test_nuttx_syscall_check(p);
+
+      assert_true(j == i);
+      assert_true(*(p - 1) && p[i]);
+    }
+
+  assert_int_equal(i, 200);
+  free(buf);
+}

--- a/testing/testsuites/kernel/syscall/cases/mkdir_test.c
+++ b/testing/testsuites/kernel/syscall/cases/mkdir_test.c
@@ -1,0 +1,198 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/mkdir_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_mkdir01
+ ****************************************************************************/
+
+void test_nuttx_syscall_mkdir01(FAR void **state)
+{
+  int ret;
+  int j;
+  int times = 100;
+  char tmpdir[40];
+
+  for (j = 0; j < 5; j += 3)
+    {
+      sprintf(tmpdir, "%s_%d_dir", __func__, j);
+      ret = mkdir(tmpdir, 0777);
+      if (ret < 0)
+        {
+          if (errno != EEXIST)
+            {
+              syslog(LOG_ERR,
+                     "Error creating permanent directories, ERRNO = %d",
+                     errno);
+              fail_msg("test fail !\n");
+              goto out;
+            }
+        }
+    }
+
+  while (times--)
+    {
+      for (j = 0; j < 5; j += 3)
+        {
+          sprintf(tmpdir, "%s_%d_dir", __func__, j);
+          ret = mkdir(tmpdir, 0777);
+          if (ret < 0)
+            {
+              if (errno != EEXIST)
+                {
+                  syslog(LOG_ERR,
+                         "MKDIR %s, errno = %d; Wrong error detected.",
+                         tmpdir, errno);
+                  fail_msg("test fail !\n");
+                  goto out;
+                }
+            }
+          else
+            {
+              syslog(LOG_ERR,
+                     "MKDIR %s succeded when it shoud have failed.",
+                     tmpdir);
+              fail_msg("test fail !\n");
+              goto out;
+            }
+        }
+    }
+
+out:
+  for (j = 0; j < 5; j += 3)
+    {
+      sprintf(tmpdir, "%s_%d_dir", __func__, j);
+      assert_int_equal(rmdir(tmpdir), 0);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_mkdir02
+ ****************************************************************************/
+
+void test_nuttx_syscall_mkdir02(FAR void **state)
+{
+  int ret;
+  int j;
+  int times = 1000;
+  char tmpdir[40];
+
+  while (times--)
+    {
+      for (j = 1; j < 5; j += 3)
+        {
+          sprintf(tmpdir, "%s_%d_dir", __func__, j);
+          ret = rmdir(tmpdir);
+          if (ret < 0)
+            {
+              if (errno != ENOENT)
+                {
+                  syslog(LOG_ERR,
+                         "RMDIR %s, errno = %d; Wrong error detected.",
+                         tmpdir, errno);
+                  fail_msg("test fail !\n");
+                }
+            }
+
+          else
+            {
+              syslog(LOG_ERR,
+                     "RMDIR %s succeded when it should have failed.",
+                     tmpdir);
+              fail_msg("test fail !\n");
+            }
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_mkdir03
+ ****************************************************************************/
+
+void test_nuttx_syscall_mkdir03(FAR void **state)
+{
+  int ret;
+  int j;
+  int times = 1000;
+  char tmpdir[40];
+
+  while (times--)
+    {
+      for (j = 2; j < 5; j += 3)
+        {
+          sprintf(tmpdir, "%s_%d_dir", __func__, j);
+          ret = mkdir(tmpdir, 0777);
+          if (ret < 0)
+            {
+              syslog(LOG_ERR,
+                     "MKDIR %s, errno = %d; Wrong error detected.",
+                     tmpdir, errno);
+              goto out;
+            }
+        }
+
+      for (j = 2; j < 5; j += 3)
+        {
+          sprintf(tmpdir, "%s_%d_dir", __func__, j);
+          ret = rmdir(tmpdir);
+          if (ret < 0)
+            {
+              syslog(LOG_ERR,
+                     "RMDIR %s, errno = %d; Wrong error detected.",
+                     tmpdir, errno);
+              goto out;
+            }
+        }
+    }
+
+  goto testpass;
+
+out:
+  for (j = 2; j < 5; j += 3)
+    {
+      sprintf(tmpdir, "%s/test%d", __func__, j);
+      rmdir(tmpdir);
+    }
+
+  assert_true(0);
+testpass:
+  assert_true(1);
+}

--- a/testing/testsuites/kernel/syscall/cases/nansleep_test.c
+++ b/testing/testsuites/kernel/syscall/cases/nansleep_test.c
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/nansleep_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <time.h>
+#include <syslog.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_nansleep01
+ ****************************************************************************/
+
+void test_nuttx_syscall_nansleep01(FAR void **state)
+{
+  time_t ret;
+  struct timespec t =
+  {
+    .tv_sec = 2, .tv_nsec = 9999
+  };
+
+  ret = nanosleep(&t, NULL);
+  assert_int_equal(ret, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_nansleep02
+ ****************************************************************************/
+
+void test_nuttx_syscall_nansleep02(FAR void **state)
+{
+  int ret;
+  struct timespec tcases[] =
+  {
+      {.tv_sec = 0, .tv_nsec = (long)1000000000},
+      {.tv_sec = 1, .tv_nsec = (long)-100},
+  };
+
+  int n = 0;
+  for (n = 0; n < 2; n++)
+    {
+      ret = nanosleep(&tcases[n], NULL);
+      if (ret != -1)
+        {
+          syslog(LOG_ERR,
+                 "test no.%d,  FAIL, nanosleep() returned %d, expected "
+                 "-1\n",
+                 n + 1, ret);
+          fail_msg("test fail !\n");
+        }
+
+      if (errno != EINVAL)
+        {
+          syslog(LOG_ERR,
+                 "test no.%d,  FAIL, nanosleep() failed,expected "
+                 "EINVAL, got\n",
+                 n + 1);
+          fail_msg("test fail !\n");
+        }
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/pathconf_test.c
+++ b/testing/testsuites/kernel/syscall/cases/pathconf_test.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/pathconf_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_pathconf01
+ ****************************************************************************/
+
+void test_nuttx_syscall_pathconf01(FAR void **state)
+{
+  long ret;
+  char *path;
+
+  struct pathconf_args
+  {
+    char define_tag[16];
+    int value;
+  }
+
+  args[] =
+    {
+        {
+          "_PC_LINK_MAX", _PC_LINK_MAX
+        },
+
+        {
+          "_PC_NAME_MAX", _PC_NAME_MAX
+        },
+
+        {
+          "_PC_PATH_MAX", _PC_PATH_MAX
+        },
+
+        {
+          "_PC_PIPE_BUF", _PC_PIPE_BUF
+        },
+    };
+
+  path = strdup(MOUNT_DIR);
+  assert_non_null(path);
+
+  for (int i = 0; i < 4; i++)
+    {
+      ret = pathconf(path, args[i].value);
+      assert_int_not_equal(ret, -1);
+    }
+
+  free(path);
+}

--- a/testing/testsuites/kernel/syscall/cases/pipe_test.c
+++ b/testing/testsuites/kernel/syscall/cases/pipe_test.c
@@ -1,0 +1,98 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/pipe_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_pipe01
+ ****************************************************************************/
+
+void test_nuttx_syscall_pipe01(FAR void **state)
+{
+  int fds[2];
+  int ret;
+  int rd_size;
+  int wr_size;
+  char wrbuf[64] = "abcdefghijklmnopqrstuvwxyz";
+  char rdbuf[128];
+
+  memset(rdbuf, 0, sizeof(rdbuf));
+
+  ret = pipe(fds);
+  assert_int_not_equal(ret, -1);
+
+  /* write fds[1] */
+
+  wr_size = write(fds[1], wrbuf, sizeof(wrbuf));
+
+  /* read fds[0] */
+
+  rd_size = read(fds[0], rdbuf, sizeof(rdbuf));
+
+  assert_int_equal(rd_size, wr_size);
+  assert_int_equal(strncmp(rdbuf, wrbuf, wr_size), 0);
+
+  assert_int_equal(close(fds[0]), 0);
+  assert_int_equal(close(fds[1]), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_pipe02
+ ****************************************************************************/
+
+void test_nuttx_syscall_pipe02(FAR void **state)
+{
+  int fd[2];
+  int ret;
+  char buf[2];
+
+  ret = pipe(fd);
+  assert_int_not_equal(ret, -1);
+
+  ret = write(fd[0], "A", 1);
+  assert_int_equal(ret, -1);
+  assert_int_equal(errno, EACCES);
+
+  ret = read(fd[1], buf, 1);
+  assert_int_equal(ret, -1);
+  assert_int_equal(errno, EACCES);
+
+  assert_int_equal(close(fd[0]), 0);
+  assert_int_equal(close(fd[1]), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/pread_test.c
+++ b/testing/testsuites/kernel/syscall/cases/pread_test.c
@@ -1,0 +1,377 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/pread_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define K1 32
+#define K2 (K1 * 2)
+#define K3 (K1 * 3)
+#define K4 (K1 * 4)
+#define K5 (K1 * 5)
+
+/****************************************************************************
+ * Private data Prototypes
+ ****************************************************************************/
+
+char pread01_filename[64] = "";
+int pread01_fildes;         /* file descriptor for tempfile */
+char *pread01_write_buf[4]; /* buffer to hold data to be written */
+char *pread01_read_buf[4];  /* buffer to hold data read from file */
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+void pread01_setup(void);   /* Main setup function of test */
+void pread01_cleanup(void); /* cleanup function for the test */
+void pread01_l_seek(int, off_t, int,
+                    off_t); /* function to call lseek() */
+void pread01_init_buffers(
+    void); /* function to initialize/allocate buffers */
+int pread01_compare_bufers(
+    void); /* function to compare o/p of pread/pwrite */
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pread01_init_buffers
+ ****************************************************************************/
+
+/*  init_buffers - allocates both write_buf and read_buf arrays.
+ *  Allocate the read and write buffers.
+ *  Fill the write buffer with the following data like,
+ *    write_buf[0] has 0's, write_buf[1] has 1's, write_buf[2] has 2's
+ *    write_buf[3] has 3's.
+ */
+
+void pread01_init_buffers(void)
+{
+  int count; /* counter variable for loop */
+
+  /* Allocate and Initialize read/write buffer */
+
+  for (count = 0; count < 4; count++)
+    {
+      pread01_write_buf[count] = (char *)malloc(K1);
+      pread01_read_buf[count] = (char *)malloc(K1);
+
+      if ((pread01_write_buf[count] == NULL) ||
+          (pread01_read_buf[count] == NULL))
+        {
+          syslog(LOG_ERR, "malloc() failed on read/write buffers\n");
+        }
+
+      memset(pread01_write_buf[count], count, K1);
+    }
+}
+
+/****************************************************************************
+ * Name: pread01_setup
+ ****************************************************************************/
+
+/* setup() - performs all ONE TIME setup for this test.
+ *
+ *  Initialize/allocate read/write buffers.
+ *  Create a temporary directory and a file under it and
+ *  write know data at different offset positions.
+ */
+
+void pread01_setup(void)
+{
+  int nwrite = 0; /* no. of bytes written by pwrite() */
+
+  /* Allocate/Initialize the read/write buffer with know data */
+
+  pread01_init_buffers();
+
+  sprintf(pread01_filename, "%s_tstfile", __func__);
+
+  /* Creat a temporary file used for mapping */
+
+  if ((pread01_fildes = open(pread01_filename, O_RDWR | O_CREAT, 0666)) <
+      0)
+    {
+      syslog(LOG_ERR, "FAIL, open() on %s failed, errno=%d : %s\n",
+             pread01_filename, errno, strerror(errno));
+    }
+
+  if (pread01_fildes > 0)
+    {
+      /* pwrite() K1 of data (0's) at offset 0 of temporary file */
+
+      if ((nwrite = pwrite(pread01_fildes, pread01_write_buf[0], K1,
+                           0)) != K1)
+        {
+          syslog(LOG_ERR,
+                 "pwrite() failed to write on %s, "
+                 "errno=%d : %s\n",
+                 pread01_filename, errno, strerror(errno));
+        }
+
+      /* We should still be at offset 0. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, 0);
+
+      /* Now, lseek() to a non K boundary, just to be different. */
+
+      pread01_l_seek(pread01_fildes, K1 / 2, SEEK_SET, K1 / 2);
+
+      /* Again, pwrite() K1 of data (2's) at offset K2 of temporary file
+       */
+
+      if ((nwrite = pwrite(pread01_fildes, pread01_write_buf[2], K1,
+                           K2)) != K1)
+        {
+          syslog(LOG_ERR,
+                 "FAIL, pwrite() failed to write at %d off. "
+                 "on %s, errno=%d : %s\n",
+                 K2, pread01_filename, errno, strerror(errno));
+        }
+
+      /* We should still be at our non K boundary. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, K1 / 2);
+
+      /* lseek() to an offset of K3. */
+
+      pread01_l_seek(pread01_fildes, K3, SEEK_SET, K3);
+
+      /* Using write(), write of K1 of data (3's) which should take
+       * place at an offset of K3, moving the file pointer to K4.
+       */
+
+      if ((nwrite = write(pread01_fildes, pread01_write_buf[3], K1)) !=
+          K1)
+        {
+          syslog(LOG_ERR,
+                 "write() failed: nwrite=%d, errno=%d "
+                 ": %s\n",
+                 nwrite, errno, strerror(errno));
+        }
+
+      /* We should be at offset K4. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, K4);
+
+      /* Again, pwrite() K1 of data (1's) at offset K1. */
+
+      if ((nwrite = pwrite(pread01_fildes, pread01_write_buf[1], K1,
+                           K1)) != K1)
+        {
+          syslog(LOG_ERR,
+                 "pwrite() failed to write at %d off. "
+                 "on %s, errno=%d : %s\n",
+                 K1, pread01_filename, errno, strerror(errno));
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: pread01_l_seek
+ ****************************************************************************/
+
+/* l_seek() - local front end to lseek().
+ *
+ *  "checkoff" is the offset at which we believe we should be at.
+ *  Used to validate pread/pwrite don't move the offset.
+ */
+
+void pread01_l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
+{
+  off_t offloc; /* offset ret. from lseek() */
+
+  if ((offloc = lseek(fdesc, offset, whence)) != checkoff)
+    {
+      syslog(LOG_WARNING,
+             "return = %" PRId64 " , expected %" PRId64 "\n",
+             (int64_t)offloc, (int64_t)checkoff);
+      syslog(LOG_ERR, "lseek() on %s failed\n", pread01_filename);
+    }
+}
+
+/****************************************************************************
+ * Name: pread01_compare_bufers
+ ****************************************************************************/
+
+/* compare_bufers() - Compare the contents of read buffer aganist the
+ *                    write buffer contents.
+ *
+ *  The contents of the index of each buffer should be as follows:
+ *  [0] has 0's, [1] has 1's, [2] has 2's, and [3] has 3's.
+ *
+ *  This function does memcmp of read/write buffer and display message
+ *  about the functionality of pread().
+ */
+
+int pread01_compare_bufers(void)
+{
+  int count;       /* index for the loop */
+  int err_flg = 0; /* flag to indicate error */
+
+  for (count = 0; count < 4; count++)
+    {
+      if (memcmp(pread01_write_buf[count], pread01_read_buf[count],
+                 K1) != 0)
+        {
+          syslog(LOG_ERR, "FAIL, read/write buffer data mismatch\n");
+          err_flg++;
+        }
+    }
+
+  /* If no erros, Test successful */
+
+  if (!err_flg)
+    {
+      /* syslog(LOG_INFO, "PASS, Functionality of pread() is correct\n"); */
+
+      return 0;
+    }
+
+  else
+    {
+      return -1;
+    }
+}
+
+/****************************************************************************
+ * Name: pread01_cleanup
+ ****************************************************************************/
+
+void pread01_cleanup(void)
+{
+  int count;
+
+  /* Free the memory allocated for the read/write buffer */
+
+  for (count = 0; count < 4; count++)
+    {
+      free(pread01_write_buf[count]);
+      free(pread01_read_buf[count]);
+    }
+
+  /* Close the temporary file */
+
+  close(pread01_fildes);
+
+  unlink(pread01_filename);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_pread01
+ ****************************************************************************/
+
+void test_nuttx_syscall_pread01(FAR void **state)
+{
+  int lc;
+  int nread; /* no. of bytes read by pread() */
+
+  pread01_setup();
+
+  for (lc = 0; lc < 1; lc++)
+    {
+      /* Call pread() of K1 data (should be 2's) at offset K2.
+       */
+
+      nread = pread(pread01_fildes, pread01_read_buf[2], K1, K2);
+
+      /* Check for the return value of pread() */
+
+      assert_int_equal(nread, K1);
+
+      /* We should still be at offset K4,
+       * which we were at the end of block 0.
+       */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, K4);
+
+      /* Now lseek() to offset 0. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_SET, 0);
+
+      /* pread() K1 of data (should be 3's) at offset K3. */
+
+      nread = pread(pread01_fildes, pread01_read_buf[3], K1, K3);
+      assert_int_equal(nread, K1);
+
+      /* We should still be at offset 0. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, 0);
+
+      /* Do a normal read() of K1 data (should be 0's)
+       * which should take place at offset 0 and move the
+       * file pointer to an offset of K1.
+       */
+
+      nread = read(pread01_fildes, pread01_read_buf[0], K1);
+      assert_int_equal(nread, K1);
+
+      /* We should now be at an offset of K1. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, K1);
+
+      /* pread() of K1 data (should be 1's) at offset K1. */
+
+      nread = pread(pread01_fildes, pread01_read_buf[1], K1, K1);
+      assert_int_equal(nread, K1);
+
+      /* We should still be at offset K1. */
+
+      pread01_l_seek(pread01_fildes, 0, SEEK_CUR, K1);
+
+      /* Compare the read buffer data read
+       * with the data written to write buffer
+       * in the setup.
+       */
+
+      assert_int_equal(pread01_compare_bufers(), 0);
+
+      /* reset our location to offset K4 in case we are looping */
+
+      pread01_l_seek(pread01_fildes, K4, SEEK_SET, K4);
+    }
+
+  pread01_cleanup();
+}

--- a/testing/testsuites/kernel/syscall/cases/pwrite_test.c
+++ b/testing/testsuites/kernel/syscall/cases/pwrite_test.c
@@ -1,0 +1,322 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/pwrite_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define K1 32
+#define K2 (K1 * 2)
+#define K3 (K1 * 3)
+#define K4 (K1 * 4)
+#define K5 (K1 * 5)
+
+/****************************************************************************
+ * Private data Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+int pwrite02_init_buffers(char *[]);
+int pwrite02_l_seek(int, off_t, int, off_t);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pwrite02_init_buffers
+ ****************************************************************************/
+
+int pwrite02_init_buffers(char *wbuf[])
+{
+  int i;
+
+  for (i = 0; i < 4; i++)
+    {
+      wbuf[i] = (char *)malloc(K1);
+      if (wbuf[i] == NULL)
+        {
+          syslog(LOG_ERR, "ib: malloc failed: errno=%d\n", errno);
+          return -1;
+        }
+
+      memset(wbuf[i], i, K1);
+    }
+
+  return 0;
+}
+
+void pwrite02_free_buffers(char *wbuf[])
+{
+  int i;
+
+  for (i = 0; i < 4; i++)
+    {
+      if (wbuf[i] != NULL)
+        {
+          free(wbuf[i]);
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: pwrite02_l_seek
+ ****************************************************************************/
+
+/* l_seek() is a local front end to lseek().
+ * "checkoff" is the offset at which we believe we should be at.
+ * Used to validate pwrite doesn't move the offset.
+ */
+
+int pwrite02_l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
+{
+  off_t offloc;
+
+  if ((offloc = lseek(fdesc, offset, whence)) != checkoff)
+    {
+      syslog(LOG_ERR,
+             "FAIL, (%ld = lseek(%d, %ld, %d)) != %ld) errno = %d\n",
+             (long int)offloc, fdesc, (long int)offset, whence,
+             (long int)checkoff, errno);
+      return -1;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_pwrite01
+ ****************************************************************************/
+
+void test_nuttx_syscall_pwrite01(FAR void **state)
+{
+  int fd;
+  int ret;
+  char filename[64] = "";
+
+  sprintf(filename, "%s_file", __func__);
+
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+  ret = pwrite(fd, NULL, 0, 0);
+  assert_int_equal(ret, 0);
+
+  if (fd > 0)
+    assert_int_equal(close(fd), 0);
+
+  assert_int_equal(unlink(filename), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_pwrite02
+ ****************************************************************************/
+
+void test_nuttx_syscall_pwrite02(FAR void **state)
+{
+  char fname[256] = "";
+  char *wbuf[4];
+  int fd;
+  int nbytes;
+  int lc;
+  struct stat statbuf;
+
+  sprintf(fname, "%s_file", __func__);
+
+  for (lc = 0; lc < 2; lc++)
+    {
+      assert_int_equal(pwrite02_init_buffers(wbuf), 0);
+
+      fd = open(fname, O_RDWR | O_CREAT, 0666);
+      assert_true(fd > 0);
+
+      /* pwrite() K1 of data (0's) at offset 0.
+       */
+
+      nbytes = pwrite(fd, wbuf[0], K1, 0);
+      assert_int_equal(nbytes, K1);
+      if (nbytes != K1)
+        {
+          syslog(LOG_ERR,
+                 "FAIL, pwrite at 0 failed: nbytes=%d, errno=%d\n",
+                 nbytes, errno);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      /* We should still be at offset 0.
+       */
+
+      assert_int_equal(pwrite02_l_seek(fd, 0, SEEK_CUR, 0), 0);
+
+      /* lseek() to a non K boundary, just to be different.
+       */
+
+      assert_int_equal(pwrite02_l_seek(fd, K1 / 2, SEEK_SET, K1 / 2), 0);
+
+      /* pwrite() K1 of data (2's) at offset K2.
+       */
+
+      nbytes = pwrite(fd, wbuf[2], K1, K2);
+      assert_int_equal(nbytes, K1);
+      if (nbytes != K1)
+        {
+          syslog(LOG_ERR,
+                 "FAIL, pwrite at K2 failed: nbytes=%d, errno=%d\n",
+                 nbytes, errno);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      /* We should still be at our non K boundary.
+       */
+
+      assert_int_equal(pwrite02_l_seek(fd, 0, SEEK_CUR, K1 / 2), 0);
+
+      /* lseek() to an offset of K3.
+       */
+
+      assert_int_equal(pwrite02_l_seek(fd, K3, SEEK_SET, K3), 0);
+
+      /* This time use a normal write() of K1 of data (3's) which should
+       * take place at an offset of K3, moving the file pointer to K4.
+       */
+
+      nbytes = write(fd, wbuf[3], K1);
+      assert_int_equal(nbytes, K1);
+      if (nbytes != K1)
+        {
+          syslog(LOG_ERR, "FAIL, write failed: nbytes=%d, errno=%d\n",
+                 nbytes, errno);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      /* We should be at offset K4.
+       */
+
+      assert_int_equal(pwrite02_l_seek(fd, 0, SEEK_CUR, K4), 0);
+
+      /* pwrite() K1 of data (1's) at offset K1.
+       */
+
+      nbytes = pwrite(fd, wbuf[1], K1, K1);
+      assert_int_equal(nbytes, K1);
+      if (nbytes != K1)
+        {
+          syslog(LOG_ERR, "FAIL, pwrite failed: nbytes=%d, errno=%d\n",
+                 nbytes, errno);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      /* -------------------------------------------------------------- */
+
+      /* Now test that O_APPEND takes precedence over any
+       * offset specified by pwrite(), but that the file
+       * pointer remains unchanged.  First, close then reopen
+       * the file and ensure it is already K4 in length and
+       * set the file pointer to it's midpoint, K2.
+       */
+
+      close(fd);
+      fd = open(fname, O_RDWR | O_APPEND, 0666);
+      assert_true(fd > 0);
+      if (fd < 0)
+        {
+          fail_msg("TEST FAIL !\n");
+          syslog(LOG_ERR, "FAIL, open failed: fname = %s, errno = %d\n",
+                 fname, errno);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      if (fstat(fd, &statbuf) == -1)
+        {
+          fail_msg("TEST FAIL !\n");
+          syslog(LOG_ERR, "FAIl, fstat failed: errno = %d\n", errno);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      if (statbuf.st_size != K4)
+        {
+          fail_msg("TEST FAIL !\n");
+          syslog(LOG_ERR, "FAIl, file size is %ld != K4\n",
+                 (long int)statbuf.st_size);
+          assert_int_equal(unlink(fname), 0);
+        }
+
+      assert_int_equal(pwrite02_l_seek(fd, K2, SEEK_SET, K2), 0);
+
+      /* Finally, pwrite() some K1 of data at offset 0.
+       * What we should end up with is:
+       *      -The file pointer should still be at K2.
+       *      -The data should have been written to the end
+       *       of the file (O_APPEND) and should be K5 in size.
+       */
+
+      if ((nbytes = pwrite(fd, wbuf[0], K1, 0)) != K1)
+        {
+          fail_msg("TEST FAIL !\n");
+          syslog(LOG_ERR,
+                 "FAIl, pwrite at 0 failed: nbytes=%d, errno=%d\n",
+                 nbytes, errno);
+        }
+
+      assert_int_equal(pwrite02_l_seek(fd, 0, SEEK_CUR, K2), 0);
+      if (fstat(fd, &statbuf) == -1)
+        {
+          fail_msg("TEST FAIL !\n");
+          syslog(LOG_ERR, "FAIl, fstat failed: errno = %d\n", errno);
+        }
+
+      if (statbuf.st_size != K5)
+        {
+          fail_msg("TEST FAIL !\n");
+          syslog(LOG_ERR, "FAIl, file size is %ld != K4\n",
+                 (long int)statbuf.st_size);
+        }
+
+      close(fd);
+      assert_int_equal(unlink(fname), 0);
+      pwrite02_free_buffers(wbuf);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/read_test.c
+++ b/testing/testsuites/kernel/syscall/cases/read_test.c
@@ -1,0 +1,201 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/read_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_read01
+ ****************************************************************************/
+
+void test_nuttx_syscall_read01(FAR void **state)
+{
+  int fd;
+  char buf[512];
+  char filename[64] = "";
+
+  memset(buf, '*', 512);
+  sprintf(filename, "%s_file", __func__);
+
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+  assert_int_equal(write(fd, buf, 512), (ssize_t)512);
+
+  lseek(fd, 0, SEEK_SET);
+
+  assert_int_equal(read(fd, buf, 512), (ssize_t)512);
+
+  if (fd > 0)
+    assert_int_equal(close(fd), 0);
+
+  assert_int_equal(unlink(filename), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_read02
+ ****************************************************************************/
+
+void test_nuttx_syscall_read02(FAR void **state)
+{
+#ifndef CONFIG_FDSAN
+
+  /* Define an invalid file descriptor */
+
+  int badfd = 99999999;
+  int ret;
+  char buf[64];
+  size_t count = 1;
+
+  /* Read with an invalid file descriptor */
+
+  ret = read(badfd, buf, count);
+
+  /* Read fail */
+
+  assert_int_equal(ret, -1);
+
+  /* Check whether the error code meets the expectation */
+
+  assert_int_equal(errno, EBADF);
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_read03
+ ****************************************************************************/
+
+void test_nuttx_syscall_read03(FAR void **state)
+{
+  char fname[255];
+  char palfa[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  int fild;
+
+  int lc;
+  int ret;
+  int rfild;
+  char prbuf[BUFSIZ];
+
+  sprintf(fname, "%s_tfile", __func__);
+
+  fild = creat(fname, 0777);
+  if (fild > 0)
+    {
+      assert_int_equal(write(fild, palfa, 27), 27);
+      close(fild);
+    }
+
+  for (lc = 0; lc < 2; lc++)
+    {
+      if ((rfild = open(fname, O_RDONLY)) == -1)
+        {
+          syslog(LOG_ERR, "can't open for reading\n");
+          continue;
+        }
+
+      ret = read(rfild, prbuf, BUFSIZ);
+
+      if (ret == -1)
+        {
+          fail_msg("test fail !\n");
+          syslog(LOG_ERR, "FAIL, call failed unexpectedly\n");
+          close(rfild);
+          continue;
+        }
+
+      if (ret != 27)
+        {
+          fail_msg("test fail !\n");
+          syslog(LOG_ERR,
+                 "FAIL, Bad read count - got %d - "
+                 "expected %d\n",
+                 ret, 27);
+          close(rfild);
+          continue;
+        }
+
+      if (memcmp(palfa, prbuf, 27) != 0)
+        {
+          fail_msg("test fail !\n");
+          syslog(LOG_ERR,
+                 "FAIL, read buffer not equal "
+                 "to write buffer\n");
+          close(rfild);
+          continue;
+        }
+
+      close(rfild);
+    }
+
+  assert_int_equal(unlink(fname), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_read04
+ ****************************************************************************/
+
+void test_nuttx_syscall_read04(FAR void **state)
+{
+  int ret;
+
+  /* Define an invalid file descriptor */
+
+  int badfd = -1;
+  char buf[64];
+  size_t count = 1;
+
+  /* Read with an invalid file descriptor */
+
+  ret = read(badfd, buf, count);
+
+  /* Read succeeded */
+
+  if (ret != -1)
+    {
+      fail_msg("FAIL, read() succeeded unexpectedly");
+    }
+
+  /* Check whether the error code meets the expectation */
+
+  if (errno != EBADF)
+    {
+      syslog(LOG_ERR,
+             "FAIL, read() failed unexpectedly, expected "
+             "EBADF:%d,actually:%d\n",
+             EBADF, errno);
+      fail_msg("read() failed unexpectedly");
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/readdir_test.c
+++ b/testing/testsuites/kernel/syscall/cases/readdir_test.c
@@ -1,0 +1,108 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/readdir_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdint.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_setup
+ ****************************************************************************/
+
+static void test_nuttx_syscall_setup(char *prefix, int nfiles)
+{
+  char fname[255] =
+  {
+    0
+  };
+
+  int i;
+  int fd;
+  int ret;
+
+  for (i = 0; i < nfiles; i++)
+    {
+      sprintf(fname, "%s_%d", prefix, i);
+      fd = open(fname, O_RDWR | O_CREAT, 0700);
+      assert_true(fd > 0);
+
+      ret = write(fd, "hello\n", 6);
+      assert_int_in_range(ret, 1, 6);
+
+      assert_int_equal(close(fd), 0);
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_readdirtest01
+ ****************************************************************************/
+
+void test_nuttx_syscall_readdirtest01(FAR void **state)
+{
+  char *prefix = "readdirfile";
+  int nfiles = 10;
+  test_nuttx_syscall_setup(prefix, nfiles);
+
+  int cnt = 0;
+  DIR *test_dir;
+  struct dirent *ent;
+
+  char buf[20] =
+  {
+    0
+  };
+
+  getcwd(buf, sizeof(buf));
+  test_dir = opendir(buf);
+  assert_non_null(test_dir);
+
+  while ((ent = readdir(test_dir)))
+    {
+      if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
+        continue;
+      if (!strncmp(ent->d_name, prefix, sizeof(prefix) - 1))
+        cnt++;
+    }
+
+  assert_int_equal(cnt, nfiles);
+  assert_int_equal(closedir(test_dir), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/recvfrom_test.c
+++ b/testing/testsuites/kernel/syscall/cases/recvfrom_test.c
@@ -1,0 +1,448 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/recvfrom_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#ifndef UCLINUX
+#define UCLINUX
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/select.h>
+#include <sys/syscall.h>
+#include <netinet/in.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Private data Prototypes
+ ****************************************************************************/
+
+__attribute__((unused)) static char buf[1024];
+__attribute__((unused)) static int s; /* socket descriptor */
+__attribute__((unused)) static int testno;
+__attribute__((unused)) static struct sockaddr_in sin1, from;
+__attribute__((unused)) static pthread_t thread;
+__attribute__((unused)) static int
+    sfd; /* shared between do_child and start_server */
+__attribute__((unused)) static socklen_t fromlen;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+__attribute__((unused)) static int setup(void), setup0(void),
+    setup1(void), setup2(void), cleanup(void), cleanup0(void),
+    cleanup1(void);
+__attribute__((unused)) static void do_child(void);
+
+__attribute__((unused)) static void *start_server(void *);
+
+__attribute__((unused)) static struct test_case_t
+{
+  int domain;            /* PF_INET, PF_UNIX, ... */
+  int type;              /* SOCK_STREAM, SOCK_DGRAM ... */
+  int proto;             /* protocol number (usually 0 = default) */
+  void *buf;             /* recv data buffer */
+  size_t buflen;         /* recv's 3rd argument */
+  unsigned flags;        /* recv's 4th argument */
+  struct sockaddr *from; /* from address */
+  socklen_t *salen;      /* from address value/result buffer length */
+  int retval;            /* syscall return value */
+  int experrno;          /* expected errno */
+  int (*setup)(void);
+  int (*cleanup)(void);
+  char *desc;
+}
+
+tdat[] =
+{
+    /* 1 */
+
+    {
+      PF_INET, SOCK_STREAM, 0, buf, sizeof(buf), 0,
+     (struct sockaddr *)&from, &fromlen, -1, EBADF, setup0, cleanup0,
+     "bad file descriptor"
+    },
+
+    /* 2 */
+
+    {
+      0, 0, 0, buf, sizeof(buf), 0, (struct sockaddr *)&from, &fromlen,
+     -1, ENOTSOCK, setup0, cleanup0, "invalid socket"
+    },
+
+    /* 3 */
+
+    {
+      PF_INET, SOCK_STREAM, 0, (void *)buf, sizeof(buf), 0,
+     (struct sockaddr *)-1, &fromlen, 0, ENOTSOCK, setup1, cleanup1,
+     "invalid socket buffer"
+    },
+
+    /* 4 */
+
+    {
+      PF_INET, SOCK_STREAM, 0, (void *)buf, sizeof(buf), 0,
+     (struct sockaddr *)&from, &fromlen, -1, EINVAL, setup2, cleanup1,
+     "invalid socket addr length"
+    },
+#ifndef UCLINUX
+
+    /* 5 */
+
+    {
+      PF_INET, SOCK_STREAM, 0, (void *)-1, sizeof(buf), 0,
+     (struct sockaddr *)&from, &fromlen, -1, EFAULT, setup1, cleanup1,
+     "invalid recv buffer"
+    },
+#endif
+    /* 6 */
+
+/* {
+ *    PF_INET, SOCK_STREAM, 0, (void *)buf, sizeof(buf), MSG_OOB,
+ *  (struct sockaddr *)&from, &fromlen,
+ *  -1, EINVAL, setup1, cleanup1, "invalid MSG_OOB flag set"
+ * },
+ */
+
+    /* 7 */
+
+    {
+      PF_INET, SOCK_STREAM, 0, (void *)buf, sizeof(buf),
+      MSG_ERRQUEUE, (struct sockaddr *)&from, &fromlen, -1, EAGAIN,
+      setup1, cleanup1, "invalid MSG_ERRQUEUE flag set"
+    },
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: setup
+ ****************************************************************************/
+
+__attribute__((unused)) static int setup(void)
+{
+  int r = pthread_create(&thread, NULL, start_server, (void *)&sin1);
+  if (r < 0)
+    {
+      syslog(LOG_ERR, "pthread_create fail, errno %d\n", errno);
+      return -1;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: cleanup
+ ****************************************************************************/
+
+__attribute__((unused)) static int cleanup(void)
+{
+  assert_true(pthread_cancel(thread) == 0);
+  assert_true(pthread_join(thread, NULL) == 0);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: setup0
+ ****************************************************************************/
+
+__attribute__((unused)) static int setup0(void)
+{
+  if (tdat[testno].experrno == EBADF)
+    {
+      s = 400; /* anything not an open file */
+    }
+
+  else if ((s = open("/dev/null", O_WRONLY)) == -1)
+    {
+      syslog(LOG_ERR, "open /dev/null fail, errno %d\n", errno);
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  fromlen = sizeof(from);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: cleanup0
+ ****************************************************************************/
+
+__attribute__((unused)) static int cleanup0(void)
+{
+  s = -1;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: setup1
+ ****************************************************************************/
+
+__attribute__((unused)) static int setup1(void)
+{
+#ifdef CONFIG_NET_TCP
+  fd_set rdfds;
+  struct timeval timeout;
+  int n;
+
+  s = safe_socket(tdat[testno].domain, tdat[testno].type,
+                  tdat[testno].proto);
+  assert_true(s >= 0);
+  if (tdat[testno].type == SOCK_STREAM &&
+      connect(s, (struct sockaddr *)&sin1, sizeof(sin1)) < 0)
+    {
+      syslog(LOG_ERR, "connect failed, errno %d\n", errno);
+      fail_msg("test fail");
+    }
+
+  /* Wait for something to be readable, else we won't detect EFAULT on
+   * recv
+   */
+
+  FD_ZERO(&rdfds);
+  FD_SET(s, &rdfds);
+  timeout.tv_sec = 2;
+  timeout.tv_usec = 0;
+  n = select(s + 1, &rdfds, 0, 0, &timeout);
+  if (n != 1 || !FD_ISSET(s, &rdfds))
+    {
+      syslog(
+          LOG_ERR,
+          "client setup1 failed - no message ready in 2 sec, errno %d\n",
+          errno);
+      fail_msg("test fail");
+    }
+
+  fromlen = sizeof(from);
+#endif
+  return s;
+}
+
+/****************************************************************************
+ * Name: setup2
+ ****************************************************************************/
+
+__attribute__((unused)) static int setup2(void)
+{
+  setup1();
+  fromlen = -1;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: cleanup1
+ ****************************************************************************/
+
+__attribute__((unused)) static int cleanup1(void)
+{
+  (void)close(s);
+  s = -1;
+  return 0;
+}
+
+/****************************************************************************
+ * Name: start_server
+ ****************************************************************************/
+
+__attribute__((unused)) static void *start_server(void *arg)
+{
+  /* 设置取消状态为启用 */
+
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+
+  /* 设置取消类型为异步取消 */
+
+  pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+
+  struct sockaddr_in *sin0 = (struct sockaddr_in *)arg;
+  socklen_t slen = sizeof(*sin0);
+
+  sin0->sin_family = AF_INET;
+  sin0->sin_port = 0; /* pick random free port */
+  sin0->sin_addr.s_addr = INADDR_ANY;
+
+  sfd = socket(PF_INET, SOCK_STREAM, 0);
+  if (sfd < 0)
+    {
+      syslog(LOG_ERR, "server socket failed\n");
+      fail_msg("test fail !");
+      return NULL;
+    }
+
+  if (bind(sfd, (struct sockaddr *)sin0, sizeof(*sin0)) < 0)
+    {
+      syslog(LOG_ERR, "server bind failed\n");
+      close(sfd);
+      fail_msg("test fail");
+      return NULL;
+    }
+
+  if (listen(sfd, 10) < 0)
+    {
+      syslog(LOG_ERR, "server listen failed\n");
+      close(sfd);
+      fail_msg("test fail");
+      return NULL;
+    }
+
+  /* assert_int_not_equal(-1,safe_getsockname(sfd, (struct sockaddr
+   * *)sin0, &slen));
+   */
+
+  safe_getsockname(sfd, (struct sockaddr *)sin0, &slen);
+  do_child();
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: do_child
+ ****************************************************************************/
+
+__attribute__((unused)) static void do_child(void)
+{
+  struct sockaddr_in fsin;
+  fd_set afds;
+  fd_set rfds;
+  int nfds;
+  int cc;
+  int fd;
+
+  FD_ZERO(&afds);
+  FD_SET(sfd, &afds);
+
+  nfds = sfd + 1;
+
+  /* accept connections until killed */
+
+  while (1)
+    {
+      socklen_t fromlen_s;
+      memcpy(&rfds, &afds, sizeof(rfds));
+
+      if (select(nfds, &rfds, NULL, NULL, NULL) < 0)
+          if (errno != EINTR)
+            {
+              syslog(LOG_ERR, "select exit fail\n");
+              fail_msg("test fail !");
+              return;
+            }
+
+      if (FD_ISSET(sfd, &rfds))
+        {
+          int newfd;
+
+          fromlen_s = sizeof(fsin);
+          newfd = accept(sfd, (struct sockaddr *)&fsin, &fromlen_s);
+          if (newfd >= 0)
+            {
+              FD_SET(newfd, &afds);
+              nfds = (nfds > newfd + 1) ? (nfds) : (newfd + 1);
+
+              /* send something back */
+
+              (void)write(newfd, "hoser\n", 6);
+            }
+        }
+
+      for (fd = 0; fd < nfds; ++fd)
+          if (fd != sfd && FD_ISSET(fd, &rfds))
+            {
+              cc = read(fd, buf, sizeof(buf));
+              if (cc == 0 || (cc < 0 && errno != EINTR))
+                {
+                  (void)close(fd);
+                  FD_CLR(fd, &afds);
+                }
+            }
+
+      pthread_testcancel();
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_recvfromtest01
+ ****************************************************************************/
+
+void test_nuttx_syscall_recvfromtest01(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  int ret;
+  int flag = 1;
+  setup();
+
+  for (testno = 0; testno < sizeof(tdat) / sizeof(tdat[0]); ++testno)
+    {
+      usleep(100000);
+      if (tdat[testno].setup() < 0)
+        {
+          tdat[testno].cleanup();
+          continue;
+        }
+
+      ret = recvfrom(s, tdat[testno].buf, tdat[testno].buflen,
+                     tdat[testno].flags, tdat[testno].from,
+                     tdat[testno].salen);
+      if (ret >= 0)
+        {
+          ret = 0; /* all nonzero equal here */
+        }
+
+      if (ret != tdat[testno].retval ||
+          (ret < 0 && errno != tdat[testno].experrno))
+        {
+          syslog(LOG_ERR,
+                 "test recvfrom01 %s failed; "
+                 "returned %d (expected %d), errno %d "
+                 "(expected %d)\n",
+                 tdat[testno].desc, ret, tdat[testno].retval, errno,
+                 tdat[testno].experrno);
+          flag = 0;
+        }
+
+      tdat[testno].cleanup();
+    }
+
+  cleanup();
+  assert_true(flag);
+#endif
+}
+
+#undef UCLINUX
+#endif

--- a/testing/testsuites/kernel/syscall/cases/rmdir_test.c
+++ b/testing/testsuites/kernel/syscall/cases/rmdir_test.c
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/rmdir_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_rmdir01
+ ****************************************************************************/
+
+void test_nuttx_syscall_rmdir01(FAR void **state)
+{
+  int ret;
+  struct stat buf;
+  char testdir[64] = "";
+
+  sprintf(testdir, "%s_dir", __func__);
+
+  ret = mkdir(testdir, 0777);
+  assert_int_equal(ret, 0);
+
+  ret = rmdir(testdir);
+  assert_int_equal(ret, 0);
+
+  assert_int_not_equal(stat(testdir, &buf), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_rmdir02
+ ****************************************************************************/
+
+void test_nuttx_syscall_rmdir02(FAR void **state)
+{
+  int ret;
+  int fd;
+
+  /* Description:
+   *   1) attempt to rmdir() non-empty directory -> ENOTEMPTY
+   *   2) attempt to rmdir() non-existing directory -> ENOENT
+   *   3) attempt to rmdir() a file -> ENOTDIR
+   */
+
+  struct testcase
+  {
+    char dir[32];
+    int exp_errno;
+  }
+
+  tcases[] =
+    {
+        {
+          "Rmdir02_testdir", ENOTEMPTY
+        },
+
+        {
+          "nosuchdir/testdir2", ENOENT
+        },
+
+        {
+          "Rmdir02_testfile2", ENOTDIR
+        },
+    };
+
+  ret = mkdir("Rmdir02_testdir", (S_IRWXU | S_IRWXG | S_IRWXO));
+  assert_int_equal(ret, 0);
+  ret = mkdir("Rmdir02_testdir/test1", (S_IRWXU | S_IRWXG | S_IRWXO));
+  assert_int_equal(ret, 0);
+  fd = open("Rmdir02_testfile2", O_CREAT | O_RDWR);
+
+  if (fd > 0)
+    close(fd);
+  for (int i = 0; i < 3; i++)
+    {
+      ret = rmdir(tcases[i].dir);
+      assert_int_not_equal(ret, 0);
+      if (ret != -1)
+        {
+          continue;
+        }
+    }
+
+  assert_int_equal(rmdir("Rmdir02_testdir/test1"), 0);
+  assert_int_equal(rmdir("Rmdir02_testdir"), 0);
+  assert_int_equal(unlink("Rmdir02_testfile2"), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/sched_test.c
+++ b/testing/testsuites/kernel/syscall/cases/sched_test.c
@@ -1,0 +1,204 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/sched_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <syslog.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <time.h>
+#include <syslog.h>
+#include <sched.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_sched01
+ ****************************************************************************/
+
+void test_nuttx_syscall_sched01(FAR void **state)
+{
+  struct test_case_t
+  {
+    int prio;
+    int policy;
+  }
+
+  TC[] =
+    {
+      /* set scheduling policy to SCHED_RR */
+
+        {
+          1, SCHED_RR
+        },
+
+      /* set scheduling policy to SCHED_FIFO */
+
+        {
+          1, SCHED_FIFO
+        }
+    };
+
+  int i;
+  int rec;
+  struct sched_param param;
+
+  i = 0;
+#if CONFIG_RR_INTERVAL > 0
+  param.sched_priority = TC[i].prio;
+
+  assert_int_not_equal(sched_setscheduler(0, TC[i].policy, &param), -1);
+
+  rec = sched_getscheduler(0);
+  assert_int_not_equal(rec, -1);
+  assert_int_equal(rec, TC[i].policy);
+#endif
+
+  i = 1;
+  param.sched_priority = TC[i].prio;
+  assert_int_not_equal(sched_setscheduler(0, TC[i].policy, &param), -1);
+
+  rec = sched_getscheduler(0);
+  assert_int_not_equal(rec, -1);
+  assert_int_equal(rec, TC[i].policy);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_sched02
+ ****************************************************************************/
+
+void test_nuttx_syscall_sched02(FAR void **state)
+{
+#if CONFIG_RR_INTERVAL > 0
+  int ret;
+  struct timespec tp;
+  struct sched_param p =
+  {
+    1
+  };
+
+  /* Change scheduling policy to SCHED_RR */
+
+  assert_int_not_equal(sched_setscheduler(0, SCHED_RR, &p), -1);
+  ret = sched_rr_get_interval(0, &tp);
+  assert_int_equal(ret, 0);
+#else
+  assert_true(1);
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_sched03
+ ****************************************************************************/
+
+void test_nuttx_syscall_sched03(FAR void **state)
+{
+  struct timespec tp;
+  struct sched_param p =
+  {
+    1
+  };
+
+  int ret;
+
+  /* Change scheduling policy to SCHED_FIFO */
+
+  assert_int_not_equal(sched_setscheduler(0, SCHED_FIFO, &p), -1);
+
+  tp.tv_sec = 99;
+  tp.tv_nsec = 99;
+
+  ret = sched_rr_get_interval(0, &tp);
+
+  assert_int_equal(ret, 0);
+  assert_int_equal(tp.tv_sec, 0);
+  assert_int_equal(tp.tv_nsec, 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_sched04
+ ****************************************************************************/
+
+void test_nuttx_syscall_sched04(FAR void **state)
+{
+  struct timespec tp;
+
+  static pid_t inval_pid = -1;
+
+  int i;
+  int ret;
+
+  struct test_cases_t
+  {
+    pid_t *pid;
+    struct timespec *tp;
+    int exp_errno;
+  }
+
+  test_cases[] =
+    {
+        {
+          &inval_pid, &tp, EINVAL
+        }
+    };
+
+  int TST_TOTAL = sizeof(test_cases) / sizeof(test_cases[0]);
+
+#if CONFIG_RR_INTERVAL > 0
+  struct sched_param p =
+  {
+    1
+  };
+
+  /* Change scheduling policy to SCHED_RR */
+
+  assert_int_not_equal(sched_setscheduler(0, SCHED_RR, &p), -1);
+#endif
+  for (i = 0; i < TST_TOTAL; ++i)
+    {
+      /* Call sched_rr_get_interval(2)
+       */
+
+      ret =
+          sched_rr_get_interval(*(test_cases[i].pid), test_cases[i].tp);
+      int ret_error = errno;
+
+      assert_int_equal(ret, -1);
+      assert_int_equal(ret_error, test_cases[i].exp_errno);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/setsocketopt01_test.c
+++ b/testing/testsuites/kernel/syscall/cases/setsocketopt01_test.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/setsocketopt01_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <syslog.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_setsockopt01
+ ****************************************************************************/
+
+void test_nuttx_syscall_setsockopt01(FAR void **state)
+{
+#if defined(CONFIG_NET) && defined(CONFIG_NET_SOCKOPTS)
+  struct sockaddr_in addr;
+  int optval;
+  struct test_case
+  {             /* test case structure */
+    int domain; /* PF_INET, PF_UNIX, ... */
+    int type;   /* SOCK_STREAM, SOCK_DGRAM ... */
+    int proto;  /* protocol number (usually 0 = default) */
+    int level;  /* IPPROTO_* */
+    int optname;
+    void *optval;
+    int optlen;
+    int experrno; /* expected errno */
+    char *desc;
+  }
+
+  testcase_list[] =
+    {
+        {
+          -1, -1, -1, SOL_SOCKET, SO_OOBINLINE, &optval, sizeof(optval),
+        EBADF, "invalid file descriptor"
+        },
+
+        {
+          -1, -1, -1, SOL_SOCKET, SO_OOBINLINE, &optval, sizeof(optval),
+        ENOTSOCK, "non-socket file descriptor"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, NULL,
+        sizeof(optval), EFAULT, "invalid option buffer"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
+        EINVAL, "invalid optlen"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, 500, SO_OOBINLINE, &optval,
+        sizeof(optval), ENOPROTOOPT, "invalid level"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, IPPROTO_UDP, SO_OOBINLINE, &optval,
+        sizeof(optval), ENOPROTOOPT, "invalid option name (UDP)"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, IPPROTO_IP, -1, &optval, sizeof(optval),
+        ENOPROTOOPT, "invalid option name (IP)"
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 0, IPPROTO_TCP, -1, &optval, sizeof(optval),
+        ENOPROTOOPT, "invalid option name (TCP)"
+        }
+    };
+
+  /* initialize local sockaddr */
+
+  addr.sin_family = AF_INET;
+  addr.sin_port = 0;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  for (int n = 0; n < sizeof(testcase_list) / sizeof(testcase_list[0]);
+       n++)
+    {
+      int ret;
+      struct test_case *tc = testcase_list + n;
+      int tmpfd;
+      int fd;
+      if (tc->domain == -1)
+        {
+          tmpfd = fd = SAFE_OPEN("/dev/null", O_WRONLY);
+          if (fd < 0)
+            continue;
+        }
+
+      else
+        {
+          tmpfd = fd = safe_socket(tc->domain, tc->type, tc->proto);
+          if (fd < 0)
+            continue;
+          if (safe_bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+            continue;
+        }
+
+      /* Use closed file descriptor rather than -1 */
+
+      if (tc->experrno == EBADF)
+          if (safe_close(tmpfd) < 0)
+            continue;
+      ret =
+          setsockopt(fd, tc->level, tc->optname, tc->optval, tc->optlen);
+      if (tc->experrno != EBADF)
+        {
+          safe_close(fd);
+          fd = -1;
+        }
+
+      if (ret != -1 || errno != tc->experrno)
+        {
+          syslog(LOG_ERR,
+                 "setsockopt %s fail, returned %d (expected -1), "
+                 "errno %d (expected %d)\n",
+                 tc->desc, ret, errno, tc->experrno);
+          fail_msg("test fail !");
+          continue;
+        }
+    }
+
+#endif
+}

--- a/testing/testsuites/kernel/syscall/cases/socket_test.c
+++ b/testing/testsuites/kernel/syscall/cases/socket_test.c
@@ -1,0 +1,208 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/socket_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_verifysocket01
+ ****************************************************************************/
+
+void test_nuttx_syscall_verifysocket01(int testno, int domain, int type,
+                                    int proto, int retval, int experrno)
+{
+  int fd;
+  int ret;
+  errno = 0;
+  fd = socket(domain, type, proto);
+  ret = fd;
+  if (fd > 0)
+    {
+      ret = 0;
+      close(fd);
+    }
+
+  else
+    {
+      ret = -1;
+    }
+
+  if (errno != experrno || ret != retval)
+    {
+      syslog(LOG_WARNING,
+             "NO.%d do socket() test, ret=%d  erron=%d experrno=%d\n",
+             testno, fd, errno, experrno);
+    }
+
+  assert_int_equal(ret, retval);
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_verifysocket02
+ ****************************************************************************/
+
+void test_nuttx_syscall_verifysocket02(int type, int flag, int fl_flag)
+{
+  int fd;
+  int res;
+  int tmp;
+
+  fd = socket(PF_INET, type, 0);
+  assert_int_not_equal(fd, -1);
+
+  res = fcntl(fd, fl_flag);
+  tmp = (res & flag);
+
+  if (flag != 0)
+    {
+      assert_int_not_equal(tmp, 0);
+    }
+
+  else
+    {
+      assert_int_equal(tmp, 0);
+    }
+
+  assert_int_equal(close(fd), 0);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_sockettest01
+ ****************************************************************************/
+
+void test_nuttx_syscall_sockettest01(FAR void **state)
+{
+  struct test_case_t
+  {
+    int domain;
+    int type;
+    int proto;
+    int retval;
+    int experrno;
+  }
+
+  tdat[] =
+    {
+        {
+          0, SOCK_STREAM, 0, -1, EAFNOSUPPORT
+        },
+
+        {
+          PF_INET, 75, 0, -1, EAFNOSUPPORT
+        },
+
+        {
+          PF_INET, SOCK_RAW, 0, -1, EAFNOSUPPORT
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 17, -1, EAFNOSUPPORT
+        },
+
+        {
+          PF_INET, SOCK_DGRAM, 6, -1, EAFNOSUPPORT
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 6, 0, 0
+        },
+
+        {
+          PF_INET, SOCK_STREAM, 1, -1, EAFNOSUPPORT
+        }
+    };
+
+  for (int i = 0; i < 7; i++)
+    {
+      test_nuttx_syscall_verifysocket01(i, tdat[i].domain, tdat[i].type,
+                                     tdat[i].proto, tdat[i].retval,
+                                     tdat[i].experrno);
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_sockettest02
+ ****************************************************************************/
+
+void test_nuttx_syscall_sockettest02(FAR void **state)
+{
+  static struct tcase
+  {
+    int type;
+    int flag;
+    int fl_flag;
+  }
+
+  tcases[] =
+    {
+        {
+          SOCK_STREAM, 0, F_GETFD
+        },
+
+        {
+          SOCK_STREAM | SOCK_CLOEXEC, FD_CLOEXEC, F_GETFD
+        },
+
+        {
+          SOCK_STREAM, 0, F_GETFL
+        },
+
+        {
+          SOCK_STREAM | SOCK_NONBLOCK, O_NONBLOCK, F_GETFL
+        }
+    };
+
+  for (int i = 0; i < 4; i++)
+    {
+      test_nuttx_syscall_verifysocket02(tcases[i].type, tcases[i].flag,
+                                     tcases[i].fl_flag);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/socketpair_test.c
+++ b/testing/testsuites/kernel/syscall/cases/socketpair_test.c
@@ -1,0 +1,230 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/socketpair_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#ifndef UCLINUX
+#define UCLINUX
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <syslog.h>
+#include <sys/syscall.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_socketpair01
+ ****************************************************************************/
+
+void test_nuttx_syscall_socketpair01(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  int fds[2];
+  int ret;
+  struct test_case_t
+  {
+    int domain;
+    int type;
+    int proto;
+    int *sv;
+    int retval;
+    int experrno;
+    char *desc;
+  }
+
+  tdat[] =
+    {
+        {
+          0, SOCK_STREAM, 0, fds, -1, EAFNOSUPPORT, "invalid domain"
+        },
+
+        {
+          PF_INET, 75, 0, fds, -1, EINVAL, "invalid type"
+        },
+
+        {
+          PF_UNIX, SOCK_DGRAM, 0, fds, 0, 0, "UNIX domain dgram"
+        },
+
+        {
+          PF_INET, SOCK_RAW, 0, fds, -1, EPROTONOSUPPORT,
+        "raw open as non-root"
+        },
+
+  #ifndef UCLINUX
+        {
+          PF_UNIX, SOCK_STREAM, 0, 0, -1, EFAULT, "bad aligned pointer"
+        },
+
+        {
+          PF_UNIX, SOCK_STREAM, 0, (int *)7, -1, EFAULT,
+        "bad unaligned pointer"
+        },
+
+  #endif
+      /* {PF_INET, SOCK_DGRAM, 17, fds, -1, EOPNOTSUPP, "UDP socket"}, */
+
+        {
+          PF_INET, SOCK_DGRAM, 6, fds, -1, EPROTONOSUPPORT, "TCP dgram"
+        },
+
+      /* {PF_INET, SOCK_STREAM, 6, fds, -1, EOPNOTSUPP, "TCP socket"}, */
+
+        {
+          PF_INET, SOCK_STREAM, 1, fds, -1, EPROTONOSUPPORT,
+        "ICMP stream"
+        }
+    };
+
+  for (int n = 0; n < sizeof(tdat) / sizeof(tdat[0]); n++)
+    {
+      struct test_case_t *tc = &tdat[n];
+      ret = socketpair(tc->domain, tc->type, tc->proto, tc->sv);
+      if (ret == 0)
+        {
+          SAFE_CLOSE(fds[0]);
+          SAFE_CLOSE(fds[1]);
+        }
+
+      if (ret != tc->retval || errno != tc->experrno)
+        {
+          syslog(LOG_ERR,
+                 "test socketpair01 %s failed; "
+                 "returned %d (expected %d), errno %d "
+                 "(expected %d)\n",
+                 tc->desc, ret, tc->retval, errno, tc->experrno);
+          assert_true(0);
+        }
+    }
+
+#endif
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_socketpair02
+ ****************************************************************************/
+
+void test_nuttx_syscall_socketpair02(FAR void **state)
+{
+#ifdef CONFIG_NET_TCP
+  int fds[2];
+  int ret;
+  int flag = 1;
+  struct tcase
+  {
+    int type;
+    int flag;
+    int fl_flag;
+    char *des;
+  }
+
+  tcases[] =
+    {
+        {
+          SOCK_STREAM, 0, F_GETFD, "no close-on-exec"
+        },
+
+        {
+          SOCK_STREAM | SOCK_CLOEXEC, FD_CLOEXEC, F_GETFD, "close-on-exec"
+        },
+
+        {
+          SOCK_STREAM, 0, F_GETFL, "no non-blocking"
+        },
+
+        {
+          SOCK_STREAM | SOCK_NONBLOCK, O_NONBLOCK, F_GETFL,
+        "non-blocking"
+        }
+    };
+
+  for (int n = 0; n < sizeof(tcases) / sizeof(tcases[0]); n++)
+    {
+      int res;
+      struct tcase *tc = &tcases[n];
+      ret = socketpair(PF_UNIX, tc->type, 0, fds);
+      if (ret == -1)
+        {
+          flag = 0;
+          syslog(LOG_ERR,
+                 "test socketpair02 %s failed; "
+                 "returned -1, errno %d\n",
+                 tc->des, errno);
+          continue;
+        }
+
+      for (int i = 0; i < 2; i++)
+        {
+          res = SAFE_FCNTL(fds[i], tc->fl_flag);
+
+          if (tc->flag != 0 && (res & tc->flag) == 0)
+            {
+              flag = 0;
+              syslog(LOG_ERR,
+                     "socketpair() failed to set %s flag for fds[%d]\n",
+                     tc->des, i);
+              break;
+            }
+
+          if (tc->flag == 0 && (res & tc->flag) != 0)
+            {
+              flag = 0;
+              syslog(LOG_ERR,
+                     "socketpair() failed to set %s flag for fds[%d]\n",
+                     tc->des, i);
+              break;
+            }
+        }
+
+      SAFE_CLOSE(fds[0]);
+      SAFE_CLOSE(fds[1]);
+    }
+
+  if (fds[0] > 0)
+    {
+      SAFE_CLOSE(fds[0]);
+    }
+
+  if (fds[1] > 0)
+    {
+      SAFE_CLOSE(fds[1]);
+    }
+
+  assert_true(flag);
+#endif
+}
+
+#undef UCLINUX
+#endif

--- a/testing/testsuites/kernel/syscall/cases/symlink_test.c
+++ b/testing/testsuites/kernel/syscall/cases/symlink_test.c
@@ -1,0 +1,132 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/symlink_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_symlink01
+ ****************************************************************************/
+
+void test_nuttx_syscall_symlink01(FAR void **state)
+{
+  char fname[255];
+  char symlnk[255];
+  int fd;
+  int ret;
+
+  sprintf(fname, "%s_tfile", __func__);
+  fd = open(fname, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+  if (fd > 0)
+    close(fd);
+  sprintf(symlnk, "/%s_t_%d", __func__, gettid());
+  ret = symlink(fname, symlnk);
+  if (fd > 0)
+    close(fd);
+  assert_int_equal(ret, OK);
+
+  assert_int_equal(unlink(fname), 0);
+  assert_int_equal(unlink(symlnk), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_symlink02
+ ****************************************************************************/
+
+void test_nuttx_syscall_symlink02(FAR void **state)
+{
+  int fd;
+  int ret;
+  struct stat stat_buf;
+  char testfile[128] =
+  {
+    0
+  };
+
+  snprintf(testfile, sizeof(testfile), "%s_file", __func__);
+
+  /* creat/open a testfile */
+
+  fd = open(testfile, O_RDWR | O_CREAT,
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  if (fd < 0)
+    {
+      syslog(LOG_ERR, "open test file fail !\n");
+      fail_msg("test fail !");
+    }
+
+  /* Close the temporary file created above */
+
+  assert_int_equal(close(fd), 0);
+
+  ret = symlink(testfile, "/Symlink02_file");
+  if (ret == -1)
+    {
+      syslog(LOG_ERR, "symlink testfile to symfile Failed, errno=%d \n",
+             errno);
+      fail_msg("test fail!");
+    }
+  else
+    {
+      /* Get the symlink file status information
+       * using lstat(2).
+       */
+
+      if (lstat("/Symlink02_file", &stat_buf) < 0)
+        {
+          syslog(LOG_ERR, "lstat(2) of symfile failed, error:%d \n",
+                 errno);
+          fail_msg("test fail!");
+        }
+
+      /* Check if the st_mode contains a link  */
+
+      if (!S_ISLNK(stat_buf.st_mode))
+        {
+          syslog(LOG_ERR, "symlink of testfile doesn't exist \n");
+          fail_msg("test fail!");
+        }
+    }
+
+  assert_int_equal(unlink(testfile), 0);
+  assert_int_equal(unlink("/Symlink02_file"), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/time_test.c
+++ b/testing/testsuites/kernel/syscall/cases/time_test.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/time_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <stdio.h>
+#include <time.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_time01
+ ****************************************************************************/
+
+void test_nuttx_syscall_time01(FAR void **state)
+{
+  int lc;
+  time_t ret;
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      /* Call time()
+       */
+
+      ret = time(NULL);
+
+      /* check return code */
+
+      assert_int_not_equal(ret, (time_t)-1);
+    }
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_time02
+ ****************************************************************************/
+
+void test_nuttx_syscall_time02(FAR void **state)
+{
+  int lc;
+  time_t tloc;
+  time_t ret; /* time_t variables for time(2) */
+
+  for (lc = 0; lc < 5; lc++)
+    {
+      /* Call time() to get the time in seconds$
+       * since Epoch.
+       */
+
+      ret = time(&tloc);
+
+      /* Check return code from time(2) */
+
+      assert_int_equal(tloc, ret);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/timer_create_test.c
+++ b/testing/testsuites/kernel/syscall/cases/timer_create_test.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/timer_create_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <stdio.h>
+#include <signal.h>
+#include <time.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_timercreate01
+ ****************************************************************************/
+
+void test_nuttx_syscall_timercreate01(FAR void **state)
+{
+  int ret;
+  struct sigevent evp;
+  clock_t clock = CLOCK_MONOTONIC;
+  timer_t created_timer_id;
+
+  memset(&evp, 0, sizeof(evp));
+
+  evp.sigev_signo = SIGALRM;
+  evp.sigev_notify = SIGEV_SIGNAL;
+
+  ret = timer_create(clock, &evp, &created_timer_id);
+  assert_int_equal(ret, 0);
+
+  ret = timer_delete(created_timer_id);
+  assert_int_equal(ret, 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/timer_delete_test.c
+++ b/testing/testsuites/kernel/syscall/cases/timer_delete_test.c
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/timer_delete_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <stdio.h>
+#include <signal.h>
+#include <time.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_timerdelete01
+ ****************************************************************************/
+
+void test_nuttx_syscall_timerdelete01(FAR void **state)
+{
+  int ret;
+  timer_t timer_id;
+  clock_t clock_list[] =
+    {
+        CLOCK_REALTIME,
+        CLOCK_MONOTONIC,
+        CLOCK_BOOTTIME,
+    };
+
+  for (int i = 0; i < 3; i++)
+    {
+      ret = timer_create(clock_list[i], NULL, &timer_id);
+      assert_int_equal(ret, 0);
+
+      ret = timer_delete(timer_id);
+      assert_int_equal(ret, 0);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/timer_gettime_test.c
+++ b/testing/testsuites/kernel/syscall/cases/timer_gettime_test.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/timer_gettime_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <errno.h>
+#include <stdio.h>
+#include <signal.h>
+#include <time.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_timergettime01
+ ****************************************************************************/
+
+void test_nuttx_syscall_timergettime01(FAR void **state)
+{
+  int lc;
+  int ret;
+  struct sigevent ev;
+  struct itimerspec spec;
+  timer_t timer;
+
+  ev.sigev_value = (union sigval)0;
+  ev.sigev_signo = SIGALRM;
+  ev.sigev_notify = SIGEV_SIGNAL;
+
+  ret = timer_create(CLOCK_REALTIME, &ev, &timer);
+  assert_int_equal(ret, 0);
+
+  for (lc = 0; lc < 1; ++lc)
+    {
+      ret = timer_gettime(timer, &spec);
+      assert_int_equal(ret, 0);
+
+      ret = timer_gettime(timer, NULL);
+      assert_int_equal(ret, -1);
+      assert_int_equal(errno, EINVAL);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/truncate_test.c
+++ b/testing/testsuites/kernel/syscall/cases/truncate_test.c
@@ -1,0 +1,150 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/truncate_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_truncate01
+ ****************************************************************************/
+
+void test_nuttx_syscall_truncate01(FAR void **state)
+{
+  int BUF_SIZE = 256;   /* buffer size */
+  int FILE_SIZE = 1024; /* test file size */
+  int TRUNC_LEN = 256;  /* truncation length */
+  struct stat stat_buf; /* stat(2) struct contents */
+  int lc;
+  int ret;
+  off_t file_length; /* test file length */
+  char truncate01_fileneme[128] = "";
+
+  /* setup */
+
+  int fd;
+  int i; /* file handler for testfile */
+  int c;
+  int c_total = 0;         /* no. bytes to be written to file */
+  char tst_buff[BUF_SIZE]; /* buffer to hold data */
+
+  snprintf(truncate01_fileneme, sizeof(truncate01_fileneme), "%s_file",
+           __func__);
+
+  /* Fill the test buffer with the known data */
+
+  for (i = 0; i < BUF_SIZE; i++)
+    {
+      tst_buff[i] = 'a';
+    }
+
+  /* Creat a testfile under temporary directory */
+
+  fd = open(truncate01_fileneme, O_RDWR | O_CREAT,
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  if (fd < 0)
+    {
+      syslog(LOG_ERR, "open test file fail !\n");
+      fail_msg("test fail !");
+    }
+
+  /* Write to the file 1k data from the buffer */
+
+  while (c_total < FILE_SIZE)
+    {
+      c = write(fd, tst_buff, sizeof(tst_buff));
+      if (c > 0)
+        {
+          c_total += c;
+        }
+    }
+
+  /* Close the testfile after writing data into it */
+
+  close(fd);
+
+  /* do test */
+
+  for (lc = 0; lc < 2; lc++)
+    {
+      ret = truncate(truncate01_fileneme, TRUNC_LEN);
+
+      if (ret == -1)
+        {
+          syslog(LOG_ERR,
+                 "FAIL, truncate(%s, %d) Failed, errno=%d : %s\n",
+                 truncate01_fileneme, TRUNC_LEN, errno, strerror(errno));
+          fail_msg("test fail !");
+        }
+      else
+        {
+          /* Get the testfile information using
+           * stat(2).
+           */
+
+          if (stat(truncate01_fileneme, &stat_buf) < 0)
+            {
+              syslog(LOG_ERR,
+                     "FAIL, stat(2) of "
+                     "%s failed, error:%d\n",
+                     truncate01_fileneme, errno);
+              fail_msg("test fail !");
+            }
+
+          stat_buf.st_mode &= ~S_IFREG;
+          file_length = stat_buf.st_size;
+
+          /* Check for expected size of testfile after
+           * truncate(2) on it.
+           */
+
+          if (file_length != TRUNC_LEN)
+            {
+              syslog(LOG_ERR,
+                     "FAIL, %s: Incorrect file "
+                     "size %" PRId64 " , Expected %d\n",
+                     truncate01_fileneme, (int64_t)file_length,
+                     TRUNC_LEN);
+              fail_msg("test fail !");
+            }
+        }
+    }
+
+  assert_int_equal(unlink(truncate01_fileneme), 0);
+}

--- a/testing/testsuites/kernel/syscall/cases/unlink_test.c
+++ b/testing/testsuites/kernel/syscall/cases/unlink_test.c
@@ -1,0 +1,78 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/unlink_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_unlink01
+ ****************************************************************************/
+
+void test_nuttx_syscall_unlink01(FAR void **state)
+{
+  char fname[64] =
+  {
+    0
+  };
+
+  int fd;
+  int ret;
+
+  sprintf(fname, "%s_file", __func__);
+
+  fd = open(fname, O_RDWR | O_CREAT);
+  if (fd > 0)
+    {
+      close(fd);
+    }
+
+  else
+    {
+      syslog(LOG_ERR, "open test file fail !\n");
+      fail_msg("test fail");
+    }
+
+  ret = unlink(fname);
+  assert_int_equal(ret, 0);
+
+  if (!access(fname, F_OK))
+    {
+      fail_msg("test fail !\n");
+      syslog(LOG_ERR,
+             "FAIL, unlink(%s) succeeded, but %s still existed\n", fname,
+             fname);
+    }
+}

--- a/testing/testsuites/kernel/syscall/cases/write_test.c
+++ b/testing/testsuites/kernel/syscall/cases/write_test.c
@@ -1,0 +1,177 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cases/write_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <syslog.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include "SyscallTest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_write01
+ ****************************************************************************/
+
+void test_nuttx_syscall_write01(FAR void **state)
+{
+  ssize_t ret;
+  char filename[64];
+  int fd;
+  int i;
+  int badcount = 0;
+  char buf[BUFSIZ];
+
+  sprintf(filename, "%s_file", __func__);
+
+  /* setup */
+
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  /* do test */
+
+  assert_non_null(memset(buf, 'w', BUFSIZ));
+
+  assert_int_equal(lseek(fd, 0, SEEK_SET), 0);
+
+  for (i = BUFSIZ; i > 0; i--)
+    {
+      ret = write(fd, buf, i);
+      if (ret == -1)
+        {
+          fail_msg("FAIL, write failed !\n");
+          break;
+        }
+
+      if (ret != i)
+        {
+          badcount++;
+          syslog(LOG_INFO,
+                 "INFO, write() returned %" PRId64 ", expected %d\n",
+                 (int64_t)ret, i);
+        }
+    }
+
+  if (badcount != 0)
+    {
+      fail_msg("FAIL, write() failed to return proper count\n");
+    }
+
+  if (fd > 0)
+    {
+      assert_int_equal(close(fd), 0);
+    }
+
+  assert_int_equal(unlink(filename), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_write02
+ ****************************************************************************/
+
+void test_nuttx_syscall_write02(FAR void **state)
+{
+  int fd;
+  int ret;
+  char filename[64];
+  sprintf(filename, "%s_file", __func__);
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  ret = write(fd, NULL, 3);
+  assert_true(ret < 0);
+
+  if (fd > 0)
+    {
+      assert_int_equal(close(fd), 0);
+    }
+
+  assert_int_equal(unlink(filename), 0);
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_write03
+ ****************************************************************************/
+
+void test_nuttx_syscall_write03(FAR void **state)
+{
+  int fd;
+  ssize_t ret;
+  char filename[64];
+  int i;
+  int badcount = 0;
+  char buf[100];
+
+  sprintf(filename, "%s_file.wav", __func__);
+
+  /* setup */
+
+  fd = open(filename, O_RDWR | O_CREAT, 0700);
+  assert_true(fd > 0);
+
+  /* do test */
+
+  assert_non_null(memset(buf, 'w', 100));
+
+  assert_int_equal(lseek(fd, 0, SEEK_SET), 0);
+
+  for (i = 100; i > 0; i--)
+    {
+      ret = write(fd, buf, i);
+      if (ret == -1)
+        {
+          fail_msg("FAIL, write failed !\n");
+          break;
+        }
+
+      if (ret != i)
+        {
+          badcount++;
+          syslog(LOG_INFO,
+                 "INFO, write() returned %" PRId64 ", expected %d\n",
+                 (int64_t)ret, i);
+        }
+    }
+
+  if (badcount != 0)
+    {
+      fail_msg("FAIL, write() failed to return proper count\n");
+    }
+
+  if (fd > 0)
+    {
+      assert_int_equal(close(fd), 0);
+    }
+
+  assert_int_equal(unlink(filename), 0);
+}

--- a/testing/testsuites/kernel/syscall/cmocka_syscall_test.c
+++ b/testing/testsuites/kernel/syscall/cmocka_syscall_test.c
@@ -1,0 +1,458 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/cmocka_syscall_test.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "SyscallTest.h"
+#include <cmocka.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cmocka_sched_test_main
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+  /* Add Test Cases */
+
+  const struct CMUnitTest nuttx_syscall_test_suites[] =
+  {
+      /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_bind01,
+       * test_nuttx_syscall_test_group_setup,
+       * test_nuttx_syscall_test_group_teardown),
+       */
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_chdir01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_chdir02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+      /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_accept01,
+       * test_nuttx_syscall_test_group_setup,
+       * test_nuttx_syscall_test_group_teardown),
+       */
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getitimer01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_clockgettime01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_clocknanosleep01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_clocksettime01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_close01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_close02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_close03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_creat01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_creat02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+      /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_fcntl01,
+       * NULL, NULL),
+       */
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fcntl02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fcntl03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fcntl04,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+  /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_fcntl05, NULL,
+   * NULL),
+   */
+
+#ifndef CONFIG_ARCH_SIM
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fcntl06,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+#endif
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fstatfs01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fsync01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+#ifdef CONFIG_NET
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fsync02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fsync03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getpeername01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getsockopt01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+      /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_recvfromtest01,
+       * test_nuttx_syscall_test_group_setup,
+       * test_nuttx_syscall_test_group_teardown),
+       */
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_setsockopt01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_listen01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+  /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_socketpair01,
+   * test_nuttx_syscall_test_group_setup,
+   * test_nuttx_syscall_test_group_teardown),
+   */
+
+#ifdef CONFIG_NET_LOCAL_DGRAM
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_socketpair02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+#endif
+#endif
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_ftruncate01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getcwd01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getcwd02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getpid01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getppid01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_gethostname01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_gettimeofday01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_lseek01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_lseek07,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_lstat01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup04,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup05,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup201,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_dup202,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_fpathconf01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getegid01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getegid02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_geteuid01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+      /* not implement
+       * cmocka_unit_test_setup_teardown(test_nuttx_syscall_geteuid02,
+       * estnuttxsyscalltestgroupsetup,
+       * test_nuttx_syscall_test_group_teardown),
+       */
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getgid01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getgid02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_getuid01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+      /* not implement
+       * cmocka_unit_test_setup_teardown(test_nuttx_syscall_getuid02,
+       * test_nuttx_syscall_test_group_setup,
+       * test_nuttx_syscall_test_group_teardown),
+       */
+
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_pathconf01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_pipe01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_pipe02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_pread01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_pwrite01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_pwrite02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_rmdir01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_rmdir02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_truncate01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_unlink01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_nansleep01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_nansleep02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_time01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_time02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_timercreate01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_timerdelete01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_timergettime01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_mkdir01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_mkdir02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_mkdir03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_sched01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_sched02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_sched03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_sched04,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_write01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_write02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_write03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_read01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_read02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_read03,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_read04,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_symlink01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_symlink02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+
+  /* cmocka_unit_test_setup_teardown(test_nuttx_syscall_connect01,
+   * test_nuttx_syscall_test_group_setup,
+   * test_nuttx_syscall_test_group_teardown),
+   */
+
+#if !defined(CONFIG_ARCH_SIM) && defined(CONFIG_NET_IPv4)
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_sockettest01,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+      cmocka_unit_test_setup_teardown(
+          test_nuttx_syscall_sockettest02,
+          test_nuttx_syscall_test_group_setup,
+          test_nuttx_syscall_test_group_teardown),
+#endif
+  };
+
+  /* Run Test cases */
+
+  cmocka_run_group_tests(nuttx_syscall_test_suites, NULL, NULL);
+  return 0;
+}

--- a/testing/testsuites/kernel/syscall/common/test_syscall_common.c
+++ b/testing/testsuites/kernel/syscall/common/test_syscall_common.c
@@ -1,0 +1,767 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/common/test_syscall_common.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <syslog.h>
+#include <errno.h>
+#include <stdlib.h>
+#include "SyscallTest.h"
+
+#define CM_SYSCALL_TESTDIR "CM_syscall_testdir"
+#define PATH_SIZE 128
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int rm_recursive(FAR char *path)
+{
+  struct dirent *d;
+  struct stat stat;
+  size_t len;
+  int ret;
+  DIR *dp;
+
+  ret = lstat(path, &stat);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (!S_ISDIR(stat.st_mode))
+    {
+      return unlink(path);
+    }
+
+  dp = opendir(path);
+  if (dp == NULL)
+    {
+      return -1;
+    }
+
+  len = strlen(path);
+  if (len > 0 && path[len - 1] == '/')
+    {
+      path[--len] = '\0';
+    }
+
+  while ((d = readdir(dp)) != NULL)
+    {
+      if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+        {
+          continue;
+        }
+
+      snprintf(&path[len], PATH_MAX - len, "/%s", d->d_name);
+      ret = rm_recursive(path);
+      if (ret < 0)
+        {
+          closedir(dp);
+          return ret;
+        }
+    }
+
+  ret = closedir(dp);
+  if (ret >= 0)
+    {
+      path[len] = '\0';
+      ret = rmdir(path);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_testgroupsetup
+ ****************************************************************************/
+
+int test_nuttx_syscall_test_group_setup(void **state)
+{
+  int res;
+  struct stat buf;
+
+  res = chdir(MOUNT_DIR);
+  if (res != 0)
+    {
+      syslog(LOG_INFO, "ERROR: Failed to switch the mount dir\n");
+      exit(1);
+    }
+
+  res = stat(CM_SYSCALL_TESTDIR, &buf);
+  if (res == 0 && buf.st_mode == S_IFDIR)
+    {
+      res = chdir(CM_SYSCALL_TESTDIR);
+      return res;
+    }
+
+  else
+    {
+      char testdir[PATH_MAX] =
+      {
+        0
+      };
+
+      sprintf(testdir, "%s/%s", MOUNT_DIR, CM_SYSCALL_TESTDIR);
+
+      /* Delete the existing test directory */
+
+      rm_recursive(testdir);
+      res = mkdir(CM_SYSCALL_TESTDIR, 0777);
+      if (res != 0)
+        {
+          syslog(LOG_ERR, "ERROR: Failed to creat the test directory\n");
+          exit(1);
+        }
+
+      res = chdir(CM_SYSCALL_TESTDIR);
+    }
+
+  return res;
+}
+
+/****************************************************************************
+ * Name: test_nuttx_syscall_test_group_teardown
+ ****************************************************************************/
+
+int test_nuttx_syscall_test_group_teardown(void **state)
+{
+  int res;
+  char testdir[PATH_MAX] =
+  {
+    0
+  };
+
+  sprintf(testdir, "%s", CM_SYSCALL_TESTDIR);
+
+  res = chdir(MOUNT_DIR);
+  if (res != 0)
+    {
+      syslog(LOG_INFO, "ERROR: Failed to switch the mount dir\n");
+      exit(1);
+    }
+
+  /* call the recursive delete interface */
+
+  rm_recursive(testdir);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: cmtestfillfilewithfd
+ ****************************************************************************/
+
+static int cmtestfillfilewithfd(int fd, char pattern, size_t bs,
+                                size_t bcount)
+{
+  size_t i;
+  char *buf;
+
+  /* Filling a memory buffer with provided pattern */
+
+  buf = (char *)malloc(bs);
+  if (buf == NULL)
+      return -1;
+
+  for (i = 0; i < bs; i++)
+    buf[i] = pattern;
+
+  /* Filling the file */
+
+  for (i = 0; i < bcount; i++)
+    {
+      if (write(fd, buf, bs) != (ssize_t)bs)
+        {
+          free(buf);
+          return -1;
+        }
+    }
+
+  free(buf);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: cmtestfillfile
+ ****************************************************************************/
+
+int cmtestfillfile(const char *path, char pattern, size_t bs,
+                   size_t bcount)
+{
+  int fd;
+
+  fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+  if (fd < 0)
+      return -1;
+
+  if (cmtestfillfilewithfd(fd, pattern, bs, bcount))
+    {
+      close(fd);
+      unlink(path);
+      return -1;
+    }
+
+  if (close(fd) < 0)
+    {
+      unlink(path);
+
+      return -1;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: checknames
+ ****************************************************************************/
+
+int checknames(char *pfilnames, DIR *ddir)
+{
+  struct dirent *dir;
+  while ((dir = readdir(ddir)) != NULL)
+    {
+      /* cout << "file name=" << dir->d_name << endl; */
+
+      if (strcmp(pfilnames, dir->d_name) == 0)
+          return 0;
+    }
+
+  return -1;
+}
+
+/****************************************************************************
+ * Name: check_and_report_ftruncatetest
+ ****************************************************************************/
+
+int check_and_report_ftruncatetest(int fd, off_t offset, char data,
+                                   off_t trunc_len)
+{
+  int i;
+  int file_length;
+  char buf[1024];
+  struct stat stat_buf;
+
+  memset(buf, '*', sizeof(buf));
+
+  fstat(fd, &stat_buf);
+  file_length = stat_buf.st_size;
+
+  if (file_length != trunc_len)
+    {
+      syslog(LOG_ERR, "FAIL, ftruncate() got incorrected size: %d\n",
+             file_length);
+      return -1;
+    }
+
+  lseek(fd, offset, SEEK_SET);
+  read(fd, buf, sizeof(buf));
+
+  for (i = 0; i < 256; i++)
+    {
+      if (buf[i] != data)
+        {
+          syslog(
+              LOG_ERR,
+              "FAIL, ftruncate() got incorrect data %i, expected %i\n",
+              buf[i], data);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: tst_fill_fd
+ ****************************************************************************/
+
+int tst_fill_fd(int fd, char pattern, size_t bs, size_t bcount)
+{
+  size_t i;
+  char *buf;
+
+  /* Filling a memory buffer with provided pattern */
+
+  buf = (char *)malloc(bs);
+  if (buf == NULL)
+      return -1;
+
+  for (i = 0; i < bs; i++)
+    buf[i] = pattern;
+
+  /* Filling the file */
+
+  for (i = 0; i < bcount; i++)
+    {
+      if (write(fd, buf, bs) != (ssize_t)bs)
+        {
+          free(buf);
+          return -1;
+        }
+    }
+
+  free(buf);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: tst_fill_file
+ ****************************************************************************/
+
+int tst_fill_file(const char *path, char pattern, size_t bs,
+                  size_t bcount)
+{
+  int fd;
+
+  fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
+  if (fd < 0)
+      return -1;
+
+  if (tst_fill_fd(fd, pattern, bs, bcount))
+    {
+      close(fd);
+      unlink(path);
+      return -1;
+    }
+
+  if (close(fd) < 0)
+    {
+      unlink(path);
+
+      return -1;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: safe_open
+ ****************************************************************************/
+
+int safe_open(const char *pathname, int oflags, ...)
+{
+  va_list ap;
+  int rval;
+  mode_t mode;
+
+  va_start(ap, oflags);
+  mode = va_arg(ap, int);
+  va_end(ap);
+
+  rval = open(pathname, oflags, mode);
+  if (rval == -1)
+    {
+      syslog(LOG_ERR, "open(%s,%d,0%o) failed\n", pathname, oflags,
+             mode);
+      fail_msg("test fail !");
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Name: safe_write
+ ****************************************************************************/
+
+ssize_t safe_write(int fildes, const void *buf, size_t nbyte)
+{
+  ssize_t rval;
+
+  rval = write(fildes, buf, nbyte);
+  if (rval == -1 || ((size_t)rval != nbyte))
+    {
+      syslog(LOG_ERR, "write(%d,%p,%zu) failed\n", fildes, buf, rval);
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Name: safe_lseek
+ ****************************************************************************/
+
+off_t safe_lseek(int fd, off_t offset, int whence)
+{
+  off_t rval;
+
+  rval = lseek(fd, offset, whence);
+
+  if (rval == (off_t)-1)
+    {
+      syslog(LOG_ERR, "lseek(%d, %ld, %d) failed\n", fd,
+             (long int)offset, whence);
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Name: safe_close
+ ****************************************************************************/
+
+int safe_close(int fildes)
+{
+  int rval;
+
+  rval = close(fildes);
+  if (rval == -1)
+    {
+      syslog(LOG_ERR, "close(%d) failed, errno %d\n", fildes, errno);
+      fail_msg("test fail !");
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Function Name: safe_touch
+ *
+ * Description:
+ *  This Function is used to touch a file.
+ *
+ * Input Parameters:
+ *   file
+ *   lineno
+ *   pathname     -  name of the file to be created
+ *   mode         -  mode
+ ****************************************************************************/
+
+void safe_touch(const char *file, const int lineno, const char *pathname,
+                mode_t mode)
+{
+  int ret;
+
+  /* Open the file */
+
+  ret = open(pathname, O_CREAT | O_WRONLY, mode);
+
+  /* Open file fail */
+
+  if (ret == -1)
+    {
+      syslog(LOG_ERR, "Failed to open file '%s' at %s:%d \n", pathname,
+             file, lineno);
+      return;
+    }
+
+  /* Close the file */
+
+  ret = close(ret);
+
+  /* Close file fail */
+
+  if (ret == -1)
+    {
+      syslog(LOG_ERR, "Failed to close file '%s' at %s:%d \n", pathname,
+             file, lineno);
+      return;
+    }
+}
+
+#ifdef CONFIG_NET
+
+/****************************************************************************
+ * Name: sock_addr
+ ****************************************************************************/
+
+char *sock_addr(const struct sockaddr *sa, socklen_t salen, char *res,
+                size_t len)
+{
+  char portstr[8];
+
+  switch (sa->sa_family)
+    {
+    case AF_INET:
+      {
+        struct sockaddr_in *sin = (struct sockaddr_in *)sa;
+
+        if (!inet_ntop(AF_INET, &sin->sin_addr, res, len))
+          return NULL;
+
+        if (ntohs(sin->sin_port) != 0)
+          {
+            snprintf(portstr, sizeof(portstr), ":%d",
+                     ntohs(sin->sin_port));
+            strcat(res, portstr);
+          }
+
+        return res;
+      }
+
+    case AF_INET6:
+      {
+        struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)sa;
+
+        res[0] = '[';
+        if (!inet_ntop(AF_INET6, &sin6->sin6_addr, res + 1, len - 1))
+          return NULL;
+
+        if (ntohs(sin6->sin6_port) != 0)
+          {
+            snprintf(portstr, sizeof(portstr), "]:%d",
+                     ntohs(sin6->sin6_port));
+            strcat(res, portstr);
+            return res;
+          }
+
+        return res + 1;
+      }
+
+    case AF_UNIX:
+      {
+        struct sockaddr_un *unp = (struct sockaddr_un *)sa;
+
+        if (unp->sun_path[0] == '\0')
+          strcpy(res, "(no pathname bound)");
+        else
+          snprintf(res, len, "%s", unp->sun_path);
+
+        return res;
+      }
+
+    default:
+      {
+        snprintf(res, len, "sock_ntop: unknown AF_xxx: %d, len: %d\n",
+                 sa->sa_family, salen);
+
+        return res;
+      }
+    }
+}
+
+/****************************************************************************
+ * Name: get_unused_port
+ * *
+ * Description:
+ *  return port in network byte order.
+ ****************************************************************************/
+
+unsigned short get_unused_port(void(cleanup_fn)(void),
+                               unsigned short family, int type)
+{
+  int sock;
+  socklen_t slen;
+  struct sockaddr_storage _addr;
+  struct sockaddr *addr = (struct sockaddr *)&_addr;
+  struct sockaddr_in *addr4 = (struct sockaddr_in *)addr;
+  struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)addr;
+
+  switch (family)
+    {
+    case AF_INET:
+      addr4->sin_family = AF_INET;
+      addr4->sin_port = 0;
+      addr4->sin_addr.s_addr = INADDR_ANY;
+      slen = sizeof(*addr4);
+      break;
+
+    case AF_INET6:
+      addr6->sin6_family = AF_INET6;
+      addr6->sin6_port = 0;
+      addr6->sin6_addr = in6addr_any;
+      slen = sizeof(*addr6);
+      break;
+
+    default:
+      syslog(LOG_ERR, "nknown family\n");
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  sock = socket(addr->sa_family, type, 0);
+  if (sock < 0)
+    {
+      syslog(LOG_ERR, "socket failed\n");
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  if (bind(sock, addr, slen) < 0)
+    {
+      syslog(LOG_ERR, "bind failed\n");
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  if (getsockname(sock, addr, &slen) == -1)
+    {
+      syslog(LOG_ERR, "getsockname failed\n");
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  if (close(sock) == -1)
+    {
+      syslog(LOG_ERR, "close failed\n");
+      fail_msg("test fail !");
+      return -1;
+    }
+
+  switch (family)
+    {
+    case AF_INET:
+      return addr4->sin_port;
+    case AF_INET6:
+      return addr6->sin6_port;
+    default:
+      return -1;
+    }
+}
+
+/****************************************************************************
+ * Name: safe_socket
+ ****************************************************************************/
+
+int safe_socket(int domain, int type, int protocol)
+{
+  int rval;
+
+  rval = socket(domain, type, protocol);
+
+  if (rval < 0)
+    {
+      syslog(LOG_ERR, "socket(%d, %d, %d) failed\n", domain, type,
+             protocol);
+      fail_msg("test fail !");
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Name: safe_connect
+ ****************************************************************************/
+
+int safe_connect(int sockfd, const struct sockaddr *addr,
+                 socklen_t addrlen)
+{
+  int rval;
+  char buf[128];
+
+  rval = connect(sockfd, addr, addrlen);
+
+  if (rval < 0)
+    {
+      syslog(LOG_ERR, "connect(%d, %s, %d) failed, errno %d\n", sockfd,
+             sock_addr(addr, addrlen, buf, sizeof(buf)), addrlen, errno);
+      fail_msg("test fail !");
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Name: safe_getsockname
+ ****************************************************************************/
+
+int safe_getsockname(int sockfd, struct sockaddr *addr,
+                     socklen_t *addrlen)
+{
+  int rval;
+  char buf[128];
+
+  rval = getsockname(sockfd, addr, addrlen);
+
+  if (rval < 0)
+    {
+      syslog(LOG_ERR, "getsockname(%d, %s, %d) failed\n", sockfd,
+             sock_addr(addr, *addrlen, buf, sizeof(buf)), *addrlen);
+    }
+
+  return rval;
+}
+
+/****************************************************************************
+ * Name: safe_bind
+ ****************************************************************************/
+
+int safe_bind(int socket, const struct sockaddr *address,
+              socklen_t address_len)
+{
+  int i;
+  char buf[128];
+
+  for (i = 0; i < 120; i++)
+    {
+      if (!bind(socket, address, address_len))
+          return 0;
+
+      if (errno != EADDRINUSE)
+        {
+          syslog(LOG_ERR, "bind(%d, %s, %d) failed\n", socket,
+                 sock_addr(address, address_len, buf, sizeof(buf)),
+                 address_len);
+          fail_msg("test fail !");
+          return -1;
+        }
+
+      if ((i + 1) % 10 == 0)
+        {
+          syslog(LOG_INFO, "address is in use, waited %3i sec\n", i + 1);
+        }
+
+      sleep(1);
+    }
+
+  syslog(LOG_ERR, "Failed to bind(%d, %s, %d) after 120 retries\n",
+         socket, sock_addr(address, address_len, buf, sizeof(buf)),
+         address_len);
+  fail_msg("test fail !");
+  return -1;
+}
+
+/****************************************************************************
+ * Name: safe_listen
+ ****************************************************************************/
+
+int safe_listen(int socket, int backlog)
+{
+  int rval;
+
+  rval = listen(socket, backlog);
+
+  if (rval < 0)
+    {
+      syslog(LOG_ERR, "listen(%d, %d) failed\n", socket, backlog);
+    }
+
+  return rval;
+}
+
+#endif

--- a/testing/testsuites/kernel/syscall/include/SyscallTest.h
+++ b/testing/testsuites/kernel/syscall/include/SyscallTest.h
@@ -1,0 +1,457 @@
+/****************************************************************************
+ * apps/testing/testsuites/kernel/syscall/include/SyscallTest.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __SYSCALLTEST_H
+#define __SYSCALLTEST_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+#include <dirent.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <dirent.h>
+
+/* Functions to help test */
+
+int checknames(char *pfilnames, DIR *ddir);
+int check_and_report_ftruncatetest(int fd, off_t offset, char data,
+                                   off_t trunc_len);
+int tst_fill_file(const char *path, char pattern, size_t bs,
+                  size_t bcount);
+
+char *sock_addr(const struct sockaddr *sa, socklen_t salen, char *res,
+                size_t len);
+
+/* @return port in network byte order.
+ */
+
+unsigned short get_unused_port(void(cleanup_fn)(void),
+                               unsigned short family, int type);
+
+int safe_close(int fildes);
+
+int safe_socket(int domain, int type, int protocol);
+
+int safe_connect(int sockfd, const struct sockaddr *addr,
+                 socklen_t addrlen);
+
+int safe_getsockname(int sockfd, struct sockaddr *addr,
+                     socklen_t *addrlen);
+
+int safe_bind(int socket, const struct sockaddr *address,
+              socklen_t address_len);
+
+int safe_listen(int socket, int backlog);
+
+int safe_open(const char *pathname, int oflags, ...);
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* The test files generated during the 'syscall-test' are stored in this
+ * directory
+ */
+
+#define SYSCALL_TEST_DIR "syscall_test_dir"
+
+#define MOUNT_DIR CONFIG_TESTS_TESTSUITES_MOUNT_DIR
+
+#define SAFE_OPEN(pathname, oflags, ...)                                \
+  safe_open((pathname), (oflags), ##__VA_ARGS__)
+
+#define SAFE_FCNTL(fd, cmd, ...)                                        \
+  ({                                                                    \
+    int tst_ret_ = fcntl(fd, cmd, ##__VA_ARGS__);                       \
+    if (tst_ret_ == -1)                                                 \
+      {                                                                 \
+        syslog(LOG_ERR, "fcntl(%i,%s,...) failed", fd, #cmd);           \
+        fail_msg("test fail !");                                        \
+      }                                                                 \
+    tst_ret_ == -1 ? 0 : tst_ret_;                                      \
+  })
+
+#define SAFE_CLOSE(fd)                                                  \
+  do                                                                    \
+    {                                                                   \
+      safe_close((fd));                                                 \
+      fd = -1;                                                          \
+  } while (0)
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* quickly fill a test file */
+
+int cmtestfillfile(const char *path, char pattern, size_t bs,
+                   size_t bcount);
+
+/* setup function */
+
+int test_nuttx_syscall_test_group_setup(void **state);
+
+/* teardown function */
+
+int test_nuttx_syscall_test_group_teardown(void **state);
+
+/* tools */
+
+int checknames(char *pfilnames, DIR *ddir);
+int check_and_report_ftruncatetest(int fd, off_t offset, char data,
+                                   off_t trunc_len);
+int tst_fill_fd(int fd, char pattern, size_t bs, size_t bcount);
+int tst_fill_file(const char *path, char pattern, size_t bs,
+                  size_t bcount);
+int safe_open(const char *pathname, int oflags, ...);
+ssize_t safe_write(int fildes, const void *buf, size_t nbyte);
+off_t safe_lseek(int fd, off_t offset, int whence);
+int safe_close(int fildes);
+void safe_touch(const char *file, const int lineno, const char *pathname,
+                mode_t mode);
+#ifdef CONFIG_NET
+char *sock_addr(const struct sockaddr *sa, socklen_t salen, char *res,
+                size_t len);
+unsigned short get_unused_port(void(cleanup_fn)(void),
+                               unsigned short family, int type);
+int safe_socket(int domain, int type, int protocol);
+int safe_connect(int sockfd, const struct sockaddr *addr,
+                 socklen_t addrlen);
+int safe_getsockname(int sockfd, struct sockaddr *addr,
+                     socklen_t *addrlen);
+int safe_bind(int socket, const struct sockaddr *address,
+              socklen_t address_len);
+int safe_listen(int socket, int backlog);
+#endif
+
+/* test case function */
+
+/* cases/chdir_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_chdir01(FAR void **state);
+void test_nuttx_syscall_chdir02(FAR void **state);
+
+/* cases/accept_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_accept01(FAR void **state);
+
+/* cases/getitimer_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_getitimer01(FAR void **state);
+
+/* cases/clock_gettime_test.c
+ * ****************************************/
+
+void test_nuttx_syscall_clockgettime01(FAR void **state);
+
+/* cases/clock_nanosleep_test.c
+ * **************************************/
+
+void test_nuttx_syscall_clocknanosleep01(FAR void **state);
+void test_nuttx_syscall_clocknanosleep02(FAR void **state);
+
+/* cases/clock_settime_test.c
+ * ****************************************/
+
+void test_nuttx_syscall_clocksettime01(FAR void **state);
+
+/* cases/close_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_close01(FAR void **state);
+void test_nuttx_syscall_close02(FAR void **state);
+void test_nuttx_syscall_close03(FAR void **state);
+
+/* cases/creat_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_creat01(FAR void **state);
+void test_nuttx_syscall_creat02(FAR void **state);
+
+/* cases/fcntl_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_fcntl01(FAR void **state);
+void test_nuttx_syscall_fcntl02(FAR void **state);
+void test_nuttx_syscall_fcntl03(FAR void **state);
+void test_nuttx_syscall_fcntl04(FAR void **state);
+void test_nuttx_syscall_fcntl05(FAR void **state);
+void test_nuttx_syscall_fcntl06(FAR void **state);
+
+/* cases/fsatfs_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_fstatfs01(FAR void **state);
+
+/* cases/fsync_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_fsync01(FAR void **state);
+void test_nuttx_syscall_fsync02(FAR void **state);
+void test_nuttx_syscall_fsync03(FAR void **state);
+
+/* cases/ftruncate_test.c
+ * ********************************************/
+
+void test_nuttx_syscall_ftruncate01(FAR void **state);
+
+/* cases/getcwd_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_getcwd01(FAR void **state);
+void test_nuttx_syscall_getcwd02(FAR void **state);
+
+/* cases/getpid_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_getpid01(FAR void **state);
+
+/* cases/getppid_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_getppid01(FAR void **state);
+
+/* cases/gethostname_test.c
+ * ******************************************/
+
+void test_nuttx_syscall_gethostname01(FAR void **state);
+
+/* cases/getTimeofday_test.c
+ * *****************************************/
+
+void test_nuttx_syscall_gettimeofday01(FAR void **state);
+
+/* cases/lseek_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_lseek01(FAR void **state);
+void test_nuttx_syscall_lseek07(FAR void **state);
+
+/* cases/lstat_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_lstat01(FAR void **state);
+
+/* cases/dup_test.c
+ * **************************************************/
+
+void test_nuttx_syscall_dup01(FAR void **state);
+void test_nuttx_syscall_dup02(FAR void **state);
+void test_nuttx_syscall_dup03(FAR void **state);
+void test_nuttx_syscall_dup04(FAR void **state);
+void test_nuttx_syscall_dup05(FAR void **state);
+
+/* cases/dup2_test.c
+ * **************************************************/
+
+void test_nuttx_syscall_dup201(FAR void **state);
+void test_nuttx_syscall_dup202(FAR void **state);
+
+/* cases/fpathconf_test.c
+ * *********************************************/
+
+void test_nuttx_syscall_fpathconf01(FAR void **state);
+
+/* cases/getegid_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_getegid01(FAR void **state);
+void test_nuttx_syscall_getegid02(FAR void **state);
+
+/* cases/geteuid_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_geteuid01(FAR void **state);
+void test_nuttx_syscall_geteuid02(FAR void **state);
+
+/* cases/getgid_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_getgid01(FAR void **state);
+void test_nuttx_syscall_getgid02(FAR void **state);
+
+/* cases/getuid_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_getuid01(FAR void **state);
+void test_nuttx_syscall_getuid02(FAR void **state);
+
+/* cases/pathconf_test.c
+ * *********************************************/
+
+void test_nuttx_syscall_pathconf01(FAR void **state);
+
+/* cases/pipe_test.c
+ * *************************************************/
+
+void test_nuttx_syscall_pipe01(FAR void **state);
+void test_nuttx_syscall_pipe02(FAR void **state);
+
+/* cases/pread_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_pread01(FAR void **state);
+
+/* cases/pwrite_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_pwrite01(FAR void **state);
+void test_nuttx_syscall_pwrite02(FAR void **state);
+
+/* cases/rmdir_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_rmdir01(FAR void **state);
+void test_nuttx_syscall_rmdir02(FAR void **state);
+
+/* ases/syscall_truncate_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_truncate01(FAR void **state);
+
+/* cases/unlink_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_unlink01(FAR void **state);
+
+/* cases/nansleep_test.c
+ * *********************************************/
+
+void test_nuttx_syscall_nansleep01(FAR void **state);
+void test_nuttx_syscall_nansleep02(FAR void **state);
+
+/* cases/time_test.c
+ * *************************************************/
+
+void test_nuttx_syscall_time01(FAR void **state);
+void test_nuttx_syscall_time02(FAR void **state);
+
+/* cases/timer_create_test.c
+ * *****************************************/
+
+void test_nuttx_syscall_timercreate01(FAR void **state);
+
+/* cases/timer_delete_test.c
+ * *****************************************/
+
+void test_nuttx_syscall_timerdelete01(FAR void **state);
+
+/* cases/timer_gettime_test.c
+ * ****************************************/
+
+void test_nuttx_syscall_timergettime01(FAR void **state);
+
+/* cases/mkdir_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_mkdir01(FAR void **state);
+void test_nuttx_syscall_mkdir02(FAR void **state);
+void test_nuttx_syscall_mkdir03(FAR void **state);
+
+/*  cases/syscall_sched_test.c
+ * ***********************************************/
+
+void test_nuttx_syscall_sched01(FAR void **state);
+void test_nuttx_syscall_sched02(FAR void **state);
+void test_nuttx_syscall_sched03(FAR void **state);
+void test_nuttx_syscall_sched04(FAR void **state);
+
+/* cases/write_test.c
+ * ************************************************/
+
+void test_nuttx_syscall_write01(FAR void **state);
+void test_nuttx_syscall_write02(FAR void **state);
+void test_nuttx_syscall_write03(FAR void **state);
+
+/* cases/read_test.c
+ * *************************************************/
+
+void test_nuttx_syscall_read01(FAR void **state);
+void test_nuttx_syscall_read02(FAR void **state);
+void test_nuttx_syscall_read03(FAR void **state);
+void test_nuttx_syscall_read04(FAR void **state);
+
+/* cases/symlink_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_symlink01(FAR void **state);
+void test_nuttx_syscall_symlink02(FAR void **state);
+
+/* cases/socket_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_sockettest01(FAR void **state);
+void test_nuttx_syscall_sockettest02(FAR void **state);
+
+/* cases/getpeername_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_connect01(FAR void **state);
+
+/* cases/getpeername_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_getpeername01(FAR void **state);
+
+/* cases/getsocketopt_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_getsockopt01(FAR void **state);
+
+/* cases/recvfrom_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_recvfromtest01(FAR void **state);
+
+/* cases/setsocketopt01_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_setsockopt01(FAR void **state);
+
+/* cases/listen_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_listen01(FAR void **state);
+
+/* cases/socketpair_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_socketpair01(FAR void **state);
+void test_nuttx_syscall_socketpair02(FAR void **state);
+
+/* cases/bind_test.c
+ * **********************************************/
+
+void test_nuttx_syscall_bind01(FAR void **state);
+
+#endif

--- a/testing/testsuites/kernel/time/cases/clock_test_clock01.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_clock01.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -65,9 +64,11 @@ void test_nuttx_clock_test_clock01(FAR void **state)
   assert_int_equal(ret, 0);
 
   syslog(LOG_INFO, "sleep 2 seconds\n");
-  sleep(2); /* 2, seconds. */
+  sleep(2);
 
-  tp.tv_sec = oldtp.tv_sec + 2; /* 2, use for testing clock setting */
+  /* 2, use for testing clock setting */
+
+  tp.tv_sec = oldtp.tv_sec + 2;
   tp.tv_nsec = oldtp.tv_nsec;
 
   /* set real time */
@@ -83,15 +84,12 @@ void test_nuttx_clock_test_clock01(FAR void **state)
 
   ret = clock_gettime(clk, &tp);
   syslog(LOG_INFO,
-         "Obtaining the current time after setting:"
-         " sec = %lld, nsec = %ld\n",
-         (long long)tp.tv_sec,
-         tp.tv_nsec);
-
-  /* 2, use for testing clock setting */
-
-  passflag = (tp.tv_sec >= 2 + oldtp.tv_sec)
-             && (tp.tv_sec <= 2 + oldtp.tv_sec + 1);
+         "Obtaining the current time after setting: sec = %lld, nsec = "
+         "%ld\n",
+         (long long)tp.tv_sec, tp.tv_nsec);
+  passflag = (tp.tv_sec >= 2 + oldtp.tv_sec) &&
+             (tp.tv_sec <=
+              2 + oldtp.tv_sec + 1); /* 2, use for testing clock setting */
 
   assert_int_equal(ret, 0);
   assert_int_equal(passflag, 1);

--- a/testing/testsuites/kernel/time/cases/clock_test_clock02.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_clock02.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/testing/testsuites/kernel/time/cases/clock_test_smoke.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_smoke.c
@@ -1,40 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/time/cases/clock_test_smoke.c
- * Copyright (c) 2013-2019 Huawei Technologies Co., Ltd. All rights reserved.
- * Copyright (c) 2020-2022 Huawei Device Co., Ltd. All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
- * 3. Neither the name of the copyright holder nor the names of its
- * contributors may be used to endorse or promote products derived from this
- * software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -59,24 +45,24 @@
 void test_nuttx_clock_test_smoke01(FAR void **state)
 {
   clockid_t clk = CLOCK_REALTIME;
-  struct timespec res = {
-      0,
-      0,
+  struct timespec res =
+  {
+    0, 0
   };
 
-  struct timespec  setts = {
-      0,
-      0,
+  struct timespec setts =
+  {
+    0, 0
   };
 
-  struct timespec oldtp = {
-      0,
-      0
+  struct timespec oldtp =
+  {
+    0, 0
   };
 
-  struct timespec  ts = {
-      0,
-      0,
+  struct timespec ts =
+  {
+    0, 0
   };
 
   int ret;
@@ -90,7 +76,8 @@ void test_nuttx_clock_test_smoke01(FAR void **state)
   /* get clock realtime */
 
   ret = clock_gettime(clk, &oldtp);
-  syslog(LOG_INFO, "the clock current time: %lld second, %ld nanosecond\n",
+  syslog(LOG_INFO,
+         "the clock current time: %lld second, %ld nanosecond\n",
          (long long)oldtp.tv_sec, oldtp.tv_nsec);
   assert_int_equal(ret, 0);
 
@@ -98,21 +85,22 @@ void test_nuttx_clock_test_smoke01(FAR void **state)
 
   setts.tv_sec = oldtp.tv_sec + 1;
   setts.tv_nsec = oldtp.tv_nsec;
-  syslog(LOG_INFO, "the clock setting time: %lld second, %ld nanosecond\n",
+  syslog(LOG_INFO,
+         "the clock setting time: %lld second, %ld nanosecond\n",
          (long long)setts.tv_sec, setts.tv_nsec);
   ret = clock_settime(CLOCK_REALTIME, &setts);
   assert_int_equal(ret, 0);
 
   ret = clock_gettime(clk, &ts);
   syslog(LOG_INFO,
-         "obtaining the current time after "
-         "setting: %lld second, %ld nanosecond\n",
-         (long long)ts.tv_sec,
-         ts.tv_nsec);
+         "obtaining the current time after setting: %lld second, %ld "
+         "nanosecond\n",
+         (long long)ts.tv_sec, ts.tv_nsec);
 
-  /* 1, means obtaining time's errno is 1 second. */
-
-  passflag = (ts.tv_sec >= setts.tv_sec) && (ts.tv_sec <= setts.tv_sec + 1);
+  passflag =
+      (ts.tv_sec >= setts.tv_sec) &&
+      (ts.tv_sec <=
+       setts.tv_sec + 1); /* 1, means obtaining time's errno is 1 second. */
   assert_int_equal(ret, 0);
   assert_int_equal(passflag, 1);
 }

--- a/testing/testsuites/kernel/time/cases/clock_test_timer01.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_timer01.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -49,21 +48,21 @@
  * Private Data
  ****************************************************************************/
 
-static int test_timer01_g_sig_hdl_cnt = 0;
+static int test_timer01_g_sighdlcnt = 0;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sig_handler01
+ * Name: sighandler01
  ****************************************************************************/
 
-static void sig_handler01(int sig)
+static void sighandler01(int sig)
 {
-  test_timer01_g_sig_hdl_cnt++;
-  syslog(LOG_INFO, "signo = %d test_timer01_g_sig_hdl_cnt = %d\n",
-         sig, test_timer01_g_sig_hdl_cnt);
+  test_timer01_g_sighdlcnt++;
+  syslog(LOG_INFO, "signo = %d test_timer01_g_sighdlcnt = %d\n", sig,
+         test_timer01_g_sighdlcnt);
 }
 
 /****************************************************************************
@@ -86,7 +85,7 @@ void test_nuttx_clock_test_timer01(FAR void **state)
   int ret;
 
   sa.sa_flags = 0;
-  sa.sa_handler = sig_handler01;
+  sa.sa_handler = sighandler01;
   sigemptyset(&sa.sa_mask);
   ret = sigaction(SIG, &sa, NULL);
   syslog(LOG_INFO, "sigaction %d: %d", SIG, ret);
@@ -141,7 +140,9 @@ void test_nuttx_clock_test_timer01(FAR void **state)
 
   syslog(LOG_INFO, "sleep %ds", interval);
 
-  /* timer signal is blocked, this sleep should not be interrupted */
+  /* timer signal is blocked,
+   * this sleep should not be interrupted
+   */
 
   sleep(interval);
 
@@ -162,13 +163,13 @@ void test_nuttx_clock_test_timer01(FAR void **state)
   interval = 1;
   syslog(LOG_INFO, "sleep another %ds", interval);
   sleep(interval); /* this sleep may be interrupted by the timer */
-  syslog(LOG_INFO, "sleep time over, test_timer01_g_sig_hdl_cnt = %d",
-         test_timer01_g_sig_hdl_cnt);
+  syslog(LOG_INFO, "sleep time over, test_timer01_g_sighdlcnt = %d",
+         test_timer01_g_sighdlcnt);
 
   syslog(LOG_INFO, "sleep another %ds", interval);
   sleep(interval); /* this sleep may be interrupted by the timer */
-  syslog(LOG_INFO, "sleep time over, test_timer01_g_sig_hdl_cnt = %d",
-         test_timer01_g_sig_hdl_cnt);
+  syslog(LOG_INFO, "sleep time over, test_timer01_g_sighdlcnt = %d",
+         test_timer01_g_sighdlcnt);
 
   ret = timer_delete(timerid01);
   syslog(LOG_INFO, "timer_delete %p %d", timerid01, ret);
@@ -178,5 +179,5 @@ void test_nuttx_clock_test_timer01(FAR void **state)
   syslog(LOG_INFO, "timer_delete %p %d", timerid02, ret);
   assert_int_equal(ret, 0);
 
-  assert_int_not_equal(test_timer01_g_sig_hdl_cnt, 0);
+  assert_int_not_equal(test_timer01_g_sighdlcnt, 0);
 }

--- a/testing/testsuites/kernel/time/cases/clock_test_timer03.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_timer03.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -61,7 +60,7 @@ void test_nuttx_clock_test_timer03(FAR void **state)
   int failed = 0;
   timer_t timerid;
   sigset_t set;
-  sigset_t old_set;
+  sigset_t oldset;
   struct sigevent sev;
 
   ret = sigemptyset(&set);
@@ -70,7 +69,7 @@ void test_nuttx_clock_test_timer03(FAR void **state)
   ret = sigaddset(&set, SIG);
   assert_int_equal(ret, 0);
 
-  ret = sigprocmask(SIG_BLOCK, &set, &old_set);
+  ret = sigprocmask(SIG_BLOCK, &set, &oldset);
   assert_int_equal(ret, 0);
 
   /* Create the timer */
@@ -82,24 +81,24 @@ void test_nuttx_clock_test_timer03(FAR void **state)
   syslog(LOG_INFO, "timer_create %p: %d", timerid, ret);
   assert_int_equal(ret, 0);
 
-  struct timespec testcases[] = {
-      {0, 30000000},
-      {1, 0},
-      {1, 5000},
-  };
+  struct timespec testcases[] =
+      {
+          {0, 30000000},
+          {1, 0},
+          {1, 5000},
+      };
 
-  struct timespec zero = {
-      0,
-      0,
-  };
+  struct timespec zero =
+      {
+        0, 0
+      };
 
   for (int i = 0; i < sizeof(testcases) / sizeof(testcases[0]); ++i)
     {
       struct timespec start;
       struct timespec end;
       struct itimerspec its;
-      int64_t expected;
-      int64_t escaped;
+      int64_t expected, escaped;
 
       its.it_interval = zero;
       its.it_value = testcases[i];
@@ -116,22 +115,21 @@ void test_nuttx_clock_test_timer03(FAR void **state)
       ret = clock_gettime(CLOCKID, &end);
       assert_int_equal(ret, 0);
 
-      expected = its.it_value.tv_sec * (int64_t)(1e9) + its.it_value.tv_nsec;
+      expected =
+          its.it_value.tv_sec * (int64_t)(1e9) + its.it_value.tv_nsec;
       escaped = end.tv_sec * (int64_t)(1e9) + end.tv_nsec -
                 start.tv_sec * (int64_t)(1e9) - start.tv_nsec;
 
-      /* 20000000, 2 ticks. */
-
-      failed += (escaped < expected || (escaped - expected) >= 20000000);
-      syslog(LOG_INFO,
-             "expected = %" PRId64 " escaped = %" PRId64 " failed = %d",
-             expected, escaped, failed);
+      failed += (escaped < expected ||
+                 (escaped - expected) >= 20000000); /* 20000000, 2 ticks. */
+      syslog(LOG_INFO, "expected = %" PRId64 " escaped = %" PRId64
+             "failed = %d", expected, escaped, failed);
     }
 
   ret = timer_delete(timerid);
   assert_int_equal(ret, 0);
 
-  ret = sigprocmask(SIG_SETMASK, &old_set, NULL);
+  ret = sigprocmask(SIG_SETMASK, &oldset, NULL);
   assert_int_equal(ret, 0);
 
   assert_int_equal(failed, 0);

--- a/testing/testsuites/kernel/time/cases/clock_test_timer04.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_timer04.c
@@ -3,25 +3,24 @@
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
  ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -43,8 +42,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* signo should be in the range SIGRTMIN to
- * SIGRTMAX when SA_SIGINFO flag is set.
+/* signo should be in the range SIGRTMIN to SIGRTMAX when SA_SIGINFO flag
+ * is set.
  */
 
 #define SIG SIGRTMIN
@@ -54,17 +53,17 @@
  * Private Data
  ****************************************************************************/
 
-static int test_timer04_g_handler_flag;
+static int test_timer04_g_handlerflag;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sig_handler
+ * Name: sighandler
  ****************************************************************************/
 
-static void sig_handler(int sig, siginfo_t *si, void *uc)
+static void sighandler(int sig, siginfo_t *si, void *uc)
 {
   if (si == NULL)
     {
@@ -72,7 +71,7 @@ static void sig_handler(int sig, siginfo_t *si, void *uc)
       return;
     }
 
-  test_timer04_g_handler_flag++;
+  test_timer04_g_handlerflag++;
   syslog(LOG_INFO, "sig %d, si %p, uc %p\n", sig, si, uc);
 }
 
@@ -97,7 +96,7 @@ void test_nuttx_clock_test_timer04(FAR void **state)
   /* Install handler for timer signal. */
 
   sa.sa_flags = SA_SIGINFO;
-  sa.sa_sigaction = sig_handler;
+  sa.sa_sigaction = sighandler;
   sigemptyset(&sa.sa_mask);
   ret = sigaction(SIG, &sa, NULL);
   syslog(LOG_INFO, "sigaction %d: %d", SIG, ret);
@@ -150,12 +149,12 @@ void test_nuttx_clock_test_timer04(FAR void **state)
 
   syslog(LOG_INFO, "sleep another %ds", interval);
   sleep(interval); /* should be interrupted */
-  syslog(LOG_INFO, "sleep time over, g_handlerFlag = %d",
-         test_timer04_g_handler_flag);
+  syslog(LOG_INFO, "sleep time over, g_handlerflag = %d",
+         test_timer04_g_handlerflag);
 
   ret = timer_delete(timerid);
   syslog(LOG_INFO, "timer_delete %p %d", timerid, ret);
   assert_int_equal(ret, 0);
 
-  assert_int_not_equal(test_timer04_g_handler_flag, 0);
+  assert_int_not_equal(test_timer04_g_handlerflag, 0);
 }

--- a/testing/testsuites/kernel/time/cases/clock_test_timer05.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_timer05.c
@@ -1,40 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/time/cases/clock_test_timer05.c
- * Copyright (c) 2013-2019 Huawei Technologies Co., Ltd. All rights reserved.
- * Copyright (c) 2020-2022 Huawei Device Co., Ltd. All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
  *
- * 3. Neither the name of the copyright holder nor the names of its
- * contributors may be used to endorse or promote products derived from this
- * software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -56,20 +42,20 @@
  * Private Data
  ****************************************************************************/
 
-static int test_timer05_g_sig_hdl_cnt01;
-static int test_timer05_g_sig_hdl_cnt02;
+static int test_timer05_g_sighdlcnt01;
+static int test_timer05_g_sighdlcnt02;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: temp_sig_handler
+ * Name: tempsighandler
  ****************************************************************************/
 
-static void temp_sig_handler(union sigval v)
+static void tempsighandler(union sigval v)
 {
-  syslog(LOG_INFO, "This is temp_sig_handler ...\r\n");
+  syslog(LOG_INFO, "This is tempsighandler ...\r\n");
   (*(void (*)(void))(v.sival_ptr))();
 }
 
@@ -78,12 +64,12 @@ static void temp_sig_handler(union sigval v)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: temp_sig_handler01
+ * Name: tempsighandler01
  ****************************************************************************/
 
-static void temp_sig_handler01(void)
+static void tempsighandler01(void)
 {
-  test_timer05_g_sig_hdl_cnt01++;
+  test_timer05_g_sighdlcnt01++;
 }
 
 /****************************************************************************
@@ -91,12 +77,12 @@ static void temp_sig_handler01(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: temp_sig_handler02
+ * Name: tempsighandler02
  ****************************************************************************/
 
-static void temp_sig_handler02(void)
+static void tempsighandler02(void)
 {
-  test_timer05_g_sig_hdl_cnt02++;
+  test_timer05_g_sighdlcnt02++;
 }
 
 /****************************************************************************
@@ -119,8 +105,8 @@ void test_nuttx_clock_test_timer05(FAR void **state)
   p = memset(&sev, 0, sizeof(struct sigevent));
   assert_non_null(p);
   sev.sigev_notify = SIGEV_THREAD;
-  sev.sigev_notify_function = temp_sig_handler;
-  sev.sigev_value.sival_ptr = (void *)temp_sig_handler01;
+  sev.sigev_notify_function = tempsighandler;
+  sev.sigev_value.sival_ptr = (void *)tempsighandler01;
 
   /* Start the timer */
 
@@ -141,7 +127,7 @@ void test_nuttx_clock_test_timer05(FAR void **state)
   its.it_interval.tv_sec = its.it_value.tv_sec;
   its.it_interval.tv_nsec = its.it_value.tv_nsec;
 
-  sev.sigev_value.sival_ptr = (void *)temp_sig_handler02;
+  sev.sigev_value.sival_ptr = (void *)tempsighandler02;
   ret = timer_create(CLOCK_REALTIME, &sev, &timerid02);
   syslog(LOG_INFO, "timer_settime %p: %d", timerid02, ret);
   assert_int_equal(ret, 0);
@@ -164,6 +150,6 @@ void test_nuttx_clock_test_timer05(FAR void **state)
   syslog(LOG_INFO, "timer_delete %p %d", timerid02, ret);
   assert_int_equal(ret, 0);
 
-  assert_int_not_equal(test_timer05_g_sig_hdl_cnt01, 0);
-  assert_int_not_equal(test_timer05_g_sig_hdl_cnt02, 0);
+  assert_int_not_equal(test_timer05_g_sighdlcnt01, 0);
+  assert_int_not_equal(test_timer05_g_sighdlcnt02, 0);
 }

--- a/testing/testsuites/kernel/time/cmocka_time_test.c
+++ b/testing/testsuites/kernel/time/cmocka_time_test.c
@@ -1,24 +1,26 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/time/cmocka_time_test.c
- * Copyright (C) 2020 Xiaomi Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ *The ASF licenses this file to you under the Apache License, Version 2.0
+ *(the "License"); you may not use this file except in compliance with
+ *the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *implied.  See the License for the specific language governing
+ *permissions and limitations under the License.
+ *
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -29,18 +31,19 @@
 #include <cmocka.h>
 
 /****************************************************************************
- * Public Functions
+ * Name: cmocka_time_test_main
  ****************************************************************************/
 
 /****************************************************************************
- * Name: cmocka_time_test_main
+ * Private Functions
  ****************************************************************************/
 
 int main(int argc, char *argv[])
 {
   /* Add Test Cases */
 
-  const struct CMUnitTest nuttx_time_testsuites[] = {
+  const struct CMUnitTest nuttx_time_test_suites[] =
+  {
       cmocka_unit_test(test_nuttx_clock_test_smoke01),
       cmocka_unit_test(test_nuttx_clock_test_timer01),
       cmocka_unit_test(test_nuttx_clock_test_timer03),
@@ -52,6 +55,6 @@ int main(int argc, char *argv[])
 
   /* Run Test cases */
 
-  cmocka_run_group_tests(nuttx_time_testsuites, NULL, NULL);
+  cmocka_run_group_tests(nuttx_time_test_suites, NULL, NULL);
   return 0;
 }

--- a/testing/testsuites/kernel/time/include/TimeTest.h
+++ b/testing/testsuites/kernel/time/include/TimeTest.h
@@ -1,43 +1,28 @@
 /****************************************************************************
  * apps/testing/testsuites/kernel/time/include/TimeTest.h
- * Copyright (c) 2013-2019 Huawei Technologies Co., Ltd. All rights reserved.
- * Copyright (c) 2020-2022 Huawei Device Co., Ltd. All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 2. Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- * 3. Neither the name of the copyright holder nor the names of its
- * contributors may be used to endorse or promote products derived from this
- * software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+ ****************************************************************************/
 
 #ifndef TIME_CLOCK_LT_CLOCK_TEST_H_
 #define TIME_CLOCK_LT_CLOCK_TEST_H_
-
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
 #include <nuttx/config.h>
 #include <stdio.h>
 #include <unistd.h>


### PR DESCRIPTION
## Summary

* Added `socket`, `syscall`, and `mutex` tests to `testing/testsuites`.
* Some test cases have been added that cover the functionality of fs, mutex, pthread, socket, and syscall.
* Code formatting fixes.

## Impact

Testing / new test scenarios.

## Testing

* GH CI.
* How did I perform local tests?