### PR TITLE
uORB/sensor: Add macro for satellite format string

### DIFF
--- a/system/uorb/sensor/gnss.c
+++ b/system/uorb/sensor/gnss.c
@@ -34,6 +34,12 @@
   "altitude:%hf,altitude_ellipsoid:%hf,eph:%hf,epv:%hf,hdop:%hf,pdop:%hf," \
   "vdop:%hf,ground_speed:%hf,course:%hf,satellites_used:%" PRIu32 ""
 
+#define SENSOR_GNSS_SATELLITE_INFO_FORMAT(idx) \
+  ",svid" #idx ":%" PRIu32 \
+  ",elevation" #idx ":%" PRIu32 \
+  ",azimuth" #idx ":%" PRIu32 \
+  ",snr" #idx ":%" PRIu32 ""
+
 static const char sensor_gnss_format[] =
   UORB_DEBUG_FORMAT_SENSOR_GNSS ",firmware_version:%" PRIu32 "";
 
@@ -62,13 +68,12 @@ static const char sensor_gnss_measurement_format[] =
 
 static const char sensor_gnss_satellite_format[] =
   "timestamp:%" PRIu64 ",count:%" PRIu32 ",satellites:%" PRIu32 ","
-  "constellation:%" PRIu32 ","
-  "svid0:%" PRIu32 ",elevation0:%" PRIu32 ",azimuth0:%" PRIu32 ","
-  "snr0:%" PRIu32 ",svid1:%" PRIu32 ",elevation1:%" PRIu32 ","
-  "azimuth1:%" PRIu32 ",snr1:%" PRIu32 ",svid2:%" PRIu32 ","
-  "elevation2:%" PRIu32 ",azimuth2:%" PRIu32 ",snr2:%" PRIu32 ","
-  "svid3:%" PRIu32 ",elevation3:%" PRIu32 ",azimuth3:%" PRIu32 ","
-  "snr3:%" PRIu32 "";
+  "constellation:%" PRIu32 ""
+  SENSOR_GNSS_SATELLITE_INFO_FORMAT(0)
+  SENSOR_GNSS_SATELLITE_INFO_FORMAT(1)
+  SENSOR_GNSS_SATELLITE_INFO_FORMAT(2)
+  SENSOR_GNSS_SATELLITE_INFO_FORMAT(3)
+  ;
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
uORB/sensor: Add macro for satellite format string.
Make it easier to extend the format of struct member.

## Impact
uORB/sensor

## Testing
1. Selftest - The format string remains the same
2. NuttX CI
