### PR TITLE
nshlib/nsh_parse: Closing fds opened for redirection if necessary 

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -2739,16 +2739,12 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
           if (param.fd_in != -1)
             {
               close(param.fd_in);
-              param.fd_in = -1;
               vtbl->np.np_redir_in = redirect_in_save;
             }
 
-          if (param.fd_out != -1)
-            {
-              close(param.fd_out);
-              param.fd_out = -1;
-              vtbl->np.np_redir_out = redirect_out_save;
-            }
+          close(param.fd_out);
+          param.fd_out = -1;
+          vtbl->np.np_redir_out = redirect_out_save;
 
           redirect_in_save = vtbl->np.np_redir_in;
           vtbl->np.np_redir_in = true;


### PR DESCRIPTION
## Summary
1. [nshlib/nsh_parse: Closing fds opened for redirection if necessary](https://github.com/apache/nuttx-apps/commit/ade300b1b9b28d295f4684f17802e5a59d874c96)
```
CID 1612743: (#1 of 1): RESOURCE_LEAK
12. leaked_handle: The handle variable fd_out is out of scope and will leak the handle.
```
2. [nshlib/nsh_parse: Removing unnecessary value assigning about redirection](https://github.com/apache/nuttx-apps/commit/6a50d76f1752e29563a680425384b239e0b74ab1)
```
CID 1612757: (#1 of 1): UNUSED_VALUE
assigned_value: The value -1 is assigned to param.fd_in here, but the stored value is overwritten before it can be used.
```
## Impact
nshlib/nsh_parse

## Testing
1. Selftesting with cmd return value and pipeline PASSED
2. NuttX CI
