### PR TITLE
fs cases: fix compile error

### DIFF
--- a/testing/testsuites/kernel/fs/cases/fs_fsync_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_fsync_test.c
@@ -137,8 +137,8 @@ void test_nuttx_fs_fsync02(FAR void **state)
     }
 
 #endif
-  syslog(LOG_INFO, "the fbsize = %"PRIu64",buffer size=%d\n",
-        statfsbuf.f_bsize, bufsize);
+  syslog(LOG_INFO, "the fbsize = %zu,buffer size=%d\n",
+         statfsbuf.f_bsize, bufsize);
 
   /* malloc memory */
 

--- a/testing/testsuites/kernel/fs/cases/fs_stream_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_stream_test.c
@@ -257,7 +257,7 @@ void test_nuttx_fs_stream03(FAR void **state)
   char *junk = "abcdefghijklmnopqrstuvwxyz";
   size_t len = strlen(junk);
   char *inbuf = NULL;
-  int ret;
+  ssize_t ret;
   int lc;
   for (lc = 0; lc < 10; lc++)
     {
@@ -274,9 +274,9 @@ void test_nuttx_fs_stream03(FAR void **state)
           assert_true(1 == 0);
         }
 
-      if ((size_t)ret != len)
+      if (ret != len)
         {
-          syslog(LOG_ERR, "len = %zu != return value from fwrite = %d",
+          syslog(LOG_ERR, "len = %zu != return value from fwrite = %zd",
                  len, ret);
           fclose(stream);
           assert_true(1 == 0);
@@ -306,9 +306,9 @@ void test_nuttx_fs_stream03(FAR void **state)
           assert_true(1 == 0);
         }
 
-      if ((size_t)ret != len)
+      if (ret != len)
         {
-          syslog(LOG_ERR, "len = %zu != return value from fread = %d",
+          syslog(LOG_ERR, "len = %zu != return value from fread = %zd",
                  len, ret);
           free(inbuf);
           fclose(stream);


### PR DESCRIPTION
## Summary
```
kernel/fs/cases/fs_stream_test.c:279:70: error: format ‘%zi’ expects argument of type ‘signed size_t’, but argument 4 has type ‘int’ [-Werror=format=]
  279 |           syslog(LOG_ERR, "len = %zi != return value from fwrite = %zi",
      |                                                                    ~~^
      |                                                                      |
      |                                                                      long int
      |                                                                    %i
  280 |                  len, ret);
      |                       ~~~
      |                       |
      |                       int
kernel/fs/cases/fs_stream_test.c:311:69: error: format ‘%zi’ expects argument of type ‘signed size_t’, but argument 4 has type ‘int’ [-Werror=format=]
  311 |           syslog(LOG_ERR, "len = %zi != return value from fread = %zi",
      |                                                                   ~~^
      |                                                                     |
      |                                                                     long int
      |                                                                   %i
  312 |                  len, ret);
      |                       ~~~
      |                       |
      |                       int
```

## Impact

fix compiler warning

## Testing

ci