### PR TITLE
{bp-2902} interpreters/luamodules/luv: use "depends on" instead of "select"

### DIFF
--- a/crypto/libtomcrypt/Kconfig
+++ b/crypto/libtomcrypt/Kconfig
@@ -54,7 +54,6 @@ endif # LIBTOMCRYPT_LTCRYPT
 
 config LIBTOMCRYPT_HASHSUM
 	tristate "LibTomCrypt hashsum"
-	depends on SCHED_ATEXIT
 	default n
 	---help---
 		Demo hashsum application

--- a/interpreters/luamodules/luv/Kconfig
+++ b/interpreters/luamodules/luv/Kconfig
@@ -15,7 +15,6 @@ config LUA_LUV_MODULE
 	select NET_TCP
 	select NET_UDP
 	select PSEUDOFS_SOFTLINKS
-	select SCHED_ATEXIT
 	select SCHED_HAVE_PARENT
 	---help---
 		Bare libuv bindings for Lua

--- a/interpreters/luamodules/luv/Kconfig
+++ b/interpreters/luamodules/luv/Kconfig
@@ -7,15 +7,15 @@ config LUA_LUV_MODULE
 	bool "Lua Luv module"
 	default n
 	depends on INTERPRETERS_LUA && LIBUV
-	select LIBC_EXECFUNCS
-	select LIBC_NETDB
-	select NET
-	select NETDEV_IFINDEX
-	select NET_SOCKOPTS
-	select NET_TCP
-	select NET_UDP
-	select PSEUDOFS_SOFTLINKS
-	select SCHED_HAVE_PARENT
+	depends on LIBC_EXECFUNCS
+	depends on LIBC_NETDB
+	depends on NET
+	depends on NETDEV_IFINDEX
+	depends on NET_SOCKOPTS
+	depends on NET_TCP
+	depends on NET_UDP
+	depends on PSEUDOFS_SOFTLINKS
+	depends on SCHED_HAVE_PARENT
 	---help---
 		Bare libuv bindings for Lua
 


### PR DESCRIPTION
## Summary
interpreters/luamodules/luv: use "depends on" instead of "select"

Included
https://github.com/apache/nuttx-apps/pull/2898

## Impact
RELEASE

## Testing
CI
