### PR TITLE
Add carrier frequency for GNSS Satellite

### DIFF
--- a/system/uorb/sensor/gnss.c
+++ b/system/uorb/sensor/gnss.c
@@ -69,6 +69,7 @@ static const char sensor_gnss_measurement_format[] =
 static const char sensor_gnss_satellite_format[] =
   "timestamp:%" PRIu64 ",count:%" PRIu32 ",satellites:%" PRIu32 ","
   "constellation:%" PRIu32 ""
+  ",cf:%hf"
   SENSOR_GNSS_SATELLITE_INFO_FORMAT(0)
   SENSOR_GNSS_SATELLITE_INFO_FORMAT(1)
   SENSOR_GNSS_SATELLITE_INFO_FORMAT(2)

--- a/system/uorb/sensor/gnss.c
+++ b/system/uorb/sensor/gnss.c
@@ -29,10 +29,21 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_UORB
-#define UORB_DEBUG_FORMAT_SENSOR_GNSS \
-  "timestamp:%" PRIu64 ",time_utc:%" PRIu64 ",latitude:%hf,longitude:%hf," \
-  "altitude:%hf,altitude_ellipsoid:%hf,eph:%hf,epv:%hf,hdop:%hf,pdop:%hf," \
-  "vdop:%hf,ground_speed:%hf,course:%hf,satellites_used:%" PRIu32 ""
+#define UORB_DEBUG_FORMAT_SENSOR_GNSS     \
+  "timestamp:%" PRIu64                    \
+  ",time_utc:%" PRIu64                    \
+  ",latitude:%hf"                         \
+  ",longitude:%hf"                        \
+  ",altitude:%hf"                         \
+  ",altitude_ellipsoid:%hf"               \
+  ",eph:%hf"                              \
+  ",epv:%hf"                              \
+  ",hdop:%hf"                             \
+  ",pdop:%hf"                             \
+  ",vdop:%hf"                             \
+  ",ground_speed:%hf"                     \
+  ",course:%hf"                           \
+  ",satellites_used:%" PRIu32 ""
 
 #define SENSOR_GNSS_SATELLITE_INFO_FORMAT(idx) \
   ",svid" #idx ":%" PRIu32 \


### PR DESCRIPTION
## Summary
1. [uORB/sensor: Add carrier frequency for GNSS Satellite](https://github.com/apache/nuttx-apps/commit/87c303cba00abb63bf9d4b6652c01b738fb5c964)
The struct sensor_gnss_satellite.cf(carrier frequency) can be parsed from GSV.signal_id(e.g. NMEA 0183 v4.11) and struct sensor_gnss_satellite.constellation(sv_type)
See https://github.com/apache/nuttx/pull/15296
2. [uORB/sensor: Update macro of sensor_gnss format string](https://github.com/apache/nuttx-apps/commit/4e00f16b43cb954fe6038732d4b9748758f24c4e)

## Impact
uORB/sensor

## Testing
NuttX CI (depends on https://github.com/apache/nuttx/pull/15296)
