### PR TITLE
scanftest:need enable CONFIG_LIBC_SCANSET

### DIFF
--- a/testing/scanftest/Kconfig
+++ b/testing/scanftest/Kconfig
@@ -5,6 +5,7 @@
 
 config TESTING_SCANFTEST
 	tristate "sscanf() test"
+	depends on LIBC_SCANSET
 	default n
 	---help---
 		Enable sscanf() test


### PR DESCRIPTION
## Summary

When I used scanftest, I found that some of its test cases depended on the function enabled by CONFIG_LIBC_SCANSET. So I added a dependency to it to ensure the correct operation of this test case.

```
"",
        instead of
"   ",
        to the first argument.

Test #29 returned 0 instead of 1.
Test #29 assigned
"",
        instead of
"  q",
        to the first argument.

Test #30 returned 0 instead of 2.
Test #30 assigned
"",
        instead of
"  ",
        to the first argument.

Test #30 assigned
"",
        instead of
"Q",
        to the second argument.

Test #31 returned 0 instead of 2.
Test #31 assigned
"",
        instead of
"qwerty-",
        to the first argument.

Test #31 assigned
"",
        instead of
"QWERTY-",
        to the second argument.
```

## Impact

Add CONFIG_LIBC_SCANSET dependency to enable the use case

## Testing

Compiles fine on local code

