### PR TITLE
apps/system: replace CONFIG_NSH_LINELEN to LINE_MAX

### DIFF
--- a/examples/lp503x/lp503x_main.c
+++ b/examples/lp503x/lp503x_main.c
@@ -624,7 +624,7 @@ static int lp503x_cmd_help(FAR char *parg)
 int main(int argc, FAR char *argv[])
 {
   bool running;
-  char buffer[CONFIG_NSH_LINELEN];
+  char buffer[LINE_MAX];
   int len;
   int x;
   char *cmd;

--- a/netutils/rexec/rexec.c
+++ b/netutils/rexec/rexec.c
@@ -155,7 +155,7 @@ static int do_rexec(FAR struct rexec_arg_s *arg)
 
 int main(int argc, FAR char **argv)
 {
-  char cmd[CONFIG_NSH_LINELEN];
+  char cmd[LINE_MAX];
   struct rexec_arg_s arg;
   int option;
   int i;

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -380,7 +380,7 @@
 /* Maximum size of one command line (telnet or serial) */
 
 #ifndef CONFIG_NSH_LINELEN
-#  define CONFIG_NSH_LINELEN 80
+#  define CONFIG_NSH_LINELEN LINE_MAX
 #endif
 
 /* The maximum number of nested if-then[-else]-fi sequences that

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -157,6 +157,14 @@ struct nsh_vtbl_s
   char traceline[CONFIG_NSH_LINELEN];
 #endif
 
+  /* Temporary line buffer */
+
+#if (!defined(CONFIG_NSH_DISABLE_MEMDUMP) && defined(NSH_HAVE_WRITEFILE)) || \
+    !defined(CONFIG_NSH_DISABLEBG) || defined(CONFIG_NSH_PIPELINE) || \
+    !defined(CONFIG_NSH_DISABLE_WATCH)
+  char templine[CONFIG_NSH_LINELEN];
+#endif
+
   /* Current working directory */
 
 #ifdef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -151,6 +151,12 @@ struct nsh_vtbl_s
 
   bool isctty;
 
+  /* Trace line buffer */
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
+  char traceline[CONFIG_NSH_LINELEN];
+#endif
+
   /* Current working directory */
 
 #ifdef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_login.c
+++ b/nshlib/nsh_login.c
@@ -171,7 +171,7 @@ int nsh_login(FAR struct console_stdio_s *pstate)
 
       /* readline() returns EOF on failure */
 
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      ret = readline_fd(pstate->cn_line, sizeof(pstate->cn_line),
                         INFD(pstate), OUTFD(pstate));
       if (ret != EOF)
         {
@@ -207,7 +207,7 @@ int nsh_login(FAR struct console_stdio_s *pstate)
         }
 
       password[0] = '\0';
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      ret = readline_fd(pstate->cn_line, sizeof(pstate->cn_line),
                         INFD(pstate), -1);
 
       /* Enable echo again after password */

--- a/nshlib/nsh_mmcmds.c
+++ b/nshlib/nsh_mmcmds.c
@@ -56,12 +56,11 @@ int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
 int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  char arg[CONFIG_NSH_LINELEN] = "";
   int i;
 
   if (argc == 1)
     {
-      strlcpy(arg, "used", CONFIG_NSH_LINELEN);
+      strlcpy(vtbl->templine, "used", sizeof(vtbl->templine));
     }
   else if (argc >= 2 && (strcmp(argv[1], "-h") == 0 ||
                          strcmp(argv[1], "help") == 0))
@@ -73,15 +72,16 @@ int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     {
       for (i = 1; i < argc; i++)
         {
-          strlcat(arg, argv[i], CONFIG_NSH_LINELEN);
+          strlcat(vtbl->templine, argv[i], sizeof(vtbl->templine));
           if (i < argc - 1)
             {
-              strlcat(arg, " ", CONFIG_NSH_LINELEN);
+              strlcat(vtbl->templine, " ", sizeof(vtbl->templine));
             }
         }
     }
 
-  return nsh_writefile(vtbl, argv[0], arg, strlen(arg),
+  return nsh_writefile(vtbl, argv[0], vtbl->templine,
+                       strlen(vtbl->templine),
                        CONFIG_NSH_PROC_MOUNTPOINT "/memdump");
 }
 

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -605,25 +605,24 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
     {
       FAR char *sh_argv[4];
       FAR char *sh_cmd = "sh";
-      char sh_arg2[CONFIG_NSH_LINELEN];
 
       DEBUGASSERT(strncmp(argv[0], sh_cmd, 3) != 0);
 
-      sh_arg2[0] = '\0';
+      vtbl->templine[0] = '\0';
 
       for (ret = 0; ret < argc; ret++)
         {
-          strlcat(sh_arg2, argv[ret], sizeof(sh_arg2));
+          strlcat(vtbl->templine, argv[ret], sizeof(vtbl->templine));
 
           if (ret < argc - 1)
             {
-              strcat(sh_arg2, " ");
+              strcat(vtbl->templine, " ");
             }
         }
 
       sh_argv[0] = sh_cmd;
       sh_argv[1] = "-c";
-      sh_argv[2] = sh_arg2;
+      sh_argv[2] = vtbl->templine;
       sh_argv[3] = NULL;
 
       /* np.np_bg still there, try use nsh_builtin or nsh_fileapp to
@@ -2466,7 +2465,7 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
 
   /* Initialize parser state */
 
-  memset(argv, 0, MAX_ARGV_ENTRIES*sizeof(FAR char *));
+  memset(argv, 0, MAX_ARGV_ENTRIES * sizeof(FAR char *));
   NSH_MEMLIST_INIT(memlist);
   NSH_ALIASLIST_INIT(alist);
 
@@ -2681,7 +2680,6 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
         {
           FAR char *arg;
           FAR char *sh_argv[4];
-          char sh_arg2[CONFIG_NSH_LINELEN];
 
           if (argv[argc][g_pipeline1_len])
             {
@@ -2699,21 +2697,22 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
               goto dynlist_free;
             }
 
-          sh_arg2[0] = '\0';
+          vtbl->templine[0] = '\0';
 
           for (ret = 0; ret < argc; ret++)
             {
-              strlcat(sh_arg2, argv[ret], sizeof(sh_arg2));
+              strlcat(vtbl->templine, argv[ret],
+                      sizeof(vtbl->templine));
 
               if (ret < argc - 1)
                 {
-                  strcat(sh_arg2, " ");
+                  strcat(vtbl->templine, " ");
                 }
             }
 
           sh_argv[0] = "sh";
           sh_argv[1] = "-c";
-          sh_argv[2] = sh_arg2;
+          sh_argv[2] = vtbl->templine;
           sh_argv[3] = NULL;
 
           ret = pipe2(pipefd, 0);

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -2460,10 +2460,8 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
-  char      tracebuf[CONFIG_NSH_LINELEN + 1];
-
-  strlcpy(tracebuf, cmdline, sizeof(tracebuf));
-  sched_note_beginex(NOTE_TAG_APP, tracebuf);
+  strlcpy(vtbl->traceline, cmdline, sizeof(vtbl->traceline));
+  sched_note_beginex(NOTE_TAG_APP, vtbl->traceline);
 #endif
 
   /* Initialize parser state */
@@ -2827,7 +2825,7 @@ dynlist_free:
   NSH_ALIASLIST_FREE(vtbl, &alist);
   NSH_MEMLIST_FREE(&memlist);
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
-  sched_note_endex(NOTE_TAG_APP, tracebuf);
+  sched_note_endex(NOTE_TAG_APP, vtbl->traceline);
 #endif
   return ret;
 }

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -207,7 +207,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
        * occurs. Either  will cause the session to terminate.
        */
 
-      ret = cle_fd(pstate->cn_line, nsh_prompt(), CONFIG_NSH_LINELEN,
+      ret = cle_fd(pstate->cn_line, nsh_prompt(), sizeof(pstate->cn_line),
                    INFD(pstate), OUTFD(pstate));
       if (ret < 0)
         {
@@ -225,7 +225,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
        * will cause the session to terminate.
        */
 
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      ret = readline_fd(pstate->cn_line, sizeof(pstate->cn_line),
                         INFD(pstate), OUTFD(pstate));
       if (ret == EOF)
         {

--- a/nshlib/nsh_telnetlogin.c
+++ b/nshlib/nsh_telnetlogin.c
@@ -176,7 +176,7 @@ int nsh_telnetlogin(FAR struct console_stdio_s *pstate)
       write(OUTFD(pstate), g_userprompt, strlen(g_userprompt));
 
       username[0] = '\0';
-      if (readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      if (readline_fd(pstate->cn_line, sizeof(pstate->cn_line),
                       INFD(pstate), OUTFD(pstate)) >= 0)
 
         {
@@ -212,8 +212,8 @@ int nsh_telnetlogin(FAR struct console_stdio_s *pstate)
         }
 
       password[0] = '\0';
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
-                      INFD(pstate), OUTFD(pstate));
+      ret = readline_fd(pstate->cn_line, sizeof(pstate->cn_line),
+                        INFD(pstate), OUTFD(pstate));
 
       /* Enable echo again after password */
 

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -550,7 +550,6 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLE_WATCH
 int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  char buffer[CONFIG_NSH_LINELEN];
   int interval = 2;
   int count = -1;
   FAR char *cmd;
@@ -593,8 +592,8 @@ int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   for (i = 0; i < count; i++)
     {
-      strlcpy(buffer, cmd, CONFIG_NSH_LINELEN);
-      ret = nsh_parse(vtbl, buffer);
+      strlcpy(vtbl->templine, cmd, sizeof(vtbl->templine));
+      ret = nsh_parse(vtbl, vtbl->templine);
       if (ret < 0)
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], cmd, NSH_ERRNO);

--- a/system/nxcamera/nxcamera_main.c
+++ b/system/nxcamera/nxcamera_main.c
@@ -396,7 +396,7 @@ static int nxcamera_cmd_help(FAR struct nxcamera_s *pcam, FAR char *parg)
 
 int main(int argc, FAR char *argv[])
 {
-  char                  buffer[CONFIG_NSH_LINELEN];
+  char                  buffer[LINE_MAX];
   int                   len;
   int                   x;
   bool                  running = true;

--- a/system/nxlooper/nxlooper_main.c
+++ b/system/nxlooper/nxlooper_main.c
@@ -500,7 +500,7 @@ static int nxlooper_cmd_help(FAR struct nxlooper_s *plooper, char *parg)
 
 int main(int argc, FAR char *argv[])
 {
-  char                  buffer[CONFIG_NSH_LINELEN];
+  char                  buffer[LINE_MAX];
   int                   len;
   int                   x;
   int                   running;

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -737,7 +737,7 @@ static int nxplayer_cmd_help(FAR struct nxplayer_s *pplayer, char *parg)
 
 int main(int argc, FAR char *argv[])
 {
-  char                    buffer[CONFIG_NSH_LINELEN];
+  char                    buffer[LINE_MAX];
   int                     len;
   int                     x;
   int                     running;

--- a/system/nxrecorder/nxrecorder_main.c
+++ b/system/nxrecorder/nxrecorder_main.c
@@ -529,7 +529,7 @@ static int nxrecorder_cmd_help(FAR struct nxrecorder_s *precorder,
 
 int main(int argc, FAR char *argv[])
 {
-  char                    buffer[CONFIG_NSH_LINELEN];
+  char                    buffer[LINE_MAX];
   int                     len;
   int                     x;
   int                     running;

--- a/system/readline/readline.c
+++ b/system/readline/readline.c
@@ -31,16 +31,6 @@
 #include "system/readline.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* Maximum size of one command line (telnet or serial) */
-
-#ifndef CONFIG_NSH_LINELEN
-#  define CONFIG_NSH_LINELEN 80
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -57,14 +47,14 @@
 
 FAR char *readline(FAR const char *prompt)
 {
-  FAR char *line = malloc(CONFIG_NSH_LINELEN);
+  FAR char *line = malloc(LINE_MAX);
 
   if (line != NULL)
     {
 #ifdef CONFIG_READLINE_TABCOMPLETION
       FAR const char *orig = readline_prompt(prompt);
 #endif
-      if (readline_fd(line, CONFIG_NSH_LINELEN,
+      if (readline_fd(line, LINE_MAX,
                       STDIN_FILENO, STDOUT_FILENO) == 0)
         {
           free(line);

--- a/system/taskset/taskset.c
+++ b/system/taskset/taskset.c
@@ -80,7 +80,7 @@ static bool get_cpuset(const char *arg, cpu_set_t *cpu_set)
 
 int main(int argc, FAR char *argv[])
 {
-  char command[CONFIG_NSH_LINELEN];
+  char command[LINE_MAX];
   int exitcode;
   int option;
   int pid = -1;
@@ -151,7 +151,7 @@ int main(int argc, FAR char *argv[])
             }
 
           /* Construct actual command with args
-           * NOTE: total length does not exceed CONFIG_NSH_LINELEN
+           * NOTE: total length does not exceed LINE_MAX
            */
 
           for (i = 0; i < argc - 2; i++)

--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -227,7 +227,7 @@ static int trace_cmd_dump(FAR const char *name, int index, int argc,
 static int trace_cmd_cmd(FAR const char *name, int index, int argc,
                          FAR char **argv, int notectlfd)
 {
-  char command[CONFIG_NSH_LINELEN];
+  char command[LINE_MAX];
   bool changed;
   bool cont = false;
 


### PR DESCRIPTION
## Summary

1. apps/system: replace CONFIG_NSH_LINELEN to LINE_MAX

Applications should not depend on any properties of nshlib

Signed-off-by: chao an <anchao@lixiang.com>

2. nshlib/nshline: move all temp line buffer to heap

Signed-off-by: chao an <anchao@lixiang.com>

3. nshlib/traceline: move traceline buffer from stack to heap

Signed-off-by: chao an <anchao@lixiang.com>


## Impact

N/A

## Testing

sim/nsh ostest