### PR TITLE
{bp-2893} system/libuv/Kconfig: depends on CONFIG_PIPES

### DIFF
--- a/system/libuv/Kconfig
+++ b/system/libuv/Kconfig
@@ -6,6 +6,7 @@
 config LIBUV
 	bool "libuv asynchronous I/O Library"
 	default n
+	depends on PIPES
 	---help---
 		Enable build for libuv asynchronous I/O Library
 


### PR DESCRIPTION
## Summary

libuv unconditionally uses pipe().

Fixes: https://github.com/apache/nuttx/issues/14773

## Impact
RELEASE

## Testing
CI
