### PR TITLE
Move debug_info target implementation to apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ all: $(BIN)
 
 .PHONY: import install dirlinks export .depdirs preconfig depend clean distclean
 .PHONY: context postinstall clean_context context_all postinstall_all register register_all
+.PHONY: debug_info
 .PRECIOUS: $(BIN)
 
 $(foreach SDIR, $(CONFIGURED_APPS), $(eval $(call SDIR_template,$(SDIR),all)))
@@ -205,6 +206,11 @@ ifneq ($(BUILTIN_REGISTRY),)
 endif
 endif
 endif
+
+# debug_info: Parse nxdiag example output file (sysinfo.h) and print
+
+debug_info:
+	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR)/system/nxdiag debug_info
 
 .depdirs: $(foreach SDIR, $(CONFIGURED_APPS), $(SDIR)_depend)
 

--- a/system/nxdiag/Makefile
+++ b/system/nxdiag/Makefile
@@ -103,9 +103,26 @@ endif
 
 endif
 
+# debug_info target flags to get diagnostic info without building nxdiag application
+
+SYSINFO_PARSE_FLAGS = "$(realpath $(TOPDIR))"
+SYSINFO_PARSE_FLAGS += "-f$(CONFIG_APPS_DIR)/system/nxdiag/sysinfo.h"
+
+SYSINFO_FLAGS = "-c"
+SYSINFO_FLAGS += "-p"
+SYSINFO_FLAGS += -f \""$(shell echo '$(CFLAGS)' | sed 's/"/\\\\\\"/g')"\"
+SYSINFO_FLAGS += \""$(shell echo '$(CXXFLAGS)' | sed 's/"/\\\\\\"/g')"\"
+SYSINFO_FLAGS += \""$(shell echo '$(LDFLAGS)' | sed 's/"/\\\\\\"/g')"\"
+
+ifneq ($(findstring esp,$(CONFIG_ARCH_CHIP)),)
+ARCH_ESP_HALDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)chip$(DELIM)esp-hal-3rdparty
+SYSINFO_FLAGS += --espressif "$(TOPDIR)" "$(ARCH_ESP_HALDIR)"
+SYSINFO_FLAGS += "--espressif_chip"
+endif
+
 # Common build
 
-.PHONY: sysinfo.h
+.PHONY: sysinfo.h debug_info
 
 checkpython3:
 	@if [ -z "$$(which python3)" ]; then \
@@ -120,6 +137,16 @@ sysinfo.h : checkpython3 $(INFO_DEPS)
 		echo "ERROR: Failed to generate sysinfo.h"; \
 		exit 1; \
 	fi
+
+# debug_info: Parse nxdiag example output file (sysinfo.h) and print
+
+debug_info: checkpython3
+	@if [[ ! -f "sysinfo.h" ]]; then \
+		echo "file $(CONFIG_APPS_DIR)/system/nxdiag/sysinfo.h not exists"; \
+		python3 $(NXTOOLSDIR)$(DELIM)host_sysinfo.py $(SYSINFO_FLAGS) \
+		 $(realpath $(TOPDIR)) > sysinfo.h; \
+	fi
+	@python3 $(NXTOOLSDIR)$(DELIM)parse_sysinfo.py $(SYSINFO_PARSE_FLAGS)
 
 depend:: sysinfo.h
 


### PR DESCRIPTION
## Summary

Related to https://github.com/apache/nuttx/pull/15304
Move `debug_info` target implementation into apps. Update suggested from https://github.com/apache/nuttx/pull/15304#discussion_r1894567114

## Impact

Common layer update

## Testing

Any config can be used after configuration step with `make debug_info` command