### PR TITLE
CI: Increase CI Jobs to 100% for Complex PRs

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -76,6 +76,8 @@ jobs:
             echo 'arch_contains_sim=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Arch: x86_64"* ]]; then
             echo 'arch_contains_x86_64=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Arch: x86"* ]]; then
+            echo 'arch_contains_x86=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Arch: xtensa"* ]]; then
             echo 'arch_contains_xtensa=1' | tee -a $GITHUB_OUTPUT
           fi
@@ -91,6 +93,8 @@ jobs:
             echo 'board_contains_sim=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Board: x86_64"* ]]; then
             echo 'board_contains_x86_64=1' | tee -a $GITHUB_OUTPUT
+          elif [[ "$labels" == *"Board: x86"* ]]; then
+            echo 'board_contains_x86=1' | tee -a $GITHUB_OUTPUT
           elif [[ "$labels" == *"Board: xtensa"* ]]; then
             echo 'board_contains_xtensa=1' | tee -a $GITHUB_OUTPUT
           fi
@@ -119,12 +123,14 @@ jobs:
           arch_contains_arm64=${{ steps.get-arch.outputs.arch_contains_arm64 }}
           arch_contains_riscv=${{ steps.get-arch.outputs.arch_contains_riscv }}
           arch_contains_sim=${{ steps.get-arch.outputs.arch_contains_sim }}
+          arch_contains_x86=${{ steps.get-arch.outputs.arch_contains_x86 }}
           arch_contains_x86_64=${{ steps.get-arch.outputs.arch_contains_x86_64 }}
           arch_contains_xtensa=${{ steps.get-arch.outputs.arch_contains_xtensa }}
           board_contains_arm=${{ steps.get-arch.outputs.board_contains_arm }}
           board_contains_arm64=${{ steps.get-arch.outputs.board_contains_arm64 }}
           board_contains_riscv=${{ steps.get-arch.outputs.board_contains_riscv }}
           board_contains_sim=${{ steps.get-arch.outputs.board_contains_sim }}
+          board_contains_x86=${{ steps.get-arch.outputs.board_contains_x86 }}
           board_contains_x86_64=${{ steps.get-arch.outputs.board_contains_x86_64 }}
           board_contains_xtensa=${{ steps.get-arch.outputs.board_contains_xtensa }}
 
@@ -151,6 +157,7 @@ jobs:
               "$arch_contains_arm64" != "$board_contains_arm64" ||
               "$arch_contains_riscv" != "$board_contains_riscv" ||
               "$arch_contains_sim" != "$board_contains_sim" ||
+              "$arch_contains_x86" != "$board_contains_x86" ||
               "$arch_contains_x86_64" != "$board_contains_x86_64" ||
               "$arch_contains_xtensa" != "$board_contains_xtensa"
             ]]; then
@@ -166,21 +173,14 @@ jobs:
 
           # If Not a Simple PR: Build all targets
           if [[ "$quit" == "1" ]]; then
-            # If PR was Created or Modified: Exclude some boards
+            # If PR was Created or Modified: Include all boards
             pr=${{github.event.pull_request.number}}
             if [[ "$pr" != "" ]]; then
-              echo "Excluding arm-0[1249], arm-1[124-9], risc-v-04..06, sim-03, xtensa-02"
+              echo "Include all boards"
               boards=$(
                 echo '${{ inputs.boards }}' |
                 jq --compact-output \
-                'map(
-                  select(
-                    test("arm-0[1249]") == false and test("arm-1[124-9]") == false and
-                    test("risc-v-0[4-9]") == false and
-                    test("sim-0[3-9]") == false and
-                    test("xtensa-0[2-9]") == false
-                  )
-                )'
+                '.'
               )
             fi
             echo "selected_builds=$boards" | tee -a $GITHUB_OUTPUT
@@ -218,6 +218,12 @@ jobs:
                 skip_build=1
               fi
 
+            # For "Arch / Board: x86": Build other
+            elif [[ "$arch_contains_x86" == "1" || "$board_contains_x86" == "1" ]]; then
+              if [[ "$board" != *"other"* ]]; then
+                skip_build=1
+              fi
+  
             # For "Arch / Board: x86_64": Build x86_64-01
             elif [[ "$arch_contains_x86_64" == "1" || "$board_contains_x86_64" == "1" ]]; then
               if [[ "$board" != *"x86_64-"* ]]; then


### PR DESCRIPTION
## Summary

This PR increases the CI Jobs for Complex PRs from 50% to 100%, as explained here:
- https://github.com/apache/nuttx/issues/15451#issuecomment-2576576664

This PR also includes the fix for Simple x86 PR:
- https://github.com/apache/nuttx/pull/14896

## Impact

By increasing the CI Checks, we will have better quality PRs that won't fail the Daily Builds.

Complex PRs will now complete CI Checks in 2 hours 10 mins. (Instead of 1.5 hours previously)

## Testing

Complex PRs will now execute 100% of CI Jobs:
- https://github.com/lupyuen5/label-nuttx-apps/actions/runs/12663507115
