### PR TITLE
cmake[enhance]:builtin register support NONE srcs target

### DIFF
--- a/builtin/CMakeLists.txt
+++ b/builtin/CMakeLists.txt
@@ -24,6 +24,8 @@ if(CONFIG_BUILTIN)
 
   # generate registry
   get_property(nuttx_app_libs GLOBAL PROPERTY NUTTX_APPS_LIBRARIES)
+  get_property(only_registers GLOBAL PROPERTY NUTTX_APPS_ONLY_REGISTER)
+  list(APPEND nuttx_app_libs ${only_registers})
   set(builtin_list_string)
   set(builtin_proto_string)
   foreach(module ${nuttx_app_libs})


### PR DESCRIPTION
## Summary

Support `add_application` to register without compiling,
used in scenarios where redefining the main symbol is not required

## Impact

enhancement

## Testing

CI test build