### PR TITLE
apps/testing: Add a cmocka framework for network testing

### DIFF
--- a/testing/nettest/CMakeLists.txt
+++ b/testing/nettest/CMakeLists.txt
@@ -1,0 +1,45 @@
+# ##############################################################################
+# apps/testing/nettest/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_NET_TEST)
+  if(CONFIG_TESTING_NET_TCP)
+    set(SRCS ${CMAKE_CURRENT_LIST_DIR}/tcp/test_tcp.c
+             ${CMAKE_CURRENT_LIST_DIR}/tcp/test_tcp_common.c)
+
+    if(CONFIG_NET_IPv4)
+      list(APPEND SRCS ${CMAKE_CURRENT_LIST_DIR}/tcp/test_tcp_connect_ipv4.c)
+    endif()
+
+    nuttx_add_application(
+      NAME
+      cmocka_net_tcp
+      PRIORITY
+      ${CONFIG_TESTING_NET_TEST_PRIORITY}
+      STACKSIZE
+      ${CONFIG_TESTING_NET_TEST_STACKSIZE}
+      MODULE
+      ${CONFIG_TESTING_NET_TEST}
+      DEPENDS
+      cmocka
+      SRCS
+      ${SRCS})
+  endif()
+
+endif()

--- a/testing/nettest/Kconfig
+++ b/testing/nettest/Kconfig
@@ -1,0 +1,28 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config TESTING_NET_TEST
+	tristate "vela cmocka net test"
+	default n
+	depends on TESTING_CMOCKA
+	---help---
+		Enable the cmocka net test
+
+if TESTING_NET_TEST
+
+config TESTING_NET_TEST_PRIORITY
+	int "Task priority"
+	default 100
+
+config TESTING_NET_TEST_STACKSIZE
+	int "Stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+config TESTING_NET_TCP
+	bool "Enable cmocka net tcp test"
+	depends on NET_TCP && NET_TCPBACKLOG
+	default y
+
+endif

--- a/testing/nettest/Make.defs
+++ b/testing/nettest/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/testing/nettest/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_TESTING_NET_TEST),)
+CONFIGURED_APPS += $(APPDIR)/testing/nettest
+endif

--- a/testing/nettest/Makefile
+++ b/testing/nettest/Makefile
@@ -1,0 +1,41 @@
+############################################################################
+# apps/testing/nettest/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PRIORITY  = $(CONFIG_TESTING_NET_TEST_PRIORITY)
+STACKSIZE = $(CONFIG_TESTING_NET_TEST_STACKSIZE)
+MODULE    = $(CONFIG_TESTING_NET_TEST)
+
+ifeq ($(CONFIG_TESTING_NET_TEST),y)
+
+ifeq ($(CONFIG_TESTING_NET_TCP),y)
+MAINSRC  += tcp/test_tcp.c
+PROGNAME += cmocka_net_tcp
+CSRCS    += tcp/test_tcp_common.c
+
+ifeq ($(CONFIG_NET_IPv4), y)
+CSRCS    += tcp/test_tcp_connect_ipv4.c
+endif
+
+endif
+
+endif
+include $(APPDIR)/Application.mk

--- a/testing/nettest/tcp/test_tcp.c
+++ b/testing/nettest/tcp/test_tcp.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/testing/nettest/tcp/test_tcp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "test_tcp.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  const struct CMUnitTest tcp_tests[] =
+    {
+#ifdef CONFIG_NET_IPv4
+      cmocka_unit_test_setup(test_tcp_connect_ipv4,
+                             test_tcp_connect_ipv4_setup),
+#endif
+    };
+
+  return cmocka_run_group_tests(tcp_tests, test_tcp_group_setup,
+                                test_tcp_group_teardown);
+}

--- a/testing/nettest/tcp/test_tcp.h
+++ b/testing/nettest/tcp/test_tcp.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * apps/testing/nettest/tcp/test_tcp.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_TESTING_NETTEST_TCP_TEST_TCP_H
+#define __APPS_TESTING_NETTEST_TCP_TEST_TCP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Name: test_tcp_group_setup
+ ****************************************************************************/
+
+int test_tcp_group_setup(FAR void **state);
+
+/****************************************************************************
+ * Name: test_tcp_group_teardown
+ ****************************************************************************/
+
+int test_tcp_group_teardown(FAR void **state);
+
+/****************************************************************************
+ * Name: test_tcp_connect_ipv4_setup
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+int test_tcp_connect_ipv4_setup(FAR void **state);
+
+/****************************************************************************
+ * Name: test_tcp_connect_ipv4
+ ****************************************************************************/
+
+void test_tcp_connect_ipv4(FAR void **state);
+#endif /* CONFIG_NET_IPv4 */
+#endif /* __APPS_TESTING_NETTEST_TCP_TEST_TCP_H */

--- a/testing/nettest/tcp/test_tcp_common.c
+++ b/testing/nettest/tcp/test_tcp_common.c
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * apps/testing/nettest/tcp/test_tcp_common.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "test_tcp.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_tcp_group_setup
+ ****************************************************************************/
+
+int test_tcp_group_setup(FAR void **state)
+{
+  return 0;
+}
+
+/****************************************************************************
+ * Name: test_tcp_group_teardown
+ ****************************************************************************/
+
+int test_tcp_group_teardown(FAR void **state)
+{
+  return 0;
+}

--- a/testing/nettest/tcp/test_tcp_connect_ipv4.c
+++ b/testing/nettest/tcp/test_tcp_connect_ipv4.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * apps/testing/nettest/tcp/test_tcp_connect_ipv4.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "test_tcp.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_tcp_connect_ipv4_setup
+ ****************************************************************************/
+
+int test_tcp_connect_ipv4_setup(FAR void **state)
+{
+  return 0;
+}
+
+/****************************************************************************
+ * Name: test_tcp_connect_ipv4
+ ****************************************************************************/
+
+void test_tcp_connect_ipv4(FAR void **state)
+{
+}


### PR DESCRIPTION
## Summary
Provides a network automated testing framework, including the main directory structure and Makefile, CMakeLists, Kconfig and other files such as tcp.

## Impact
N/A

## Testing
Local qemu environment verification
