### PR TITLE
apps/nshlib: Using `lib_get_tempbuffer()` to save stack space

### DIFF
--- a/examples/lp503x/lp503x_main.c
+++ b/examples/lp503x/lp503x_main.c
@@ -626,7 +626,7 @@ static int lp503x_cmd_help(FAR char *parg)
 int main(int argc, FAR char *argv[])
 {
   bool running;
-  char buffer[CONFIG_NSH_LINELEN];
+  char buffer[LINE_MAX];
   int len;
   int x;
   char *cmd;

--- a/netutils/rexec/rexec.c
+++ b/netutils/rexec/rexec.c
@@ -155,7 +155,7 @@ static int do_rexec(FAR struct rexec_arg_s *arg)
 
 int main(int argc, FAR char **argv)
 {
-  char cmd[CONFIG_NSH_LINELEN];
+  char cmd[LINE_MAX];
   struct rexec_arg_s arg;
   int option;
   int i;

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -379,12 +379,6 @@
 #  define NSH_HERRNO_OF(err) (err)
 #endif
 
-/* Maximum size of one command line (telnet or serial) */
-
-#ifndef CONFIG_NSH_LINELEN
-#  define CONFIG_NSH_LINELEN LINE_MAX
-#endif
-
 /* The maximum number of nested if-then[-else]-fi sequences that
  * are permissible.
  */

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -382,7 +382,7 @@
 /* Maximum size of one command line (telnet or serial) */
 
 #ifndef CONFIG_NSH_LINELEN
-#  define CONFIG_NSH_LINELEN 80
+#  define CONFIG_NSH_LINELEN LINE_MAX
 #endif
 
 /* The maximum number of nested if-then[-else]-fi sequences that

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -188,7 +188,7 @@ struct console_stdio_s
 
   /* Line input buffer */
 
-  char   cn_line[CONFIG_NSH_LINELEN];
+  char   cn_line[LINE_MAX];
 };
 
 /****************************************************************************

--- a/nshlib/nsh_login.c
+++ b/nshlib/nsh_login.c
@@ -173,7 +173,7 @@ int nsh_login(FAR struct console_stdio_s *pstate)
 
       /* readline() returns EOF on failure */
 
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      ret = readline_fd(pstate->cn_line, LINE_MAX,
                         INFD(pstate), OUTFD(pstate));
       if (ret != EOF)
         {
@@ -209,8 +209,7 @@ int nsh_login(FAR struct console_stdio_s *pstate)
         }
 
       password[0] = '\0';
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
-                        INFD(pstate), -1);
+      ret = readline_fd(pstate->cn_line, LINE_MAX, INFD(pstate), -1);
 
       /* Enable echo again after password */
 

--- a/nshlib/nsh_mmcmds.c
+++ b/nshlib/nsh_mmcmds.c
@@ -58,12 +58,12 @@ int cmd_free(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
 int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  char arg[CONFIG_NSH_LINELEN] = "";
+  char arg[LINE_MAX] = "";
   int i;
 
   if (argc == 1)
     {
-      strlcpy(arg, "used", CONFIG_NSH_LINELEN);
+      strlcpy(arg, "used", LINE_MAX);
     }
   else if (argc >= 2 && (strcmp(argv[1], "-h") == 0 ||
                          strcmp(argv[1], "help") == 0))
@@ -75,10 +75,10 @@ int cmd_memdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     {
       for (i = 1; i < argc; i++)
         {
-          strlcat(arg, argv[i], CONFIG_NSH_LINELEN);
+          strlcat(arg, argv[i], LINE_MAX);
           if (i < argc - 1)
             {
-              strlcat(arg, " ", CONFIG_NSH_LINELEN);
+              strlcat(arg, " ", LINE_MAX);
             }
         }
     }

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -607,7 +607,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
     {
       FAR char *sh_argv[4];
       FAR char *sh_cmd = "sh";
-      char sh_arg2[CONFIG_NSH_LINELEN];
+      char sh_arg2[LINE_MAX];
 
       DEBUGASSERT(strncmp(argv[0], sh_cmd, 3) != 0);
 
@@ -2462,7 +2462,7 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
 #endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
-  char      tracebuf[CONFIG_NSH_LINELEN + 1];
+  char      tracebuf[LINE_MAX + 1];
 
   strlcpy(tracebuf, cmdline, sizeof(tracebuf));
   sched_note_beginex(NOTE_TAG_APP, tracebuf);
@@ -2685,7 +2685,7 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
         {
           FAR char *arg;
           FAR char *sh_argv[4];
-          char sh_arg2[CONFIG_NSH_LINELEN];
+          char sh_arg2[LINE_MAX];
 
           if (argv[argc][g_pipeline1_len])
             {

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -163,7 +163,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
 
           /* Now read the next line from the script file */
 
-          ret = readline_fd(buffer, CONFIG_NSH_LINELEN, vtbl->np.np_fd, -1);
+          ret = readline_fd(buffer, LINE_MAX, vtbl->np.np_fd, -1);
           if (ret >= 0)
             {
               /* Parse process the command.  NOTE:  this is recursive...

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -209,7 +209,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
        * occurs. Either  will cause the session to terminate.
        */
 
-      ret = cle_fd(pstate->cn_line, nsh_prompt(), CONFIG_NSH_LINELEN,
+      ret = cle_fd(pstate->cn_line, nsh_prompt(), LINE_MAX,
                    INFD(pstate), OUTFD(pstate));
       if (ret < 0)
         {
@@ -227,7 +227,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
        * will cause the session to terminate.
        */
 
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      ret = readline_fd(pstate->cn_line, LINE_MAX,
                         INFD(pstate), OUTFD(pstate));
       if (ret == EOF)
         {

--- a/nshlib/nsh_telnetlogin.c
+++ b/nshlib/nsh_telnetlogin.c
@@ -178,7 +178,7 @@ int nsh_telnetlogin(FAR struct console_stdio_s *pstate)
       write(OUTFD(pstate), g_userprompt, strlen(g_userprompt));
 
       username[0] = '\0';
-      if (readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      if (readline_fd(pstate->cn_line, LINE_MAX,
                       INFD(pstate), OUTFD(pstate)) >= 0)
 
         {
@@ -214,7 +214,7 @@ int nsh_telnetlogin(FAR struct console_stdio_s *pstate)
         }
 
       password[0] = '\0';
-      ret = readline_fd(pstate->cn_line, CONFIG_NSH_LINELEN,
+      ret = readline_fd(pstate->cn_line, LINE_MAX,
                       INFD(pstate), OUTFD(pstate));
 
       /* Enable echo again after password */

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -552,7 +552,7 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifndef CONFIG_NSH_DISABLE_WATCH
 int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  char buffer[CONFIG_NSH_LINELEN];
+  char buffer[LINE_MAX];
   int interval = 2;
   int count = -1;
   FAR char *cmd;
@@ -595,7 +595,7 @@ int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   for (i = 0; i < count; i++)
     {
-      strlcpy(buffer, cmd, CONFIG_NSH_LINELEN);
+      strlcpy(buffer, cmd, LINE_MAX);
       ret = nsh_parse(vtbl, buffer);
       if (ret < 0)
         {

--- a/system/nxcamera/nxcamera_main.c
+++ b/system/nxcamera/nxcamera_main.c
@@ -398,7 +398,7 @@ static int nxcamera_cmd_help(FAR struct nxcamera_s *pcam, FAR char *parg)
 
 int main(int argc, FAR char *argv[])
 {
-  char                  buffer[CONFIG_NSH_LINELEN];
+  char                  buffer[LINE_MAX];
   int                   len;
   int                   x;
   bool                  running = true;

--- a/system/nxlooper/nxlooper_main.c
+++ b/system/nxlooper/nxlooper_main.c
@@ -502,7 +502,7 @@ static int nxlooper_cmd_help(FAR struct nxlooper_s *plooper, char *parg)
 
 int main(int argc, FAR char *argv[])
 {
-  char                  buffer[CONFIG_NSH_LINELEN];
+  char                  buffer[LINE_MAX];
   int                   len;
   int                   x;
   int                   running;

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -739,7 +739,7 @@ static int nxplayer_cmd_help(FAR struct nxplayer_s *pplayer, char *parg)
 
 int main(int argc, FAR char *argv[])
 {
-  char                    buffer[CONFIG_NSH_LINELEN];
+  char                    buffer[LINE_MAX];
   int                     len;
   int                     x;
   int                     running;

--- a/system/nxrecorder/nxrecorder_main.c
+++ b/system/nxrecorder/nxrecorder_main.c
@@ -531,7 +531,7 @@ static int nxrecorder_cmd_help(FAR struct nxrecorder_s *precorder,
 
 int main(int argc, FAR char *argv[])
 {
-  char                    buffer[CONFIG_NSH_LINELEN];
+  char                    buffer[LINE_MAX];
   int                     len;
   int                     x;
   int                     running;

--- a/system/readline/readline.c
+++ b/system/readline/readline.c
@@ -33,16 +33,6 @@
 #include "system/readline.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* Maximum size of one command line (telnet or serial) */
-
-#ifndef CONFIG_NSH_LINELEN
-#  define CONFIG_NSH_LINELEN 80
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -59,14 +49,14 @@
 
 FAR char *readline(FAR const char *prompt)
 {
-  FAR char *line = malloc(CONFIG_NSH_LINELEN);
+  FAR char *line = malloc(LINE_MAX);
 
   if (line != NULL)
     {
 #ifdef CONFIG_READLINE_TABCOMPLETION
       FAR const char *orig = readline_prompt(prompt);
 #endif
-      if (readline_fd(line, CONFIG_NSH_LINELEN,
+      if (readline_fd(line, LINE_MAX,
                       STDIN_FILENO, STDOUT_FILENO) == 0)
         {
           free(line);

--- a/system/taskset/taskset.c
+++ b/system/taskset/taskset.c
@@ -82,7 +82,7 @@ static bool get_cpuset(const char *arg, cpu_set_t *cpu_set)
 
 int main(int argc, FAR char *argv[])
 {
-  char command[CONFIG_NSH_LINELEN];
+  char command[LINE_MAX];
   int exitcode;
   int option;
   int pid = -1;
@@ -153,7 +153,7 @@ int main(int argc, FAR char *argv[])
             }
 
           /* Construct actual command with args
-           * NOTE: total length does not exceed CONFIG_NSH_LINELEN
+           * NOTE: total length does not exceed LINE_MAX
            */
 
           for (i = 0; i < argc - 2; i++)

--- a/system/trace/trace.c
+++ b/system/trace/trace.c
@@ -229,7 +229,7 @@ static int trace_cmd_dump(FAR const char *name, int index, int argc,
 static int trace_cmd_cmd(FAR const char *name, int index, int argc,
                          FAR char **argv, int notectlfd)
 {
-  char command[CONFIG_NSH_LINELEN];
+  char command[LINE_MAX];
   bool changed;
   bool cont = false;
 


### PR DESCRIPTION
## Summary
Using `lib_get_tempbuffer()` to save stack space
1. apps/nshlib: Using `lib_get_tempbuffer()` to save stack space
2. apps/**nshlib**: replace `CONFIG_NSH_LINELEN` to `LINE_MAX`
3. apps/**system**: replace `CONFIG_NSH_LINELEN` to `LINE_MAX` (Picked from https://github.com/apache/nuttx-apps/pull/2918 by @anchao )

## Impact
- apps/nshlib
- apps/system

## Testing
1. Selftest as commit message shown
    - Config: "esp32s3-devkit:adb" with `CONFIG_LINE_MAX=512`
    - Test CMD: `ls | cat | cat | cat`

    - Without this patch

      |                | Before Test CMD | After Test CMD  |
      |---------------:|----------------:|----------------:|
      | nsh_main.STACK | 0002624/0008096 | 0002624/0008096 |
      |       sh.STACK | 0003360/0004008 | 0003360/0004008 |
      |     Free/Total |   355288/403116 |   355288/403116 |

    - With this patch

      |                | Before Test CMD | After Test CMD  |
      |---------------:|----------------:|----------------:|
      | nsh_main.STACK | 0001616/0008096 | 0001616/0008096 |
      |       sh.STACK | 0002352/0004008 | 0002352/0004008 |
      |     Free/Total |   355288/403116 |   354760/403116 |
2. CI
