### PR TITLE
examples/rust: Rename hello_rust to rust/baremetal

### DIFF
--- a/examples/rust/baremetal/Kconfig
+++ b/examples/rust/baremetal/Kconfig
@@ -7,7 +7,8 @@ config EXAMPLES_HELLO_RUST
 	tristate "\"Hello, Rust!\" example"
 	default n
 	---help---
-		Enable the \"Hello, Rust!\" example
+		Enable the \"Hello, Rust!\" example to show how to build
+		and run a baremetal Rust application with rustc.
 
 if EXAMPLES_HELLO_RUST
 

--- a/examples/rust/baremetal/Make.defs
+++ b/examples/rust/baremetal/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/examples/hello_rust/Makefile
+# apps/examples/rust/baremetal/Make.defs
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,19 +20,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
-# Hello, Rust! built-in application info
-
-PROGNAME  = $(CONFIG_EXAMPLES_HELLO_RUST_PROGNAME)
-PRIORITY  = $(CONFIG_EXAMPLES_HELLO_RUST_PRIORITY)
-STACKSIZE = $(CONFIG_EXAMPLES_HELLO_RUST_STACKSIZE)
-MODULE    = $(CONFIG_EXAMPLES_HELLO_RUST)
-
-# Hello, Rust! Example
-
-MAINSRC = hello_rust_main.rs
-
-RUSTFLAGS += -C panic=abort -O
-
-include $(APPDIR)/Application.mk
+ifneq ($(CONFIG_EXAMPLES_HELLO_RUST),)
+CONFIGURED_APPS += $(APPDIR)/examples/rust/baremetal
+endif

--- a/examples/rust/baremetal/Makefile
+++ b/examples/rust/baremetal/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/examples/hello_rust/Make.defs
+# apps/examples/rust/baremetal/Makefile
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,6 +20,19 @@
 #
 ############################################################################
 
-ifneq ($(CONFIG_EXAMPLES_HELLO_RUST),)
-CONFIGURED_APPS += $(APPDIR)/examples/hello_rust
-endif
+include $(APPDIR)/Make.defs
+
+# Hello, Rust! built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_HELLO_RUST_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_HELLO_RUST_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_HELLO_RUST_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_HELLO_RUST)
+
+# Hello, Rust! Example
+
+MAINSRC = hello_rust_main.rs
+
+RUSTFLAGS += -C panic=abort -O
+
+include $(APPDIR)/Application.mk

--- a/examples/rust/baremetal/hello_rust_main.rs
+++ b/examples/rust/baremetal/hello_rust_main.rs
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/examples/hello_rust/hello_rust_main.rs
+ * apps/examples/rust/baremetal/hello_rust_main.rs
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
## Summary:
- Renamed hello_rust example to rust/baremetal to better reflect its purpose
- Updated file headers and Makefile paths
- Maintained all existing Kconfig options and functionality
- Prepares for future Rust development patterns where Cargo will be the mainstream approach, with baremetal demonstrating traditional build method
- Creates clearer structure for Rust examples as we expand Rust support

## Impact:
- No functional changes to the example itself
- Better organization of Rust examples under examples/rust/
- Existing configurations using this example will continue to work
- Build system will now look for the example in the new location

## Testing:
- Confirmed Kconfig options remain unchanged
- GitHub CI passed and local build tested


