### PR TITLE
apps/nshlib: Save result and return ERROR if `lib_get_tempbuffer()` fails

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -616,6 +616,7 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
         {
           nsh_error(vtbl, g_fmtcmdoutofmemory, sh_cmd);
           ret = -errno;
+          goto close_redir;
         }
 
       sh_arg2[0] = '\0';


### PR DESCRIPTION
## Summary
apps/nshlib: Save result and return ERROR if `lib_get_tempbuffer()` fails, missing goto ;-(

## Impact
apps/nshlib: background

## Testing
CI