### PR TITLE
Driver test issue fix

### DIFF
--- a/examples/camera/camera_main.c
+++ b/examples/camera/camera_main.c
@@ -680,7 +680,7 @@ int main(int argc, FAR char *argv[])
               {
                 gettimeofday(&now, NULL);
                 timersub(&now, &start, &delta);
-                if (timercmp(&delta, &wait, >))
+                if (timercmp(&delta, &wait, > /* For checkpatch */))
                   {
                     printf("Expire time is pasted. GoTo next state.\n");
                     if (app_state == APP_STATE_BEFORE_CAPTURE)

--- a/testing/drivertest/drivertest_audio.c
+++ b/testing/drivertest/drivertest_audio.c
@@ -481,7 +481,7 @@ static bool audio_test_timeout(FAR struct audio_state_s *state,
 
   gettimeofday(&now, NULL);
   timersub(&now, &start, &delta);
-  return timercmp(&delta, &wait, >);
+  return timercmp(&delta, &wait, > /* For checkpatch */);
 }
 
 static int audio_test_stop(FAR struct audio_state_s *state, int direction)
@@ -741,8 +741,8 @@ static int audio_test_setup(FAR void **audio_state)
   attr.mq_curmsgs = 0;
   attr.mq_flags   = 0;
 
-  snprintf(state->mqname, sizeof(state->mqname), "/tmp/%0lx",
-           (unsigned long)((uintptr_t)state));
+  snprintf(state->mqname, sizeof(state->mqname), "/tmp/%p",
+           ((void *)state));
 
   state->mq = mq_open(state->mqname, O_RDWR | O_CREAT, 0644, &attr);
   assert_false(state->mq < 0);

--- a/testing/drivertest/drivertest_framebuffer.c
+++ b/testing/drivertest/drivertest_framebuffer.c
@@ -532,7 +532,6 @@ int main(int argc, FAR char *argv[])
   /* Initialize the state data */
 
   struct fb_state_s fb_state;
-  char test_filter[64];
 
   memset(&fb_state, 0, sizeof(struct fb_state_s));
   snprintf(fb_state.devpath, sizeof(fb_state.devpath), "%s",
@@ -551,10 +550,6 @@ int main(int argc, FAR char *argv[])
     cmocka_unit_test_prestate_setup_teardown(test_case_fb_3, fb_setup,
                                              fb_teardown, &fb_state),
   };
-
-  snprintf(test_filter, sizeof(test_filter), "test_case_fb_%d",
-           fb_state.test_case_id);
-  cmocka_set_test_filter(test_filter);
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/testing/drivertest/drivertest_lcd.c
+++ b/testing/drivertest/drivertest_lcd.c
@@ -418,7 +418,6 @@ int main(int argc, FAR char *argv[])
   /* Initialize the state data */
 
   struct lcd_state_s lcd_state;
-  char test_filter[64];
 
   memset(&lcd_state, 0, sizeof(struct lcd_state_s));
   snprintf(lcd_state.devpath, sizeof(lcd_state.devpath), "%s",
@@ -437,10 +436,6 @@ int main(int argc, FAR char *argv[])
     cmocka_unit_test_prestate_setup_teardown(test_case_lcd_3, lcd_setup,
                                                lcd_teardown, &lcd_state),
   };
-
-  snprintf(test_filter, sizeof(test_filter), "test_case_lcd_%d",
-                                         lcd_state.test_case_id);
-  cmocka_set_test_filter(test_filter);
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Summary
1.Fixed skipped logic errors
2.Fix the GPIO test sim error
## Impact
driver test
## Testing
./tools/configure.sh -l sim:citest
make -j20

nsh> cmocka_driver_gpio
[==========] tests: Running 1 test(s).
[ RUN      ] drivertest_gpio
[input and output test]  outvalue is 1, invalue is 1
[input and output test]  outvalue is 0, invalue is 0
[input and output test]  outvalue is 0, invalue is 0
[input and output test]  outvalue is 0, invalue is 0
[input and output test]  outvalue is 1, invalue is 1
[input and output test]  outvalue is 0, invalue is 0
[input and output test]  outvalue is 0, invalue is 0
[input and output test]  outvalue is 0, invalue is 0
[input and output test]  outvalue is 1, invalue is 1
[input and output test]  outvalue is 1, invalue is 1
[       OK ] drivertest_gpio
[==========] tests: 1 test(s) run.
[  PASSED  ] 1 test(s).


