### PR TITLE
wamr: Map armv7a/thumbv7a to armv7/thumbv7 for wamrc

### DIFF
--- a/interpreters/wamr/Toolchain.defs
+++ b/interpreters/wamr/Toolchain.defs
@@ -39,12 +39,16 @@ else ifeq ($(CONFIG_ARCH_SIM),y)
   else
     WTARGET = x86_64
   endif
+else ifeq ($(LLVM_ARCHTYPE),thumbv7a)
+  WTARGET = thumbv7
 else ifeq ($(findstring thumb,$(LLVM_ARCHTYPE)),thumb)
 
   # target triple of thumb may very complex, such as thumbv8m.main+dsp+mve.fp+fp.dp
   # so we just use the target name before the first plus sign
 
   WTARGET = $(shell echo $(LLVM_ARCHTYPE) | cut -d'+' -f1)
+else ifeq ($(LLVM_ARCHTYPE),armv7a)
+  WTARGET = armv7
 endif
 
 # If WTARGET is not defined, then use the same as LLVM_ARCHTYPE


### PR DESCRIPTION

## Summary
- Added explicit mapping of thumbv7a architecture to thumbv7 in the WAMR toolchain definitions
- WAMR's AOT compiler uses armv7/thumbv7 as the target architecture for all ARMv7-A processors
- This includes Cortex-A series processors like Cortex-A9 which use the armv7a/thumbv7a ISA

## Impact
- Fixes AOT compilation for ARM Cortex-A processors using thumbv7a architecture
- Maintains compatibility with WAMR's expected target architecture naming
- Ensures consistent architecture targeting across all ARMv7-A processors
- No impact on other architectures or build configurations

## Testing
GitHub CI and internal CI
