### PR TITLE
tools/Rust: Add support for panic_immediate_abort

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -122,8 +122,10 @@ function(nuttx_add_rust)
   # Determine build profile based on CONFIG_DEBUG_FULLOPT
   if(CONFIG_DEBUG_FULLOPT)
     set(RUST_PROFILE "release")
+    set(RUST_DEBUG_FLAGS "-Zbuild-std-features=panic_immediate_abort")
   else()
     set(RUST_PROFILE "debug")
+    set(RUST_DEBUG_FLAGS "")
   endif()
 
   # Get the Rust target triple
@@ -142,9 +144,9 @@ function(nuttx_add_rust)
   add_custom_command(
     OUTPUT ${RUST_LIB_PATH}
     COMMAND
-      cargo build --${RUST_PROFILE} -Zbuild-std=std,panic_abort --manifest-path
-      ${CRATE_PATH}/Cargo.toml --target ${RUST_TARGET} --target-dir
-      ${RUST_BUILD_DIR}
+      cargo build --${RUST_PROFILE} -Zbuild-std=std,panic_abort
+      ${RUST_DEBUG_FLAGS} --manifest-path ${CRATE_PATH}/Cargo.toml --target
+      ${RUST_TARGET} --target-dir ${RUST_BUILD_DIR}
     COMMENT "Building Rust crate ${CRATE_NAME}"
     VERBATIM)
 

--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -82,6 +82,7 @@ endef
 ifeq ($(CONFIG_DEBUG_FULLOPT),y)
 define RUST_CARGO_BUILD
 	cargo build --release -Zbuild-std=std,panic_abort \
+    -Zbuild-std-features=panic_immediate_abort \
 		--manifest-path $(2)/$(1)/Cargo.toml \
 		--target $(call RUST_TARGET_TRIPLE)
 endef


### PR DESCRIPTION
## Summary
- Added support for `panic_immediate_abort` in Rust builds, which causes the system to abort immediately on panic instead of unwinding the stack
- Enabled `-Zbuild-std-features=panic_immediate_abort` flag for release builds when `CONFIG_DEBUG_FULLOPT` is set
- Updated both CMake and Makefile build systems to include the new flag

## Impact
- Significantly reduces binary size (e.g., from 2270605 to 84987 bytes for riscv64imc)
- Changes panic behavior to immediate abort, which may be preferred for embedded systems
- Improves system reliability by preventing undefined behavior from stack unwinding in constrained environments
- Maintains compatibility with existing Rust code while providing a more deterministic panic handling mechanism

## Testing

For example, if it is enabled, the system will panic immediately:
```
NuttShell (NSH) NuttX-12.8.0
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}
riscv_exception: EXCEPTION: Illegal instruction. MCAUSE: 0000000000000002, EPC: 0000000080027df6, MTVAL: 0000000000000000
riscv_exception: PANIC!!! Exception = 0000000000000002
dump_assert_info: Current Version: NuttX  12.8.0 8e3621e059 Jan 20 2025 14:45:00 risc-v
dump_assert_info: Assertion failed panic: at file: :0 task: hello_rust_cargo process: hello_rust_cargo 0x80020588
/* Stack dump from NuttX */
```
vs the default behavior:
```
NuttShell (NSH) NuttX-12.8.0
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}

thread '<unnamed>' panicked at /home/huang/Work/rust/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/src/rust/library/std/src/sys/random/unix_legacy.rs:19:10:
failed to generate random data: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
nsh>
```



