### PR TITLE
gdbstub: add const to send buffer

### DIFF
--- a/system/gdbstub/gdbstub.c
+++ b/system/gdbstub/gdbstub.c
@@ -70,15 +70,14 @@ static int gdb_monitor(FAR struct gdb_state_s *state, FAR const char *cmd)
 #endif
 }
 
-static ssize_t gdb_send(FAR void *priv, FAR void *buf,
-                        size_t len)
+static ssize_t gdb_send(FAR void *priv, FAR const char *buf, size_t len)
 {
   int fd = *(FAR int *)priv;
   size_t i = 0;
 
   while (i < len)
     {
-      ssize_t ret = write(fd, (FAR char *)buf + i, len - i);
+      ssize_t ret = write(fd, buf + i, len - i);
       if (ret < 0)
         {
           return -errno;


### PR DESCRIPTION
## Summary

Add const for send buffer.

## Impact

Minor, should have no impact on existing projects.

## Testing

CI build pass.

