### PR TITLE
examples/i2schar: Make tx/rx count value generic on transmit/recieve …

### DIFF
--- a/examples/i2schar/i2schar_receiver.c
+++ b/examples/i2schar/i2schar_receiver.c
@@ -99,7 +99,7 @@ pthread_addr_t i2schar_receiver(pthread_addr_t arg)
 
   /* Loop for the requested number of times */
 
-  for (i = 0; i < CONFIG_EXAMPLES_I2SCHAR_TXBUFFERS; i++)
+  for (i = 0; i < g_i2schar.rxcount; i++)
     {
       /* Allocate an audio buffer of the configured size */
 

--- a/examples/i2schar/i2schar_transmitter.c
+++ b/examples/i2schar/i2schar_transmitter.c
@@ -102,7 +102,7 @@ pthread_addr_t i2schar_transmitter(pthread_addr_t arg)
 
   /* Loop for the requested number of times */
 
-  for (i = 0, crap = 0; i < CONFIG_EXAMPLES_I2SCHAR_TXBUFFERS; i++)
+  for (i = 0, crap = 0; i < g_i2schar.txcount; i++)
     {
       /* Allocate an audio buffer of the configured size */
 


### PR DESCRIPTION
## Summary
i2char example does not got effected from `-r/-t` (rx count/tx count) parameters.

* examples/i2schar: Make tx/rx count value generic on transmit/recieve operations

## Impact

i2char example

## Testing

