### PR TITLE
system/cu: remove canonical input mode from termios flag

### DIFF
--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -2,7 +2,8 @@
  * apps/system/cu/cu_main.c
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2014 sysmocom - s.f.m.c. GmbH. All rights reserved.
+ * SPDX-FileCopyrightText:
+ *  2014 sysmocom - s.f.m.c. GmbH. All rights reserved.
  * SPDX-FileContributor: Harald Welte <hwelte@sysmocom.de>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -194,7 +194,7 @@ static int set_termios(FAR struct cu_globals_s *cu, int nocrlf)
 
       tio.c_iflag = 0;
       tio.c_oflag = 0;
-      tio.c_lflag &= ~ECHO;
+      tio.c_lflag &= ~(ECHO | ICANON);
 
       ret = tcsetattr(cu->stdfd, TCSANOW, &tio);
       if (ret)


### PR DESCRIPTION
## Summary

* `system/cu`: remove canonical input mode from termios flag.
* `ASCII_DEL` stopped working after below change:
https://github.com/apache/nuttx/pull/14037

```
| commit df5c876932c4c82e8aee32adca651bb99d9d6200
| Author: zhangwenjian <zhangwenjian@xiaomi.com>
| Date:   Thu May 23 13:13:48 2024 +0800
|
|     libc:getline support backspace
|
|     Signed-off-by: zhangwenjian <zhangwenjian@xiaomi.com>
```

* Remove canonical input mode in order to again bring back support backspace in `cu`.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

CU: Backspace works again on cu / nsh console.

## Testing

sim/rpproxy   sim/rpserver  cu and check the backspace whether works as expected.