### PR TITLE
Allow GPS serial port to be specified as argument to `gps` example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ build
 .ccls-cache
 compile_commands.json
 .aider*
+.clang-format

--- a/examples/gps/Kconfig
+++ b/examples/gps/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_GPS
 	tristate "GPS example"
 	default n
-	select GPSUTILS_MINMEA_LIB
+	depends on GNSSUTILS_MINMEA_LIB
 	---help---
 		Enable the gps test example
 

--- a/examples/gps/gps_main.c
+++ b/examples/gps/gps_main.c
@@ -54,13 +54,22 @@ int main(int argc, FAR char *argv[])
   int cnt;
   char ch;
   char line[MINMEA_MAX_LENGTH];
+  char *port = "/dev/ttyS1";
+
+  /* Get the GPS serial port argument. If none specified, default to ttyS1 */
+
+  if (argc > 1)
+    {
+      port = argv[1];
+    }
 
   /* Open the GPS serial port */
 
-  fd = open("/dev/ttyS1", O_RDONLY);
+  fd = open(port, O_RDONLY);
   if (fd < 0)
     {
-      printf("Unable to open file /dev/ttyS1\n");
+      fprintf(stderr, "Unable to open file %s\n", port);
+      return 1;
     }
 
   /* Run forever */


### PR DESCRIPTION
## Summary

This PR adds the ability to specify the GPS's serial port in the `gps` example, instead of only being able to use `/dev/ttyS1`. It also marks the MINMEA library as a dependency for the `gps` example.

## Impact

Now that MINMEA is marked as a dependency, the `gps` example is unfortunately not visible in the list of applications until MINMEA is available. However, I wanted to avoid the use of `select` in Kconfig since it will not recursively enable dependencies.

The user is now also able to run the `gps` example with a serial port for the GPS specified, supporting this example on boards where the serial port is different. I have left `/dev/ttyS1` as the default when no port is specified to keep backward compatibility.

Closes #2966.

## Testing

Tested this example with a board that has GPS on `/dev/ttyS0` and it worked as expected. I also tried specifying a bad path and the program exited gracefully with the error.

```console
NuttShell (NSH) NuttX-12.8.0
nsh> gps /dev/ttyS0
Fix quality....................: 0
Altitude.......................: 0
Tracked satellites.............: 0
Fixed-point Latitude...........: 0
Fixed-point Longitude..........: 0
Fixed-point Speed..............: 0
Floating point degree latitude.: *float*
Floating point degree longitude: *float*
Floating point speed...........: *float*
```

```console
NuttShell (NSH) NuttX-12.8.0
nsh> gps /dev/ttyS2
Unable to open file /dev/ttyS2
```