### PR TITLE
examples/module: allow module on hostfs

### DIFF
--- a/examples/module/main/Kconfig
+++ b/examples/module/main/Kconfig
@@ -115,6 +115,14 @@ config EXAMPLES_MODULE_BINDIR
 		The full, absolute path to the location for the binaries can be
 		located in a pre-mounted external file system.
 
+config EXAMPLES_MODULE_FSDATA
+	string "Additional data passed to mount"
+	default ""
+	depends on EXAMPLES_MODULE_FSMOUNT
+	---help---
+		Additional data needed by mount. For example, when hostfs
+		is used, this can be "fs=../apps/bin"
+
 config EXAMPLES_MODULE_LIBC
 	bool "Link with LIBC"
 	default n

--- a/examples/module/main/module_main.c
+++ b/examples/module/main/module_main.c
@@ -253,7 +253,8 @@ int main(int argc, FAR char *argv[])
          CONFIG_EXAMPLES_MODULE_FSTYPE, MOUNTPT);
 
   ret = mount(CONFIG_EXAMPLES_MODULE_DEVPATH, MOUNTPT,
-              CONFIG_EXAMPLES_MODULE_FSTYPE, MS_RDONLY, NULL);
+              CONFIG_EXAMPLES_MODULE_FSTYPE, MS_RDONLY,
+              CONFIG_EXAMPLES_MODULE_FSDATA);
   if (ret < 0)
     {
       printf("ERROR: mount(%s, %s, %s) failed: %d\n",


### PR DESCRIPTION
## Summary

This allows loading kernel modules from hostfs file system.

## Impact

None

## Testing

- local checks with FLAT mode NuttX on qemu-armv7a
- CI checks
