### PR TITLE
apps/testing: Move sd_bench to apps/bechmarks

### DIFF
--- a/benchmarks/sd_bench/Kconfig
+++ b/benchmarks/sd_bench/Kconfig
@@ -3,31 +3,31 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config TESTING_SD_BENCH
+config BENCHMARK_SD_BENCH
 	tristate "SD benchmark program"
 	depends on ALLOW_BSD_COMPONENTS
 	default n
 	---help---
 		SD benchmark application based on https://github.com/PX4/PX4-Autopilot/blob/main/src/systemcmds/sd_bench/sd_bench.cpp
 
-if TESTING_SD_BENCH
+if BENCHMARK_SD_BENCH
 
-config TESTING_SD_BENCH_PROGNAME
+config BENCHMARK_SD_BENCH_PROGNAME
 	string "Program name"
 	default "sdbench"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.
 
-config TESTING_SD_BENCH_PRIORITY
+config BENCHMARK_SD_BENCH_PRIORITY
 	int "SD bench task priority"
 	default 100
 
-config TESTING_SD_BENCH_STACKSIZE
+config BENCHMARK_SD_BENCH_STACKSIZE
 	int "SD bench stack size"
 	default DEFAULT_TASK_STACKSIZE
 
-config TESTING_SD_BENCH_DEVICE
+config BENCHMARK_SD_BENCH_DEVICE
 	string "SD / MMC mount point"
 	default "/mnt"
 

--- a/benchmarks/sd_bench/Make.defs
+++ b/benchmarks/sd_bench/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/testing/sd_bench/Makefile
+# apps/benchmarks/sd_bench/Make.defs
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,13 +20,6 @@
 #
 ############################################################################
 
-include $(APPDIR)/Make.defs
-
-PROGNAME  = $(CONFIG_TESTING_SD_BENCH_PROGNAME)
-PRIORITY  = $(CONFIG_TESTING_SD_BENCH_PRIORITY)
-STACKSIZE = $(CONFIG_TESTING_SD_BENCH_STACKSIZE)
-MODULE    = $(CONFIG_TESTING_SD_BENCH)
-
-MAINSRC = sd_bench_main.c
-
-include $(APPDIR)/Application.mk
+ifneq ($(CONFIG_BENCHMARK_SD_BENCH),)
+CONFIGURED_APPS += $(APPDIR)/benchmarks/sd_bench
+endif

--- a/benchmarks/sd_bench/Makefile
+++ b/benchmarks/sd_bench/Makefile
@@ -1,5 +1,5 @@
 ############################################################################
-# apps/testing/sd_bench/Make.defs
+# apps/benchmarks/sd_bench/Makefile
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,6 +20,13 @@
 #
 ############################################################################
 
-ifneq ($(CONFIG_TESTING_SD_BENCH),)
-CONFIGURED_APPS += $(APPDIR)/testing/sd_bench
-endif
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_BENCHMARK_SD_BENCH_PROGNAME)
+PRIORITY  = $(CONFIG_BENCHMARK_SD_BENCH_PRIORITY)
+STACKSIZE = $(CONFIG_BENCHMARK_SD_BENCH_STACKSIZE)
+MODULE    = $(CONFIG_BENCHMARK_SD_BENCH)
+
+MAINSRC = sd_bench_main.c
+
+include $(APPDIR)/Application.mk

--- a/benchmarks/sd_bench/sd_bench_main.c
+++ b/benchmarks/sd_bench/sd_bench_main.c
@@ -1,8 +1,9 @@
 /****************************************************************************
- * apps/testing/sd_bench/sd_bench_main.c
+ * apps/benchmarks/sd_bench/sd_bench_main.c
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2016-2021 PX4 Development Team. All rights reserved.
+ * SPDX-FileCopyrightText: 2016-2021 PX4 Development Team.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +78,7 @@ typedef struct sdb_config
  ****************************************************************************/
 
 static const char *BENCHMARK_FILE =
-    CONFIG_TESTING_SD_BENCH_DEVICE "/sd_bench";
+    CONFIG_BENCHMARK_SD_BENCH_DEVICE "/sd_bench";
 
 static const size_t max_block = 65536;
 static const size_t min_block = 1;
@@ -350,7 +351,7 @@ static int read_test(int fd, sdb_config_t *cfg, uint8_t *block,
 static void usage(void)
 {
   printf("Test the speed of an SD card or mount point\n");
-  printf(CONFIG_TESTING_SD_BENCH_PROGNAME
+  printf(CONFIG_BENCHMARK_SD_BENCH_PROGNAME
          ": [-b] [-r] [-d] [-k] [-s] [-a] [-v]\n");
   printf("  -b   Block size per write (%zu-%zu), default %zu\n",
          min_block, max_block, default_block);


### PR DESCRIPTION
## Summary

Benchmark utils relocation from `apps/testing` to `apps/benchmarks` as discussed in https://github.com/apache/nuttx-apps/pull/2931 and https://github.com/apache/nuttx-apps/pull/2961.

## Impact

Benchmarks relocation (`apps/testing -> apps/benchmarks`).

## Testing

pass ci