### PR TITLE
ostest: fix cmake build break

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -85,6 +85,10 @@ if(CONFIG_TESTING_OSTEST)
       list(APPEND SRCS specific.c)
     endif()
 
+    if(CONFIG_SCHED_THREAD_LOCAL)
+      list(APPEND SRCS sched_thread_local.c)
+    endif()
+
     if(NOT CONFIG_TLS_NCLEANUP EQUAL 0)
       list(APPEND SRCS pthread_cleanup.c)
     endif()


### PR DESCRIPTION


## Summary

Fix build break using cmake.

```
/nuttx/apps/testing/ostest/ostest_main.c:322:(.text.user_main+0x3c3): undefined reference to `sched_thread_local_test'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

## Impact

cmake works now.

## Testing

```
cmake -Bbuild -GNinja -DBOARD_CONFIG=qemu-intel64:nsh nuttx
ninja -C build
```
