### PR TITLE
tools/Rust: Add support for x86 platform

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -33,6 +33,8 @@ include(nuttx_parse_function_args)
 #   - thumbv8m.base: thumbv8m.base-nuttx-eabi, thumbv8m.base-nuttx-eabihf
 #   - riscv32: riscv32imc/imac/imafc-unknown-nuttx-elf
 #   - riscv64: riscv64imac/imafdc-unknown-nuttx-elf
+#   - x86: i686-unknown-nuttx
+#   - x86_64: x86_64-unknown-nuttx
 #
 # Inputs:
 #   ARCHTYPE - Architecture type (e.g. thumbv7m, riscv32)
@@ -45,7 +47,11 @@ include(nuttx_parse_function_args)
 # ~~~
 
 function(nuttx_rust_target_triple ARCHTYPE ABITYPE CPUTYPE OUTPUT)
-  if(ARCHTYPE MATCHES "thumb")
+  if(ARCHTYPE STREQUAL "x86_64")
+    set(TARGET_TRIPLE "x86_64-unknown-nuttx")
+  elseif(ARCHTYPE STREQUAL "x86")
+    set(TARGET_TRIPLE "i686-unknown-nuttx")
+  elseif(ARCHTYPE MATCHES "thumb")
     if(ARCHTYPE MATCHES "thumbv8m")
       # Extract just the base architecture type (thumbv8m.main or thumbv8m.base)
       if(ARCHTYPE MATCHES "thumbv8m.main")

--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -26,6 +26,8 @@
 #   - LLVM_CPUTYPE: CPU type (e.g. cortex-m23, sifive-e20)
 #
 # Supported architectures and their target triples:
+#   - x86: i686-unknown-nuttx
+#   - x86_64: x86_64-unknown-nuttx
 #   - armv7a: armv7a-nuttx-eabi, armv7a-nuttx-eabihf
 #   - thumbv6m: thumbv6m-nuttx-eabi
 #   - thumbv7a: thumbv7a-nuttx-eabi, thumbv7a-nuttx-eabihf
@@ -44,6 +46,12 @@
 
 define RUST_TARGET_TRIPLE
 $(or \
+  $(and $(filter x86_64,$(LLVM_ARCHTYPE)), \
+    x86_64-unknown-nuttx \
+  ), \
+  $(and $(filter x86,$(LLVM_ARCHTYPE)), \
+    i686-unknown-nuttx \
+  ), \
   $(and $(filter thumb%,$(LLVM_ARCHTYPE)), \
     $(if $(filter thumbv8m%,$(LLVM_ARCHTYPE)), \
       $(if $(filter cortex-m23,$(LLVM_CPUTYPE)),thumbv8m.base,thumbv8m.main)-nuttx-$(LLVM_ABITYPE), \


### PR DESCRIPTION
## Summary
- Added support for x86 and x86_64 architectures in the Rust build system
- Updated `nuttx_rust_target_triple` function in `cmake/nuttx_add_rust.cmake` to handle x86 and x86_64 target triples
- Updated `RUST_TARGET_TRIPLE` macro in `tools/Rust.mk` to include x86 and x86_64 target triples

## Impact
- Enables Rust crate compilation for x86 and x86_64 platforms
- No functional changes for existing architectures (ARM, RISC-V, etc.)
- Improves platform compatibility and expands Rust support in NuttX
## Testing

GitHub CI and local build with rust on sim32/sim64

Refer to https://github.com/rust-lang/rust/pull/136181

