### PR TITLE
examples/amg88xx: fix kconfig

### DIFF
--- a/examples/amg88xx/Kconfig
+++ b/examples/amg88xx/Kconfig
@@ -1,6 +1,7 @@
 config EXAMPLES_AMG88XX
 	tristate "AMG88xx sensor example"
 	default n
+	depends on SENSORS_AMG88XX
 	---help---
 		Enable the AMG88xx sensor example
 
@@ -17,7 +18,7 @@ config EXAMPLES_AMG88XX_PRIORITY
 	int "AMG88xx task priority"
 	default 100
 
-config EXAMPLES_DHTXX_STACKSIZE
+config EXAMPLES_AMG88XX_STACKSIZE
 	int "AMG88xx stack size"
 	default DEFAULT_TASK_STACKSIZE
 


### PR DESCRIPTION
## Summary
Small fix for my previous sloppy work on amg88xx example.
I forgot to add correct dependency for kconfig options.
Also, I've followed DTH driver as example, you can see that in the kconfig stack size option :D

## Impact
In non-interactive build, some defines previously polluted the header file with no impact on build. Now is fixed.
In interactive build (running make menuconfig ~or equivalent~) the amg88xx example was visible without enabling the needed driver

## Testing
Manually.
Checked that the define is no longer included in the output header.
Check that the amg88xx example is not longer present in the menuconfig if the amg88xx driver is disabled.
