### PR TITLE
testing/libc/wcstombs: Add testing application for wcstombs

### DIFF
--- a/testing/libc/wcstombs/CMakeLists.txt
+++ b/testing/libc/wcstombs/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/testing/libc/wcstombs/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_WCSTOMBS)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_TESTING_WCSTOMBS_PROGNAME}
+    PRIORITY
+    ${CONFIG_TESTING_WCSTOMBS_PRIORITY}
+    STACKSIZE
+    ${CONFIG_TESTING_WCSTOMBS_STACKSIZE}
+    MODULE
+    ${CONFIG_TESTING_WCSTOMBS}
+    SRCS
+    wcstombs_main.c)
+endif()

--- a/testing/libc/wcstombs/Kconfig
+++ b/testing/libc/wcstombs/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config TESTING_WCSTOMBS
+	tristate "wcstombs() test"
+	default n
+	depends on LIBC_LOCALE
+	---help---
+		Enable wcstombs() test
+
+if TESTING_WCSTOMBS
+
+config TESTING_WCSTOMBS_PROGNAME
+	string "Program name"
+	default "wcstombs"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config TESTING_WCSTOMBS_PRIORITY
+	int "wcstombs task priority"
+	default 100
+
+config TESTING_WCSTOMBS_STACKSIZE
+	int "wcstombs stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/testing/libc/wcstombs/Make.defs
+++ b/testing/libc/wcstombs/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/testing/libc/wcstombs/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_TESTING_WCSTOMBS),)
+CONFIGURED_APPS += $(APPDIR)/testing/libc/wcstombs
+endif

--- a/testing/libc/wcstombs/Makefile
+++ b/testing/libc/wcstombs/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/testing/libc/wcstombs/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# wcstombs() test built-in application info
+
+PROGNAME  = $(CONFIG_TESTING_WCSTOMBS_PROGNAME)
+PRIORITY  = $(CONFIG_TESTING_WCSTOMBS_PRIORITY)
+STACKSIZE = $(CONFIG_TESTING_WCSTOMBS_STACKSIZE)
+MODULE    = $(CONFIG_TESTING_WCSTOMBS)
+
+# wcstombs test files
+
+MAINSRC = wcstombs_main.c
+
+include $(APPDIR)/Application.mk

--- a/testing/libc/wcstombs/wcstombs_main.c
+++ b/testing/libc/wcstombs/wcstombs_main.c
@@ -1,0 +1,224 @@
+/****************************************************************************
+ * apps/testing/libc/wcstombs/wcstombs_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <wchar.h>
+#include <locale.h>
+#include <stdint.h>
+#include <string.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(void)
+{
+  /* Local variable declarations */
+
+  const wchar_t *src;
+  size_t dst_size;
+  char *dst;
+  size_t ret;
+  size_t i;
+
+  printf("wcstombs Test application:\n");
+
+  /* Set the locale to the user's default locale */
+
+  setlocale(LC_ALL, "");
+
+  /* Example wide character array (source) */
+
+  src = L"Hello, world!";
+
+  /* Calculate the required size for the dst buffer */
+
+  dst_size = wcstombs(NULL, src, 0) + 1; /* +1 for the null terminator */
+  dst = (char *)malloc(dst_size);
+
+  if (dst == NULL)
+    {
+      printf("ERROR: malloc failed.\n");
+      return EXIT_FAILURE;
+    }
+
+  printf("\nTest Scenario: len is bigger than the size of the converted "
+         "string. Expected the null-terminator at the end of the converted "
+         "string.\n");
+
+  /* Initialize dst with a known value (0xaa) */
+
+  memset(dst, 0xaa, dst_size);
+
+  /* Convert wide characters to multibyte characters */
+
+  ret = wcstombs(dst, src, dst_size);
+
+  /* Check if the conversion was successful */
+
+  if (ret == (size_t)-1)
+    {
+      printf("ERROR: wcstombs failed.\n");
+      free(dst);
+      return EXIT_FAILURE;
+    }
+
+  /* Print the return code */
+
+  printf("Return code: %zu\n", ret);
+
+  /* Print the dst buffer as an array of uint8_t elements */
+
+  printf("dst buffer (as uint8_t array): ");
+  for (i = 0; i < dst_size; i++) /* Include the null terminator in the output */
+    {
+      printf("%02x ", (uint8_t)dst[i]);
+    }
+
+  printf("\n");
+
+  /* Check if the dst value just after the return value is as expected */
+
+  if (dst[ret] == '\0')
+    {
+      printf("The character just after the return value is the null "
+             "terminating character.\n");
+    }
+  else
+    {
+      printf("The character just after the return value is not the expected "
+             "null-terminator (value: %02x). This is a bug!\n", dst[ret]);
+      free(dst);
+      return EXIT_FAILURE;
+    }
+
+  printf("\nTest Scenario: len is exactly the size of the converted string. "
+         "Do not expected the null-terminator at the end of the converted "
+         "string.\n");
+
+  /* Initialize dst with a known value (0xaa) */
+
+  memset(dst, 0xaa, dst_size);
+
+  /* Convert wide characters to multibyte characters */
+
+  ret = wcstombs(dst, src, dst_size - 1);
+
+  /* Check if the conversion was successful */
+
+  if (ret == (size_t)-1)
+    {
+      printf("ERROR: wcstombs failed.\n");
+      free(dst);
+      return EXIT_FAILURE;
+    }
+
+  /* Print the return code */
+
+  printf("Return code: %zu\n", ret);
+
+  /* Print the dst buffer as an array of uint8_t elements */
+
+  printf("dst buffer (as uint8_t array): ");
+  for (i = 0; i < dst_size; i++) /* Include the null terminator in the output */
+    {
+      printf("%02x ", (uint8_t)dst[i]);
+    }
+
+  printf("\n");
+
+  /* Check if the dst value just after the return value is as expected */
+
+  if ((uint8_t)dst[ret] == 0xaa)
+    {
+      printf("The character just after the return value is the expected "
+             "0xaa value. No null-terminator.\n");
+    }
+  else
+    {
+      printf("The character just after the return value is not the expected "
+             "0xaa (value: %02x). This is a bug!\n", dst[ret]);
+      free(dst);
+      return EXIT_FAILURE;
+    }
+
+  printf("\nTest Scenario: len is smaller than the size of the converted "
+         " string. Do not expected the null-terminator at the end of the "
+         "converted string.\n");
+
+  /* Initialize dst with a known value (0xaa) */
+
+  memset(dst, 0xaa, dst_size);
+
+  /* Convert wide characters to multibyte characters */
+
+  ret = wcstombs(dst, src, dst_size - 2);
+
+  /* Check if the conversion was successful */
+
+  if (ret == (size_t)-1)
+    {
+      printf("ERROR: wcstombs failed.\n");
+      free(dst);
+      return EXIT_FAILURE;
+    }
+
+  /* Print the return code */
+
+  printf("Return code: %zu\n", ret);
+
+  /* Print the dst buffer as an array of uint8_t elements */
+
+  printf("dst buffer (as uint8_t array): ");
+  for (i = 0; i < dst_size; i++) /* Include the null terminator in the output */
+    {
+      printf("%02x ", (uint8_t)dst[i]);
+    }
+
+  printf("\n");
+
+  /* Check if the dst value just after the return value is as expected */
+
+  if ((uint8_t)dst[ret] == 0xaa)
+    {
+      printf("The character just after the return value is the expected "
+             "0xaa value. No null-terminator.\n");
+    }
+  else
+    {
+      printf("The character just after the return value is not the expected "
+             "0xaa (value: %02x). This is a bug!\n", dst[ret]);
+      free(dst);
+      return EXIT_FAILURE;
+    }
+
+  /* Free the allocated memory */
+
+  free(dst);
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

* testing/libc/wcstombs: Add testing application for wcstombs

This application tests the libc's `wcstombs` function for different len sizes (bigger than the converted string, exactly the size of it and smaller than it).

## Impact

Enabling testing the libc's `wcstombs()`function. No impact on existing applications. This application is used to test a bugfix regarding `wcstombs` behavior.

## Testing

Internal CI testing + `rv-virt:nsh`:

Build with:
```
make -j distclean && ./tools/configure.sh rv-virt:nsh && kconfig-tweak -e LIBC_LOCALE && kconfig-tweak -e TESTING_WCSTOMBS && make olddefconfig && make
```

Run with:
```
$ qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 1 -bios none -kernel nuttx -nographic
ABC
NuttShell (NSH) NuttX-10.4.0
nsh> help
help usage:  help [-v] [<cmd>]

    .           cmp         false       mount       set         uptime      
    [           dirname     fdinfo      mv          sleep       usleep      
    ?           dd          free        pidof       source      watch       
    alias       df          help        poweroff    test        xd          
    unalias     dmesg       hexdump     quit        time        wait        
    basename    echo        kill        printf      true        
    break       env         pkill       ps          truncate    
    cat         exec        ls          pwd         uname       
    cd          exit        mkdir       rm          umount      
    cp          expr        mkrd        rmdir       unset       

Builtin Apps:
    getprime    hello       nsh         ostest      sh          wcstombs    
nsh> wcstombs
wcstombs Test application:

Test Scenario: len is bigger than the size of the converted string. Expected the null-terminator at the end of the converted string.
Return code: 13
dst buffer (as uint8_t array): 48 65 6c 6c 6f 2c 20 77 6f 72 6c 64 21 aa 
The character just after the return value is not the expected null-terminator (value: aa). This is a bug!
nsh> QEMU: Terminated
```