### PR TITLE
system/uorb: require that LIBC_FLOATINGPOINT be enabled for DEBUG_UORB

### DIFF
--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -41,6 +41,7 @@ endif # UORB_TESTS
 config DEBUG_UORB
 	bool "uorb debug output"
 	select LIBC_PRINT_EXTENSION
+	depends on LIBC_FLOATINGPOINT
 	default n
 
 if DEBUG_UORB

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -49,6 +49,10 @@
 #define ORB_TOP_WAIT_TIME  1000
 #define ORB_DATA_DIR       "/data/uorb/"
 
+#if defined(CONFIG_DEBUG_UORB) && !defined(CONFIG_LIBC_FLOATINGPOINT)
+#error "Enable CONFIG_LIBC_FLOATINGPOINT, required to see debug output"
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary

This pull request closes the issue raised [here](https://github.com/apache/nuttx/issues/15599).

Now `DEBUG_UORB` depends on `LIBC_FLOATINGPOINT`. This is because it is not possible to view sensor debug output without this enabled, which is only a problem for systems without an FPU (systems with an FPU have this enabled by default).

## Impact

Users now have to enable `LIBC_FLOATINGPOINT` on systems without an FPU in order to use `DEBUG_UORB`. The dependency marked with `depends on` means that the uORB debug option will not be visible until `LIBC_FLOATINGPOINT` is selected, but this was determined to be acceptable in the discussion under the linked issue.

This prevents the annoyance of re-flashing the device because floating point printing was disabled, rendering debug output almost useless.

I have also included a compile time error for the configuration mismatch.

## Testing

Verified that enabling `LIBC_FLOATINGPOINT` caused `DEBUG_UORB` to appear and that the dependency was marked in Kconfig.

Output after building by selecting `LIBC_FLOATINGPOINT` followed by `DEBUG_UORB` in Kconfig.
```
nsh> uorb_listener

Mointor objects num:4
object_name:sensor_mag, object_instance:0
object_name:sensor_gyro, object_instance:0
object_name:sensor_baro, object_instance:0
object_name:sensor_accel, object_instance:0
sensor_mag(now:203370000):timestamp:203370000,x:-63.750000,y:-10.500000,z:-2280
sensor_accel(now:203380000):timestamp:203370000,x:0.047856,y:-0.196212,z:6.5380
sensor_baro(now:203390000):timestamp:203390000,pressure:496.140015,temperature0
```