### PR TITLE
 nshlib/builtin: check background task before restore the signal

### DIFF
--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -234,7 +234,13 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
           /* Restore the old actions */
 
-          sigaction(SIGCHLD, &old, NULL);
+#  ifndef CONFIG_SCHED_WAITPID
+          if (vtbl->np.np_bg == true)
+#  endif
+            {
+              sigaction(SIGCHLD, &old, NULL);
+            }
+
 #  endif
           struct sched_param sched;
           sched_getparam(ret, &sched);


### PR DESCRIPTION
## Summary

nshlib/builtin: check background task before restore the signal

fix crash if:
CONFIG_SCHED_WAITPID=n
CONFIG_SCHED_CHILD_STATUS=y

The old signal will be restored only when sigaction is saved to avoid invaild access.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

1. build qemu-armv7a/rpserver_ivshmem
cmake -B build -DBOARD_CONFIG=qemu-armv7a/rpserver_ivshmem -GNinja
2. enable CONFIG_SCHED_CHILD_STATUS=y
cmake --build build -t menuconfig
3. start qemu
qemu-system-arm -cpu cortex-a7 -nographic -machine virt,highmem=off  -kernel build/nuttx -nographic
4. exec hello and system will hangup
