### PR TITLE
interpreters/python: fix patch to set `_PyRuntime` attribute

### DIFF
--- a/interpreters/python/patch/0012-hack-place-_PyRuntime-structure-into-PSRAM-bss-regio.patch
+++ b/interpreters/python/patch/0012-hack-place-_PyRuntime-structure-into-PSRAM-bss-regio.patch
@@ -1,7 +1,7 @@
-From d1e903f516849c535455904b3c3f8a33665c1a88 Mon Sep 17 00:00:00 2001
+From 79b6142580bad5235588faf38c0a22c7280a2d1b Mon Sep 17 00:00:00 2001
 From: Ivan Grokhotkov <ivan@espressif.com>
 Date: Wed, 23 Oct 2024 16:52:52 +0200
-Subject: [PATCH 12/12] hack: place _PyRuntime structure into PSRAM bss region,
+Subject: [PATCH 12/13] hack: place _PyRuntime structure into PSRAM bss region,
  initialize later
 
 _PyRuntime occupies around 100kB of RAM in .data region, making it
@@ -22,14 +22,14 @@ Co-authored-by: Tiago Medicci Serrano <tiago.medicci@espressif.com>
  1 file changed, 11 insertions(+)
 
 diff --git a/Python/pylifecycle.c b/Python/pylifecycle.c
-index 1701a1cd217..2a8e544f0ac 100644
+index 1701a1cd217..93aa808bc03 100644
 --- a/Python/pylifecycle.c
 +++ b/Python/pylifecycle.c
 @@ -102,12 +102,23 @@ __attribute__((
  _PyRuntimeState _PyRuntime
  #if defined(__linux__) && (defined(__GNUC__) || defined(__clang__))
  __attribute__ ((section (".PyRuntime")))
-+#elif defined(ESP_PLATFORM)
++#elif defined(ESP_PLATFORM) || defined(__NuttX__)
 +__attribute__ ((section (".PyRuntime")))
  #endif
  = _PyRuntimeState_INIT(_PyRuntime, _Py_Debug_Cookie);
@@ -38,7 +38,7 @@ index 1701a1cd217..2a8e544f0ac 100644
  static int runtime_initialized = 0;
  
 +void _PyRuntime_Early_Init(void) {
-+#if defined(ESP_PLATFORM)
++#if defined(ESP_PLATFORM) || defined(__NuttX__)
 +    // Normally, _PyRuntime is in .data and is initialized by the C runtime.
 +    // This function allows us to place it into external RAM .bss section
 +    // and initialize it manually, saving some internal RAM.
@@ -50,5 +50,5 @@ index 1701a1cd217..2a8e544f0ac 100644
  _PyRuntime_Initialize(void)
  {
 -- 
-2.47.1
+2.48.1
 


### PR DESCRIPTION
## Summary

* interpreters/python: fix patch to set `_PyRuntime` attribute

This commit also adds the check for the `__NuttX__` macro to the patch file that allows setting an attribute to the `_PyRuntime` structure. The `__NuttX__` macro is guaranteed to be present when building any application for NuttX.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: YES. Local changes to the Python application can use the `__NuttX__` macro.

Impact on build: YES.  Local changes to the Python application can use the `__NuttX__` macro to enable/disable features.

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

It can be tested with `rv-virt:python` (the only board currently supporting Python) by checking if the attribute is set to the `_PyRuntime` structure.

### Building
Build it with:
```
make -j distclean && ./tools/configure.sh rv-virt:python && make -j$(nproc)
```

### Results

Check the generated `nuttx.map` file: it should shows that the `_PyRuntime` structure is at section `.PyRuntime`:
```
 .PyRuntime     0x80d70078    0x247a8 /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace_alfa/apps/interpreters/python/install/target/libpython3.13.a(pylifecycle.o)
                0x80d70078                _PyRuntime
```

