### PR TITLE
system/fastboot: Add prefix "SYSTEM" for USB boardctl configuration

### DIFF
--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -24,8 +24,9 @@ config SYSTEM_FASTBOOTD_DOWNLOAD_MAX
 	int "USB-fastboot download buffer size"
 	default 40960
 
-config FASTBOOTD_USB_BOARDCTL
+config SYSTEM_FASTBOOTD_USB_BOARDCTL
 	bool "USB Board Control"
+	default n
 	depends on BOARDCTL
 	depends on BOARDCTL_USBDEVCTRL
 	---help---

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -958,7 +958,7 @@ int main(int argc, FAR char **argv)
   FAR void *buffer = NULL;
   int ret = OK;
 
-#ifdef CONFIG_FASTBOOTD_USB_BOARDCTL
+#ifdef CONFIG_SYSTEM_FASTBOOTD_USB_BOARDCTL
   struct boardioc_usbdev_ctrl_s ctrl;
 #  ifdef CONFIG_USBDEV_COMPOSITE
     uint8_t dev = BOARDIOC_USBDEV_COMPOSITE;
@@ -992,7 +992,7 @@ int main(int argc, FAR char **argv)
       fb_err("boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", ret);
       return ret;
     }
-#endif /* FASTBOOTD_USB_BOARDCTL */
+#endif /* SYSTEM_FASTBOOTD_USB_BOARDCTL */
 
   if (argc > 1)
     {


### PR DESCRIPTION
## Summary
Add prefix "SYSTEM" for USB boardctl configuration

```diff
- FASTBOOTD_USB_BOARDCTL
+ SYSTEM_FASTBOOTD_USB_BOARDCTL
```
Reason:
```
$ grep "^config " Kconfig -rn
15:config SYSTEM_FASTBOOTD_PRIORITY
19:config SYSTEM_FASTBOOTD_STACKSIZE
23:config SYSTEM_FASTBOOTD_DOWNLOAD_MAX
27:config SYSTEM_FASTBOOTD_USB_BOARDCTL
```

## Impact
system/fastboot

## Testing
CI
