### PR TITLE
toywasm: bump to v66.0.0

### DIFF
--- a/interpreters/toywasm/Makefile
+++ b/interpreters/toywasm/Makefile
@@ -146,7 +146,7 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libdyld
 
 CFLAGS += -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-variable -Wno-return-type
 
-TOYWASM_VERSION  = e972e94fa427c3371fb21ad4bb9f238a1cca7795
+TOYWASM_VERSION  = b0e100a4ebd666f02b2bb9222d402a9f399a740b
 TOYWASM_UNPACK   = toywasm
 TOYWASM_TARBALL  = $(TOYWASM_VERSION).zip
 TOYWASM_URL_BASE = https://github.com/yamt/toywasm/archive/

--- a/interpreters/toywasm/include/toywasm_version.h
+++ b/interpreters/toywasm/include/toywasm_version.h
@@ -23,6 +23,6 @@
 #if !defined(_TOYWASM_VERSION_H)
 #define _TOYWASM_VERSION_H
 
-#define TOYWASM_VERSION "v65.0.0"
+#define TOYWASM_VERSION "v66.0.0"
 
 #endif /* !defined(_TOYWASM_VERSION_H) */


### PR DESCRIPTION
## Summary
toywasm: bump version v65.0.0 -> v66.0.0.

see https://github.com/yamt/toywasm/releases/tag/v66.0.0

## Impact
interpreters/toywasm

## Testing
?
