### PR TITLE
system/cpuload: Fix application's Make.defs location

### DIFF
--- a/system/cpuload/Make.defs
+++ b/system/cpuload/Make.defs
@@ -21,5 +21,5 @@
 ############################################################################
 
 ifneq ($(CONFIG_SYSTEM_CPULOAD),)
-CONFIGURED_APPS += $(APPDIR)/testing/sched/cpuload
+CONFIGURED_APPS += $(APPDIR)/system/cpuload
 endif


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* system/cpuload: Fix application's Make.defs location

The PR https://github.com/apache/nuttx-apps/pull/2974 first moved it to `testing/sched/cpuload` and the `Make.defs` was adjusted accordingly. However, during the review process, it was moved to `system/cpuload` folder, but its `Make.defs` wasn't updated. This PR fixes it.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: YES. It enables users to build `cpuload` app.
<!-- Does it impact user's applications? How? -->

Impact on build: YES. Now we can build it.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: NO.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: NO.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: NO.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: NO.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing

Test it for ESP32-S3's `nsh` defconfig, for instance:

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:nsh && kconfig-tweak -e SCHED_CPULOAD_SYSCLK && kconfig-tweak -e CONFIG_SYSTEM_CPULOAD && make olddefconfig && make flash ESPTOOL_BINDIR=./ ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc) && minicom -D /dev/ttyUSB0
```

### Running

Run `cpuload` on NSH:

```
nsh> cpuload &
cpuload [2:253]
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    CPU COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003056 88.0% Idle_Task
    1     1 100 RR       Task      - Running            0000000000000000 0003024  0.0% nsh_main
    2     2 253 RR       Task      - Waiting  Signal    0000000000000000 0002016 11.9% cpuload
nsh> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    CPU COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003056 57.4% Idle_Task
    1     1 100 RR       Task      - Running            0000000000000000 0003024  0.0% nsh_main
    2     2 253 RR       Task      - Waiting  Signal    0000000000000000 0002016 42.5% cpuload
```

### Results

Before applying this patch, it fails to build with:
```
make[3]: *** /home/tiago/Documents/work/espressif/projects/nuttx/nuttxspace_alfa/apps/testing/sched/cpuload: No such file or directory.  Stop.
```

Now, it's been fixed ;)