### PR TITLE
system/fastboot: Add support for fastboot oem shell

### DIFF
--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -32,4 +32,14 @@ config SYSTEM_FASTBOOTD_USB_BOARDCTL
 	---help---
 		Connect usbdev before running fastboot daemon.
 
+config SYSTEM_FASTBOOTD_SHELL
+	bool "Execute custom commands"
+	default n
+	depends on SCHED_CHILD_STATUS
+	depends on SYSTEM_POPEN
+	---help---
+		Enable to support executing custom commands.
+		e.g. fastboot oem shell ps
+		e.g. fastboot oem shell "mkrd -m 10 -s 512 640"
+
 endif # SYSTEM_FASTBOOTD

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -260,9 +260,15 @@ static void fastboot_ack(FAR struct fastboot_ctx_s *context,
 }
 
 static void fastboot_fail(FAR struct fastboot_ctx_s *context,
-                          FAR const char *reason)
+                          FAR const char *fmt, ...)
 {
+  char reason[FASTBOOT_MSG_LEN];
+  va_list ap;
+
+  va_start(ap, fmt);
+  vsnprintf(reason, sizeof(reason), fmt, ap);
   fastboot_ack(context, "FAIL", reason);
+  va_end(ap);
 }
 
 static void fastboot_okay(FAR struct fastboot_ctx_s *context,


### PR DESCRIPTION
## Summary
Add support for fastboot oem shell to support executing custom commands.

Usage
```
fastboot oem shell <command>
```
## Impact
system/fastboot
## Testing
```
# Configuration "esp32s3-devkit:fastboot" with `SYSTEM_FASTBOOTD_SHELL` enabled

$ fastboot --version
fastboot version 35.0.2-12147458

$ fastboot oem shell ls /FILE_NOT_EXISTS
FAILED (remote: 'error detected 255 4')
fastboot: error: Command failed

$ fastboot oem shell ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003056 Idle_Task
    1     0 224 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001976 hpwork 0x3fc8bd50 0x3fc8bd80
    2     2 100 RR       Task      - Waiting  Semaphore 0000000000000000 0004048 nsh_main
    3     3 100 RR       Task      - Ready              0000000000000000 0001992 fastbootd
    4     4 100 RR       Task      - Running            0000000000000000 0001992 popen -c ps
OKAY [  0.010s]
Finished. Total time: 0.010s
```
