### PR TITLE
system/irtest/Make.defs: fixed the wrong path

### DIFF
--- a/system/irtest/Make.defs
+++ b/system/irtest/Make.defs
@@ -21,5 +21,5 @@
 ############################################################################
 
 ifneq ($(CONFIG_SYSTEM_IRTEST),)
-CONFIGURED_APPS += $(APPDIR)/testing/irtest
+CONFIGURED_APPS += $(APPDIR)/system/irtest
 endif


### PR DESCRIPTION
## Summary

fix this error
make[3] *** /nuttxspace/nuttx/apps/testing/irtest: No such file or directory.  Stop.

same error with macOS on Nuttx mirror

```
make: *** /Users/runner/work/nuttx/nuttx/sources/apps/testing/irtest: No such file or directory.  Stop.
make[2]: *** [/Users/runner/work/nuttx/nuttx/sources/apps/testing/irtest_context] Error 2
make[2]: Target `context_all' not remade because of errors.
make[1]: *** [context] Error 2
make: *** [/Users/runner/work/nuttx/nuttx/sources/apps/.context] Error 2
make: Target `all' not remade because of errors.
/Users/runner/work/nuttx/nuttx/sources/nuttx/tools/testbuild.sh: line 385: /Users/runner/work/nuttx/nuttx/sources/nuttx/../nuttx/nuttx.manifest: No such file or directory
```

https://github.com/NuttX/nuttx/actions/runs/13430411340/job/37521010985#logs


error due to this change
apps/testing: Move irtest/sensortest/resmonitor/monkey to apps/system #2976

## Impact
Impact on user: NO.

Impact on build: YES. fix the build with Make

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
Build it with:
./tools/configure.sh -l sim:rc
make -j

Without this PR

![err_rc](https://github.com/user-attachments/assets/cb18540c-e8ff-4cfd-98e2-2493420763c0)

With this PR

![ok_rc](https://github.com/user-attachments/assets/69ed7375-d497-4403-8263-7156021b74ef)
