### PR TITLE
netutils/pppd/ppp.h: Fix build issue when network debug is enabled

### DIFF
--- a/netutils/pppd/ppp.h
+++ b/netutils/pppd/ppp.h
@@ -51,6 +51,7 @@
 
 #include "netutils/chat.h"
 
+#include "debug.h"
 #include "ppp_conf.h"
 #include "ahdlc.h"
 #include "lcp.h"


### PR DESCRIPTION
This commit add include necessary when we enable network debug feature using ppp feature.

## Summary
When we enable debug feature :
-> Debug Options, Network Debug Feature, [enable all].
Build issue happens:
CC:  netlib_ipv4addrconv.c In file included from ahdlc.c:45:
```
ahdlc.c: In function 'ahdlc_rx':
ppp_conf.h:57:33: warning: implicit declaration of function 'ninfo' [-Wimplicit-function-declaration]
   57 | #define debug_printf            ninfo
      |                                 ^~~~~
ahdlc.c:53:21: note: in expansion of macro 'debug_printf'
   53 | #  define DEBUG1(x) debug_printf x
      |                     ^~~~~~~~~~~~
ahdlc.c:152:11: note: in expansion of macro 'DEBUG1'
  152 |           DEBUG1(("Discard since char is < 0x20 hex and asysnc map is 0\n"));
      |           ^~~~~~
CC:  nsh_fscmds.c In file included from ipcp.c:45:
ipcp.c: In function 'printip':
ppp_conf.h:57:33: warning: implicit declaration of function 'ninfo' [-Wimplicit-function-declaration]
   57 | #define debug_printf            ninfo
      |                                 ^~~~~
ipcp.c:56:21: note: in expansion of macro 'debug_printf'
   56 | #  define DEBUG1(x) debug_printf x
      |                     ^~~~~~~~~~~~
ipcp.c:91:3: note: in expansion of macro 'DEBUG1'
   91 |   DEBUG1((" %u.%u.%u.%u ", ip[0], ip[1], ip[2], ip[3]));
      |   ^~~~~~
In file included from lcp.c:47:
lcp.c: In function 'lcp_rx':
CC:  iob/iob_reserve.c ppp_conf.h:57:33: warning: implicit declaration of function 'ninfo' [-Wimplicit-function-declaration]
   57 | #define debug_printf            ninfo
      |                                 ^~~~~
lcp.c:60:21: note: in expansion of macro 'debug_printf'
   60 | #  define DEBUG1(x) debug_printf x
      |                     ^~~~~~~~~~~~
lcp.c:145:7: note: in expansion of macro 'DEBUG1'
  145 |       DEBUG1(("received [LCP Config Request id %u\n", id));
      |       ^~~~~~
In file included from ppp.c:46:
ppp.c: In function 'ppp_reject_protocol':
ppp_conf.h:57:33: warning: implicit declaration of function 'ninfo' [-Wimplicit-function-declaration]
   57 | #define debug_printf            ninfo
      |                                 ^~~~~
ppp.c:62:21: note: in expansion of macro 'debug_printf'
   62 | #  define DEBUG1(x) debug_printf x
      |                     ^~~~~~~~~~~~
ppp.c:94:3: note: in expansion of macro 'DEBUG1'
   94 |   DEBUG1(("Rejecting Protocol\n"));
```
This commit solve this issue
## Impact
Solve issue

## Testing
use wifi config as base. Enable pppd example, enable debug features, network debug and enable all.
After this commit you will be able build and see debug prints in the console.
