### PR TITLE
[nxstyle] fix Relative file path

### DIFF
--- a/benchmarks/superpi/CMakeLists.txt
+++ b/benchmarks/superpi/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/benchmarks/superpi/CMakeList.txt
+# apps/benchmarks/superpi/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/examples/charger/Kconfig
+++ b/examples/charger/Kconfig
@@ -1,3 +1,7 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
 
 config EXAMPLES_CHARGER
 	bool "Battery charger example"

--- a/examples/udpblaster/udpblaster_host.cmake
+++ b/examples/udpblaster/udpblaster_host.cmake
@@ -1,5 +1,5 @@
 # ##############################################################################
-# apps/examples/udpblaster/udpblaster.cmake
+# apps/examples/udpblaster/udpblaster_host.cmake
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
## Summary
fix Relative file path does not match actual file.

EOL Conversion  -> Unix (LF)

Adding the message header to the Kconfig file

## Impact
Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO
## Testing
local
