### PR TITLE
apps/testing:fix uclibc atomic make.defs error

### DIFF
--- a/testing/cxx/uclibcxx_test/Make.defs
+++ b/testing/cxx/uclibcxx_test/Make.defs
@@ -21,5 +21,5 @@
 ############################################################################
 
 ifneq ($(CONFIG_TESTING_UCLIBCXXTEST),)
-CONFIGURED_APPS += $(APPDIR)/testing//cxx/uclibcxx_test
+CONFIGURED_APPS += $(APPDIR)/testing/cxx/uclibcxx_test
 endif

--- a/testing/libc/atomic/Make.defs
+++ b/testing/libc/atomic/Make.defs
@@ -21,5 +21,5 @@
 ############################################################################
 
 ifneq ($(CONFIG_TESTING_ATOMIC),)
-CONFIGURED_APPS += $(APPDIR)/testing/sched/atomic
+CONFIGURED_APPS += $(APPDIR)/testing/libc/atomic
 endif


### PR DESCRIPTION


## Summary
I'm sorry. In my previous modification to apps/testing folder, I made a mistake in the make.defs of uclibcxx and atomic.
## Impact
The main impacts are the testing/libc/atomic/Make.defs file and testing/cxx/uclibcxx_test/Make.defs
testing/libc/atomic/Make.defs:23:
CONFIGURED_APPS += $(APPDIR)/testing/sched/atomic

CONFIGURED_APPS += $(APPDIR)/testing/libc/atomic

testing/cxx/uclibcxx_test/Make.defs:22:
CONFIGURED_APPS += $(APPDIR)/testing//cxx/uclibcxx_test
--------->
CONFIGURED_APPS += $(APPDIR)/testing/cxx/uclibcxx_test
## Testing
CI TEST.
