### PR TITLE
benchmarks/osperf: fix warning maybe-uninitialized

### DIFF
--- a/benchmarks/osperf/osperf.c
+++ b/benchmarks/osperf/osperf.c
@@ -239,6 +239,7 @@ static size_t hpwork_performance(void)
     (FAR void *)&result
   };
 
+  memset(&result, 0, sizeof(result));
   memset(&work, 0, sizeof(work));
   performance_start(&result);
   ret = work_queue(HPWORK, &work, work_handle, args, 0);


### PR DESCRIPTION
## Summary
  Fix osperf build warning
```
In function 'performance_gettime',
    inlined from 'hpwork_performance' at osperf.c:245:10:
osperf.c:123:3: error: 'result.end' may be used uninitialized [-Werror=maybe-uninitialized]
  123 |   up_perf_convert(result->end - result->start, &ts);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
osperf.c: In function 'hpwork_performance':
osperf.c:228:29: note: 'result.end' was declared here
  228 |   struct performance_time_s result;
      |                             ^~~~~~
CC:  audio/lib_buffer.c
CC:  common/arm64_initialize.c
CC:  builtin/lib_builtin_getname.c
```

## Impact
* Build: fix warnings.
* Runtime: initialize memory before use.

## Testing
  Local build success