### PR TITLE
examples/romfs:add EXAMPLES_ROMFS_RAMDEVNO

### DIFF
--- a/examples/romfs/Kconfig
+++ b/examples/romfs/Kconfig
@@ -11,4 +11,11 @@ config EXAMPLES_ROMFS
 		Enable the ROMFS example
 
 if EXAMPLES_ROMFS
+
+config EXAMPLES_ROMFS_RAMDEVNO
+	int "ROMFS example ramdevno"
+	default 10
+	---help---
+		Custom RAMDisk number
+
 endif


### PR DESCRIPTION
## Summary
  In order to avoid conflicts between the ramdisk created by the romfs demo at runtime and other processes, a custom register ramdisk number is added.

## Impact
  None.

## Testing
  Local test pass
