### PR TITLE
ostest:Fix the issue that nxevent pthread was not executed, causing case failed

### DIFF
--- a/testing/ostest/nxevent.c
+++ b/testing/ostest/nxevent.c
@@ -281,7 +281,7 @@ void nxevent_test(void)
 
   /* Lower priority */
 
-  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY - 1;
+  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY;
   pthread_attr_setschedparam(&attr, &sparam);
 
   /* Create thread */
@@ -304,7 +304,7 @@ void nxevent_test(void)
 
   /* Lower priority */
 
-  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY - 1;
+  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY;
   pthread_attr_setschedparam(&attr, &sparam);
 
   /* Create thread */


### PR DESCRIPTION
## Summary
  In the case of slow overall system response (such as when MM_KASAN is turned on and RR_INTERVAL > 200), the nxevent case work thread will not be executed and will be switched back to the main thread, so that the event does not get the expected result and the case fails.
  By adjusting the thread priority, the work thread can be scheduled to avoid the expected result failure.

## Impact
  Adjusted the priority of the nxevent creation thread in ostest.

## Testing
  Local test in QEMU with case of slow overall system response is ok.
