### PR TITLE
nshlib: typo fixed in Kconfig

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -506,7 +506,7 @@ config NSH_DISABLE_MW
 	bool "Disable mw"
 	default y
 
-config NSH_DISABLE_NSFMOUNT
+config NSH_DISABLE_NFSMOUNT
 	bool "Disable nfsmount"
 	default DEFAULT_SMALL
 	depends on NFS


### PR DESCRIPTION
## Summary
In `nshlib/Kconfig:509`:
`NSH_DISABLE_NSFMOUNT` should be `NSH_DISABLE_NFSMOUNT`

## Impact
Typo fixed. Without this fix, the function "Disable nfsmount" in nsh would not work,
as the code is controlled by `CONFIG_NSH_DISABLE_NFSMOUNT`

## Testing
Test on `sim:nsh`
1. enabled NFS function from menuconfig
2. build and enter nsh shell
3. use `help` to check available command
```
$ ./nuttx 

NuttShell (NSH)
nsh> help
help usage:  help [-v] [<cmd>]

    .           cmp         fdinfo      ls          printf      true        
    [           dirname     free        mkdir       ps          truncate    
    ?           dd          help        mkfatfs     pwd         uname       
    alias       df          hexdump     mkfifo      readlink    umount      
    unalias     dmesg       ifconfig    mkrd        rm          unset       
    arp         echo        ifdown      mount       rmdir       uptime      
    basename    env         ifup        mv          set         usleep      
    break       exec        kill        nfsmount    sleep       watch       
    cat         exit        pkill       pidof       source      xd          
    cd          expr        losetup     poweroff    test        wait        
    cp          false       ln          quit        time        

Builtin Apps:
    dumpstack    gpio         nsh          sh           
    gcov         hello        ostest       
```
We can see `nfsmount` is there.

4. Select  "Disable nfsmount" option in menuconfig, then build and check in nsh:
```
$ ./nuttx 

NuttShell (NSH)
nsh> help
help usage:  help [-v] [<cmd>]

    .           cmp         fdinfo      ls          ps          truncate    
    [           dirname     free        mkdir       pwd         uname       
    ?           dd          help        mkfatfs     readlink    umount      
    alias       df          hexdump     mkfifo      rm          unset       
    unalias     dmesg       ifconfig    mkrd        rmdir       uptime      
    arp         echo        ifdown      mount       set         usleep      
    basename    env         ifup        mv          sleep       watch       
    break       exec        kill        pidof       source      xd          
    cat         exit        pkill       poweroff    test        wait        
    cd          expr        losetup     quit        time        
    cp          false       ln          printf      true        

Builtin Apps:
    dumpstack    gpio         nsh          sh           
    gcov         hello        ostest       
nsh> 
```
We can see the `nfsmount` has been disabled.

