### PR TITLE
Enhancement for Rust build

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -150,6 +150,8 @@ function(nuttx_add_rust)
   add_custom_command(
     OUTPUT ${RUST_LIB_PATH}
     COMMAND
+      ${CMAKE_COMMAND} -E env
+      NUTTX_INCLUDE_DIR=${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include:${CMAKE_BINARY_DIR}/include/arch
       cargo build --${RUST_PROFILE} -Zbuild-std=std,panic_abort
       ${RUST_DEBUG_FLAGS} --manifest-path ${CRATE_PATH}/Cargo.toml --target
       ${RUST_TARGET} --target-dir ${RUST_BUILD_DIR}

--- a/examples/rust/slint/Cargo.toml
+++ b/examples/rust/slint/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = 'z'
 [dependencies]
 libc = "0.2"
 slint = { version = "1.9", default-features = false, features = ["compat-1-2", "renderer-software", "libm", "unsafe-single-threaded"] }
-nuttx = { git = "https://github.com/no1wudi/nuttx-rs.git", branch = "master" }
+nuttx = { git = "https://github.com/no1wudi/nuttx-rs.git", branch = "main" }
 
 [build-dependencies]
 slint-build = { version = "1.9" }

--- a/examples/rust/slint/src/lib.rs
+++ b/examples/rust/slint/src/lib.rs
@@ -94,7 +94,7 @@ pub extern "C" fn slint_main() {
     println!("{:?}", planeinfo);
     println!("{:?}", videoinfo);
 
-    if videoinfo.fmt != Format::RGB565 as u8 {
+    if videoinfo.fmt != FB_FMT_RGB16_565 as u8 {
         println!("Unsupported pixel format, only RGB565 is supported for now");
         return;
     }

--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -89,7 +89,8 @@ endef
 
 ifeq ($(CONFIG_DEBUG_FULLOPT),y)
 define RUST_CARGO_BUILD
-	cargo build --release -Zbuild-std=std,panic_abort \
+	NUTTX_INCLUDE_DIR=$(TOPDIR)/include:$(TOPDIR)/include/arch \
+    cargo build --release -Zbuild-std=std,panic_abort \
     -Zbuild-std-features=panic_immediate_abort \
 		--manifest-path $(2)/$(1)/Cargo.toml \
 		--target $(call RUST_TARGET_TRIPLE)
@@ -97,7 +98,8 @@ endef
 else
 define RUST_CARGO_BUILD
 	@echo "Building Rust code with cargo..."
-	cargo build -Zbuild-std=std,panic_abort \
+	NUTTX_INCLUDE_DIR=$(TOPDIR)/include:$(TOPDIR)/include/arch \
+    cargo build -Zbuild-std=std,panic_abort \
 		--manifest-path $(2)/$(1)/Cargo.toml \
 		--target $(call RUST_TARGET_TRIPLE)
 endef


### PR DESCRIPTION
**Summary:**
* Update the NuttX Rust crate dependency to use the `main` branch instead of `master` for consistency with upstream repository changes.
* Fix framebuffer pixel format check by replacing `Format::RGB565` with `FB_FMT_RGB16_565` to ensure accurate validation of the video format.

nuttx-rs (https://github.com/no1wudi/nuttx-rs) generate binding from NuttX's C header now, which simplify the build setup and get more accurate struct/data type definitions.

**Impact:**
* **New feature added?** NO  
* **Impact on user?** NO
* **Impact on build?** YES - Updates dependency branch in `Cargo.toml`, affecting crate resolution.  
* **Impact on hardware?** NO  
* **Impact on documentation?** NO  
* **Impact on security?** NO  
* **Impact on compatibility?** NO  

This PR ensures compatibility with the latest NuttX Rust crate repository structure and corrects a critical pixel format check for reliable framebuffer handling.