### PR TITLE
examples/bmi160: Fix typo of depends on

### DIFF
--- a/examples/bmi160/Kconfig
+++ b/examples/bmi160/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_SIXAXIS
 	bool "BMI160 sensor example"
 	default n
-	depends on SENSORS_BMG160
+	depends on SENSORS_BMI160
 	---help---
 		Enable the 6 axis sensor example
 


### PR DESCRIPTION
## Summary
Fix SENSORS_BMG160 to SENSORS_BMI160.

## Impact
examples/bmi160 with BMI160 sensor. 

## Testing
Build and test pass with BMI160 sensor.
