### PR TITLE
system/nxplayer/nxrecorder: move apb buffer instance to stack

### DIFF
--- a/system/nxrecorder/nxrecorder.c
+++ b/system/nxrecorder/nxrecorder.c
@@ -528,7 +528,6 @@ static FAR void *nxrecorder_recordthread(pthread_addr_t pvarg)
   bool                    streaming = true;
   bool                    failed = false;
   struct ap_buffer_info_s buf_info;
-  FAR struct ap_buffer_s  **pbuffers;
   unsigned int            prio;
 #ifdef CONFIG_DEBUG_FEATURES
   int                     outstanding = 0;
@@ -551,23 +550,11 @@ static FAR void *nxrecorder_recordthread(pthread_addr_t pvarg)
 
   /* Create array of pointers to buffers */
 
-  pbuffers = (FAR struct ap_buffer_s **) malloc(buf_info.nbuffers *
-                                                sizeof(FAR void *));
-  if (pbuffers == NULL)
-    {
-      /* Error allocating memory for buffer storage! */
-
-      ret = -ENOMEM;
-      running = false;
-      goto err_out;
-    }
+  FAR struct ap_buffer_s *pbuffers[buf_info.nbuffers];
 
   /* Create our audio pipeline buffers to use for queueing up data */
 
-  for (x = 0; x < buf_info.nbuffers; x++)
-    {
-      pbuffers[x] = NULL;
-    }
+  memset(pbuffers, 0, sizeof(pbuffers));
 
   for (x = 0; x < buf_info.nbuffers; x++)
     {
@@ -820,28 +807,20 @@ static FAR void *nxrecorder_recordthread(pthread_addr_t pvarg)
 err_out:
   audinfo("Clean-up and exit\n");
 
-  if (pbuffers != NULL)
+  audinfo("Freeing buffers\n");
+  for (x = 0; x < buf_info.nbuffers; x++)
     {
-      audinfo("Freeing buffers\n");
-      for (x = 0; x < buf_info.nbuffers; x++)
+      /* Fill in the buffer descriptor struct to issue a free request */
+
+      if (pbuffers[x] != NULL)
         {
-          /* Fill in the buffer descriptor struct to issue a free request */
-
-          if (pbuffers[x] != NULL)
-            {
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-              buf_desc.session = precorder->session;
+         buf_desc.session = precorder->session;
 #endif
-              buf_desc.u.buffer = pbuffers[x];
-              ioctl(precorder->dev_fd,
-                    AUDIOIOC_FREEBUFFER,
-                    (uintptr_t)&buf_desc);
-            }
+          buf_desc.u.buffer = pbuffers[x];
+          ioctl(precorder->dev_fd, AUDIOIOC_FREEBUFFER,
+                (uintptr_t)&buf_desc);
         }
-
-      /* Free the pointers to the buffers */
-
-      free(pbuffers);
     }
 
   /* Unregister the message queue and release the session */


### PR DESCRIPTION
## Summary

system/nxplayer/nxrecorder: move apb buffer instance to stack

move apb buffer instance to stack to avoid alloc buffer from heap

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

ci-check