### PR TITLE
examples/notedump: Add a example to dump trace data by udp

### DIFF
--- a/examples/notedump/CMakeLists.txt
+++ b/examples/notedump/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/examples/notedump/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_NOTEDUMP)
+  nuttx_add_application(NAME notedump)
+endif()

--- a/examples/notedump/Kconfig
+++ b/examples/notedump/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_NOTEDUMP
+	tristate "Note dump example"
+	default n
+	depends on SCHED_INSTRUMENTATION_DUMP && NET_UDP
+	---help---
+		Enable the Note dump example
+
+if EXAMPLES_NOTEDUMP
+
+config EXAMPLES_NOTEDUMP_PROGNAME
+	string "Program name"
+	default "notedump"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_NOTEDUMP_PRIORITY
+	int "Note dump task priority"
+	default 100
+
+config EXAMPLES_NOTEDUMP_STACKSIZE
+	int "Note dump stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/notedump/Make.defs
+++ b/examples/notedump/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/notedump/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_NOTEDUMP),)
+CONFIGURED_APPS += $(APPDIR)/examples/notedump
+endif

--- a/examples/notedump/Makefile
+++ b/examples/notedump/Makefile
@@ -1,0 +1,32 @@
+############################################################################
+# apps/examples/notedump/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_NOTEDUMP_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_NOTEDUMP_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_NOTEDUMP_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_NOTEDUMP_)
+
+MAINSRC = notedump_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/notedump/notedump.h
+++ b/examples/notedump/notedump.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * apps/examples/notedump/notedump.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_EXAMPLES_NOTEDUMP_H
+#define __APPS_EXAMPLES_NOTEDUMP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifdef EXAMPLES_UDP_HOST
+#else
+#  include <debug.h>
+#endif
+
+#include <arpa/inet.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_EXAMPLES_UDP_IPv6
+#  define AF_INETX AF_INET6
+#  define PF_INETX PF_INET6
+#else
+#  define AF_INETX AF_INET
+#  define PF_INETX PF_INET
+#endif
+
+#ifndef CONFIG_EXAMPLES_NOTEDUMP_SERVER_PORTNO
+#  define CONFIG_EXAMPLES_NOTEDUMP_SERVER_PORTNO 6666
+#endif
+
+#ifndef CONFIG_EXAMPLES_NOTEDUMP_METRIC_FREQ
+#  define CONFIG_EXAMPLES_NOTEDUMP_METRIC_FREQ 10
+#endif
+
+#endif /* __APPS_EXAMPLES_NOTEDUMP_H */

--- a/examples/notedump/notedump_main.c
+++ b/examples/notedump/notedump_main.c
@@ -1,0 +1,259 @@
+/*****************************************************************************
+ * apps/examples/notedump/notedump_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ *****************************************************************************/
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "notedump.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#include <netinet/in.h>
+#include <fcntl.h>
+
+#define NOTE_MSG_SIZE CONFIG_SYSTEM_NOTE_BUFFERSIZE
+
+/*****************************************************************************
+ * Public Data
+ *****************************************************************************/
+
+/*****************************************************************************
+ * Private Data
+ *****************************************************************************/
+
+static uint32_t g_udpserver_ipv4;
+static uint32_t g_udpserver_port;
+static uint32_t note_sent_bytes;
+
+/*****************************************************************************
+ * Private Functions
+ *****************************************************************************/
+
+/*****************************************************************************
+ * show_usage
+ *****************************************************************************/
+
+static void show_usage(FAR const char *progname)
+{
+  fprintf(stderr, "USAGE: %s [<server-addr>] [<server-port>]\n", progname);
+  exit(1);
+}
+
+/*****************************************************************************
+ * udp_cmdline
+ *****************************************************************************/
+
+bool udp_cmdline(int argc, char **argv)
+{
+  int ret;
+  long port;
+  char *endptr;
+
+  /* Init the default IP address */
+
+  g_udpserver_ipv4 = HTONL(0x01020304);
+  g_udpserver_port = HTONS(1234);
+
+  /* Currently only a single command line option is supported:  The server
+   * IP address. Used to override default.
+   */
+
+  if (argc == 3)
+    {
+      /* Convert the <server-addr> argument into a binary address */
+
+      ret = inet_pton(AF_INET, argv[1], &g_udpserver_ipv4);
+      if (ret == 1)
+        {
+          fprintf(stderr, "Server address: %s\n", argv[1]);
+        }
+      else
+        {
+          fprintf(stderr, "ERROR: Invalid server address: %s\n", argv[1]);
+          show_usage(argv[0]);
+          return false;
+        }
+
+      port = strtol(argv[2], &endptr, 10);
+      if (*endptr != '\0' || port < 1 || port > 65535)
+        {
+          fprintf(stderr, "ERROR: Invalid port: %s\n", argv[2]);
+          show_usage(argv[0]);
+          return false;
+        }
+
+      g_udpserver_port = (uint32_t)port;
+    }
+  else if (argc != 1)
+    {
+      fprintf(stderr, "ERROR: Too many arguments\n");
+      show_usage(argv[0]);
+      return false;
+    }
+
+  return true;
+}
+
+/*****************************************************************************
+ * Private Functions
+ *****************************************************************************/
+
+static int create_socket(void)
+{
+  socklen_t addrlen;
+  int sockfd;
+
+  struct sockaddr_in addr;
+
+  /* Create a new IPv4 UDP socket */
+
+  sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sockfd < 0)
+    {
+      printf("client ERROR: client socket failure %d\n", errno);
+      return -1;
+    }
+
+  /* Bind the UDP socket to a IPv4 port */
+
+  addr.sin_family      = AF_INET;
+  addr.sin_port        = HTONS(CONFIG_EXAMPLES_NOTEDUMP_SERVER_PORTNO);
+  addr.sin_addr.s_addr = HTONL(INADDR_ANY);
+  addrlen              = sizeof(struct sockaddr_in);
+
+  if (bind(sockfd, (FAR struct sockaddr *)&addr, addrlen) < 0)
+    {
+      printf("client ERROR: Bind failure: %d\n", errno);
+      return -1;
+    }
+
+  return sockfd;
+}
+
+/*****************************************************************************
+ * Public Functions
+ *****************************************************************************/
+
+/*****************************************************************************
+ * main
+ *****************************************************************************/
+
+int main(int argc, char **argv, char **envp)
+{
+  struct sockaddr_in server;
+  unsigned char outbuf[NOTE_MSG_SIZE];
+  socklen_t addrlen;
+  int sockfd;
+  int nbytes;
+  int metric_freq = 0;
+
+  /* Parse any command line options */
+
+  if (udp_cmdline(argc, argv) == false)
+    {
+      fprintf(stderr, "ERROR: Invalid arguments\n");
+      return -1;
+    }
+
+  /* Create a UDP socket */
+
+  sockfd = create_socket();
+  if (sockfd < 0)
+    {
+      printf("client ERROR: create_socket failed\n");
+      exit(1);
+    }
+
+    int note_fd;
+
+  /* Open the note driver */
+
+  printf("notedump_daemon: Opening /dev/note/ram\n");
+  note_fd = open("/dev/note/ram", O_RDONLY);
+  if (note_fd < 0)
+    {
+      int errcode = errno;
+      printf("notedump_daemon: ERROR: Failed to open /dev/note/ram: %d\n",
+             errcode);
+      return -1;
+    }
+
+  server.sin_family      = AF_INET;
+  server.sin_port        = HTONS(CONFIG_EXAMPLES_NOTEDUMP_SERVER_PORTNO);
+  server.sin_addr.s_addr = (in_addr_t)g_udpserver_ipv4;
+  addrlen                = sizeof(struct sockaddr_in);
+
+  printf("Sending note info to %s %ld\n", argv[1], g_udpserver_port);
+
+  while (true)
+    {
+      /* Read from note to fill the output buffer */
+
+      int note_bytes = read(note_fd, outbuf, CONFIG_SYSTEM_NOTE_BUFFERSIZE);
+
+      /* Send the note message */
+
+      nbytes = sendto(sockfd, outbuf, note_bytes, 0,
+                      (struct sockaddr *)&server, addrlen);
+
+      if (nbytes < 0)
+        {
+          printf("client: sendto failed: %d\n", errno);
+          goto errout;
+        }
+      else if (nbytes != note_bytes)
+        {
+          printf("client: Bad send length: %d Expected: %d\n",
+                 nbytes, note_bytes);
+          goto errout;
+        }
+
+      note_sent_bytes += nbytes;
+      metric_freq++;
+
+      if (metric_freq == CONFIG_EXAMPLES_NOTEDUMP_METRIC_FREQ)
+        {
+          metric_freq = 0;
+          printf("Sent %ld bytes\n", note_sent_bytes);
+        }
+
+      /* Now, sleep a bit. */
+
+      sleep(1);
+    }
+
+errout:
+  syslog(LOG_INFO, "note_daemon: Terminating\n");
+  close(note_fd);
+  close(sockfd);
+
+  return 0;
+}


### PR DESCRIPTION

## Summary
Add a example to send the note trace data by udp

Usage:
```
nsh> notedump 192.168.31.9 6666
```

## Impact
* Add a Bultin App notedump when enable the notedump in example

## Testing

* Tested with board nucle-f746zg 


```
NuttShell (NSH) NuttX-12.8.0
nsh> help
help usage:  help [-v] [<cmd>]

    .           cp          false       mkdir       rmdir       umount
    [           cmp         fdinfo      mkfifo      rmmod       unset
    ?           dirname     free        mkrd        route       uptime
    addroute    dd          help        mount       set         usleep
    alias       delroute    hexdump     mv          sleep       watch
    unalias     df          ifconfig    nslookup    source      xd
    arp         dmesg       insmod      pidof       test        wait
    basename    echo        kill        printf      time
    break       exec        pkill       ps          true
    cat         exit        ls          pwd         truncate
    cd          expr        lsmod       rm          uname

Builtin Apps:
    note        nsh         renew       telnetd
    notedump    ping        sh          trace
nsh> notedump 192.168.31.9 6666
Server address: 192.168.31.9
notedump_daemon: Opening /dev/note/ram
Sending note info to 192.168.31.9 6666
Sent 1396 bytes

```
