### PR TITLE
examples/xmlrpc: Fix calls buffers size.

### DIFF
--- a/examples/xmlrpc/calls.c
+++ b/examples/xmlrpc/calls.c
@@ -70,10 +70,10 @@ struct xmlrpc_entry_s get_device_stats =
 
 static int calls_get_device_stats(struct xmlrpc_s *xmlcall)
 {
-  char username[80];
-  char password[80];
-  char lastCommand[80];
-  char curState[80];
+  char username[CONFIG_XMLRPC_STRINGSIZE + 1];
+  char password[CONFIG_XMLRPC_STRINGSIZE + 1];
+  char lastcmd[CONFIG_XMLRPC_STRINGSIZE + 1];
+  char curstate[CONFIG_XMLRPC_STRINGSIZE + 1];
   int request = 0;
   int status;
   int ret;
@@ -105,13 +105,13 @@ static int calls_get_device_stats(struct xmlrpc_s *xmlcall)
       /* Dummy up some data... */
 
       status = 1;
-      strlcpy(lastCommand, "reboot", sizeof(lastCommand));
-      strlcpy(curState, "Normal Operation", sizeof(curState));
+      strlcpy(lastcmd, "reboot", sizeof(lastcmd));
+      strlcpy(curstate, "Normal Operation", sizeof(curstate));
 
       ret = xmlrpc_buildresponse(xmlcall, "{iss}",
                                  "status", status,
-                                 "lastCommand", lastCommand,
-                                 "currentState", curState);
+                                 "lastCommand", lastcmd,
+                                 "currentState", curstate);
     }
 
   return ret;


### PR DESCRIPTION
## Summary

* examples/xmlrpc/calls.c used 80 bytes call buffers.
* update buffers to CONFIG_XMLRPC_STRINGSIZE+1 that is build time configurable.
* this keeps buffers size coherent with configuration.
* updated internal variable names to pass lint checks.

## Impact

* xmlrpc strings and buffers are now equal in size that prevents overflows.

## Testing

Please help in runtime testing :-)

```
% uname -a
FreeBSD octagon 14.2-RELEASE-p1 FreeBSD 14.2-RELEASE-p1 GENERIC amd64

% ./tools/configure.sh -B esp32-devkitc:wifinsh

% gmake menuconfig <- enable apps / examples / xmlrpc.

% kconfig-diff
 BASE_DEFCONFIG "esp32-devkitc:wifinsh" -> "esp32-devkitc:wifinsh-dirty"
 EXAMPLES_XMLRPC n -> y
 NETUTILS_XMLRPC n -> y
+EXAMPLES_XMLRPC_BUFFERSIZE 1024
+XMLRPC_STRINGSIZE 64

% gmake -j8
Create version.h
Cloning Espressif HAL for 3rd Party Platforms
Clone: chip/esp-hal-3rdparty
Downloading: v1.7.12.tar.gz
Unpacking: v1.7.12.tar.gz -> cJSON
Register: xmlrpc
Register: renew
Register: nsh
Register: ping
Register: sh
Register: telnetd
Register: wapi
Espressif HAL for 3rd Party Platforms: e5cef265cca9d272c428d210453d574bcc25c5f4
Espressif HAL for 3rd Party Platforms: initializing submodules...
Applying patches...
CPP:  /XXX/nuttx.git/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld-> /XXX/nuttx.git/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32/ld/esp32.rom.newlib-funcs.ld.tmpLD: nuttx
Memory region         Used Size  Region Size  %age Used
             ROM:      776692 B    4194272 B     18.52%
     iram0_0_seg:      128812 B       168 KB     74.88%
     irom0_0_seg:      580084 B    3342304 B     17.36%
     dram0_0_seg:       73064 B     180736 B     40.43%
     drom0_0_seg:      139276 B    4194272 B      3.32%
    rtc_iram_seg:          0 GB         8 KB      0.00%
    rtc_slow_seg:          0 GB         4 KB      0.00%
      extmem_seg:          0 GB         4 MB      0.00%
CP: nuttx.hex
MKIMAGE: ESP32 binary
esptool.py -c esp32 elf2image --ram-only-header -fs 4MB -fm dio -ff 40m -o nuttx.bin nuttx
esptool.py v4.8.1
Creating esp32 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Merged 1 ELF section
Successfully created esp32 image.
Generated: nuttx.bin

```