### PR TITLE
build.yml: Brought into sync with NuttX repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,7 @@ jobs:
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
             else
+                ( sleep 7200 ; echo Killing pytest after timeout... ; pkill -f pytest )&
                 ./cibuild.sh -c -A -N -R -S testlist/${{matrix.boards}}.dat
             fi
 
@@ -329,4 +330,56 @@ jobs:
         with:
           name: msys2-${{matrix.boards}}-builds
           path: buildartifacts/
+        continue-on-error: true
+
+  # Select the msvc Builds based on PR Arch Label
+  msvc-Arch:
+    uses: apache/nuttx-apps/.github/workflows/arch.yml@master
+    needs: Fetch-Source
+    with:
+      os: msvc
+      boards: |
+        ["msvc_placeholder_with_sim_keyword"]
+
+  # Build with MSVC in Windows native
+  msvc:
+    needs: msvc-Arch
+    if: ${{ needs.msvc-Arch.outputs.skip_all_builds != '1' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Set up Python environment and install kconfiglib
+      - name: Set up Python and install kconfiglib
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install kconfiglib
+        run: |
+          pip install kconfiglib
+
+      - run: git config --global core.autocrlf false
+
+      - name: Download Source Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: source-bundle
+          path: .
+
+      - name: Extract sources
+        run: |
+          7z x sources.tar.gz -y
+          7z x sources.tar -y
+
+      - name: Run Builds
+        run: |
+          "ARTIFACTDIR=${{github.workspace}}\sources\buildartifacts" >> $env:GITHUB_ENV
+          git config --global --add safe.directory ${{github.workspace}}\sources\nuttx
+          git config --global --add safe.directory ${{github.workspace}}\sources\apps
+          cd sources\nuttx\tools\ci
+          .\cibuild.ps1 -n -i -A -C -N testlist\windows.dat
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: msvc-builds
+          path: ./sources/buildartifacts/
         continue-on-error: true


### PR DESCRIPTION
## Summary

msvc job is missing brought into sync with nuttx repository

added:

- CI: Kill CI Test after 2 hours
       see https://github.com/apache/nuttx/pull/14849
- msvc job => Windows native

     https://github.com/apache/nuttx/pull/13894
    https://github.com/apache/nuttx/pull/15989


## Impact
Impact on user: NO.

Impact on build: NO.

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
CI
