### PR TITLE
examples/fbcon: Fix endchoice and help in Kconfig

### DIFF
--- a/examples/fbcon/Kconfig
+++ b/examples/fbcon/Kconfig
@@ -58,6 +58,8 @@ config EXAMPLES_FBCON_BPP_NX_DEFAULT
 config EXAMPLES_FBCON_CUSTOM_BPP
 	bool "Choose custom BPP (must not be disabled in NX)"
 
+endchoice # EXAMPLES_FBCON_BPP_SELECTION
+
 choice EXAMPLES_FBCON_CUSTOM_BPP
 	prompt "Custom Font pixel depth (BPP - Bits Per Pixel)"
 	depends on EXAMPLES_FBCON_CUSTOM_BPP
@@ -93,7 +95,6 @@ config EXAMPLES_FBCON_32BPP
 	depends on !NX_DISABLE_32BPP
 
 endchoice # EXAMPLES_FBCON_CUSTOM_BPP
-endchoice # EXAMPLES_FBCON_BPP_SELECTION
 
 comment "Console appearance"
 
@@ -169,7 +170,7 @@ comment "FB Console App Escape code decoding"
 config EXAMPLES_FBCON_VT100_DECODE
 	bool "Decode VT100 Escape Codes"
 	default y
-	---help--
+	---help---
 		Decode VT100 ESC codes - only minimal supporting functions
 
 comment "FB Console spawn task configuration"


### PR DESCRIPTION
## Summary

This PR fixes the `endchoice` and `help` in the Kconfig for fbcon
- https://github.com/apache/nuttx-apps/pull/3029#discussion_r2006527306

This patch will fix these build errors:
```text
apps/examples/fbcon/Kconfig:62: syntax error
apps/examples/fbcon/Kconfig:172: unknown option "---help--"
```
https://github.com/lupyuen/nuttx-riscv64/actions/runs/13981663903/job/39147989438#step:5:158

## Impact

This PR will fix the build errors for various NuttX Targets, e.g. `rv-virt:nsh`

![Screenshot 2025-03-21 at 9 40 36 AM](https://github.com/user-attachments/assets/98a0ae44-feaf-4aa3-bd06-20af241eb4fc)

## Testing

Tested with local build of `rv-virt:nsh` on macOS.
