### PR TITLE
benchmarks/mtd: Add MTD transfer rates benchmark.

### DIFF
--- a/benchmarks/mtd/CMakeLists.txt
+++ b/benchmarks/mtd/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/benchmarks/mtd/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BENCHMARK_MTD)
+  nuttx_add_application(
+    NAME
+    mtd
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_BENCHMARK_MTD}
+    SRCS
+    mtd.c)
+endif()

--- a/benchmarks/mtd/Kconfig
+++ b/benchmarks/mtd/Kconfig
@@ -1,0 +1,18 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config BENCHMARK_MTD
+	tristate "MTD test and transfer rate benchmark"
+	default n
+	depends on BUILD_FLAT && MTD
+	---help---
+		This testing/benchmark application performs an erase/write
+		operation to evaluate write transfer rate and then reads the
+		written content back to evaluate the read transfer rate. Finally,
+		it compares the read data with the previously written data to
+		ensure the MTD device is working as expected.
+
+		NOTE:  This application uses internal OS interfaces and so it is not
+		available in the NuttX kernel build.

--- a/benchmarks/mtd/Make.defs
+++ b/benchmarks/mtd/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/benchmarks/mtd/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_BENCHMARK_MTD),)
+CONFIGURED_APPS += $(APPDIR)/benchmarks/mtd/
+endif

--- a/benchmarks/mtd/Makefile
+++ b/benchmarks/mtd/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/benchmarks/mtd/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# MTD test and transfer rate benchmark
+
+PROGNAME = mtd
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
+MODULE = $(CONFIG_BENCHMARK_MTD)
+
+MAINSRC = mtd.c
+
+include $(APPDIR)/Application.mk

--- a/benchmarks/mtd/mtd.c
+++ b/benchmarks/mtd/mtd.c
@@ -1,0 +1,207 @@
+/****************************************************************************
+ * apps/benchmarks/mtd/mtd.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <nuttx/mtd/mtd.h>
+#include <nuttx/fs/smart.h>
+#include <nuttx/fs/ioctl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct inode            *inode;
+  struct timespec         start;
+  struct timespec         end;
+  struct mtd_geometry_s   geo;
+  struct partition_info_s info;
+  int                     ret;
+  int                     x;
+  double                  elapsed_time;
+  double                  transfer_rate;
+  size_t                  total_bytes_written = 0;
+  size_t                  total_bytes_read = 0;
+  char                    *buffer;
+
+  /* Argument given? */
+
+  if (argc < 2)
+    {
+      fprintf(stderr, "usage: mtd flash_block_device\n");
+      return -1;
+    }
+
+  /* Find the inode of the block driver identified by 'source' */
+
+  ret = open_blockdriver(argv[1], 0, &inode);
+  if (ret < 0)
+    {
+      fprintf(stderr, "Failed to open %s\n", argv[1]);
+      return ret;
+    }
+
+  /* Get the low-level format from the device. */
+
+  ret = inode->u.i_bops->ioctl(inode, BIOC_PARTINFO, (unsigned long) &info);
+  if (ret != OK)
+    {
+      fprintf(stderr, "Device is not a block device\n");
+      goto errout_with_driver;
+    }
+
+  /* Get the MTD geometry */
+
+  ret = inode->u.i_bops->ioctl(inode, MTDIOC_GEOMETRY, (unsigned long) &geo);
+  if (ret != OK)
+    {
+      fprintf(stderr, "Device is not a MTD device\n");
+      goto errout_with_driver;
+    }
+
+  /* Report the device structure */
+
+  printf("FLASH device parameters:\n");
+  printf("   Sector size:  %10d\n", info.sectorsize);
+  printf("   Sector count: %10d\n", info.numsectors);
+  printf("   Erase block:  %10d\n", geo.erasesize);
+  printf("   Total size:   %10d\n", info.sectorsize * info.numsectors);
+
+  if (info.sectorsize != geo.erasesize)
+    {
+      fprintf(stderr, "Sector size does not match the erase block size.\n"
+             "Please adjust the sector size to enable erasing and writing "
+             "without using an intermediary read buffer.\n");
+      goto errout_with_driver;
+    }
+
+  /* Allocate buffers to use */
+
+  buffer = (char *)malloc(info.sectorsize);
+  if (buffer == NULL)
+    {
+      fprintf(stderr, "Error allocating buffer\n");
+      goto errout_with_driver;
+    }
+
+  /* Fill the buffer with known data and print it in hex format */
+
+  for (int i = 0; i < info.sectorsize; i++)
+    {
+      buffer[i] = (char)(i & 0xff);
+    }
+
+  /* Now write some data to the sector */
+
+  printf("\nStarting write operation...\n");
+
+  clock_gettime(CLOCK_MONOTONIC, &start);
+  for (x = 0; x < info.numsectors; x++)
+    {
+      inode->u.i_bops->write(inode, (const unsigned char *)buffer, x, 1);
+
+      total_bytes_written += info.sectorsize;
+    }
+
+  clock_gettime(CLOCK_MONOTONIC, &end);
+
+  elapsed_time = (end.tv_sec - start.tv_sec) + \
+                 (end.tv_nsec - start.tv_nsec) / 1e9;
+  transfer_rate = (total_bytes_written / elapsed_time) / 1024;
+
+  printf("\nWrite operation completed in %.2f seconds\n", elapsed_time);
+  printf("Total bytes written: %zu\n", total_bytes_written);
+  printf("Transfer rate [write]: %.2f KiB/s\n", transfer_rate);
+
+  /* Now read the data back to validate everything was written and can
+   * be read.
+   */
+
+  printf("\nStarting read operation...\n");
+
+  clock_gettime(CLOCK_MONOTONIC, &start);
+
+  for (x = 0; x < info.numsectors; x++)
+    {
+      inode->u.i_bops->read(inode, (unsigned char *)buffer, x, 1);
+
+      total_bytes_read += info.sectorsize;
+    }
+
+  clock_gettime(CLOCK_MONOTONIC, &end);
+
+  elapsed_time = (end.tv_sec - start.tv_sec) + \
+                 (end.tv_nsec - start.tv_nsec) / 1e9;
+  transfer_rate = (total_bytes_written / elapsed_time) / 1024;
+
+  printf("\nRead operation completed in %.2f seconds\n", elapsed_time);
+  printf("Total bytes read: %zu\n", total_bytes_read);
+  printf("Transfer rate [read]: %.2f KiB/s\n", transfer_rate);
+
+  /* Compare the read data with the written data */
+
+  for (int i = 0; i < info.sectorsize; i++)
+    {
+      if (buffer[i] != (char)(i & 0xff))
+        {
+          printf("\nData mismatch at byte %d: expected %02X, got %02X\n",
+                 i, (unsigned char)(i & 0xff), (unsigned char)buffer[i]);
+          goto errout_with_buffers;
+        }
+    }
+
+  printf("\nData verification successful: read data matches written data\n");
+
+errout_with_buffers:
+
+  /* Free the allocated buffers */
+
+  free(buffer);
+
+errout_with_driver:
+
+  /* Now close the block device and exit */
+
+  close_blockdriver(inode);
+  return 0;
+}


### PR DESCRIPTION
## Summary

This test allows measuring write and read operations on an MTD flash device, evaluating its transfer rates.

## Impact

Impact on user: YES, by providing a testing application for MTD devices (without any kind of buffering or file system).

Impact on build: NO.

Impact on hardware: NO.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

To test it, create an MTD partition and register it as a block driver. Using `esp32s3-devkit:spiflash` defconfig, let's try it:

### Building

First of all, apply the following patch (which will be submitted to the `nuttx` repository):

```
diff --git a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
index 7d0ceecc6d..37c15357c2 100644
--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -333,6 +333,14 @@ static int init_storage_partition(void)
       return ret;
     }
 
+  ret = ftl_initialize(0, mtd);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize the FTL layer: %d\n",
+              ret);
+      return ret;
+    }
+
 #ifdef CONFIG_MTD_PARTITION
   ret = parse_mtd_partition(mtd, NULL, NULL);
   if (ret < 0)
```

After applying it, build the defconfig with the following additional configs:
```
make -j distclean && ./tools/configure.sh esp32s3-devkit:spiflash && kconfig-tweak -d ESP32S3_SPIFLASH_SMARTFS && kconfig-tweak --set-val ESP32S3_SPIFLASH_MTD_BLKSIZE 4096 && kconfig-tweak -e BENCHMARK_MTD &&  make olddefconfig && make flash ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc) && minicom -D /dev/ttyUSB0
```

### Running

Run the MTD test application:

```
nsh> mtd /dev/mtdblock0
```

### Results

```
nsh> mtd /dev/mtdblock0
FLASH Test on device with:
   Sector size:        4096
   Sector count:        256
   Erase block:        4096
   Total size:      1048576

Starting write operation...

Write operation completed in 4.29 seconds
Total bytes written: 1048576
Transfer rate [write]: 238.69 KiB/s

Starting read operation...

Read operation completed in 0.43 seconds
Total bytes read: 1048576
Transfer rate [read]: 2381.40 KiB/s

Data verification successful: read data matches written data
```