### PR TITLE
cmake: fix cmake build for FreeModBus

### DIFF
--- a/modbus/CMakeLists.txt
+++ b/modbus/CMakeLists.txt
@@ -93,21 +93,26 @@ if(CONFIG_MODBUS)
   # rtu/Make.defs
 
   if(CONFIG_MB_RTU_ENABLED OR CONFIG_MB_RTU_MASTER)
-    list(APPEND rtu/mbcrc.c)
+    list(APPEND CSRCS rtu/mbcrc.c)
     if(CONFIG_MB_RTU_ENABLED)
-      list(APPEND rtu/mbrtu.c)
+      list(APPEND CSRCS rtu/mbrtu.c)
     endif()
 
     if(CONFIG_MB_RTU_MASTER)
-      list(APPEND rtu/mbrtu_m.c)
+      list(APPEND CSRCS rtu/mbrtu_m.c)
     endif()
   endif()
 
   # tcp/Make.defs
 
   if(CONFIG_MB_TCP_ENABLED)
-    list(APPEND tcp/mbtcp.c)
+    list(APPEND CSRCS tcp/mbtcp.c)
   endif()
+
+  # include private headers
+
+  target_include_directories(apps PRIVATE nuttx)
+  target_include_directories(apps PRIVATE rtu)
 
   target_sources(apps PRIVATE ${CSRCS})
 


### PR DESCRIPTION
## Summary
fix cmake build for FreeModBus:

  1. nuttx-apps/modbus/mb.c:50:12: fatal error: mbrtu.h: No such file or directory 50 | #  include "mbrtu.h"

  2. nuttx-apps/modbus/functions/mbutils.c:41:10: fatal error: port.h: No such file or directory 41 | #include "port.h"

  3. various "undefined reference to" errors
  
## Impact
fix cmake build for modbus

## Testing
local modbus RTU configuration with cmake
