### PR TITLE
modbus: add an option to disable log

### DIFF
--- a/modbus/Kconfig
+++ b/modbus/Kconfig
@@ -251,4 +251,13 @@ config MB_MASTER_FUNC_READWRITE_HOLDING_ENABLED
 
 endif # MB_ASCII_MASTER || MB_RTU_MASTER
 endif # MODBUS
+
+config MODBUS_DISABLE_LOG
+	bool "Disable logging for FreeModBus"
+	default !FILE_STREAM
+	---help---
+		Disable all logging features for FreeModBus which can be useful
+		for small optimized systems without console or log file support.
+		This also must be enabled when fputs() is not supported.
+
 endmenu # FreeModBus

--- a/modbus/nuttx/port.h
+++ b/modbus/nuttx/port.h
@@ -80,8 +80,12 @@ typedef enum
 
 void vMBPortEnterCritical(void);
 void vMBPortExitCritical(void);
+#ifndef CONFIG_MODBUS_DISABLE_LOG
 void vMBPortLog(eMBPortLogLevel eLevel, const char *szModule,
                 const char *szFmt, ...) printf_like(3, 4);
+#else
+#  define vMBPortLog(l, m, c, ...)
+#endif
 void vMBPortTimerPoll(void);
 bool xMBPortSerialPoll(void);
 bool xMBPortSerialSetTimeout(uint32_t dwTimeoutMs);

--- a/modbus/nuttx/portother.c
+++ b/modbus/nuttx/portother.c
@@ -74,6 +74,7 @@ void vMBPortLogFile(FILE * fNewLogFile)
   fLogFile = fNewLogFile;
 }
 
+#ifndef CONFIG_MODBUS_DISABLE_LOG
 void vMBPortLog(eMBPortLogLevel eLevel, const char * szModule,
                 const char * szFmt, ...)
 {
@@ -104,6 +105,7 @@ void vMBPortLog(eMBPortLogLevel eLevel, const char * szModule,
         }
     }
 }
+#endif
 
 void vMBPortEnterCritical(void)
 {


### PR DESCRIPTION
## Summary
Introduce new configuration option that allow disable all logging functionality for FreeModBus. This option is useful for small systems when we don't use any logging features.

## Impact
fix broken compilation when FILE_STREAM is disabled

## Testing
local modbus RTU configuration with file streams disabled
