### PR TITLE
mbedtls: add MBEDTLS_SSL_COOKIE_C to Kconfig for manual configuration

### DIFF
--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -639,6 +639,10 @@ config MBEDTLS_SSL_CACHE_C
 	bool "Enable simple SSL cache implementation."
 	default y
 
+config MBEDTLS_SSL_COOKIE_C
+	bool "Enable SSL cookie implementation."
+	default y
+
 config MBEDTLS_SSL_TICKET_C
 	bool "Enable an implementation of TLS server-side callbacks for session tickets."
 	depends on (MBEDTLS_CIPHER_C || MBEDTLS_USE_PSA_CRYPTO) && \


### PR DESCRIPTION
## Summary
Current defconfig and mbedtls_config.h can not enable the definition of MBEDTLS_SSL_COOKIE_C. This option is now added to Kconfig.

## Impact
mbedtls: Add "Enable SSL cookie implementation" to Kconfig.

## Testing
sim:matter
