### PR TITLE
nxlooper: fix typo in nxlooper

### DIFF
--- a/system/nxlooper/nxlooper.c
+++ b/system/nxlooper/nxlooper.c
@@ -577,7 +577,7 @@ static void *nxlooper_loopthread(pthread_addr_t pvarg)
 
             if (ret == OK && plooper->loopstate == NXLOOPER_STATE_RECORDING)
               {
-#ifdef CONFIG_O_MULTI_SESSION
+#ifdef CONFIG_AUDIO_MULTI_SESSION
                 ret = ioctl(plooper->playdev_fd, AUDIOIOC_START,
                             (unsigned long)plooper->pplayses);
 #else


### PR DESCRIPTION
## Summary

nxlooper: fix typo in nxlooper

replace CONFIG_O_MULTI_SESSION to CONFIG_AUDIO_MULTI_SESSION

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

enable CONFIG_AUDIO_MULTI_SESSION