### PR TITLE
testing/drivers/drivertest: Uniform test case name

### DIFF
--- a/testing/drivers/drivertest/drivertest_adc.c
+++ b/testing/drivers/drivertest/drivertest_adc.c
@@ -161,10 +161,10 @@ int32_t adc_read_one_sample(int fd, bool soft_trigger)
 }
 
 /****************************************************************************
- * Name: test_case_adc
+ * Name: drivertest_adc
  ****************************************************************************/
 
-static void test_case_adc(FAR void** state)
+static void drivertest_adc(FAR void** state)
 {
   int fd;
   bool succ = false;
@@ -228,7 +228,7 @@ int main(int argc, FAR char *argv[])
   parse_commandline(&adc_state, argc, argv);
 
   const struct CMUnitTest tests[] = {
-      cmocka_unit_test_prestate(test_case_adc, &adc_state),
+      cmocka_unit_test_prestate(drivertest_adc, &adc_state),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_audio.c
+++ b/testing/drivers/drivertest/drivertest_audio.c
@@ -528,7 +528,7 @@ static int audio_test_cleanup(FAR struct audio_state_s *state, int direction)
   return 0;
 }
 
-static void audio_test_case(void **audio_state)
+static void drivertest_audio(void **audio_state)
 {
   FAR struct audio_state_s *state;
   FAR struct ap_buffer_s **bufs = NULL;
@@ -801,7 +801,7 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(audio_test_case,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_audio,
                                                audio_test_setup,
                                                audio_test_teardown,
                                                &state),

--- a/testing/drivers/drivertest/drivertest_block.c
+++ b/testing/drivers/drivertest/drivertest_block.c
@@ -226,10 +226,10 @@ static int setup_driver(FAR void **state)
 }
 
 /****************************************************************************
- * Name: blktest_stress
+ * Name: drivertest_block_stress
  ****************************************************************************/
 
-static void blktest_stress(FAR void **state)
+static void drivertest_block_stress(FAR void **state)
 {
   FAR struct pre_build_s *pre;
   FAR void *input;
@@ -287,10 +287,10 @@ static void blktest_stress(FAR void **state)
 }
 
 /****************************************************************************
- * Name: blktest_multiple_write
+ * Name: drivertest_block_cache_write
  ****************************************************************************/
 
-static void blktest_cachesize_write(FAR void **state)
+static void drivertest_block_cache_write(FAR void **state)
 {
   FAR struct pre_build_s *pre;
   FAR void *input;
@@ -387,10 +387,10 @@ static void blktest_cachesize_write(FAR void **state)
 }
 
 /****************************************************************************
- * Name: blktest_single_write
+ * Name: drivertest_block_single_write
  ****************************************************************************/
 
-static void blktest_single_write(FAR void **state)
+static void drivertest_block_single_write(FAR void **state)
 {
   FAR struct pre_build_s *pre;
   FAR void *input;
@@ -490,12 +490,12 @@ int main(int argc, FAR char *argv[])
   parse_commandline(argc, argv, pre);
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(blktest_stress, setup_bch,
-                                               teardown_bch, pre),
-      cmocka_unit_test_prestate_setup_teardown(blktest_single_write,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_block_stress,
+                                               setup_bch, teardown_bch, pre),
+      cmocka_unit_test_prestate_setup_teardown(drivertest_block_single_write,
                                                setup_driver, teardown_driver,
                                                pre),
-      cmocka_unit_test_prestate_setup_teardown(blktest_cachesize_write,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_block_cache_write,
                                                setup_driver, teardown_driver,
                                                pre),
     };

--- a/testing/drivers/drivertest/drivertest_framebuffer.c
+++ b/testing/drivers/drivertest/drivertest_framebuffer.c
@@ -406,10 +406,10 @@ static void draw_rect(FAR struct fb_state_s *fb_state, int x, int y,
 }
 
 /****************************************************************************
- * Name: test_case_fb_0
+ * Name: drivertest_framebuffer_black
  ****************************************************************************/
 
-static void test_case_fb_0(FAR void **state)
+static void drivertest_framebuffer_black(FAR void **state)
 {
   FAR struct fb_state_s * fb_state;
   fb_state = (struct fb_state_s *)*state;
@@ -421,10 +421,10 @@ static void test_case_fb_0(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_fb_1
+ * Name: drivertest_framebuffer_white
  ****************************************************************************/
 
-static void test_case_fb_1(FAR void **state)
+static void drivertest_framebuffer_white(FAR void **state)
 {
   FAR struct fb_state_s * fb_state;
   fb_state = (struct fb_state_s *)*state;
@@ -436,10 +436,10 @@ static void test_case_fb_1(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_fb_2
+ * Name: drivertest_framebuffer_cross
  ****************************************************************************/
 
-static void test_case_fb_2(FAR void **state)
+static void drivertest_framebuffer_cross(FAR void **state)
 {
   FAR struct fb_state_s * fb_state;
   fb_state = (struct fb_state_s *)*state;
@@ -470,10 +470,10 @@ static void test_case_fb_2(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_fb_3
+ * Name: drivertest_framebuffer_vertical
  ****************************************************************************/
 
-static void test_case_fb_3(FAR void **state)
+static void drivertest_framebuffer_vertical(FAR void **state)
 {
   FAR struct fb_state_s * fb_state;
   fb_state = (struct fb_state_s *)*state;
@@ -541,14 +541,18 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate_setup_teardown(test_case_fb_0, fb_setup,
-                                             fb_teardown, &fb_state),
-    cmocka_unit_test_prestate_setup_teardown(test_case_fb_1, fb_setup,
-                                             fb_teardown, &fb_state),
-    cmocka_unit_test_prestate_setup_teardown(test_case_fb_2, fb_setup,
-                                             fb_teardown, &fb_state),
-    cmocka_unit_test_prestate_setup_teardown(test_case_fb_3, fb_setup,
-                                             fb_teardown, &fb_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_framebuffer_black,
+                                             fb_setup, fb_teardown,
+                                             &fb_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_framebuffer_white,
+                                             fb_setup, fb_teardown,
+                                             &fb_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_framebuffer_cross,
+                                             fb_setup, fb_teardown,
+                                             &fb_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_framebuffer_vertical,
+                                             fb_setup, fb_teardown,
+                                             &fb_state),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_i2c_spi.c
+++ b/testing/drivers/drivertest/drivertest_i2c_spi.c
@@ -100,10 +100,10 @@ static int teardown(FAR void **state)
 }
 
 /****************************************************************************
- * Name: read_from_device
+ * Name: drivertest_i2c_spi
  ****************************************************************************/
 
-static void read_from_device(FAR void **state)
+static void drivertest_i2c_spi(FAR void **state)
 {
   FAR struct test_state_s *test_state;
   struct accel_gyro_st_s data;
@@ -163,7 +163,7 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(read_from_device, setup,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_i2c_spi, setup,
                                                teardown, &test_state),
     };
 

--- a/testing/drivers/drivertest/drivertest_lcd.c
+++ b/testing/drivers/drivertest/drivertest_lcd.c
@@ -296,10 +296,10 @@ static void draw_rect(FAR struct lcd_info_s *lcd_info, int x, int y,
 }
 
 /****************************************************************************
- * Name: test_case_lcd_0
+ * Name: drivertest_lcd_black
  ****************************************************************************/
 
-static void test_case_lcd_0(FAR void **state)
+static void drivertest_lcd_black(FAR void **state)
 {
   FAR struct lcd_state_s * lcd_state;
   lcd_state = (struct lcd_state_s *)*state;
@@ -311,10 +311,10 @@ static void test_case_lcd_0(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_lcd_1
+ * Name: drivertest_lcd_white
  ****************************************************************************/
 
-static void test_case_lcd_1(FAR void **state)
+static void drivertest_lcd_white(FAR void **state)
 {
   FAR struct lcd_state_s * lcd_state;
   lcd_state = (struct lcd_state_s *)*state;
@@ -326,10 +326,10 @@ static void test_case_lcd_1(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_lcd_2
+ * Name: drivertest_lcd_cross
  ****************************************************************************/
 
-static void test_case_lcd_2(FAR void **state)
+static void drivertest_lcd_cross(FAR void **state)
 {
   FAR struct lcd_state_s * lcd_state = (struct lcd_state_s *)*state;
   int i = 0;
@@ -360,10 +360,10 @@ static void test_case_lcd_2(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_lcd_3
+ * Name: drivertest_lcd_vertical
  ****************************************************************************/
 
-static void test_case_lcd_3(FAR void **state)
+static void drivertest_lcd_vertical(FAR void **state)
 {
   FAR struct lcd_state_s * lcd_state = (struct lcd_state_s *)*state;
   int i = 0;
@@ -427,14 +427,18 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate_setup_teardown(test_case_lcd_0, lcd_setup,
-                                               lcd_teardown, &lcd_state),
-    cmocka_unit_test_prestate_setup_teardown(test_case_lcd_1, lcd_setup,
-                                               lcd_teardown, &lcd_state),
-    cmocka_unit_test_prestate_setup_teardown(test_case_lcd_2, lcd_setup,
-                                               lcd_teardown, &lcd_state),
-    cmocka_unit_test_prestate_setup_teardown(test_case_lcd_3, lcd_setup,
-                                               lcd_teardown, &lcd_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_lcd_black,
+                                             lcd_setup, lcd_teardown,
+                                             &lcd_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_lcd_white,
+                                             lcd_setup, lcd_teardown,
+                                             &lcd_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_lcd_cross,
+                                             lcd_setup, lcd_teardown,
+                                             &lcd_state),
+    cmocka_unit_test_prestate_setup_teardown(drivertest_lcd_vertical,
+                                             lcd_setup, lcd_teardown,
+                                             &lcd_state),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_mps2.c
+++ b/testing/drivers/drivertest/drivertest_mps2.c
@@ -419,7 +419,7 @@ static void *test_irq_prio_thread_entry(void *arg)
   return NULL;
 }
 
-static void test_irqprio(void **argv)
+static void drivertest_mps2(void **argv)
 {
   pid_t tid[CONFIG_TEST_IRQPRIO_TTHREAD + 1];
   pthread_attr_t attr;
@@ -489,7 +489,7 @@ int main(int argc, char *argv[])
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test_prestate_setup_teardown(
-        test_irqprio, setup, teardown, NULL),
+        drivertest_mps2, setup, teardown, NULL),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_mps2_zerointerrupt.c
+++ b/testing/drivers/drivertest/drivertest_mps2_zerointerrupt.c
@@ -206,7 +206,7 @@ static void *test_irq_awaker_thread_entry(void *arg)
   return 0;
 }
 
-static void test_irqprio(void **argv)
+static void drivertest_mps2_zerointerrupt(void **argv)
 {
   pid_t tid;
   irqstate_t flags;
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test_prestate_setup_teardown(
-        test_irqprio, setup, teardown, NULL),
+        drivertest_mps2_zerointerrupt, setup, teardown, NULL),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_oneshot.c
+++ b/testing/drivers/drivertest/drivertest_oneshot.c
@@ -135,10 +135,10 @@ static void parse_commandline(FAR struct oneshot_state_s *oneshot_state,
 }
 
 /****************************************************************************
- * Name: test_case_oneshot
+ * Name: drivertest_oneshot
  ****************************************************************************/
 
-static void test_case_oneshot(FAR void **state)
+static void drivertest_oneshot(FAR void **state)
 {
   int ret;
   int fd;
@@ -222,7 +222,7 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_oneshot, &oneshot_state)
+    cmocka_unit_test_prestate(drivertest_oneshot, &oneshot_state)
   };
 
   parse_commandline(&oneshot_state, argc, argv);

--- a/testing/drivers/drivertest/drivertest_pm.c
+++ b/testing/drivers/drivertest/drivertest_pm.c
@@ -150,7 +150,7 @@ static void test_pm_callback_notify(FAR struct pm_callback_s *cb,
   return;
 }
 
-static void test_pm(FAR void **argv)
+static void drivertest_pm(FAR void **argv)
 {
   int persist_stay_cnt[PM_COUNT];
   int init_delay;
@@ -409,7 +409,7 @@ int main(int argc, FAR char *argv[])
 {
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(test_pm, setup,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_pm, setup,
                                                teardown, NULL),
     };
 

--- a/testing/drivers/drivertest/drivertest_pm_runtime.c
+++ b/testing/drivers/drivertest/drivertest_pm_runtime.c
@@ -97,7 +97,7 @@ static int test_pm_runtime_resume(FAR struct pm_runtime_s *dev)
   return 0;
 }
 
-static void test_pm_runtime(FAR void **state)
+static void drivertest_pm_runtime(FAR void **state)
 {
   int ret = 0;
   int cnt = 10;
@@ -167,7 +167,7 @@ int main(int argc, FAR char *argv[])
 {
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(test_pm_runtime, setup,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_pm_runtime, setup,
                                                teardown, NULL),
     };
 

--- a/testing/drivers/drivertest/drivertest_pm_smp.c
+++ b/testing/drivers/drivertest/drivertest_pm_smp.c
@@ -432,7 +432,7 @@ error_out:
   return (void *)(uintptr_t)ret;
 }
 
-static void test_pm_smp(FAR void **argv)
+static void drivertest_pm_smp(FAR void **argv)
 {
   for (int i = 0; i < CONFIG_SMP_NCPUS; i++)
     {
@@ -486,7 +486,7 @@ int main(int argc, FAR char *argv[])
 {
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(test_pm_smp, setup,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_pm_smp, setup,
                                                teardown, NULL),
     };
 

--- a/testing/drivers/drivertest/drivertest_posix_timer.c
+++ b/testing/drivers/drivertest/drivertest_posix_timer.c
@@ -168,10 +168,10 @@ static void posix_timer_callback(union sigval arg)
 }
 
 /****************************************************************************
- * Name: test_case_posix_timer
+ * Name: drivertest_posix_timer
  ****************************************************************************/
 
-static void test_case_posix_timer(FAR void **state)
+static void drivertest_posix_timer(FAR void **state)
 {
   int ret;
   timer_t timerid;
@@ -230,7 +230,8 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_posix_timer, &posix_timer_state)
+    cmocka_unit_test_prestate_setup_teardown(drivertest_posix_timer, NULL,
+                                             NULL, &posix_timer_state)
   };
 
   parse_commandline(&posix_timer_state, argc, argv);

--- a/testing/drivers/drivertest/drivertest_pwm.c
+++ b/testing/drivers/drivertest/drivertest_pwm.c
@@ -219,7 +219,7 @@ static void parse_commandline(FAR struct pwm_state_s *pwm_state, int argc,
  * Name: test_case_pwm
  ****************************************************************************/
 
-static void test_case_pwm(FAR void **state)
+static void drivertest_pwm(FAR void **state)
 {
   int fd;
   int ret;
@@ -314,7 +314,7 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_pwm, &pwm_state)
+    cmocka_unit_test_prestate(drivertest_pwm, &pwm_state)
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_regulator.c
+++ b/testing/drivers/drivertest/drivertest_regulator.c
@@ -198,7 +198,7 @@ static int test_regulator_resume(FAR struct regulator_dev_s *rdev)
   return 0;
 }
 
-static void test_regulator_register(FAR void **state)
+static void drivertest_reg_register(FAR void **state)
 {
   FAR struct regulator_dev_s *test = NULL;
 
@@ -213,7 +213,7 @@ static void test_regulator_register(FAR void **state)
   regulator_unregister(g_fake_regulator.rdev);
 }
 
-static void test_regulator_always_on(FAR void **state)
+static void drivertest_reg_always_on(FAR void **state)
 {
   FAR struct regulator_s *test = NULL;
   int ret = 0;
@@ -254,7 +254,7 @@ static void test_regulator_always_on(FAR void **state)
   return;
 }
 
-static void test_regulator_supply_1(FAR void **state)
+static void drivertest_reg_supply_always_on_boot_off(FAR void **state)
 {
   FAR struct regulator_s *test = NULL;
   int cnt = 10;
@@ -313,7 +313,7 @@ static void test_regulator_supply_1(FAR void **state)
   return;
 }
 
-static void test_regulator_supply_2(FAR void **state)
+static void drivertest_reg_supply_boot_on_always_on(FAR void **state)
 {
   FAR struct regulator_s *test = NULL;
   int cnt = 10;
@@ -372,7 +372,7 @@ static void test_regulator_supply_2(FAR void **state)
   return;
 }
 
-static void test_regulator_supply_3(FAR void **state)
+static void drivertest_reg_supply_boot_on_always_off(FAR void **state)
 {
   FAR struct regulator_s *test = NULL;
   int cnt = 10;
@@ -435,7 +435,7 @@ static void test_regulator_supply_3(FAR void **state)
   return;
 }
 
-static void test_regulator_supply_4(FAR void **state)
+static void drivertest_reg_supply_boot_off_always_off(FAR void **state)
 {
   FAR struct regulator_s *test = NULL;
   int cnt = 10;
@@ -495,7 +495,7 @@ static void test_regulator_supply_4(FAR void **state)
   return;
 }
 
-static void test_regulator_mode(FAR void **state)
+static void drivertest_reg_mode(FAR void **state)
 {
   FAR struct regulator_s *test = NULL;
   int cnt = 10;
@@ -535,7 +535,7 @@ static void test_regulator_mode(FAR void **state)
 }
 
 #ifdef CONFIG_PM
-static void test_regulator_pm_register(FAR void **state)
+static void drivertest_reg_pm_register(FAR void **state)
 {
   g_fake_regulator_desc.auto_lp = 0;
   g_fake_regulator.lpmode = REGULATOR_MODE_INVALID;
@@ -556,7 +556,7 @@ static void test_regulator_pm_register(FAR void **state)
   return;
 }
 
-static void test_regulator_pm_callback(FAR void **state)
+static void drivertest_reg_pm_callback(FAR void **state)
 {
   g_fake_regulator_desc.supply_name = NULL;
   g_fake_regulator_desc.auto_lp = 1;
@@ -611,16 +611,20 @@ int main(int argc, FAR char *argv[])
 {
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate(test_regulator_register, NULL),
-      cmocka_unit_test_prestate(test_regulator_always_on, NULL),
-      cmocka_unit_test_prestate(test_regulator_supply_1, NULL),
-      cmocka_unit_test_prestate(test_regulator_supply_2, NULL),
-      cmocka_unit_test_prestate(test_regulator_supply_3, NULL),
-      cmocka_unit_test_prestate(test_regulator_supply_4, NULL),
-      cmocka_unit_test_prestate(test_regulator_mode, NULL),
+      cmocka_unit_test_prestate(drivertest_reg_register, NULL),
+      cmocka_unit_test_prestate(drivertest_reg_always_on, NULL),
+      cmocka_unit_test_prestate(drivertest_reg_supply_always_on_boot_off,
+                                NULL),
+      cmocka_unit_test_prestate(drivertest_reg_supply_boot_on_always_on,
+                                NULL),
+      cmocka_unit_test_prestate(drivertest_reg_supply_boot_on_always_off,
+                                NULL),
+      cmocka_unit_test_prestate(drivertest_reg_supply_boot_off_always_off,
+                                NULL),
+      cmocka_unit_test_prestate(drivertest_reg_mode, NULL),
 #ifdef CONFIG_PM
-      cmocka_unit_test_prestate(test_regulator_pm_register, NULL),
-      cmocka_unit_test_prestate(test_regulator_pm_callback, NULL),
+      cmocka_unit_test_prestate(drivertest_reg_pm_register, NULL),
+      cmocka_unit_test_prestate(drivertest_reg_pm_callback, NULL),
 #endif
     };
 

--- a/testing/drivers/drivertest/drivertest_relay.c
+++ b/testing/drivers/drivertest/drivertest_relay.c
@@ -125,10 +125,10 @@ static int setup(FAR void **state)
 }
 
 /****************************************************************************
- * Name: relaytest01
+ * Name: drivertest_relay
  ****************************************************************************/
 
-static void relaytest01(FAR void **state)
+static void drivertest_relay(FAR void **state)
 {
   FAR struct relay_args_s *relay_args;
   int fd;
@@ -243,7 +243,7 @@ int main(int argc, FAR char *argv[])
   parse_commandline(argc, argv, &relay_args);
   const struct CMUnitTest tests[] =
     {
-      cmocka_unit_test_prestate_setup_teardown(relaytest01, setup,
+      cmocka_unit_test_prestate_setup_teardown(drivertest_relay, setup,
                                                teardown, &relay_args),
     };
 

--- a/testing/drivers/drivertest/drivertest_rtc.c
+++ b/testing/drivers/drivertest/drivertest_rtc.c
@@ -150,10 +150,10 @@ static void parse_commandline(FAR struct rtc_state_s *rtc_state, int argc,
 }
 
 /****************************************************************************
- * Name: test_case_rtc_01
+ * Name: drivertest_rtc_api
  ****************************************************************************/
 
-static void test_case_rtc_01(FAR void **state)
+static void drivertest_rtc_api(FAR void **state)
 {
   int fd;
   int ret;
@@ -245,10 +245,10 @@ static void add_timeout(struct rtc_time * rtc_tm, const int delay)
 }
 
 /****************************************************************************
- * Name: test_case_rtc_02
+ * Name: drivertest_rtc_alarm
  ****************************************************************************/
 
-static void test_case_rtc_02(FAR void **state)
+static void drivertest_rtc_alarm(FAR void **state)
 {
   int fd;
   int ret;
@@ -372,10 +372,10 @@ static void rtc_periodic_callback(union sigval arg)
 }
 
 /****************************************************************************
- * Name: test_case_rtc_03
+ * Name: drivertest_rtc_periodic
  ****************************************************************************/
 
-static void test_case_rtc_03(FAR void **state)
+static void drivertest_rtc_periodic(FAR void **state)
 {
   int alarmid = 0;
   int ret;
@@ -434,12 +434,12 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_rtc_01, &rtc_state),
+    cmocka_unit_test_prestate(drivertest_rtc_api, &rtc_state),
 #ifdef CONFIG_RTC_ALARM
-    cmocka_unit_test_prestate(test_case_rtc_02, &rtc_state),
+    cmocka_unit_test_prestate(drivertest_rtc_alarm, &rtc_state),
 #endif
 #ifdef CONFIG_RTC_PERIODIC
-    cmocka_unit_test_prestate(test_case_rtc_03, &rtc_state),
+    cmocka_unit_test_prestate(drivertest_rtc_periodic, &rtc_state),
 #endif
   };
 

--- a/testing/drivers/drivertest/drivertest_simple.c
+++ b/testing/drivers/drivertest/drivertest_simple.c
@@ -34,13 +34,13 @@
  * Private Functions
  ****************************************************************************/
 
-static void test_case_01(FAR void **state)
+static void drivertest_simple_assert(FAR void **state)
 {
   UNUSED(state);
   assert_int_equal(0, 0);
 }
 
-static void test_case_02(FAR void **state)
+static void drivertest_simple_assert_string(FAR void **state)
 {
   UNUSED(state);
   assert_string_not_equal("hello", "world");
@@ -58,8 +58,8 @@ int main(int argc, FAR char *argv[])
 {
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test(test_case_01),
-    cmocka_unit_test(test_case_02),
+    cmocka_unit_test(drivertest_simple_assert),
+    cmocka_unit_test(drivertest_simple_assert_string),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_timer.c
+++ b/testing/drivers/drivertest/drivertest_timer.c
@@ -201,10 +201,10 @@ static void parse_commandline(FAR struct timer_state_s *timer_state,
 }
 
 /****************************************************************************
- * Name: test_case_timer
+ * Name: drivertest_timer
  ****************************************************************************/
 
-static void test_case_timer(FAR void **state)
+static void drivertest_timer(FAR void **state)
 {
   int i;
   int fd;
@@ -318,7 +318,7 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_timer, &timer_state)
+    cmocka_unit_test_prestate(drivertest_timer, &timer_state)
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/testing/drivers/drivertest/drivertest_touchpanel.c
+++ b/testing/drivers/drivertest/drivertest_touchpanel.c
@@ -717,10 +717,10 @@ static void parse_commandline(uint32_t *screen_shape,
 }
 
 /****************************************************************************
- * Name: test_case_touchpanel
+ * Name: drivertest_touchpanel
  ****************************************************************************/
 
-static void test_case_touchpanel(FAR void **state)
+static void drivertest_touchpanel(FAR void **state)
 {
   lv_nuttx_dsc_t info;
   lv_nuttx_result_t result;
@@ -780,7 +780,7 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_touchpanel, &screen_shape)
+    cmocka_unit_test_prestate(drivertest_touchpanel, &screen_shape)
   };
 
   parse_commandline(&screen_shape, argc, argv);

--- a/testing/drivers/drivertest/drivertest_watchdog.c
+++ b/testing/drivers/drivertest/drivertest_watchdog.c
@@ -288,14 +288,14 @@ static int capture_callback(int irq, FAR void *context, FAR void *arg)
 }
 
 /****************************************************************************
- * Name: test_case_wdog_01
+ * Name: drivertest_watchdog_feeding
  *
  * Description:
  *   This function is used to test whether the watchdog can take effect after
  *   timeout without relying on automatic feeding
  ****************************************************************************/
 
-static void test_case_wdog_01(FAR void **state)
+static void drivertest_watchdog_feeding(FAR void **state)
 {
   int dev_fd;
   int ret;
@@ -347,14 +347,14 @@ static void test_case_wdog_01(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_wdog_02
+ * Name: drivertest_watchdog_interrupts
  *
  * Description:
  *   This function is used to test whether the watchdog takes effect when
  *   the interrupt is turned off.
  ****************************************************************************/
 
-static void test_case_wdog_02(FAR void **state)
+static void drivertest_watchdog_interrupts(FAR void **state)
 {
   FAR struct wdg_state_s *wdg_state;
   struct boardioc_reset_cause_s reset_cause;
@@ -390,14 +390,14 @@ static void wdg_wdentry(wdparm_t arg)
 }
 
 /****************************************************************************
- * Name: test_case_wdog_03
+ * Name: drivertest_watchdog_loop
  *
  * Description:
  *   This function is used to test whether the infinite loop will start
  *   watchdog after opening the interrupt.
  ****************************************************************************/
 
-static void test_case_wdog_03(FAR void **state)
+static void drivertest_watchdog_loop(FAR void **state)
 {
   int ret;
   static struct wdog_s wdog;
@@ -428,13 +428,13 @@ static void test_case_wdog_03(FAR void **state)
 }
 
 /****************************************************************************
- * Name: test_case_wdog_04
+ * Name: drivertest_watchdog_api
  *
  * Description:
  *   This function is used to test the watchdog driver interface.
  ****************************************************************************/
 
-static void test_case_wdog_04(FAR void **state)
+static void drivertest_watchdog_api(FAR void **state)
 {
   int dev_fd;
   int ret;
@@ -541,10 +541,10 @@ int main(int argc, FAR char *argv[])
 
   const struct CMUnitTest tests[] =
   {
-    cmocka_unit_test_prestate(test_case_wdog_01, &wdg_state),
-    cmocka_unit_test_prestate(test_case_wdog_02, &wdg_state),
-    cmocka_unit_test_prestate(test_case_wdog_03, &wdg_state),
-    cmocka_unit_test_prestate(test_case_wdog_04, &wdg_state)
+    cmocka_unit_test_prestate(drivertest_watchdog_feeding, &wdg_state),
+    cmocka_unit_test_prestate(drivertest_watchdog_interrupts, &wdg_state),
+    cmocka_unit_test_prestate(drivertest_watchdog_loop, &wdg_state),
+    cmocka_unit_test_prestate(drivertest_watchdog_api, &wdg_state)
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary
1.Some test functions are named too simply
2.Many driver tests depend on specific configurations and hardware, and the unified specification name facilitates cmocka to skip tests by using the skip parameter for wildcard matching
## Impact
None
## Testing
local test
