### PR TITLE
gps: modify printf to use format specifier macros

### DIFF
--- a/examples/gps/gps_main.c
+++ b/examples/gps/gps_main.c
@@ -99,11 +99,11 @@ int main(int argc, FAR char *argv[])
 
               if (minmea_parse_rmc(&frame, line))
                 {
-                  printf("Fixed-point Latitude...........: %d\n",
+                  printf("Fixed-point Latitude...........: %" PRId32 "\n",
                          minmea_rescale(&frame.latitude, 1000));
-                  printf("Fixed-point Longitude..........: %d\n",
+                  printf("Fixed-point Longitude..........: %" PRId32 "\n",
                          minmea_rescale(&frame.longitude, 1000));
-                  printf("Fixed-point Speed..............: %d\n",
+                  printf("Fixed-point Speed..............: %" PRId32 "\n",
                          minmea_rescale(&frame.speed, 1000));
                   printf("Floating point degree latitude.: %2.6f\n",
                          minmea_tocoord(&frame.latitude));
@@ -127,7 +127,7 @@ int main(int argc, FAR char *argv[])
                 {
                   printf("Fix quality....................: %d\n",
                          frame.fix_quality);
-                  printf("Altitude.......................: %d\n",
+                  printf("Altitude.......................: %" PRId32 "\n",
                          frame.altitude.value);
                   printf("Tracked satellites.............: %d\n",
                          frame.satellites_tracked);


### PR DESCRIPTION
## Summary
This PR modifies some `printf` calls from `%d` to `PRId32` to solve warnings due to compiler changes.
Relates to this [issue](https://github.com/apache/nuttx/issues/15755).

Example of the build warning, when compiling with new int types for Xtensa devices:
```
Error: gps_main.c:102:61: error: format '%d' expects argument of type 'int', but argument 2 has type 'int_least32_t' {aka 'long int'} [-Werror=format=]
  102 |                   printf("Fixed-point Latitude...........: %d\n",
      |                                                            ~^
      |                                                             |
      |                                                             int
      |                                                            %ld
  103 |                          minmea_rescale(&frame.latitude, 1000));
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                          |
      |                          int_least32_t {aka long int}
```

## Impact
Minimum impact. Improves the code by making it more independent from compiler types.

## Testing
Tested through building a GPS defconfig from `lylygo_tbeam`.
- ./tools/configure.sh lilygo_tbeam_lora_gps:gps
- make -j

Output now shows no errors.
