### PR TITLE
examples: fix coding standard issues for nimble_blecent and nimble_bleprpt

### DIFF
--- a/examples/nimble_blecent/CMakeLists.txt
+++ b/examples/nimble_blecent/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # apps/examples/nimble_blecent/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this
@@ -21,7 +23,7 @@
 if(CONFIG_EXAMPLES_NIMBLE_BLECENT)
   nuttx_add_application(
     NAME
-    nimble
+    ${CONFIG_EXAMPLES_NIMBLE_BLECENT_PROGNAME}
     SRCS
     ${CMAKE_CURRENT_LIST_DIR}/nimble_blecent_main.c
     ${CMAKE_CURRENT_LIST_DIR}/misc.c

--- a/examples/nimble_blecent/Kconfig
+++ b/examples/nimble_blecent/Kconfig
@@ -4,16 +4,16 @@
 #
 
 config EXAMPLES_NIMBLE_BLECENT
-	tristate "NimBLE peripheral"
+	tristate "NimBLE central"
 	default n
 	---help---
-		Enable the nimble peripheral
+		Enable the nimble central example
 
 if EXAMPLES_NIMBLE_BLECENT
 
 config EXAMPLES_NIMBLE_BLECENT_PROGNAME
 	string "Program name"
-	default "nimble"
+	default "blecent"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.

--- a/examples/nimble_blecent/Make.defs
+++ b/examples/nimble_blecent/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # apps/examples/nimble_blecent/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -19,5 +21,5 @@
 ############################################################################
 
 ifneq ($(CONFIG_EXAMPLES_NIMBLE_BLECENT),)
-CONFIGURED_APPS += $(APPDIR)/examples/nimble
+CONFIGURED_APPS += $(APPDIR)/examples/nimble_blecent
 endif

--- a/examples/nimble_blecent/Makefile
+++ b/examples/nimble_blecent/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # apps/examples/nimble_blecent/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/examples/nimble_blecent/blecent.h
+++ b/examples/nimble_blecent/blecent.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * apps/examples/nimble_blecent/blecent.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -18,8 +20,8 @@
  *
  ****************************************************************************/
 
-#ifndef H_BLECENT_
-#define H_BLECENT_
+#ifndef __APPS_EXAMPLES_NIMBLE_BLECENT_BLECENT_H
+#define __APPS_EXAMPLES_NIMBLE_BLECENT_BLECENT_H
 
 /****************************************************************************
  * Included Files
@@ -27,16 +29,9 @@
 
 #include <stdio.h>
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-struct ble_hs_adv_fields;
-struct ble_gap_conn_desc;
-struct ble_hs_cfg;
-union ble_store_value;
-union ble_store_key;
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
 
 #define BLECENT_SVC_ALERT_UUID              0x1811
 #define BLECENT_CHR_SUP_NEW_ALERT_CAT_UUID  0x2A47
@@ -45,39 +40,34 @@ union ble_store_key;
 #define BLECENT_CHR_UNR_ALERT_STAT_UUID     0x2A45
 #define BLECENT_CHR_ALERT_NOT_CTRL_PT       0x2A44
 
-/* Misc. */
-
-void print_bytes(const uint8_t *bytes, int len);
-void print_mbuf(const struct os_mbuf *om);
-char *addr_str(const void *addr);
-void print_uuid(const ble_uuid_t *uuid);
-void print_conn_desc(const struct ble_gap_conn_desc *desc);
-void print_adv_fields(const struct ble_hs_adv_fields *fields);
+/****************************************************************************
+ * Public Type Definition
+ ****************************************************************************/
 
 /* Peer. */
 
 struct peer_dsc
 {
-    SLIST_ENTRY(peer_dsc) next;
-    struct ble_gatt_dsc dsc;
+  SLIST_ENTRY(peer_dsc) next;
+  struct ble_gatt_dsc dsc;
 };
 SLIST_HEAD(peer_dsc_list, peer_dsc);
 
 struct peer_chr
 {
-    SLIST_ENTRY(peer_chr) next;
-    struct ble_gatt_chr chr;
+  SLIST_ENTRY(peer_chr) next;
+  struct ble_gatt_chr chr;
 
-    struct peer_dsc_list dscs;
+  struct peer_dsc_list dscs;
 };
 SLIST_HEAD(peer_chr_list, peer_chr);
 
 struct peer_svc
 {
-    SLIST_ENTRY(peer_svc) next;
-    struct ble_gatt_svc svc;
+  SLIST_ENTRY(peer_svc) next;
+  struct ble_gatt_svc svc;
 
-    struct peer_chr_list chrs;
+  struct peer_chr_list chrs;
 };
 SLIST_HEAD(peer_svc_list, peer_svc);
 
@@ -86,35 +76,68 @@ typedef void peer_disc_fn(const struct peer *peer, int status, void *arg);
 
 struct peer
 {
-    SLIST_ENTRY(peer) next;
+  SLIST_ENTRY(peer) next;
 
-    uint16_t conn_handle;
+  uint16_t conn_handle;
 
-    /* List of discovered GATT services. */
+  /* List of discovered GATT services. */
 
-    struct peer_svc_list svcs;
+  struct peer_svc_list svcs;
 
-    /* Keeps track of where we are in the service discovery process. */
+  /* Keeps track of where we are in the service discovery process. */
 
-    uint16_t disc_prev_chr_val;
-    struct peer_svc *cur_svc;
+  uint16_t disc_prev_chr_val;
+  struct peer_svc *cur_svc;
 
-    /* Callback that gets executed when service discovery completes. */
+  /* Callback that gets executed when service discovery completes. */
 
-    peer_disc_fn *disc_cb;
-    void *disc_cb_arg;
+  peer_disc_fn *disc_cb;
+  void *disc_cb_arg;
 };
 
-int peer_disc_all(uint16_t conn_handle, peer_disc_fn *disc_cb,
-                  void *disc_cb_arg);
-const struct peer_dsc *
-peer_dsc_find_uuid(const struct peer *peer, const ble_uuid_t *svc_uuid,
-                   const ble_uuid_t *chr_uuid, const ble_uuid_t *dsc_uuid);
-const struct peer_chr *
-peer_chr_find_uuid(const struct peer *peer, const ble_uuid_t *svc_uuid,
-                   const ble_uuid_t *chr_uuid);
-const struct peer_svc *
-peer_svc_find_uuid(const struct peer *peer, const ble_uuid_t *uuid);
+/****************************************************************************
+ * Public Type Definition
+ ****************************************************************************/
+
+/* Forward references */
+
+struct ble_hs_adv_fields;
+struct ble_gap_conn_desc;
+struct ble_hs_cfg;
+union ble_store_value;
+union ble_store_key;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Misc. */
+
+void print_mbuf(FAR const struct os_mbuf *om);
+FAR char *addr_str(FAR const void *addr);
+void print_uuid(FAR const ble_uuid_t *uuid);
+void print_conn_desc(FAR const struct ble_gap_conn_desc *desc);
+void print_adv_fields(FAR const struct ble_hs_adv_fields *fields);
+
+int peer_disc_all(uint16_t conn_handle, FAR peer_disc_fn *disc_cb,
+                  FAR void *disc_cb_arg);
+FAR const struct peer_dsc *
+peer_dsc_find_uuid(FAR const struct peer *peer,
+                   FAR const ble_uuid_t *svc_uuid,
+                   FAR const ble_uuid_t *chr_uuid,
+                   FAR const ble_uuid_t *dsc_uuid);
+FAR const struct peer_chr *
+peer_chr_find_uuid(FAR const struct peer *peer,
+                   FAR const ble_uuid_t *svc_uuid,
+                   FAR const ble_uuid_t *chr_uuid);
+FAR const struct peer_svc *
+peer_svc_find_uuid(FAR const struct peer *peer,
+                   FAR const ble_uuid_t *uuid);
 int peer_delete(uint16_t conn_handle);
 int peer_add(uint16_t conn_handle);
 int peer_init(int max_peers, int max_svcs, int max_chrs, int max_dscs);
@@ -123,4 +146,4 @@ int peer_init(int max_peers, int max_svcs, int max_chrs, int max_dscs);
 }
 #endif
 
-#endif
+#endif  /* __APPS_EXAMPLES_NIMBLE_BLECENT_BLECENT_H */

--- a/examples/nimble_blecent/misc.c
+++ b/examples/nimble_blecent/misc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * apps/examples/nimble_blecent/misc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -25,15 +27,16 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+
 #include "host/ble_hs.h"
 #include "host/ble_uuid.h"
 #include "blecent.h"
 
 /****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
-void print_bytes(FAR const uint8_t *bytes, int len)
+static void print_bytes(FAR const uint8_t *bytes, int len)
 {
   int i;
 
@@ -42,6 +45,10 @@ void print_bytes(FAR const uint8_t *bytes, int len)
       printf("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 void print_mbuf(FAR const struct os_mbuf *om)
 {
@@ -64,7 +71,7 @@ void print_mbuf(FAR const struct os_mbuf *om)
     }
 }
 
-char * addr_str(FAR const void *addr)
+FAR char *addr_str(FAR const void *addr)
 {
   static char buf[6 * 2 + 5 + 1];
   const uint8_t *u8p;

--- a/examples/nimble_blecent/nimble_blecent_main.c
+++ b/examples/nimble_blecent/nimble_blecent_main.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * apps/examples/nimble_blecent/nimble_blecent_main.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -69,7 +71,7 @@ void ble_hci_sock_set_device(int dev);
 static int blecent_gap_event(FAR struct ble_gap_event *event, FAR void *arg);
 
 /****************************************************************************
- * Private Data
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
@@ -85,10 +87,11 @@ blecent_on_read(uint16_t conn_handle,
   printf("Read complete; status=%d conn_handle=%d", error->status,
          conn_handle);
   if (error->status == 0)
-  {
-    printf(" attr_handle=%d value=", attr->handle);
-    print_mbuf(attr->om);
-  }
+    {
+      printf(" attr_handle=%d value=", attr->handle);
+      print_mbuf(attr->om);
+    }
+
   printf("\n");
 
   return 0;
@@ -110,8 +113,7 @@ blecent_on_write(uint16_t conn_handle,
   return 0;
 }
 
-/**
- * Application callback. Called when the attempt to subscribe to
+/* Application callback. Called when the attempt to subscribe to
  * notifications for the ANS Unread Alert Status characteristic
  * has completed.
  */
@@ -133,8 +135,7 @@ blecent_on_subscribe(uint16_t conn_handle,
  * Name: blecent_read_write_subscribe
  ****************************************************************************/
 
-static void
-blecent_read_write_subscribe(FAR const struct peer *peer)
+static void blecent_read_write_subscribe(FAR const struct peer *peer)
 {
   const struct peer_chr *chr;
   const struct peer_dsc *dsc;
@@ -143,76 +144,74 @@ blecent_read_write_subscribe(FAR const struct peer *peer)
 
   /* Read the supported-new-alert-category characteristic. */
 
-  chr = peer_chr_find_uuid(peer,
-            BLE_UUID16_DECLARE(BLECENT_SVC_ALERT_UUID),
-            BLE_UUID16_DECLARE(BLECENT_CHR_SUP_NEW_ALERT_CAT_UUID));
+  chr = peer_chr_find_uuid(
+      peer, BLE_UUID16_DECLARE(BLECENT_SVC_ALERT_UUID),
+      BLE_UUID16_DECLARE(BLECENT_CHR_SUP_NEW_ALERT_CAT_UUID));
   if (chr == NULL)
-  {
-    printf("Error: Peer doesn't support the Supported New "
-           "Alert Category characteristic\n");
-    goto err;
-  }
+    {
+      printf("Error: Peer doesn't support the Supported New "
+             "Alert Category characteristic\n");
+      goto err;
+    }
 
   rc = ble_gattc_read(peer->conn_handle, chr->chr.val_handle,
                       blecent_on_read, NULL);
   if (rc != 0)
-  {
-    printf("Error: Failed to read characteristic; rc=%d\n",
-           rc);
-    goto err;
-  }
+    {
+      printf("Error: Failed to read characteristic; rc=%d\n", rc);
+      goto err;
+    }
 
   /* Write two bytes (99, 100) to the alert-notification-control-point
    * characteristic.
    */
 
-  chr = peer_chr_find_uuid(peer,
-              BLE_UUID16_DECLARE(BLECENT_SVC_ALERT_UUID),
-              BLE_UUID16_DECLARE(BLECENT_CHR_ALERT_NOT_CTRL_PT));
+  chr = peer_chr_find_uuid(
+      peer, BLE_UUID16_DECLARE(BLECENT_SVC_ALERT_UUID),
+      BLE_UUID16_DECLARE(BLECENT_CHR_ALERT_NOT_CTRL_PT));
   if (chr == NULL)
-  {
-    printf("Error: Peer doesn't support the Alert "
-           "Notification Control Point characteristic\n");
-    goto err;
-  }
+    {
+      printf("Error: Peer doesn't support the Alert "
+             "Notification Control Point characteristic\n");
+      goto err;
+    }
 
   value[0] = 99;
   value[1] = 100;
-  rc = ble_gattc_write_flat(peer->conn_handle, chr->chr.val_handle,
-                            value, sizeof value, blecent_on_write, NULL);
+  rc = ble_gattc_write_flat(peer->conn_handle, chr->chr.val_handle, value,
+                            sizeof value, blecent_on_write, NULL);
   if (rc != 0)
-  {
-    printf("Error: Failed to write characteristic; rc=%d\n",
-           rc);
-  }
+    {
+      printf("Error: Failed to write characteristic; rc=%d\n", rc);
+    }
 
   /* Subscribe to notifications for the Battery Level characteristic.
    * A central enables notifications by writing two bytes (1, 0) to the
    * characteristic's client-characteristic-configuration-descriptor (CCCD).
    */
 
-  dsc = peer_dsc_find_uuid(peer,
-                BLE_UUID16_DECLARE(BLE_SVC_BAS_UUID16),
-                BLE_UUID16_DECLARE(BLE_SVC_BAS_CHR_UUID16_BATTERY_LEVEL),
-                BLE_UUID16_DECLARE(BLE_GATT_DSC_CLT_CFG_UUID16));
+  dsc = peer_dsc_find_uuid(
+      peer, BLE_UUID16_DECLARE(BLE_SVC_BAS_UUID16),
+      BLE_UUID16_DECLARE(BLE_SVC_BAS_CHR_UUID16_BATTERY_LEVEL),
+      BLE_UUID16_DECLARE(BLE_GATT_DSC_CLT_CFG_UUID16));
   if (dsc == NULL)
-  {
-    printf("Error: Peer lacks a CCCD for the \
+    {
+      printf("Error: Peer lacks a CCCD for the \
           Battery Level characteristic\n");
-    goto err;
-  }
+      goto err;
+    }
 
   value[0] = 1;
   value[1] = 0;
-  rc = ble_gattc_write_flat(peer->conn_handle, dsc->dsc.handle,
-                            value, sizeof value, blecent_on_subscribe, NULL);
+  rc       = ble_gattc_write_flat(peer->conn_handle, dsc->dsc.handle, value,
+                                  sizeof value, blecent_on_subscribe, NULL);
   if (rc != 0)
-  {
-    printf("Error: Failed to subscribe to characteristic; "
-           "rc=%d\n",
-           rc);
-    goto err;
-  }
+    {
+      printf("Error: Failed to subscribe to characteristic; "
+             "rc=%d\n",
+             rc);
+      goto err;
+    }
 
   return;
 
@@ -236,8 +235,8 @@ blecent_on_disc_complete(FAR const struct peer *peer, int status,
       /* Service discovery failed.  Terminate the connection. */
 
       printf("Error: Service discovery failed; status=%d "
-            "conn_handle=%d\n",
-            status, peer->conn_handle);
+             "conn_handle=%d\n",
+             status, peer->conn_handle);
       ble_gap_terminate(peer->conn_handle, BLE_ERR_REM_USER_CONN_TERM);
       return;
     }
@@ -264,8 +263,8 @@ blecent_on_disc_complete(FAR const struct peer *peer, int status,
 
 static void blecent_scan(void)
 {
-  uint8_t own_addr_type;
   struct ble_gap_disc_params disc_params;
+  uint8_t own_addr_type;
   int rc;
 
   /* Figure out address to use while advertising (no privacy for now) */
@@ -283,8 +282,7 @@ static void blecent_scan(void)
 
   disc_params.filter_duplicates = 1;
 
-  /**
-   * Perform a passive scan.  I.e., don't send follow-up scan requests to
+  /* Perform a passive scan.  I.e., don't send follow-up scan requests to
    * each advertiser.
    */
 
@@ -292,26 +290,24 @@ static void blecent_scan(void)
 
   /* Use defaults for the rest of the parameters. */
 
-  disc_params.itvl = 0;
-  disc_params.window = 0;
+  disc_params.itvl          = 0;
+  disc_params.window        = 0;
   disc_params.filter_policy = 0;
-  disc_params.limited = 0;
+  disc_params.limited       = 0;
 
   rc = ble_gap_disc(own_addr_type, BLE_HS_FOREVER, &disc_params,
                     blecent_gap_event, NULL);
   if (rc != 0)
-  {
-    printf("Error initiating GAP discovery procedure; rc=%d\n",
-           rc);
-  }
+    {
+      printf("Error initiating GAP discovery procedure; rc=%d\n", rc);
+    }
 }
 
 /****************************************************************************
  * Name: blecent_should_connect
  ****************************************************************************/
 
-static int
-blecent_should_connect(const struct ble_gap_disc_desc *disc)
+static int blecent_should_connect(const struct ble_gap_disc_desc *disc)
 {
   struct ble_hs_adv_fields fields;
   int rc;
@@ -319,8 +315,8 @@ blecent_should_connect(const struct ble_gap_disc_desc *disc)
 
   /* The device has to be advertising connectability. */
 
-  if (disc->event_type != BLE_HCI_ADV_RPT_EVTYPE_ADV_IND &&
-      disc->event_type != BLE_HCI_ADV_RPT_EVTYPE_DIR_IND)
+  if (disc->event_type != BLE_HCI_ADV_RPT_EVTYPE_ADV_IND
+      && disc->event_type != BLE_HCI_ADV_RPT_EVTYPE_DIR_IND)
     {
       return 0;
     }
@@ -359,27 +355,27 @@ blecent_connect_if_interesting(FAR const struct ble_gap_disc_desc *disc)
   /* Don't do anything if we don't care about this advertiser. */
 
   if (!blecent_should_connect(disc))
-  {
-    return;
-  }
+    {
+      return;
+    }
 
   /* Scanning must be stopped before a connection can be initiated. */
 
   rc = ble_gap_disc_cancel();
   if (rc != 0)
-  {
-    printf("Failed to cancel scan; rc=%d\n", rc);
-    return;
-  }
+    {
+      printf("Failed to cancel scan; rc=%d\n", rc);
+      return;
+    }
 
   /* Figure out address to use for connect (no privacy for now) */
 
   rc = ble_hs_id_infer_auto(0, &own_addr_type);
   if (rc != 0)
-  {
-    printf("error determining address type; rc=%d\n", rc);
-    return;
-  }
+    {
+      printf("error determining address type; rc=%d\n", rc);
+      return;
+    }
 
   /* Try to connect the the advertiser.  Allow 30 seconds (30000 ms) for
    * timeout.
@@ -388,182 +384,181 @@ blecent_connect_if_interesting(FAR const struct ble_gap_disc_desc *disc)
   rc = ble_gap_connect(own_addr_type, &disc->addr, 30000, NULL,
                        blecent_gap_event, NULL);
   if (rc != 0)
-  {
-    printf("Error: Failed to connect to device; addr_type=%d "
-           "addr=%s\n; rc=%d",
-           disc->addr.type, addr_str(disc->addr.val), rc);
-    return;
-  }
+    {
+      printf("Error: Failed to connect to device; addr_type=%d "
+             "addr=%s\n; rc=%d",
+             disc->addr.type, addr_str(disc->addr.val), rc);
+      return;
+    }
 }
 
 /****************************************************************************
  * Name: blecent_gap_event
  ****************************************************************************/
 
-static int
-blecent_gap_event(FAR struct ble_gap_event *event, FAR void *arg)
+static int blecent_gap_event(FAR struct ble_gap_event *event, FAR void *arg)
 {
   struct ble_gap_conn_desc desc;
   struct ble_hs_adv_fields fields;
   int rc;
 
   switch (event->type)
-  {
-  case BLE_GAP_EVENT_DISC:
-    rc = ble_hs_adv_parse_fields(&fields, event->disc.data,
-                                 event->disc.length_data);
-    if (rc != 0)
     {
-      return 0;
-    }
+      case BLE_GAP_EVENT_DISC:
+        rc = ble_hs_adv_parse_fields(&fields, event->disc.data,
+                                     event->disc.length_data);
+        if (rc != 0)
+          {
+            return 0;
+          }
 
-    /* An advertisment report was received during GAP discovery. */
+        /* An advertisment report was received during GAP discovery. */
 
-    print_adv_fields(&fields);
+        print_adv_fields(&fields);
 
-    /* Try to connect to the advertiser if it looks interesting. */
+        /* Try to connect to the advertiser if it looks interesting. */
 
-    blecent_connect_if_interesting(&event->disc);
-    return 0;
-
-  case BLE_GAP_EVENT_CONNECT:
-
-    /* A new connection was established or a connection attempt failed. */
-
-    if (event->connect.status == 0)
-    {
-      /* Connection successfully established. */
-
-      printf("Connection established ");
-
-      rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
-      assert(rc == 0);
-      print_conn_desc(&desc);
-      printf("\n");
-
-      /* Remember peer. */
-
-      rc = peer_add(event->connect.conn_handle);
-      if (rc != 0)
-      {
-        printf("Failed to add peer; rc=%d\n", rc);
+        blecent_connect_if_interesting(&event->disc);
         return 0;
-      }
 
-      /* Perform service discovery. */
+      case BLE_GAP_EVENT_CONNECT:
 
-      rc = peer_disc_all(event->connect.conn_handle,
-                         blecent_on_disc_complete, NULL);
-      if (rc != 0)
-      {
-        printf("Failed to discover services; rc=%d\n", rc);
+        /* A new connection was established or a connection attempt failed.
+         */
+
+        if (event->connect.status == 0)
+          {
+            /* Connection successfully established. */
+
+            printf("Connection established ");
+
+            rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+            assert(rc == 0);
+            print_conn_desc(&desc);
+            printf("\n");
+
+            /* Remember peer. */
+
+            rc = peer_add(event->connect.conn_handle);
+            if (rc != 0)
+              {
+                printf("Failed to add peer; rc=%d\n", rc);
+                return 0;
+              }
+
+            /* Perform service discovery. */
+
+            rc = peer_disc_all(event->connect.conn_handle,
+                               blecent_on_disc_complete, NULL);
+            if (rc != 0)
+              {
+                printf("Failed to discover services; rc=%d\n", rc);
+                return 0;
+              }
+          }
+        else
+          {
+            /* Connection attempt failed; resume scanning. */
+
+            printf("Error: Connection failed; status=%d\n",
+                   event->connect.status);
+            blecent_scan();
+          }
+
         return 0;
-      }
+
+      case BLE_GAP_EVENT_DISCONNECT:
+
+        /* Connection terminated. */
+
+        printf("disconnect; reason=%d ", event->disconnect.reason);
+        print_conn_desc(&event->disconnect.conn);
+        printf("\n");
+
+        /* Forget about peer. */
+
+        peer_delete(event->disconnect.conn.conn_handle);
+
+        /* Resume scanning. */
+
+        blecent_scan();
+        return 0;
+
+      case BLE_GAP_EVENT_DISC_COMPLETE:
+        printf("discovery complete; reason=%d\n",
+               event->disc_complete.reason);
+        return 0;
+
+      case BLE_GAP_EVENT_ENC_CHANGE:
+
+        /* Encryption has been enabled or disabled for this connection. */
+
+        printf("encryption change event; status=%d ",
+               event->enc_change.status);
+        rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
+        assert(rc == 0);
+        print_conn_desc(&desc);
+        return 0;
+
+      case BLE_GAP_EVENT_NOTIFY_RX:
+
+        /* Peer sent us a notification or indication. */
+
+        printf("received %s; conn_handle=%d attr_handle=%d "
+               "attr_len=%d\n",
+               event->notify_rx.indication ? "indication" : "notification",
+               event->notify_rx.conn_handle, event->notify_rx.attr_handle,
+               OS_MBUF_PKTLEN(event->notify_rx.om));
+
+        uint8_t notif_data[100]; /* Size depending on the actual size of the
+                                    notification data you have */
+        uint16_t notif_len;
+        int offset = 0;
+        notif_len  = OS_MBUF_PKTLEN(event->notify_rx.om);
+        os_mbuf_copydata(event->notify_rx.om, offset, notif_len, notif_data);
+
+        printf("notification data: ");
+        for (int i = 0; i < notif_len; i++)
+          {
+            printf("%02d ", notif_data[i]);
+          }
+
+        printf("\n");
+
+        /* Attribute data is contained in event->notify_rx.attr_data. */
+
+        return 0;
+
+      case BLE_GAP_EVENT_MTU:
+        printf("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+               event->mtu.conn_handle, event->mtu.channel_id,
+               event->mtu.value);
+        return 0;
+
+      case BLE_GAP_EVENT_REPEAT_PAIRING:
+        /* We already have a bond with the peer, but it is attempting to
+         * establish a new secure link.  This app sacrifices security for
+         * convenience: just throw away the old bond and accept the new link.
+         */
+
+        /* Delete the old bond. */
+
+        rc = ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc);
+        assert(rc == 0);
+        ble_store_util_delete_peer(&desc.peer_id_addr);
+
+        /* Return BLE_GAP_REPEAT_PAIRING_RETRY to indicate that the host
+         * should continue with the pairing operation.
+         */
+
+        return BLE_GAP_REPEAT_PAIRING_RETRY;
+
+      default:
+        return 0;
     }
-    else
-    {
-      /* Connection attempt failed; resume scanning. */
-
-      printf("Error: Connection failed; status=%d\n",
-             event->connect.status);
-      blecent_scan();
-    }
-
-    return 0;
-
-  case BLE_GAP_EVENT_DISCONNECT:
-
-    /* Connection terminated. */
-
-    printf("disconnect; reason=%d ", event->disconnect.reason);
-    print_conn_desc(&event->disconnect.conn);
-    printf("\n");
-
-    /* Forget about peer. */
-
-    peer_delete(event->disconnect.conn.conn_handle);
-
-    /* Resume scanning. */
-
-    blecent_scan();
-    return 0;
-
-  case BLE_GAP_EVENT_DISC_COMPLETE:
-    printf("discovery complete; reason=%d\n",
-           event->disc_complete.reason);
-    return 0;
-
-  case BLE_GAP_EVENT_ENC_CHANGE:
-
-    /* Encryption has been enabled or disabled for this connection. */
-
-    printf("encryption change event; status=%d ",
-           event->enc_change.status);
-    rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
-    assert(rc == 0);
-    print_conn_desc(&desc);
-    return 0;
-
-  case BLE_GAP_EVENT_NOTIFY_RX:
-
-    /* Peer sent us a notification or indication. */
-
-    printf("received %s; conn_handle=%d attr_handle=%d "
-           "attr_len=%d\n",
-           event->notify_rx.indication ? "indication" : "notification",
-           event->notify_rx.conn_handle,
-           event->notify_rx.attr_handle,
-           OS_MBUF_PKTLEN(event->notify_rx.om));
-
-    uint8_t notif_data[100]; /* Size depending on the actual size of the notification data you have */
-    uint16_t notif_len;
-    int offset = 0;
-    notif_len = OS_MBUF_PKTLEN(event->notify_rx.om);
-    os_mbuf_copydata(event->notify_rx.om, offset, notif_len, notif_data);
-
-    printf("notification data: ");
-    for (int i = 0; i < notif_len; i++)
-    {
-      printf("%02d ", notif_data[i]);
-    }
-    printf("\n");
-
-    /* Attribute data is contained in event->notify_rx.attr_data. */
-
-    return 0;
-
-  case BLE_GAP_EVENT_MTU:
-    printf("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
-           event->mtu.conn_handle,
-           event->mtu.channel_id,
-           event->mtu.value);
-    return 0;
-
-  case BLE_GAP_EVENT_REPEAT_PAIRING:
-    /* We already have a bond with the peer, but it is attempting to
-     * establish a new secure link.  This app sacrifices security for
-     * convenience: just throw away the old bond and accept the new link.
-     */
-
-    /* Delete the old bond. */
-
-    rc = ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc);
-    assert(rc == 0);
-    ble_store_util_delete_peer(&desc.peer_id_addr);
-
-    /* Return BLE_GAP_REPEAT_PAIRING_RETRY to indicate that the host should
-     * continue with the pairing operation.
-     */
-
-    return BLE_GAP_REPEAT_PAIRING_RETRY;
-
-  default:
-    return 0;
-  }
 }
 
-static void
-blecent_on_reset(int reason)
+static void blecent_on_reset(int reason)
 {
   printf("Resetting state; reason=%d\n", reason);
 }
@@ -572,8 +567,7 @@ blecent_on_reset(int reason)
  * Name: blecent_on_sync
  ****************************************************************************/
 
-static void
-blecent_on_sync(void)
+static void blecent_on_sync(void)
 {
   int rc;
 
@@ -654,8 +648,8 @@ int main(int argc, FAR char **argv)
 
   /* Configure the host. */
 
-  ble_hs_cfg.reset_cb = blecent_on_reset;
-  ble_hs_cfg.sync_cb = blecent_on_sync;
+  ble_hs_cfg.reset_cb        = blecent_on_reset;
+  ble_hs_cfg.sync_cb         = blecent_on_sync;
   ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
 
   /* Initialize data structures to track connected peers. */
@@ -665,8 +659,8 @@ int main(int argc, FAR char **argv)
 
   /* Create task which handles HCI socket */
 
-  ret = ble_npl_task_init(&s_task_hci, "hci_sock", ble_hci_sock_task,
-                          NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
+  ret = ble_npl_task_init(&s_task_hci, "hci_sock", ble_hci_sock_task, NULL,
+                          TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
                           TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
   if (ret != 0)
     {
@@ -675,8 +669,8 @@ int main(int argc, FAR char **argv)
 
   /* Create task which handles default event queue for host stack. */
 
-  ret = ble_npl_task_init(&s_task_host, "ble_host", ble_host_task,
-                          NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
+  ret = ble_npl_task_init(&s_task_host, "ble_host", ble_host_task, NULL,
+                          TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
                           TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
   if (ret != 0)
     {

--- a/examples/nimble_bleprph/CMakeLists.txt
+++ b/examples/nimble_bleprph/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ##############################################################################
 # apps/examples/nimble_bleprph/CMakeLists.txt
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements.  See the NOTICE file distributed with this work for
 # additional information regarding copyright ownership.  The ASF licenses this
@@ -21,7 +23,7 @@
 if(CONFIG_EXAMPLES_NIMBLE_BLEPRPH)
   nuttx_add_application(
     NAME
-    nimble
+    ${CONFIG_EXAMPLES_NIMBLE_BLECENT_PROGNAME}
     SRCS
     ${CMAKE_CURRENT_LIST_DIR}/nimble_bleprph_main.c
     ${CMAKE_CURRENT_LIST_DIR}/misc.c

--- a/examples/nimble_bleprph/Kconfig
+++ b/examples/nimble_bleprph/Kconfig
@@ -7,13 +7,13 @@ config EXAMPLES_NIMBLE_BLEPRPH
 	tristate "NimBLE peripheral"
 	default n
 	---help---
-		Enable the nimble peripheral
+		Enable the nimble peripheral example
 
 if EXAMPLES_NIMBLE_BLEPRPH
 
 config EXAMPLES_NIMBLE_BLEPRPH_PROGNAME
 	string "Program name"
-	default "nimble"
+	default "bleprph"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.

--- a/examples/nimble_bleprph/Make.defs
+++ b/examples/nimble_bleprph/Make.defs
@@ -1,6 +1,8 @@
 ############################################################################
 # apps/examples/nimble_bleprph/Make.defs
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -19,5 +21,5 @@
 ############################################################################
 
 ifneq ($(CONFIG_EXAMPLES_NIMBLE_BLEPRPH),)
-CONFIGURED_APPS += $(APPDIR)/examples/nimble
+CONFIGURED_APPS += $(APPDIR)/examples/nimble_bleprph
 endif

--- a/examples/nimble_bleprph/Makefile
+++ b/examples/nimble_bleprph/Makefile
@@ -1,6 +1,8 @@
 ############################################################################
 # apps/examples/nimble_bleprph/Makefile
 #
+# SPDX-License-Identifier: Apache-2.0
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The

--- a/examples/nimble_bleprph/bleprph.h
+++ b/examples/nimble_bleprph/bleprph.h
@@ -1,6 +1,8 @@
 /****************************************************************************
  * apps/examples/nimble_bleprph/bleprph.h
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -27,14 +29,12 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include "nimble/ble.h"
-#ifdef __cplusplus
-extern "C"
-{
-#endif
 
-struct ble_hs_cfg;
-struct ble_gatt_register_ctxt;
+#include "nimble/ble.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
 
 /* GATT server. */
 
@@ -45,13 +45,30 @@ struct ble_gatt_register_ctxt;
 #define GATT_SVR_CHR_UNR_ALERT_STAT_UUID      0x2A45
 #define GATT_SVR_CHR_ALERT_NOT_CTRL_PT        0x2A44
 
-void gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg);
+/****************************************************************************
+ * Public Type Definition
+ ****************************************************************************/
+
+/* Forward references */
+
+struct ble_gatt_register_ctxt;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void gatt_svr_register_cb(FAR struct ble_gatt_register_ctxt *ctxt,
+                          FAR void *arg);
 int gatt_svr_init(void);
 
 /* Misc. */
 
-void print_bytes(const uint8_t *bytes, int len);
-void print_addr(const void *addr);
+void print_addr(FAR const void *addr);
 
 #ifdef __cplusplus
 }

--- a/examples/nimble_bleprph/misc.c
+++ b/examples/nimble_bleprph/misc.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * apps/examples/nimble_bleprph/misc.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -28,19 +30,9 @@
  * Public Functions
  ****************************************************************************/
 
-void print_bytes(FAR const uint8_t *bytes, int len)
-{
-  int i;
-
-  for (i = 0; i < len; i++)
-    {
-      printf("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
-    }
-}
-
 void print_addr(FAR const void *addr)
 {
-  const uint8_t *u8p;
+  FAR const uint8_t *u8p;
 
   u8p = addr;
   printf("%02x:%02x:%02x:%02x:%02x:%02x",

--- a/examples/nimble_bleprph/nimble_bleprph_main.c
+++ b/examples/nimble_bleprph/nimble_bleprph_main.c
@@ -1,6 +1,8 @@
 /****************************************************************************
  * apps/examples/nimble_bleprph/nimble_bleprph_main.c
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The
@@ -68,15 +70,14 @@ static FAR void *ble_host_task(FAR void *param);
 static int bleprph_gap_event(FAR struct ble_gap_event *event, FAR void *arg);
 
 /****************************************************************************
- * Private Data
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
  * Name: bleprph_print_conn_desc
  ****************************************************************************/
 
-static void
-bleprph_print_conn_desc(FAR struct ble_gap_conn_desc *desc)
+static void bleprph_print_conn_desc(FAR struct ble_gap_conn_desc *desc)
 {
   printf("handle=%d our_ota_addr_type=%d our_ota_addr=",
          desc->conn_handle, desc->our_ota_addr.type);
@@ -105,20 +106,20 @@ bleprph_print_conn_desc(FAR struct ble_gap_conn_desc *desc)
 
 static void bleprph_advertise(void)
 {
-  uint8_t own_addr_type;
   struct ble_gap_adv_params adv_params;
   struct ble_hs_adv_fields fields;
-  const char *name;
+  uint8_t own_addr_type;
+  FAR const char *name;
   int rc;
 
   /* Figure out address to use while advertising (no privacy for now) */
 
   rc = ble_hs_id_infer_auto(0, &own_addr_type);
   if (rc != 0)
-  {
-    printf("error determining address type; rc=%d\n", rc);
-    return;
-  }
+    {
+      printf("error determining address type; rc=%d\n", rc);
+      return;
+    }
 
   /**
    *  Set the advertisement data included in our advertisements:
@@ -136,7 +137,7 @@ static void bleprph_advertise(void)
    */
 
   fields.flags = BLE_HS_ADV_F_DISC_GEN |
-                 BLE_HS_ADV_F_BREDR_UNSUP;
+    BLE_HS_ADV_F_BREDR_UNSUP;
 
   /* Indicate that the TX power level field should be included; have the
    * stack fill this value automatically.  This is done by assiging the
@@ -147,23 +148,24 @@ static void bleprph_advertise(void)
   fields.tx_pwr_lvl = BLE_HS_ADV_TX_PWR_LVL_AUTO;
 
   name = ble_svc_gap_device_name();
-  fields.name = (uint8_t *)name;
+  fields.name = (FAR uint8_t *)name;
   fields.name_len = strlen(name);
   fields.name_is_complete = 1;
 
   fields.uuids16 = (ble_uuid16_t[])
-  {
+    {
       BLE_UUID16_INIT(GATT_SVR_SVC_ALERT_UUID)
-  };
+    };
+
   fields.num_uuids16 = 1;
   fields.uuids16_is_complete = 1;
 
   rc = ble_gap_adv_set_fields(&fields);
   if (rc != 0)
-  {
-    printf("error setting advertisement data; rc=%d\n", rc);
-    return;
-  }
+    {
+      printf("error setting advertisement data; rc=%d\n", rc);
+      return;
+    }
 
   /* Begin advertising. */
 
@@ -173,124 +175,120 @@ static void bleprph_advertise(void)
   rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
                          &adv_params, bleprph_gap_event, NULL);
   if (rc != 0)
-  {
-    printf("error enabling advertisement; rc=%d\n", rc);
-    return;
-  }
+    {
+      printf("error enabling advertisement; rc=%d\n", rc);
+      return;
+    }
 }
 
 /****************************************************************************
  * Name: bleprph_gap_event
  ****************************************************************************/
 
-static int
-bleprph_gap_event(FAR struct ble_gap_event *event, FAR void *arg)
+static int bleprph_gap_event(FAR struct ble_gap_event *event, FAR void *arg)
 {
   struct ble_gap_conn_desc desc;
   int rc;
 
   switch (event->type)
-  {
-  case BLE_GAP_EVENT_CONNECT:
-
-    /* A new connection was established or a connection attempt failed. */
-
-    printf("connection %s; status=%d ",
-           event->connect.status == 0 ? "established" : "failed",
-           event->connect.status);
-    if (event->connect.status == 0)
     {
-      rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
-      assert(rc == 0);
-      bleprph_print_conn_desc(&desc);
+      case BLE_GAP_EVENT_CONNECT:
+
+        /* A new connection was established or a connection attempt failed.
+         */
+
+        printf("connection %s; status=%d ",
+               event->connect.status == 0 ? "established" : "failed",
+               event->connect.status);
+        if (event->connect.status == 0)
+          {
+            rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+            assert(rc == 0);
+            bleprph_print_conn_desc(&desc);
+          }
+
+        printf("\n");
+
+        if (event->connect.status != 0)
+          {
+            /* Connection failed; resume advertising. */
+
+            bleprph_advertise();
+          }
+
+        return 0;
+
+      case BLE_GAP_EVENT_DISCONNECT:
+        printf("disconnect; reason=%d ", event->disconnect.reason);
+        bleprph_print_conn_desc(&event->disconnect.conn);
+        printf("\n");
+
+        /* Connection terminated; resume advertising. */
+
+        bleprph_advertise();
+        return 0;
+
+      case BLE_GAP_EVENT_CONN_UPDATE:
+
+        /* The central has updated the connection parameters. */
+
+        printf("connection updated; status=%d ", event->conn_update.status);
+        rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
+        assert(rc == 0);
+        bleprph_print_conn_desc(&desc);
+        printf("\n");
+        return 0;
+
+      case BLE_GAP_EVENT_ADV_COMPLETE:
+        printf("advertise complete; reason=%d", event->adv_complete.reason);
+        bleprph_advertise();
+        return 0;
+
+      case BLE_GAP_EVENT_ENC_CHANGE:
+
+        /* Encryption has been enabled or disabled for this connection. */
+
+        printf("encryption change event; status=%d ",
+               event->enc_change.status);
+        rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+        assert(rc == 0);
+        bleprph_print_conn_desc(&desc);
+        printf("\n");
+        return 0;
+
+      case BLE_GAP_EVENT_SUBSCRIBE:
+        printf("subscribe event; conn_handle=%d attr_handle=%d "
+               "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
+               event->subscribe.conn_handle, event->subscribe.attr_handle,
+               event->subscribe.reason, event->subscribe.prev_notify,
+               event->subscribe.cur_notify, event->subscribe.prev_indicate,
+               event->subscribe.cur_indicate);
+        return 0;
+
+      case BLE_GAP_EVENT_MTU:
+        printf("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+               event->mtu.conn_handle, event->mtu.channel_id,
+               event->mtu.value);
+        return 0;
+
+      case BLE_GAP_EVENT_REPEAT_PAIRING:
+        /* We already have a bond with the peer, but it is attempting to
+         * establish a new secure link.  This app sacrifices security for
+         * convenience: just throw away the old bond and accept the new link.
+         */
+
+        /* Delete the old bond. */
+
+        rc = ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc);
+        assert(rc == 0);
+        ble_store_util_delete_peer(&desc.peer_id_addr);
+
+        /* Return BLE_GAP_REPEAT_PAIRING_RETRY to indicate that the host
+         * should continue with the pairing operation.
+         */
+
+        return BLE_GAP_REPEAT_PAIRING_RETRY;
     }
-    printf("\n");
-
-    if (event->connect.status != 0)
-    {
-      /* Connection failed; resume advertising. */
-
-      bleprph_advertise();
-    }
-    return 0;
-
-  case BLE_GAP_EVENT_DISCONNECT:
-    printf("disconnect; reason=%d ", event->disconnect.reason);
-    bleprph_print_conn_desc(&event->disconnect.conn);
-    printf("\n");
-
-    /* Connection terminated; resume advertising. */
-
-    bleprph_advertise();
-    return 0;
-
-  case BLE_GAP_EVENT_CONN_UPDATE:
-
-    /* The central has updated the connection parameters. */
-
-    printf("connection updated; status=%d ",
-           event->conn_update.status);
-    rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
-    assert(rc == 0);
-    bleprph_print_conn_desc(&desc);
-    printf("\n");
-    return 0;
-
-  case BLE_GAP_EVENT_ADV_COMPLETE:
-    printf("advertise complete; reason=%d",
-           event->adv_complete.reason);
-    bleprph_advertise();
-    return 0;
-
-  case BLE_GAP_EVENT_ENC_CHANGE:
-
-    /* Encryption has been enabled or disabled for this connection. */
-
-    printf("encryption change event; status=%d ",
-           event->enc_change.status);
-    rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
-    assert(rc == 0);
-    bleprph_print_conn_desc(&desc);
-    printf("\n");
-    return 0;
-
-  case BLE_GAP_EVENT_SUBSCRIBE:
-    printf("subscribe event; conn_handle=%d attr_handle=%d "
-           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
-           event->subscribe.conn_handle,
-           event->subscribe.attr_handle,
-           event->subscribe.reason,
-           event->subscribe.prev_notify,
-           event->subscribe.cur_notify,
-           event->subscribe.prev_indicate,
-           event->subscribe.cur_indicate);
-    return 0;
-
-  case BLE_GAP_EVENT_MTU:
-    printf("mtu update event; conn_handle=%d cid=%d mtu=%d\n",
-           event->mtu.conn_handle,
-           event->mtu.channel_id,
-           event->mtu.value);
-    return 0;
-
-  case BLE_GAP_EVENT_REPEAT_PAIRING:
-    /* We already have a bond with the peer, but it is attempting to
-     * establish a new secure link.  This app sacrifices security for
-     * convenience: just throw away the old bond and accept the new link.
-     */
-
-    /* Delete the old bond. */
-
-    rc = ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc);
-    assert(rc == 0);
-    ble_store_util_delete_peer(&desc.peer_id_addr);
-
-    /* Return BLE_GAP_REPEAT_PAIRING_RETRY to indicate that the host should
-     * continue with the pairing operation.
-     */
-
-    return BLE_GAP_REPEAT_PAIRING_RETRY;
-  }
 
   return 0;
 }
@@ -299,8 +297,7 @@ bleprph_gap_event(FAR struct ble_gap_event *event, FAR void *arg)
  * Name: bleprph_on_reset
  ****************************************************************************/
 
-static void
-bleprph_on_reset(int reason)
+static void bleprph_on_reset(int reason)
 {
   printf("Resetting state; reason=%d\n", reason);
 }
@@ -309,8 +306,7 @@ bleprph_on_reset(int reason)
  * Name: bleprph_on_sync
  ****************************************************************************/
 
-static void
-bleprph_on_sync(void)
+static void bleprph_on_sync(void)
 {
   int rc;
 
@@ -366,8 +362,8 @@ int main(int argc, FAR char *argv[])
 {
   struct ble_npl_task s_task_host;
   struct ble_npl_task s_task_hci;
-  int ret = 0;
   uint8_t batt_level = 0;
+  int ret = 0;
 
   /* allow to specify custom hci */
 


### PR DESCRIPTION
## Summary
1.   examples/nimble_bleprph: fix various coding standard issues and fix compilation for make
    
 2. examples/nimble_blecent: fix various coding standard issues  and fix compilation for make
    
## Impact
fix various coding standard issues, no functional changes

## Testing

compile nimble_bleprph and nimble_blecent with make