### PR TITLE
cmake: remove empty strings from FetchContent

### DIFF
--- a/boot/mcuboot/CMakeLists.txt
+++ b/boot/mcuboot/CMakeLists.txt
@@ -33,14 +33,6 @@ if(CONFIG_BOOT_MCUBOOT)
           ${CMAKE_CURRENT_LIST_DIR}/mcuboot
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/boot/mcuboot/mcuboot
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/crypto/tinydtls/CMakeLists.txt
+++ b/crypto/tinydtls/CMakeLists.txt
@@ -32,14 +32,6 @@ if(CONFIG_CRYPTO_TINYDTLS)
           ${CMAKE_CURRENT_LIST_DIR}/tinydtls
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/crypto/tinydtls/tinydtls
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -31,19 +31,9 @@ if(CONFIG_GRAPHICS_LVGL)
     FetchContent_Declare(
       lvgl_fetch
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://github.com/lvgl/lvgl/archive/refs/tags/v9.2.1.zip"
-          SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/lvgl
-          BINARY_DIR
+      URL "https://github.com/lvgl/lvgl/archive/refs/tags/v9.2.1.zip" SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/lvgl BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/graphics/lvgl/lvgl
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 120)
 

--- a/netutils/cjson/CMakeLists.txt
+++ b/netutils/cjson/CMakeLists.txt
@@ -40,14 +40,6 @@ if(CONFIG_NETUTILS_CJSON)
           ${CMAKE_CURRENT_LIST_DIR}/cJSON
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/netutils/cjson/cJSON
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/wakaama/CMakeLists.txt
+++ b/netutils/wakaama/CMakeLists.txt
@@ -32,14 +32,6 @@ if(CONFIG_NETUTILS_WAKAAMA)
           ${CMAKE_CURRENT_LIST_DIR}/wakaama
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/netutils/wakaama/wakaama
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/system/adb/CMakeLists.txt
+++ b/system/adb/CMakeLists.txt
@@ -34,19 +34,9 @@ if(CONFIG_SYSTEM_ADBD)
 
     FetchContent_Declare(
       microADB
-      URL "${ADBD_URL}/${ADBD_VERSION}.zip"
-          SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/microADB
-          BINARY_DIR
+      URL "${ADBD_URL}/${ADBD_VERSION}.zip" SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/microADB BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/system/microADB/microADB
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/system/argtable3/CMakeLists.txt
+++ b/system/argtable3/CMakeLists.txt
@@ -43,14 +43,6 @@ if(CONFIG_SYSTEM_ARGTABLE3)
           ${CMAKE_CURRENT_LIST_DIR}/argtable3
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/system/argtable3/argtable3
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/testing/mm/stressapptest/CMakeLists.txt
+++ b/testing/mm/stressapptest/CMakeLists.txt
@@ -37,14 +37,6 @@ if(CONFIG_TESTING_STRESSAPPTEST)
           ${CMAKE_CURRENT_LIST_DIR}/stressapptest
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/stressapptest
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/testing/unity/CMakeLists.txt
+++ b/testing/unity/CMakeLists.txt
@@ -29,18 +29,8 @@ if(CONFIG_TESTING_UNITY)
       DOWNLOAD_NAME "v${CONFIG_TESTING_UNITY_VERSION}.tar.gz"
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
       URL "${CONFIG_TESTING_UNITY_URL}/v${CONFIG_TESTING_UNITY_VERSION}.tar.gz"
-          SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/Unity
-          BINARY_DIR
+          SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/Unity BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/testing/unity/unity
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/wireless/bluetooth/nimble/CMakeLists.txt
+++ b/wireless/bluetooth/nimble/CMakeLists.txt
@@ -33,14 +33,6 @@ if(CONFIG_NIMBLE)
           ${CMAKE_CURRENT_LIST_DIR}/mynewt-nimble
           BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/wireless/bluetooth/nimble/mynewt-nimble
-          CONFIGURE_COMMAND
-          ""
-          BUILD_COMMAND
-          ""
-          INSTALL_COMMAND
-          ""
-          TEST_COMMAND
-          ""
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 


### PR DESCRIPTION
## Summary
remove empty strings from FetchContent to eliminate cmake build warnings like this:

CMake Warning (dev) at /usr/share/cmake/Modules/FetchContent.cmake:1564 (cmake_parse_arguments):
  The BUILD_COMMAND keyword was followed by an empty string or no value at
  all.  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  ARG_BUILD_COMMAND variable rather than setting it to an empty string.
  
## Impact
eliminate empty commands which cause warnings for cmake version >= 3.31

## Testing
unity and nimble with cmake build with no warnings