### PR TITLE
examples/adc: fix printf warning

### DIFF
--- a/examples/adc/adc_main.c
+++ b/examples/adc/adc_main.c
@@ -310,7 +310,7 @@ int main(int argc, FAR char *argv[])
           if (nsamples * sizeof(struct adc_msg_s) != nbytes)
             {
               printf("adc_main: read size=%ld is not a multiple of "
-                     "sample size=%d, Ignoring\n",
+                     "sample size=%zu, Ignoring\n",
                      (long)nbytes, sizeof(struct adc_msg_s));
             }
           else


### PR DESCRIPTION
## Summary
examples/adc: fix printf warning

## Impact
none

## Testing
adc with sim
