### PR TITLE
benchmarks/mtd: Select libc's floating point support and improve format specifiers portability

### DIFF
--- a/benchmarks/mtd/Kconfig
+++ b/benchmarks/mtd/Kconfig
@@ -7,6 +7,7 @@ config BENCHMARK_MTD
 	tristate "MTD test and transfer rate benchmark"
 	default n
 	depends on BUILD_FLAT && MTD
+	select LIBC_FLOATINGPOINT
 	---help---
 		This testing/benchmark application performs an erase/write
 		operation to evaluate write transfer rate and then reads the

--- a/benchmarks/mtd/Kconfig
+++ b/benchmarks/mtd/Kconfig
@@ -6,8 +6,7 @@
 config BENCHMARK_MTD
 	tristate "MTD test and transfer rate benchmark"
 	default n
-	depends on BUILD_FLAT && MTD
-	select LIBC_FLOATINGPOINT
+	depends on BUILD_FLAT && MTD && LIBC_FLOATINGPOINT
 	---help---
 		This testing/benchmark application performs an erase/write
 		operation to evaluate write transfer rate and then reads the

--- a/benchmarks/mtd/mtd.c
+++ b/benchmarks/mtd/mtd.c
@@ -95,7 +95,7 @@ int main(int argc, FAR char *argv[])
   ret = inode->u.i_bops->ioctl(inode, MTDIOC_GEOMETRY, (unsigned long) &geo);
   if (ret != OK)
     {
-      fprintf(stderr, "Device is not a MTD device\n");
+      fprintf(stderr, "Device is not a MTD device");
       goto errout_with_driver;
     }
 
@@ -104,7 +104,7 @@ int main(int argc, FAR char *argv[])
   printf("FLASH device parameters:\n");
   printf("   Sector size:  %10d\n", info.sectorsize);
   printf("   Sector count: %10d\n", info.numsectors);
-  printf("   Erase block:  %10d\n", geo.erasesize);
+  printf("   Erase block:  %10" PRIx32 "\n", geo.erasesize);
   printf("   Total size:   %10d\n", info.sectorsize * info.numsectors);
 
   if (info.sectorsize != geo.erasesize)


### PR DESCRIPTION
## Summary

The application requires libc's floating point support. Although it may be already enabled by other applications and/or hardware support, it should be explicitly selected by the app too. Also, to improve portability, use `PRIxxx` macro instead of int/long int format specifiers.

## Impact

Impact on user: YES, by improving portability.

Impact on build: YES, by avoiding build errors related to the variable format.

Impact on hardware: NO.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

Not a specific one. One can use the same testing procedure at https://github.com/apache/nuttx-apps/pull/3033