### PR TITLE
foc/foc_feedforward.c: vdq_comp->q should use idq->d

### DIFF
--- a/industry/foc/fixed16/foc_feedforward.c
+++ b/industry/foc/fixed16/foc_feedforward.c
@@ -63,7 +63,7 @@ int foc_feedforward_pmsm_b16(FAR struct motor_phy_params_b16_s *phy,
 
   vdq_comp->q = -b16mulb16(vel_now,
                            (phy->flux_link + b16mulb16(phy->ind,
-                                                       idq->q)));
+                                                       idq->d)));
   vdq_comp->d = b16mulb16(b16mulb16(vel_now, phy->ind), idq->q);
 
   return OK;

--- a/industry/foc/float/foc_feedforward.c
+++ b/industry/foc/float/foc_feedforward.c
@@ -61,7 +61,7 @@ int foc_feedforward_pmsm_f32(FAR struct motor_phy_params_f32_s *phy,
    * so vq compensation must be negative here.
    */
 
-  vdq_comp->q = -vel_now * (phy->flux_link + phy->ind * idq->q);
+  vdq_comp->q = -vel_now * (phy->flux_link + phy->ind * idq->d);
   vdq_comp->d = vel_now * phy->ind * idq->q;
 
   return OK;


### PR DESCRIPTION
## Summary
fix typo in calculations for vdq_comp->q. It should use idq->d not idq->q.

Reported in https://github.com/apache/nuttx-apps/issues/3047

here foc diagram for reference: https://i.sstatic.net/ltXRB.png

## Impact
obvious typo

## Testing
CI
