### PR TITLE
tools/bitmap_converter.py: Fix print to allow use of Python3

### DIFF
--- a/tools/bitmap_converter.py
+++ b/tools/bitmap_converter.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
   import os.path
 
   if len(sys.argv) != 3:
-    print "Usage: bitmap_converter.py source.png output.cxx"
+    print("Usage: bitmap_converter.py source.png output.cxx")
     sys.exit(1)
 
   img = Image.open(sys.argv[1]).convert("RGB")
@@ -129,7 +129,7 @@ if __name__ == '__main__':
 
   outfile.write(
 '''
-/* Automatically NuttX bitmap file. */
+/* Automatically generated NuttX bitmap file. */
 /* Generated from %(src)s by bitmap_converter.py. */
 
 #include <nxconfig.hxx>


### PR DESCRIPTION
Amends print statement to Python3 standard

I gladly declare that I have never coded in Python, but I believe python3 is the current standard and I was trying to use this converter in relation to a PR I'm working in and it wouldn't run for this reason.

If I've missed anything that means this PR is not necessary let me know and I can close it.

I haven't run checkpatch...I have assumed it doesn't work for Python anyway, and the change is trivial.

## Testing
I have used to it successfully to convert a PNG file to a c file using Python3

