### PR TITLE
toywasm: bump to v67

### DIFF
--- a/interpreters/toywasm/Makefile
+++ b/interpreters/toywasm/Makefile
@@ -146,7 +146,7 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/toywasm/toywasm/libdyld
 
 CFLAGS += -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-variable -Wno-return-type
 
-TOYWASM_VERSION  = b0e100a4ebd666f02b2bb9222d402a9f399a740b
+TOYWASM_VERSION  = 2e4474d1af3bf9bc5a4b571be7ee69694f4a8aef
 TOYWASM_UNPACK   = toywasm
 TOYWASM_TARBALL  = $(TOYWASM_VERSION).zip
 TOYWASM_URL_BASE = https://github.com/yamt/toywasm/archive/

--- a/interpreters/toywasm/include/toywasm_version.h
+++ b/interpreters/toywasm/include/toywasm_version.h
@@ -23,6 +23,6 @@
 #if !defined(_TOYWASM_VERSION_H)
 #define _TOYWASM_VERSION_H
 
-#define TOYWASM_VERSION "v66.0.0"
+#define TOYWASM_VERSION "v67.0.0"
 
 #endif /* !defined(_TOYWASM_VERSION_H) */


### PR DESCRIPTION
## Summary

toywasm: bump to v67.
https://github.com/yamt/toywasm/releases/tag/v67.0.0

## Impact

the "fix GCC warnings for the target with long uint32_t" change is for https://github.com/apache/nuttx/pull/16022.

## Testing

* tested on sim/macOS/amd64
* build-tested esp32s3-devkit:toywasm with https://github.com/apache/nuttx/pull/16022