### PR TITLE
Make slcan brin the interface up/down with the appropiate commands

### DIFF
--- a/canutils/slcan/slcan.c
+++ b/canutils/slcan/slcan.c
@@ -137,8 +137,7 @@ static int caninit(char *candev, int *s, struct sockaddr_can *addr,
       syslog(LOG_ERR, "Error opening CAN socket\n");
       return -1;
     }
-  strncpy(ifr.ifr_name, candev, 4);
-  ifr.ifr_name[4] = '\0';
+  strlcpy(ifr.ifr_name, candev, IFNAMSIZ);
   ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);
   if (!ifr.ifr_ifindex)
     {

--- a/canutils/slcan/slcan.c
+++ b/canutils/slcan/slcan.c
@@ -316,9 +316,22 @@ int main(int argc, char *argv[])
                         {
                           /* open CAN interface */
 
-                          mode = 1;
-                          debug_print("Open interface\n");
-                          ok_return(fd);
+                          struct ifreq ifr;
+
+                          strlcpy(ifr.ifr_name, argv[1], IFNAMSIZ);
+
+                          ifr.ifr_flags = IFF_UP;
+                          if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0)
+                            {
+                              syslog(LOG_ERR, "Open interface failed\n");
+                              fail_return(fd);
+                            }
+                          else
+                            {
+                              mode = 1;
+                              debug_print("Open interface\n");
+                              ok_return(fd);
+                            }
                         }
                       else if (buf[0] == 'S')
                         {
@@ -394,9 +407,22 @@ int main(int argc, char *argv[])
                         {
                           /* close interface */
 
-                          mode = 0;
-                          debug_print("Close interface\n");
-                          ok_return(fd);
+                          struct ifreq ifr;
+
+                          strlcpy(ifr.ifr_name, argv[1], IFNAMSIZ);
+
+                          ifr.ifr_flags = 0;
+                          if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0)
+                            {
+                              syslog(LOG_ERR, "Close interface failed\n");
+                              fail_return(fd);
+                            }
+                          else
+                            {
+                              mode = 0;
+                              debug_print("Close interface\n");
+                              ok_return(fd);
+                            }
                         }
                       else if (buf[0] == 'T')
                         {


### PR DESCRIPTION
## Summary

A recent change (https://github.com/apache/nuttx/pull/16199) has made the bitrate setting no longer bring the interface up. Moreover, it is now no longer possible to change bitrate of a CAN interface if it is up. Therefore, slcan needs to bring the interface down to change it. Fortunately, it already had commands to open and close the interface which map nicely to this.

## Impact

slcan would be unable to change the interface bitrate after the aforementioned (already merged) Nuttx patch, without this change.

## Testing

Tested using a second serial line (/dev/gsmtty2) and CAN interface (named can_6_14) on a custom board. The CAN bus is attacked using an adapter talking socketcand protocol:
```
< hi >< can_6_14 B 1000000 -1 -1 -1 -1 -1 -1 -1 >
< ok >< open can_6_14 >
< ok >< send 123 0 >
```
Before this patch (and with Nuttx updated so the patch there is applied) changing bitrate no longer brings the interface up, so no frames can be seen. After this patch, I can explicitly bring the interface up with the "O" command and see the traffic:
```
nsh> slcan can_6_14 /dev/gsmtty2
[01/01/70 00:00:28.620152] Starting slcan on NuttX
[01/01/70 00:00:28.620274] slcanBus
[01/01/70 00:00:28.620427] CAN socket open
[01/01/70 00:00:28.620518] Serial interface open /dev/gsmtty2
[01/01/70 00:00:34.440030] set speed 1000000
[01/01/70 00:00:53.280061] Open interface
[01/01/70 00:01:03.243936] R1, Id:0x123
```
I also checked bringing the interface down with "C" stops receiving frames.

I had to make another small fix to slcan.c (in a separate commit also in this patchset) because it originally only supported CAN interface names of up to 4 characters.



