### PR TITLE
examples/camera: Initialize g_nximage semaphore with SEM_INITIALIZER

### DIFF
--- a/examples/camera/camera_bkgd.c
+++ b/examples/camera/camera_bkgd.c
@@ -97,13 +97,13 @@ static const struct nx_callback_s g_nximagecb =
 
 static struct nximage_data_s g_nximage =
 {
-  NULL,          /* hnx */
-  NULL,          /* hbkgd */
-  false,         /* connected */
-  0,             /* xres */
-  0,             /* yres */
-  false,         /* havpos */
-  { 0 },         /* sem */
+  NULL,               /* hnx */
+  NULL,               /* hbkgd */
+  false,              /* connected */
+  0,                  /* xres */
+  0,                  /* yres */
+  false,              /* havpos */
+  SEM_INITIALIZER(0), /* sem */
 };
 
 /****************************************************************************


### PR DESCRIPTION
Use SEM_INITIALIZER macro instead of direct { 0 }

## Summary

Initialize the semaphore using the SEM_INITIALIZER macro

## Impact

No impact, but direct assigning 0 conflicts with NuttX PR https://github.com/apache/nuttx/pull/16194

## Testing

Tested that this compiles
