### PR TITLE
canutils: use bps units for bitrate in SocketCAN interfaces.

### DIFF
--- a/canutils/lely-canopen/0005-add-NuttX-support.patch
+++ b/canutils/lely-canopen/0005-add-NuttX-support.patch
@@ -120,7 +120,7 @@ index ca7e7d95..fed1ae16 100644
 +		return -1;
 +	}
 +
-+  *pbitrate = ifr.ifr_ifru.ifru_can_data.arbi_bitrate * 1000;
++  *pbitrate = ifr.ifr_ifru.ifru_can_data.arbi_bitrate;
 +
 +  return 0;
 +}
@@ -141,8 +141,8 @@ index ca7e7d95..fed1ae16 100644
 +  struct ifreq ifr;
 +  if_indextoname(can->ifindex, ifr.ifr_name);
 +
-+  ifr.ifr_ifru.ifru_can_data.arbi_bitrate = bitrate / 1000;
-+  ifr.ifr_ifru.ifru_can_data.data_bitrate = bitrate / 1000;
++  ifr.ifr_ifru.ifru_can_data.arbi_bitrate = bitrate;
++  ifr.ifr_ifru.ifru_can_data.data_bitrate = bitrate;
 +  ifr.ifr_ifru.ifru_can_data.arbi_samplep = 0;
 +  ifr.ifr_ifru.ifru_can_data.data_samplep = 0;
 +

--- a/canutils/slcan/slcan.c
+++ b/canutils/slcan/slcan.c
@@ -363,9 +363,7 @@ int main(int argc, char *argv[])
                           /* set the device name */
 
                           strlcpy(ifr.ifr_name, argv[1], IFNAMSIZ);
-
-                          ifr.ifr_ifru.ifru_can_data.arbi_bitrate =
-                            canspeed / 1000; /* Convert bit/s to kbit/s */
+                          ifr.ifr_ifru.ifru_can_data.arbi_bitrate = canspeed;
                           ifr.ifr_ifru.ifru_can_data.arbi_samplep = 80;
 
                           if (ioctl(s, SIOCSCANBITRATE, &ifr) < 0)


### PR DESCRIPTION
## Summary

This matches PR https://github.com/apache/nuttx/pull/16225 in Nuttx, where units for SocketCAN bitrate ioctls were changed to bits-per-second, matching what Linux uses for SocketCAN bitrate (though Linux uses netlink instead of ioctl). In that PR, the data structure passed to bitrate ioctls was changed to use bps, so all code in nuttx-apps using those iotctls needs to be changed as well.

## Impact

No user impact.
The change is needed for tools to work after Nuttx PR is merged.

* Is new feature added? NO Is existing feature changed? NO
* Impact on build: NO
* Impact on hardware: NO
* Impact on documentation: NO
* Impact on security: NO
* Impact on compatibility: NO

## Testing

Tested using slcan to check bitrate is properly set (CAN message still arrive properly) after this change.

