### PR TITLE
examples/elf: add possibility to create romfs image

### DIFF
--- a/examples/elf/Kconfig
+++ b/examples/elf/Kconfig
@@ -39,7 +39,7 @@ config EXAMPLES_ELF_EXTERN
 		The file system is assumed to reside on some external media
 		such as an SD card or a USB FLASH drive.  In this case, that
 		external file system must be created manually by copying the
-		files in apps/examples/elf/tests/romfs to the volume.
+		files in apps/examples/elf/tests/extfs to the volume.
 
 		The external volume can optionally be mounted by the test if
 		the CONFIG_EXAMPLES_FSMOUNT option is also selected.
@@ -81,7 +81,10 @@ config EXAMPLES_ELF_FSTYPE
 	depends on EXAMPLES_ELF_FSMOUNT
 	---help---
 		The type of the external file system as will be used in the mount()
-		command.  Default: "vfat"
+		command.  Default: "vfat".
+		If the type of the external file system is set to "romfs" a romfs.img
+		is created in apps/examples/elf/tests/ this can be copied to an
+		internal block device.
 
 config EXAMPLES_ELF_DEVPATH
 	string "Block driver device path"

--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -215,7 +215,11 @@ int main(int argc, FAR char *argv[])
 
   mm_initmonitor();
 
+#if defined(CONFIG_EXAMPLES_ELF_FSMOUNT)
+  sprintf(devname, CONFIG_EXAMPLES_ELF_DEVPATH);
+#else
   sprintf(devname, ELF_DEVPATH_FMT, CONFIG_EXAMPLES_ELF_DEVMINOR);
+#endif
 
 #if defined(CONFIG_EXAMPLES_ELF_ROMFS)
 
@@ -298,8 +302,8 @@ int main(int argc, FAR char *argv[])
 
   /* Mount the external file system */
 
-  message("Mounting %s filesystem at target=%s\n",
-          CONFIG_EXAMPLES_ELF_FSTYPE, MOUNTPT);
+  message("Mounting %s filesystem at target=%s on %s\n",
+          CONFIG_EXAMPLES_ELF_FSTYPE, MOUNTPT, devname);
 
   ret = mount(devname, MOUNTPT, CONFIG_EXAMPLES_ELF_FSTYPE, MS_RDONLY, NULL);
   if (ret < 0)

--- a/examples/elf/tests/.gitignore
+++ b/examples/elf/tests/.gitignore
@@ -4,4 +4,5 @@
 /cromfs
 /cromfs.c
 /dirlist.c
+/extfs
 /symtab.c

--- a/examples/elf/tests/Makefile
+++ b/examples/elf/tests/Makefile
@@ -51,7 +51,9 @@ ifeq ($(CONFIG_EXAMPLES_ELF_ROMFS),y)
   FSIMG_DIR = $(TESTS_DIR)/$(FSIMG_SUBDIR)
   ROMFS_IMG = $(TESTS_DIR)/romfs.img
   FSIMG_SRC = $(TESTS_DIR)/romfs.c
-else
+endif
+
+ifeq ($(CONFIG_EXAMPLES_ELF_CROMFS),y)
   NXTOOLDIR = $(TOPDIR)/tools
   GENCROMFSSRC = gencromfs.c
   GENCROMFSEXE = gencromfs$(HOSTEXEEXT)
@@ -59,6 +61,19 @@ else
   FSIMG_SUBDIR = cromfs
   FSIMG_DIR = $(TESTS_DIR)/$(FSIMG_SUBDIR)
   FSIMG_SRC = $(TESTS_DIR)/cromfs.c
+endif
+
+ifeq ($(CONFIG_EXAMPLES_ELF_EXTERN),y)
+  FSIMG_SUBDIR = extfs
+  FSIMG_DIR = $(TESTS_DIR)/$(FSIMG_SUBDIR)
+endif
+
+# generate the romfs image in case the fs type is romfs
+# the FSIMG_SRC is not actually generated.
+
+ifeq ($(CONFIG_EXAMPLES_ELF_FSTYPE), "romfs")
+  ROMFS_IMG = $(TESTS_DIR)/romfs.img
+  FSIMG_SRC = $(TESTS_DIR)/romfs.c
 endif
 
 define DIR_template
@@ -90,7 +105,9 @@ $(FSIMG_SRC): $(ROMFS_IMG)
 		xxd -i romfs.img | sed -e "s/^unsigned char/const unsigned char aligned_data(4)/g" | \
 		sed -e "s/romfs_img/elf_romfs_img/g" >>$@)
 
-else
+endif
+
+ifeq ($(CONFIG_EXAMPLES_ELF_CROMFS),y)
 # Make sure that the NuttX gencromfs tool has been built
 
 $(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
@@ -101,6 +118,19 @@ $(NXTOOLDIR)/$(GENCROMFSEXE): $(NXTOOLDIR)/$(GENCROMFSSRC)
 $(FSIMG_SRC): install $(NXTOOLDIR)/$(GENCROMFSEXE)
 	$(Q) $(NXTOOLDIR)/$(GENCROMFSEXE) $(FSIMG_DIR) $@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
+
+endif
+
+ifeq ($(CONFIG_EXAMPLES_ELF_FSTYPE),"romfs")
+# Create the romfs.img file from the populated romfs directory
+
+$(ROMFS_IMG): install
+	$(Q) genromfs -f $@.tmp -d $(FSIMG_DIR) -V "ELFTEST"
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
+
+# Create the romfs.c file from the romfs.img file
+
+$(FSIMG_SRC): $(ROMFS_IMG)
 
 endif
 


### PR DESCRIPTION
Add the possibility to create a `romfs` image for an "external" file system. The `romfs.img` can directly be written to a configurable `mtdblock` device.

## Summary

The elf loader can also be used to generate a `romfs.img` that contains applications. This `romfs.img` can be written directly to a internal `mtdblock` device. The example then provides a method to illustrate how to separate `kernel` from applications and allows recompilation and update of the `romfs` without a kernel update.   

## Impact

None, it is an extra sample configuration.

## Testing

Tested on `esp32_devkitc:elf`. The example configuration is:
```console
<*> ELF Loader Example
        ELF File System (External File system)  --->
[*]     Mount external file system
[ ]         Removable file system
(romfs) External file system type
(/dev/mtdblock0) Block driver device path
[ ]     Link with LIBC
```
After compilation the romfs.img is copied to mtdblock0 using (0x180000 is the start of mtdblock0):
```
esptool.py write_flash 0x180000 nuttx/apps/examples/elf/tests/romfs.img
```

The test is then performed as:
```console
nsh> elf
Initial memory usage: 13908
Mounting romfs filesystem at target=/mnt/elf/romfs on /dev/mtdblock0

Memory Usage after mount:
  Before:    13908 After:    19052 Change:     5144

****************************************************************************
* Executing errno
****************************************************************************


Memory Usage after exec:
  Before:    19052 After:    22324 Change:     3272
Hello, World on stdout
Wait a bit for test completion
Hello, World on stderr
We failed to open "aflav-sautga-ay!" errno is 0

Memory Usage after program execution:
  Before:    22324 After:    22140 Change:     -184

****************************************************************************
* Executing hello
****************************************************************************


Memory Usage after exec:
  Before:    22140 After:    22324 Change:      184
Wait a bit for test completion
Getting ready to say "Hello, world"

Hello, world!
It has been said.

argc    = 1
argv    = 0x3ffe38b8
argv[0] = (0x3ffe38c0) "hello"
argv[1] = 0
Goodbye, world!

Memory Usage after program execution:
  Before:    22324 After:    22140 Change:     -184

****************************************************************************
* Executing hello++1
****************************************************************************


Memory Usage after exec:
  Before:    22140 After:    22324 Change:      184
Wait a bit for test completion
Hello, World!

Memory Usage after program execution:
  Before:    22324 After:    22140 Change:     -184

****************************************************************************
* Executing hello++2
****************************************************************************


Memory Usage after exec:
  Before:    22140 After:    22324 Change:      184
Wait a bit for test completion
main: Started.  Creating MyThingSayer
CThingSayer::CThingSayer: I am!
main: Created MyThingSayer=0x3ffe3120
main: Calling MyThingSayer->Initialize
CThingSayer::Initialize: When told, I will say 'Hello, World!'
main: Calling MyThingSayer->SayThing
CThingSayer::SayThing: I am now saying 'Hello, World!'
main: Destroying MyThingSayer
CThingSayer::~CThingSayer: I cease to be
CThingSayer::~CThingSayer: I will never say 'Hello, World!' again
main: Returning

Memory Usage after program execution:
  Before:    22324 After:    22140 Change:     -184

****************************************************************************
* Executing hello++3
****************************************************************************


Memory Usage after exec:
  Before:    22140 After:    22348 Change:      208
Wait a bit for test completion
CThingSayer::CThingSayer: I am!
main: Started.  MyThingSayer should already exist
main: Calling MyThingSayer.Initialize
CThingSayer::Initialize: When told, I will say 'Hello, World!'
main: Calling MyThingSayer.SayThing
CThingSayer::SayThing: I am now saying 'Hello, World!'
main: Returning.  MyThingSayer should be destroyed
CThingSayer::~CThingSayer: I cease to be
CThingSayer::~CThingSayer: I will never say 'Hello, World!' again

Memory Usage after program execution:
  Before:    22348 After:    22140 Change:     -208

****************************************************************************
* Executing mutex
****************************************************************************


Memory Usage after exec:
  Before:    22140 After:    22380 Change:      240
Wait a bit for test completion
Starting thread 1
Starting thread 2
Stopping threads
        Thread1 Thread2
Loops   10      10
Errors  0       0

Memory Usage after program execution:
  Before:    22380 After:    26684 Change:     4304

****************************************************************************
* Executing pthread
****************************************************************************


Memory Usage after exec:
  Before:    26684 After:    22324 Change:    -4360
Wait a bit for test completion
PARENT: started

PARENT: calling pthread_start with arg=305419896
CHILD: started with arg=305419896
CHILD: returning -2023406815
PARENT child exitted with -2023406815
PARENT returning success


Memory Usage after program execution:
  Before:    22324 After:    24412 Change:     2088

****************************************************************************
* Executing signal
****************************************************************************


Memory Usage after exec:
  Before:    24412 After:    22348 Change:    -2064
Wait a bit for test completion
Setting up signal handlers from pid=13
Old SIGUSR1 sighandler at 0
New SIGUSR1 sighandler at 0x40086480
Old SIGUSR2 sighandler at 0
New SIGUSR2 sighandler at 0x40086480
Raising SIGUSR1 from pid=13
Kill-ing SIGUSR1 from pid=13
siguser_action: Received signo=10 siginfo=0x3ffb13fc arg=0
  SIGUSR1 received
siginfo:
  si_signo  = 10
  si_code   = 0
  si_errno  = 4
  si_value  = 0
SIGUSR1 raised from pid=13
SIGUSR1 not received

Memory Usage after program execution:
  Before:    22348 After:    22172 Change:     -176

****************************************************************************
* Executing struct
****************************************************************************


Memory Usage after exec:
  Before:    22172 After:    22380 Change:      208
Wait a bit for test completion
Calling getstruct()
getstruct returned 0x40086688
  n = 42 (vs 42) PASS
  pn = 0x3ffe3290 (vs 0x3ffe3290) PASS
 *pn = 87 (vs 87) PASS
  ps = 0x40086684 (vs 0x40086684) PASS
  ps->n = 117 (vs 117) PASS
  pf = 0x40086454 (vs 0x40086454) PASS
Calling mystruct->pf()
In dummyfunc() -- PASS
Exit-ing

Memory Usage after program execution:
  Before:    22380 After:    22172 Change:     -208

****************************************************************************
* Executing task
****************************************************************************


Memory Usage after exec:
  Before:    22172 After:    22412 Change:      240
Wait a bit for test completion
Parent: Started, pid=20
Parent: Calling task_create()
Parent: Waiting for child (pid=22)
Child: execv was successful!
Child: argc=2
Child: argv[0]="child"
Child: argv[1]="Hello from your parent!"
Child: Exit-ting with status=0
Parent: Exit-ing

Memory Usage after program execution:
  Before:    22412 After:    25260 Change:     2848

Memory Usage End-of-Test:
  Before:    25260 After:    25260 Change:        0
nsh> 
```