### PR TITLE
system/uORB: Add support for exiting loop by writing eventfd

### DIFF
--- a/system/uorb/CMakeLists.txt
+++ b/system/uorb/CMakeLists.txt
@@ -29,7 +29,11 @@ if(CONFIG_UORB)
 
   nuttx_add_library(uorb STATIC)
 
-  file(GLOB_RECURSE CSRCS "sensor/*.c" "uORB/*.c")
+  file(GLOB_RECURSE CSRCS "sensor/*.c" "uORB/uORB.c")
+
+  if(CONFIG_UORB_LOOP_MAX_EVENTS)
+    file(GLOB_RECURSE CSRCS "uORB/loop.c" "uORB/epoll.c")
+  endif()
 
   if(CONFIG_UORB_LISTENER)
     nuttx_add_application(

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -28,6 +28,7 @@ config UORB_TESTS
 
 config UORB_LOOP_MAX_EVENTS
 	int "uorb loop max events"
+	depends on EVENT_FD
 	default 0
 
 if UORB_TESTS

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -28,7 +28,7 @@ config UORB_TESTS
 
 config UORB_LOOP_MAX_EVENTS
 	int "uorb loop max events"
-	default 16
+	default 0
 
 if UORB_TESTS
 

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -25,8 +25,10 @@ include $(APPDIR)/Make.defs
 CSRCS    += uORB/uORB.c
 CSRCS    += $(wildcard sensor/*.c)
 
+ifneq ($(CONFIG_UORB_LOOP_MAX_EVENTS),)
 ifneq ($(CONFIG_UORB_LOOP_MAX_EVENTS),0)
 CSRCS    += uORB/loop.c uORB/epoll.c
+endif
 endif
 
 ifneq ($(CONFIG_UORB_LISTENER),)

--- a/system/uorb/Makefile
+++ b/system/uorb/Makefile
@@ -22,8 +22,12 @@
 
 include $(APPDIR)/Make.defs
 
-CSRCS    += $(wildcard uORB/*.c)
+CSRCS    += uORB/uORB.c
 CSRCS    += $(wildcard sensor/*.c)
+
+ifneq ($(CONFIG_UORB_LOOP_MAX_EVENTS),0)
+CSRCS    += uORB/loop.c uORB/epoll.c
+endif
 
 ifneq ($(CONFIG_UORB_LISTENER),)
 MAINSRC  += listener.c

--- a/system/uorb/uORB/loop.c
+++ b/system/uorb/uORB/loop.c
@@ -25,6 +25,11 @@
  ****************************************************************************/
 
 #include <errno.h>
+#include <sys/poll.h>
+#include <unistd.h>
+#include <sys/eventfd.h>
+#include <sys/wait.h>
+#include <sys/types.h>
 
 #include "internal.h"
 
@@ -35,6 +40,7 @@
 int orb_loop_init(FAR struct orb_loop_s *loop, enum orb_loop_type_e type)
 {
   int ret = -EINVAL;
+  int fd;
 
   if (loop == NULL)
     {
@@ -57,20 +63,65 @@ int orb_loop_init(FAR struct orb_loop_s *loop, enum orb_loop_type_e type)
     {
       uorberr("loop init failed! ret:%d", ret);
       loop->ops = NULL;
+      return ret;
     }
 
+  fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  if (fd < 0)
+    {
+      ret = -errno;
+      uorberr("loop init eventfd failed! ret:%d", ret);
+      goto err_event;
+    }
+
+  ret = orb_handle_init(&loop->exit_handle, fd, POLLIN, loop,
+                        NULL, NULL, NULL, NULL);
+  if (ret < 0)
+    {
+      uorberr("loop init eventfd handle init failed! ret:%d", ret);
+      goto err_init;
+    }
+
+  ret = orb_handle_start(loop, &loop->exit_handle);
+  if (ret < 0)
+    {
+      uorberr("loop init eventfd handle start failed! ret:%d", ret);
+      goto err_init;
+    }
+
+  return ret;
+
+err_init:
+  close(fd);
+err_event:
+  orb_loop_deinit(loop);
   return ret;
 }
 
 int orb_loop_run(FAR struct orb_loop_s *loop)
 {
+  loop->self = gettid();
   return loop->ops->run(loop);
 }
 
 int orb_loop_deinit(FAR struct orb_loop_s *loop)
 {
+  eventfd_t exit = 1;
   int ret;
 
+  loop->running = false;
+  write(loop->exit_handle.fd, &exit, sizeof(exit));
+
+  if (gettid() != loop->self)
+    {
+      ret = waitpid(loop->self, &ret, 0);
+      if (ret < 0)
+        {
+          uorberr("loop deinit waitpid failed! ret:%d", -errno);
+        }
+    }
+
+  close(loop->exit_handle.fd);
   ret = loop->ops->uninit(loop);
   if (ret >= 0)
     {

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -39,6 +39,15 @@
 #include <stdbool.h>
 #include <syslog.h>
 #include <inttypes.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_UORB_LOOP_MAX_EVENTS
+#  define CONFIG_UORB_LOOP_MAX_EVENTS 0
+#endif
 
 /****************************************************************************
  * Public Types
@@ -94,14 +103,6 @@ enum orb_loop_type_e
   ORB_EPOLL_TYPE = 0,
 };
 
-struct orb_loop_ops_s;
-struct orb_loop_s
-{
-  FAR const struct orb_loop_ops_s *ops;      /* Loop handle ops. */
-  bool                             running;  /* uORB loop is running flag. */
-  int                              fd;       /* Loop fd. */
-};
-
 struct orb_handle_s
 {
   int                events;      /* Events of interest. */
@@ -111,6 +112,16 @@ struct orb_handle_s
   orb_dataout_cb_t   dataout_cb;  /* User EPOLLOUT callback funtion. */
   orb_eventpri_cb_t  eventpri_cb; /* User EPOLLPRI callback funtion. */
   orb_eventerr_cb_t  eventerr_cb; /* User EPOLLERR callback funtion. */
+};
+
+struct orb_loop_ops_s;
+struct orb_loop_s
+{
+  FAR const struct orb_loop_ops_s *ops;         /* Loop handle ops. */
+  bool                             running;     /* uORB loop is running flag. */
+  int                              fd;          /* Loop fd. */
+  struct orb_handle_s              exit_handle; /* The exit handle */
+  pid_t                            self;        /* The pid of the loop */
 };
 #endif
 

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -88,6 +88,7 @@ typedef CODE int (*orb_eventpri_cb_t)(FAR struct orb_handle_s *handle,
 typedef CODE int (*orb_eventerr_cb_t)(FAR struct orb_handle_s *handle,
                                       FAR void *arg);
 
+#if CONFIG_UORB_LOOP_MAX_EVENTS
 enum orb_loop_type_e
 {
   ORB_EPOLL_TYPE = 0,
@@ -111,6 +112,7 @@ struct orb_handle_s
   orb_eventpri_cb_t  eventpri_cb; /* User EPOLLPRI callback funtion. */
   orb_eventerr_cb_t  eventerr_cb; /* User EPOLLERR callback funtion. */
 };
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -896,6 +898,7 @@ int orb_fprintf(FAR FILE *stream, FAR const char *format,
                 FAR const void *data);
 #endif
 
+#if CONFIG_UORB_LOOP_MAX_EVENTS
 /****************************************************************************
  * Name: orb_loop_init
  *
@@ -1003,6 +1006,7 @@ int orb_handle_start(FAR struct orb_loop_s *loop,
 
 int orb_handle_stop(FAR struct orb_loop_s *loop,
                     FAR struct orb_handle_s *handle);
+#endif
 
 #ifdef __cplusplus
 }

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -118,10 +118,8 @@ struct orb_loop_ops_s;
 struct orb_loop_s
 {
   FAR const struct orb_loop_ops_s *ops;         /* Loop handle ops. */
-  bool                             running;     /* uORB loop is running flag. */
   int                              fd;          /* Loop fd. */
   struct orb_handle_s              exit_handle; /* The exit handle */
-  pid_t                            self;        /* The pid of the loop */
 };
 #endif
 
@@ -958,6 +956,21 @@ int orb_loop_run(FAR struct orb_loop_s *loop);
  ****************************************************************************/
 
 int orb_loop_deinit(FAR struct orb_loop_s *loop);
+
+/****************************************************************************
+ * Name: orb_loop_exit_async
+ *
+ * Description:
+ *   Send exit event to the current loop(not wait).
+ *
+ * Input Parameters:
+ *   loop   orb loop contains multiple handles.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a -1 (ERROR) or negated errno value on failure.
+ ****************************************************************************/
+
+int orb_loop_exit_async(FAR struct orb_loop_s *loop);
 
 /****************************************************************************
  * Name: orb_handle_init


### PR DESCRIPTION
## Summary
Configured loop function with `UORB_LOOP_MAX_EVENTS`, added eventfd for loop exit notification, fixed orb_loop_s undeclared error, and included API for sending loop exit event. We can exit the loop by calling the new API `orb_loop_exit_async()`.
1. Using `UORB_LOOP_MAX_EVENTS` to config loop function
2. Add eventfd to notify loop exit
3. Fix orb_loop_s undeclared error
4. Add API for sending loop exit event

## Impact
- system/uorb/uORB: Add new API `orb_loop_exit_async()`
```diff
+/****************************************************************************
+ * Name: orb_loop_exit_async
+ *
+ * Description:
+ *   Send exit event to the current loop(not wait).
+ *
+ * Input Parameters:
+ *   loop   orb loop contains multiple handles.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a -1 (ERROR) or negated errno value on failure.
+ ****************************************************************************/
+
+int orb_loop_exit_async(FAR struct orb_loop_s *loop);
```

## Testing
1. Selftest
    - The main thread
    ```
      orb_loop_init(&mLoop, orb_loop_type_e::ORB_EPOLL_TYPE);
    
      // ... ...
    
      if (orb_loop_exit_async(&mLoop) == 0) {
          mThread.join();
      }
    ```

    - The uORB loop thread
    ```
      mThread= std::thread([=]() {
          if (orb_loop_run(&mLoop) < 0) {
              // error ...
          }
    
          orb_loop_deinit(&mLoop); 
      });
    ```
2. CI
