### PR TITLE
examples/posix_stdio: Adding posix stdio example for new joiners.

### DIFF
--- a/examples/posix_stdio/CMakeLists.txt
+++ b/examples/posix_stdio/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/posix_stdio/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_POSIX_STDIO)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_POSIX_STDIO_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_POSIX_STDIO_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_POSIX_STDIO_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_POSIX_STDIO}
+    SRCS
+    posix_stdio.c)
+endif()

--- a/examples/posix_stdio/Kconfig
+++ b/examples/posix_stdio/Kconfig
@@ -1,0 +1,20 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_POSIX_STDIO
+	bool "Posix stdio example"
+	default n
+	---help---
+    	Enable POSIX stdio example that shows how to use open(), write() and close() via /dev/console.
+
+config EXAMPLES_POSIX_STDIO_PROGNAME
+	string "Program name"
+	default "posix_stdio"
+	depends on EXAMPLES_POSIX_STDIO
+
+config EXAMPLES_POSIX_STDIO_PRIORITY
+	int "POSIX_STDIO test priority"
+	default 100
+	depends on EXAMPLES_POSIX_STDIO

--- a/examples/posix_stdio/Make.defs
+++ b/examples/posix_stdio/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/posix_stdio/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_POSIX_STDIO),)
+CONFIGURED_APPS += $(APPDIR)/examples/posix_stdio
+endif

--- a/examples/posix_stdio/Makefile
+++ b/examples/posix_stdio/Makefile
@@ -1,0 +1,32 @@
+############################################################################
+# apps/examples/posix_stdio/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_POSIX_STDIO_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_POSIX_STDIO_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_POSIX_STDIO_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_POSIX_STDIO)
+
+MAINSRC = posix_stdio.c
+
+include $(APPDIR)/Application.mk

--- a/examples/posix_stdio/posix_stdio.c
+++ b/examples/posix_stdio/posix_stdio.c
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * apps/examples/posix_stdio/posix_stdio.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * This is a single POSIX example that works for both Nuttx and Linux distros
+ * (with minimal changes). By this example its possible to learn how to use
+ * posix style and also works with onpen(), close() and write() functions.
+ *
+ * For linux, need to change the headers and the output device
+ * A) Headers:
+ *     #include <fcntl.h>
+ *     #include <unistd.h>
+ *     #include <stdio.h>
+ *     #include <string.h>
+ *
+ * B) output:
+ *     /dev/tty
+ *
+ * To compile it on Linux, you can simple use gcc:
+ *  gcc posix_stdio.c -o posix_stdio
+ *
+ * To run, just send the following command: ./posix_stdio
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ * *************************************************************************/
+
+/* define how many times the message will be printed in the console */
+
+#ifndef PRINT_N_TIMES
+#  define PRINT_N_TIMES 10
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+static void print_message(int fd)
+{
+  const char *message = "Hello, NuttX users, welcome!!!\n";
+
+  write(fd, message, strlen(message));
+}
+
+/****************************************************************************
+ * hello_nuttx_main
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+  int counter;
+  int fd = open("/dev/console", O_WRONLY);
+
+  if (fd < 0)
+    {
+      fprintf(stderr, "Failed to open console\n");
+      return 1;
+    }
+
+  for (counter = 0; counter < PRINT_N_TIMES; counter++)
+    {
+      print_message(fd);
+    }
+
+  close(fd);
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
As new on nuttx and posix style, I missed some simple examples for the classic 'hello world' (note from @cederom see https://github.com/apache/nuttx-apps/tree/master/examples/hello).
To solve it, just create one simple code that can be compiled in both nuttx env and linux. 
For this example we are using the basic nuttx shell feature and no additional documentation should be required.

How does it works?
0 - configure your rtos (for this test I've used: sim:nsh)
1 - run: make menuconfig
2 - enable the example "Hello Nuttx"
3 - save it and exit from menuconfig. 
4 - Then run: make
5 - Next, run: ./nuttx
6 - At NSH, just call the app: `./posix_stdio`.
7 - This will be the output (test logs):

```
nsh> posix_stdio
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
```

## Impact
Just adding a new example to `apps/examples/posix_stdio`.

## Testing
Tested on: sim:nsh

Environment:
Nuttx> NuttX 12.9.0 c12aa5663d Apr 27 2025 17:50:43 sim sim
OS> Ubuntu oracular 24.10 x86_64
Kernel> Linux labs 6.11.0-24-generic #24-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar 14 18:13:56 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux


