### PR TITLE
testing/ostest/signest: Replace kill with pthread_kill to fix running in SMP

### DIFF
--- a/testing/ostest/signest.c
+++ b/testing/ostest/signest.c
@@ -328,13 +328,13 @@ void signest_test(void)
         {
           if (signest_catchable(j))
             {
-              kill(waiterpid, j);
+              pthread_kill(waiterpid, j);
               odd_signals++;
             }
 
           if (signest_catchable(j + 1))
             {
-              kill(waiterpid, j + 1);
+              pthread_kill(waiterpid, j + 1);
               even_signals++;
             }
 
@@ -344,13 +344,13 @@ void signest_test(void)
 
           if (signest_catchable(j + 1))
             {
-              kill(waiterpid, j + 1);
+              pthread_kill(waiterpid, j + 1);
               even_signals++;
             }
 
           if (signest_catchable(j))
             {
-              kill(waiterpid, j);
+              pthread_kill(waiterpid, j);
               odd_signals++;
             }
 
@@ -387,13 +387,13 @@ void signest_test(void)
 
           if (signest_catchable(j))
             {
-              kill(waiterpid, j);
+              pthread_kill(waiterpid, j);
               odd_signals++;
             }
 
           if (signest_catchable(j + 1))
             {
-              kill(waiterpid, j + 1);
+              pthread_kill(waiterpid, j + 1);
               even_signals++;
             }
 
@@ -407,13 +407,13 @@ void signest_test(void)
 
           if (signest_catchable(j + 1))
             {
-              kill(waiterpid, j + 1);
+              pthread_kill(waiterpid, j + 1);
               even_signals++;
             }
 
           if (signest_catchable(j))
             {
-              kill(waiterpid, j);
+              pthread_kill(waiterpid, j);
               odd_signals++;
             }
 
@@ -449,7 +449,7 @@ void signest_test(void)
 
           if (signest_catchable(j))
             {
-              kill(waiterpid, j);
+              pthread_kill(waiterpid, j);
               odd_signals++;
             }
 
@@ -457,7 +457,7 @@ void signest_test(void)
 
           if (signest_catchable(j + 1))
             {
-              kill(waiterpid, j + 1);
+              pthread_kill(waiterpid, j + 1);
               even_signals++;
             }
 
@@ -470,7 +470,7 @@ void signest_test(void)
           sched_lock();
           if (signest_catchable(j + 1))
             {
-              kill(waiterpid, j + 1);
+              pthread_kill(waiterpid, j + 1);
               even_signals++;
             }
 
@@ -478,7 +478,7 @@ void signest_test(void)
 
           if (signest_catchable(j))
             {
-              kill(waiterpid, j);
+              pthread_kill(waiterpid, j);
               odd_signals++;
             }
 


### PR DESCRIPTION
## Summary

"kill" sends the signal to any of the the threads in the group. The intention of the test is to send signals only to the "waiter" thread.

I believe this test has been broken since 2023 when the test changed from using tasks to using pthreads. This has gone unnoticed since the test doesn't really fail in single CPU systems (since the threads have different priorities), even if the signals were executed in other thread's context than the "waiter".

In SMP systems, the signest test threads actually run in parallel, so scheduling signal actions to different threads in the same group causes also signal actions to run in parallel (for different signals of course).

Running signal actions in parallel is not compatible behaviour with the signest test, which assumes that signals are being run one after another. For example running signals 38 and 40 in parallel on two threads/two cpus would cause the test incorrectly fail on "even signals nested". Or, sending two signals with the same number sequentially may be scheduled to two threads/two cpus, and end up running in paralle..

## Impact

Fixes ostest:
1. Removes false negatives in SMP caused by the explanation in Summary
2. Removes false positives in SMP caused by signals being run by other threads than intended - before this they may get executed by "ostest" or "interferer" threads as well.

## Testing

Tested in qemu rv-virt:smp w. 8 cores and mpfs with 4 cores.
