### PR TITLE
boot/nxboot: Enhancements to add progress messages and copy-to-RAM

### DIFF
--- a/boot/nxboot/Kconfig
+++ b/boot/nxboot/Kconfig
@@ -64,6 +64,36 @@ config NXBOOT_BOOTLOADER
 
 if NXBOOT_BOOTLOADER
 
+config NXBOOT_COPY_TO_RAM
+	bool "Copy bootable image to RAM before calling board boot-image function"
+	default n
+	---help---
+		The is a board and/or arch specific option that may be used when running
+		directly from flash, especially if external flash, even in XIP mode, is too
+		slow.
+		Running from RAM usually results in faster execution but the board must, of
+		course, have sufficient RAM available for the application image, stack
+		and heap.
+
+config NXBOOT_RAMSTART
+	hex "Start address in RAM that the application is to be loaded"
+	default 0x0
+	depends on NXBOOT_COPY_TO_RAM
+	---help---
+		This will be board specific. A check of the board's linker script
+		may be informative. For example the SAMA5D2-XULT eval board's uboot
+		linker script - boards/arm/sama5/sama5d2-xult/scripts/uboot.ld - has:
+		
+		sdram (W!RX) : ORIGIN = 0x20008000, LENGTH = 256M - 32K
+
+		This shows the load address to be 0x20008000 and would be the address
+		to use here if the same linker script is to be be used for NXboot.
+
+		Typically the address is the base address of the RAM to be used, plus the
+		size of the NXboot image itself. The example above has reserved
+		32KiB (0x8000) for this from the 256MiB available on the board at
+		address 0x20000000.
+
 config NXBOOT_SWRESET_ONLY
 	bool "Perform update/revert only on SW reset"
 	default n
@@ -86,11 +116,34 @@ config NXBOOT_PREVENT_DOWNGRADE
 		NXboot uses Semantic Version 2.0.0 (without build metadata). By default
 		the update is performed for every version that doesn't match the
 		currently running one. If NXBOOT_PREVENT_DOWNGRADE selected, update is
-		performed only for newer versions  (according to Semantic Version
+		performed only for newer versions (according to Semantic Version
 		preference rules).
 
 		WARNING: NXboot currently implements preferences only for
 		MAJOR.MINOR.PATCH and ignores prerelease.
+
+config NXBOOT_PRINTF_PROGRESS
+	bool "Enable progress messages to be sent to STDOUT"
+	default y
+	---help---
+		This will display progress during typically lengthy operations:
+			- Calculating checksums
+			- copying images between slots
+
+		Note: the NXboot binary will be approximately 2KiB larger with this enabled.
+
+choice
+	prompt "Choose preferred progress indication type"
+	depends on NXBOOT_PRINTF_PROGRESS
+	default NXBOOT_PRINTF_PROGRESS_PERCENT
+
+config NXBOOT_PRINTF_PROGRESS_DOTS
+	bool "Display progress using sequential dots"
+
+config NXBOOT_PRINTF_PROGRESS_PERCENT
+	bool "Display progress using percentage remaining"
+
+endchoice
 
 endif # NXBOOT_BOOTLOADER
 

--- a/boot/nxboot/loader/flash.c
+++ b/boot/nxboot/loader/flash.c
@@ -202,8 +202,8 @@ int flash_partition_read(int fd, void *buf, size_t count, off_t off)
   nbytes = read(fd, buf, count);
   if (nbytes != count)
     {
-      syslog(LOG_ERR, "Read from offset %ld failed %s\n",
-              off, strerror(errno));
+      syslog(LOG_ERR, "Read from offset %ld failed %s\n", off,
+                      strerror(errno));
       return ERROR;
     }
 
@@ -265,7 +265,7 @@ int flash_partition_erase_first_sector(int fd)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Could not erase the partition: %s\n",
-              strerror(errno));
+                      strerror(errno));
       return ERROR;
     }
 
@@ -295,7 +295,8 @@ int flash_partition_info(int fd, struct flash_partition_info *info)
   ret = ioctl(fd, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geometry));
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ioctl MTDIOC_GEOMETRY failed: %s\n", strerror(errno));
+      syslog(LOG_ERR, "ioctl MTDIOC_GEOMETRY failed: %s\n",
+                              strerror(errno));
       return ERROR;
     }
 

--- a/boot/nxboot/nxboot_main.c
+++ b/boot/nxboot/nxboot_main.c
@@ -28,28 +28,235 @@
 
 #include <stdio.h>
 #include <syslog.h>
-
+#include <nuttx/ascii.h>
+#include <sys/param.h>
 #include <nxboot.h>
 #include <sys/boardctl.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+static bool g_progress_started = false;
+#ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT
+static bool g_progress_percent_started = false;
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_NXBOOT_PRINTF_PROGRESS
+
+#  ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT  
+static const char backtab[] =
+{
+  ASCII_BS, ASCII_BS, ASCII_BS, ASCII_BS, '\0',
+};
+#  endif
+
+static const char *progress_msgs[] =
+{
+  [startup_msg]              = "*** nxboot ***",
+  [power_reset]              = "Power Reset detected, check images only",
+  [soft_reset]               = "Soft reset detected, check for update",
+  [found_bootable_image]     = "Found bootable image, boot from primary",
+  [no_bootable_image]        = "No bootable image found",
+  [boardioc_image_boot_fail] = "Board failed to boot bootable image",
+  [ramcopy_started]          = "Copying bootable image to RAM",
+  [recovery_revert]          = "Reverting image to recovery",
+  [recovery_create]          = "Creating recovery image",
+  [update_from_update]       = "Updating from update image",
+  [validate_primary]         = "Validating primary image",
+  [validate_recovery]        = "Validating recovery image",
+  [validate_update]          = "Validating update image",
+  [recovery_created]         = "Recovery image created",
+  [recovery_invalid]         = "Recovery image invalid, update stopped",
+  [update_failed]            = "Update failed",
+};
+#endif /* CONFIG_NXBOOT_PRINTF_PROGRESS */
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: nxboot_progress
+ *
+ * Description:
+ *   If enabled, this function prints progress messages to stdout.
+ *   Messages are handled via integer enums, allowing this function to be
+ *   easily replaced if required with no changes needed to the underlying
+ *   code
+ *
+ * Input Parameters:
+ *   type - the progress message type to be printed, as per progress_type_e:
+ *          - nxboot_info:             Prefixes arg. string with "INFO:"
+ *          - nxboot_error:            Prefixes arg. string with "ERR:"
+ *          - nxboot_progress_start:   Prints arg. string with no newline
+ *                                     to allow a ..... sequence
+ *                                     or % remaining to follow
+ *          - nxboot_progress_dot:     Prints a "." to the ..... sequence
+ *          - nxboot_progress_percent: Displays progress as % remaining
+ *          - nxboot_progress_end,     Flags end of a progrees sequence
+ *
+ *   ... - variadic argument:
+ *          - the enum (int) reference to the message string or
+ *          - the % remaining in the case of type: nxboot_progress_percent
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void nxboot_progress(enum progress_type_e type, ...)
+{
+#ifdef CONFIG_NXBOOT_PRINTF_PROGRESS
+  va_list arg;
+
+  va_start(arg, type);
+
+  switch (type)
+    {
+      case nxboot_info:
+        {
+          int idx = va_arg(arg, int);
+          assert(progress_msgs[idx]);
+          if (strlen(progress_msgs[idx]) == 0)
+            {
+              syslog(LOG_ERR, "No progress message for idx: %d\n", idx);
+              break;
+            }
+
+          dprintf(STDOUT_FILENO, "%s\n", progress_msgs[idx]);
+        }
+      break;
+      case nxboot_error:
+        {
+          int idx = va_arg(arg, int);
+          assert(progress_msgs[idx]);
+          if (strlen(progress_msgs[idx]) == 0)
+            {
+              syslog(LOG_ERR, "No progress message for idx: %d\n", idx);
+              break;
+            }
+
+          dprintf(STDOUT_FILENO, "ERROR: %s\n", progress_msgs[idx]);
+        }
+      break;
+      case nxboot_progress_start:
+        {
+          int idx = va_arg(arg, int);
+          assert(progress_msgs[idx]);
+          if (strlen(progress_msgs[idx]) == 0)
+            {
+              syslog(LOG_ERR, "No progress message for idx: %d\n", idx);
+              break;
+            }
+
+          dprintf(STDOUT_FILENO, "%s", progress_msgs[idx]);
+          g_progress_started = true;
+        }
+      break;
+      case nxboot_progress_dot:
+        {
+          assert(g_progress_started);
+          if (!g_progress_started)
+            {
+              syslog(LOG_ERR, "Progress dot requested "
+                              "but no previous progress start\n");
+            }
+          else
+            {
+              dprintf(STDOUT_FILENO, ".");
+            }
+        }
+      break;
+#ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT      
+      case nxboot_progress_percent:
+        {
+          assert(g_progress_started);
+          if (!g_progress_started)
+            {
+              syslog(LOG_ERR, "Progress percent requested "
+                              "but no previous progress start\n");
+            }
+          else
+            {
+              int percent = va_arg(arg, int);
+              if (!g_progress_percent_started)
+                {
+                  g_progress_percent_started = true;
+                  dprintf(STDOUT_FILENO, ": ");
+                }
+              else
+                {
+                  dprintf(STDOUT_FILENO, "%s", backtab);
+                }
+
+              dprintf(STDOUT_FILENO, "%3d%%", MIN(percent, 100));
+            }
+        }
+      break;
+#endif
+      case nxboot_progress_end:
+        {
+          assert(g_progress_started);
+          if (!g_progress_started)
+            {
+              syslog(LOG_ERR, "Progress dot stop requested "
+                              "but no previous progress start\n");
+            }
+          else
+            {
+              dprintf(STDOUT_FILENO, "\n");
+            }
+
+          g_progress_started = false;
+#ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT   
+          g_progress_percent_started = false;
+#endif
+        }
+      break;
+      default:
+        {
+          assert(false);
+          syslog(LOG_ERR, "Invalid progress message type: %d\n", type);
+          dprintf(STDOUT_FILENO, "progress: unknown type!\n");
+        }
+      break;
+    }
+
+  va_end(arg);
+#endif /* CONFIG_NXBOOT_PRINTF_PROGRESS */
+}
+
+/****************************************************************************
  * Name: nxboot_main
  *
  * Description:
- *   NuttX bootlaoder entry point.
+ *   NuttX bootloader entry point.
  *
  ****************************************************************************/
 
 int main(int argc, FAR char *argv[])
 {
+  int ret;
   struct boardioc_boot_info_s info;
   bool check_only;
 #ifdef CONFIG_NXBOOT_SWRESET_ONLY
-  int ret;
   FAR struct boardioc_reset_cause_s cause;
 #endif
 
@@ -66,6 +273,7 @@ int main(int argc, FAR char *argv[])
 #endif
 
   syslog(LOG_INFO, "*** nxboot ***\n");
+  nxboot_progress(nxboot_info, startup_msg);
 
 #ifdef CONFIG_NXBOOT_SWRESET_ONLY
   check_only = true;
@@ -77,10 +285,12 @@ int main(int argc, FAR char *argv[])
           cause.cause == BOARDIOC_RESETCAUSE_PIN)
         {
           check_only = false;
+          nxboot_progress(nxboot_info, soft_reset);
         }
       else
         {
           syslog(LOG_INFO, "Power reset detected, performing check only.\n");
+          nxboot_progress(nxboot_info, power_reset);
         }
     }
 #else
@@ -90,15 +300,28 @@ int main(int argc, FAR char *argv[])
   if (nxboot_perform_update(check_only) < 0)
     {
       syslog(LOG_ERR, "Could not find bootable image.\n");
-      return 0;
+      nxboot_progress(nxboot_error, no_bootable_image);
+      return OK;
     }
 
   syslog(LOG_INFO, "Found bootable image, boot from primary.\n");
+  nxboot_progress(nxboot_info, found_bootable_image);
+
+#ifdef CONFIG_NXBOOT_COPY_TO_RAM
+  syslog(LOG_INFO, "Copying image to RAM.\n");
+  nxboot_ramcopy();
+#endif
 
   /* Call board specific image boot */
 
   info.path        = CONFIG_NXBOOT_PRIMARY_SLOT_PATH;
   info.header_size = CONFIG_NXBOOT_HEADER_SIZE;
 
-  return boardctl(BOARDIOC_BOOT_IMAGE, (uintptr_t)&info);
+  ret = boardctl(BOARDIOC_BOOT_IMAGE, (uintptr_t)&info);
+
+  /* Only get here if the board boot fails */
+
+  nxboot_progress(nxboot_error, boardioc_image_boot_fail);
+
+  return ret;
 }


### PR DESCRIPTION
## Summary

This PR has been created after email-list discussions mainly with with @Cynerd and @michallenc

## Details

### Progress Reporting

This was driven as a result of the inevitable time that firmware upgrades can take. The progress is reported via syslog, but not all embedded systems use this and, in the case (such as mine) where a user LCD is available, it is beneficial to allow progress to be displayed duringh booting and upgrades - especially should things go wrong.

To achieve this there is a new Kconfig choice - `NXBOOT_PRINTF_PROGRESS` which is disabled by defailt - to allow messages to be printed to stdout.

Since other users may wish to treat NXboot as a library, and perhaps handle the messages differently, the feature is implemented by calls to a specific `nxboot_progress` function using new enums to indicate the type of message: info, error, or that a potentially lengthy procedure has started, stopped or is in progress using the "." character printed periodically.

A user wishing to implement this in another way would use the existing top-level public function `nxboot_main` and would only need to modify this to report errors in a different way.

Enabling this feature adds approximately 1.5KiB to the size of the binary, in my case.

### RAM copy

In my case, the ultimate boot_image function needs to copy the validated and bootable image to SDRAM. Although this could be handled by the board-specific logic, the NXboot header does not conatin the size of the actual image to be copied meaning an image copy can only be of the entire NXboot "slot" size. This means it is a little slower then it could be and it made sense to have that implemented by a new function `nxboot_ramcopy` before calling the board boot function via `BOARDIOC_BOOT_IMAGE`

This is enabled by a new Kconfig choice - `NXBOOT_COPY_TO_RAM` - that is disabled by default

The address to copy the image to is also configured via Kconfig - BUT there is no way that I can see for NXboot to determine the validity or otherwise of the configured address.

## Impact

Since the new features are selected via Kconfig, defaulting to off, the is no intended impact to existing implementations. Lower level functions have been edited carefully, and I can confirm that NXboot still behaves for me as it did before the changes, with the added benefit of progress messages if required.

The copy-to-ram function also works, for me, as required.

## Testing

This has been tested on my custom board using a SAMA5D27C-D1G processor, equipped with a partitioned 256Mbyte NOR flash that for the NXboot slots, and an 800x40 TFT for stdout courtesy of the FBCON example application

