### PR TITLE
interpreters/python: Do not link to standard libraries

### DIFF
--- a/interpreters/python/Makefile
+++ b/interpreters/python/Makefile
@@ -56,7 +56,7 @@ CFLAGS += -Wno-shadow -Wno-undef -Wno-format -Wno-builtin-macro-redefined
 CFLAGS += -Wno-type-limits -Wno-implicit-fallthrough -Wno-char-subscripts
 CFLAGS += -Wno-sign-compare -Wno-unused-const-variable -Wno-unused-function
 CFLAGS += -Wno-unused-variable -Wno-overflow -Wno-unused-but-set-variable
-CFLAGS += -Wno-strict-prototypes
+CFLAGS += -Wno-strict-prototypes -nostdlib
 
 DEPPATH += --dep-path $(CPYTHON_UNPACKNAME)$(DELIM)Programs
 VPATH   += :$(CPYTHON_UNPACKNAME)$(DELIM)Programs


### PR DESCRIPTION
## Summary

* interpreters/python: Do not link to standard libraries

This prevents Python from linking to standard libraries.

This is needed because Python's `configure` script tests for a set of available functions that are provided by NuttX (instead of the toolchain) and not having `-nostdlib` set may give wrong results.

## Impact

Impact on user: NO.

Impact on build: YES. Prevent Python's from linking toolchain's libraries.

Impact on hardware: NO.

Impact on documentation: NO.

Impact on security: NO.

Impact on compatibility: NO.

## Testing

This can be tested by checking the `apps/interpreters/python/build/target/config.log` file when building the `esp32s3-devkit:python` defconfig file.

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:python && make -s -j$(nproc)
```

### Results

At `apps/interpreters/python/build/target/config.log`, look for the `checking for wait` test. If using the recommended toolchain for ESP32-S3 (`xtensa-esp32s3-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0`), this test fails. But trying with a newer toolchain (`xtensa-esp-elf-gcc (crosstool-NG esp-14.2.0_20241119) 14.2.0`, for instance), the test pass. This is a false-positive because NuttX requires its implementation of `wait` function (at `sched/sched/sched_wait.c`) to be used instead. In this case, NuttX's implementation is not enabled and the test should fail. Applying this patch, we can guarantee that the `checking for wait` test fails as expected.