### PR TITLE
nsh/script: remove double close for output fd

### DIFF
--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -74,7 +74,6 @@ static int nsh_script_redirect(FAR struct nsh_vtbl_s *vtbl,
       if (fd > 0)
         {
           nsh_undirect(vtbl, save);
-          close(fd);
         }
     }
 


### PR DESCRIPTION

## Summary
nsh/script: remove double close for output fd

the output fd had been closed in nsh_closeifnotclosed, so remove double close.

## Impact
fix double close
## Testing
sim:nsh
