### PR TITLE
logging/nxscope: allow use in C++ code

### DIFF
--- a/include/logging/nxscope/nxscope.h
+++ b/include/logging/nxscope/nxscope.h
@@ -53,6 +53,14 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /* Nxscope header ID */
 
 enum nxscope_hdr_id_e
@@ -487,5 +495,10 @@ int nxscope_recv(FAR struct nxscope_s *s);
  ****************************************************************************/
 
 int nxscope_stream_start(FAR struct nxscope_s *s, bool start);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* __APPS_INCLUDE_LOGGING_NXSCOPE_NXSCOPE_H */

--- a/include/logging/nxscope/nxscope_chan.h
+++ b/include/logging/nxscope/nxscope_chan.h
@@ -37,6 +37,14 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /* Nxscope sample type */
 
 enum nxscope_sample_dtype_e
@@ -399,5 +407,10 @@ int nxscope_put_b16(FAR struct nxscope_s *s, uint8_t ch, b16_t val);
 int nxscope_put_ub32(FAR struct nxscope_s *s, uint8_t ch, ub32_t val);
 int nxscope_put_b32(FAR struct nxscope_s *s, uint8_t ch, b32_t val);
 int nxscope_put_char(FAR struct nxscope_s *s, uint8_t ch, char val);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* __APPS_INCLUDE_LOGGING_NXSCOPE_NXSCOPE_CHAN_H */

--- a/include/logging/nxscope/nxscope_intf.h
+++ b/include/logging/nxscope/nxscope_intf.h
@@ -37,6 +37,14 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /* Forward declaration */
 
 struct nxscope_intf_s;
@@ -123,6 +131,11 @@ int nxscope_ser_init(FAR struct nxscope_intf_s *intf,
  ****************************************************************************/
 
 void nxscope_ser_deinit(FAR struct nxscope_intf_s *intf);
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
 #endif
 
 #endif  /* __APPS_INCLUDE_LOGGING_NXSCOPE_NXSCOPE_INTF_H */

--- a/include/logging/nxscope/nxscope_proto.h
+++ b/include/logging/nxscope/nxscope_proto.h
@@ -33,6 +33,14 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /* Nxscope frame handler */
 
 struct nxscope_frame_s
@@ -102,6 +110,11 @@ int nxscope_proto_ser_init(FAR struct nxscope_proto_s *proto, FAR void *cfg);
  ****************************************************************************/
 
 void nxscope_proto_ser_deinit(FAR struct nxscope_proto_s *proto);
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
 #endif
 
 #endif  /* __APPS_INCLUDE_LOGGING_NXSCOPE_NXSCOPE_PROTO_H */


### PR DESCRIPTION
## Summary
logging/nxscope: allow use in C++ code

## Impact
nxscope can be used in C++ code

## Testing
custom project
