### PR TITLE
wireless/bluetooth/nimble/Kconfig: add missing header

### DIFF
--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -1,3 +1,8 @@
+#
+# For a description of the syntax of this configuration file,
+# see misc/tools/kconfig-language.txt.
+#
+
 config NIMBLE
 	bool "Apache NimBLE (BLE host-layer)"
 	default n


### PR DESCRIPTION
## Summary
wireless/bluetooth/nimble/Kconfig: add missing header

## Impact
cosmetic change

## Testing
none
