### PR TITLE
examples/optee_gp: Fix Kconfig if/else condition

### DIFF
--- a/examples/optee_gp/Kconfig
+++ b/examples/optee_gp/Kconfig
@@ -10,7 +10,7 @@ config EXAMPLES_OPTEE_GP
 	---help---
 		Enable the OP-TEE GP API client example which uses libteec
 
-if EXAMPLES_OPTEE
+if EXAMPLES_OPTEE_GP
 
 config EXAMPLES_OPTEE_GP_PROGNAME
 	string "Program name"


### PR DESCRIPTION
## Summary

Previous Kconfig had a mistake guarding optee_gp Kconfig values based on `EXAMPLES_OPTEE` instead of `EXAMPLES_OPTEE_GP`.

## Impact

Fixes the case where `CONFIG_EXAMPLES_OPTEE_GP` is enabled without `CONFIG_EXAMPLES_OPTEE`, which is a valid case.

## Testing
Tested on a NXP i.MX93 EVK running:
 - TF-A: version v2.10.0, tag `lf-6.6.52_2.2.0`
 - OP-TEE OS: revision 4.4 (60beb308810f9561), tag `lf-6.6.52_2.2.0`
 - NuttX config `imx93-evk:koptee` with additional config:
      ```
      CONFIG_EXAMPLES_OPTEE_GP=y
      CONFIG_LIBTEEC=y
     ```
 - Logs
    ```
    [...]
    OP-TEE: OS revision 4.4 (60beb308810f9561)
    
    NuttShell (NSH)
    knsh> optee_gp
    INF [6] TEEC:main:159: Available devices:
    INF [6] TEEC:main:169:   d96a5b40-c3e5-21e3-8794-1002a5d5c61b
    INF [6] TEEC:main:169:   f04a0fe7-1f5d-4b9b-abf7-619b85b4ce8c
    ```
