### PR TITLE
Fixing Kconfig file, adding the STACKSIZE symbol to example posix_stdio

### DIFF
--- a/examples/posix_stdio/Kconfig
+++ b/examples/posix_stdio/Kconfig
@@ -7,7 +7,8 @@ config EXAMPLES_POSIX_STDIO
 	bool "Posix stdio example"
 	default n
 	---help---
-    	Enable POSIX stdio example that shows how to use open(), write() and close() via /dev/console.
+		Enable POSIX stdio example that shows how to use open(), write() and
+		close() via /dev/console.
 
 config EXAMPLES_POSIX_STDIO_PROGNAME
 	string "Program name"
@@ -15,6 +16,11 @@ config EXAMPLES_POSIX_STDIO_PROGNAME
 	depends on EXAMPLES_POSIX_STDIO
 
 config EXAMPLES_POSIX_STDIO_PRIORITY
-	int "POSIX_STDIO test priority"
+	int "POSIX_STDIO priority"
 	default 100
+	depends on EXAMPLES_POSIX_STDIO
+
+config EXAMPLES_POSIX_STDIO_STACKSIZE
+	int "POSIX_STDIO stack size"
+	default DEFAULT_TASK_STACKSIZE
 	depends on EXAMPLES_POSIX_STDIO


### PR DESCRIPTION
## Summary
When I have submitted the example, somehow, there was an issue on the Kconfig, where the stack size was absent.
Thus, it cause an issue to compile nuttx when 'examples/posix_stdio' was included. Now it was tested properly and it is as expected.

## Impact
To fix the example, it was needed to add the the following onto Kconfig file:

config EXAMPLES_POSIX_STDIO_STACKSIZE
  int "POSIX_STDIO stack size"
	default 2048
	depends on EXAMPLES_POSIX_STDIO

## Testing
vinicius@labs:~/embedded_sys/nuttxspace/nuttx$ ./nuttx 

NuttShell (NSH) NuttX-12.9.0
nsh> uname -a
NuttX 12.9.0 de0c697db8 May 25 2025 17:39:28 sim sim
nsh> 
nsh> 
nsh> posix_stdio
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
Hello, NuttX users, welcome!!!
nsh> 


