### PR TITLE
apps/testing: fix typo

### DIFF
--- a/testing/drivers/Makefile
+++ b/testing/drivers/Makefile
@@ -20,6 +20,6 @@
 #
 ############################################################################
 
-MENUDESC = "dirvers"
+MENUDESC = "drivers"
 
 include $(APPDIR)/Directory.mk


### PR DESCRIPTION
## Summary
Small typo fix in the drivers directory.
Nitpicking but it made searching for this in menuconfig slightly more difficult. 

## Impact
None

## Testing
None
