### PR TITLE
testing/fs: update api name fs_getfilep/fs_putfilep to file_get/file_put

### DIFF
--- a/testing/testsuites/kernel/fs/cases/fs_file_get_test.c
+++ b/testing/testsuites/kernel/fs/cases/fs_file_get_test.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/testing/testsuites/kernel/fs/cases/fs_getfilep_test.c
+ * apps/testing/testsuites/kernel/fs/cases/fs_file_get_test.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -45,10 +45,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_nuttx_fs_getfilep01
+ * Name: test_nuttx_fs_file_get01
  ****************************************************************************/
 
-void test_nuttx_fs_getfilep01(FAR void **state)
+void test_nuttx_fs_file_get01(FAR void **state)
 {
   FAR struct file *filep;
   int ret;
@@ -72,7 +72,7 @@ void test_nuttx_fs_getfilep01(FAR void **state)
 
   /* get struct file */
 
-  ret = fs_getfilep(fileno(fp), &filep);
+  ret = file_get(fileno(fp), &filep);
   assert_int_equal(ret, 0);
 
   /* malloc memory */
@@ -100,11 +100,11 @@ void test_nuttx_fs_getfilep01(FAR void **state)
 
   /* put filep */
 
-  fs_putfilep(filep);
+  file_put(filep);
 
   /* get struct file again */
 
-  ret = fs_getfilep(fileno(fp), &filep);
+  ret = file_get(fileno(fp), &filep);
   assert_int_equal(ret, 0);
 
   assert_int_equal(filep->f_pos, BUF_SIZE);
@@ -113,7 +113,7 @@ void test_nuttx_fs_getfilep01(FAR void **state)
 
   /* put filep */
 
-  fs_putfilep(filep);
+  file_put(filep);
 
   assert_int_equal(fclose(fp), 0);
 }

--- a/testing/testsuites/kernel/fs/cmocka_fs_test.c
+++ b/testing/testsuites/kernel/fs/cmocka_fs_test.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
       cmocka_unit_test_setup_teardown(test_nuttx_fs_fsync02,
                                       test_nuttx_fs_test_group_setup,
                                       test_nuttx_fs_test_group_teardown),
-      cmocka_unit_test_setup_teardown(test_nuttx_fs_getfilep01,
+      cmocka_unit_test_setup_teardown(test_nuttx_fs_file_get01,
                                       test_nuttx_fs_test_group_setup,
                                       test_nuttx_fs_test_group_teardown),
       cmocka_unit_test_setup_teardown(test_nuttx_fs_mkdir01,

--- a/testing/testsuites/kernel/fs/include/fstest.h
+++ b/testing/testsuites/kernel/fs/include/fstest.h
@@ -111,10 +111,10 @@ void test_nuttx_fs_fstatfs01(FAR void **state);
 void test_nuttx_fs_fsync01(FAR void **state);
 void test_nuttx_fs_fsync02(FAR void **state);
 
-/* cases/fs_getfilep_test.c
+/* cases/fs_file_get_test.c
  * ************************************************/
 
-void test_nuttx_fs_getfilep01(FAR void **state);
+void test_nuttx_fs_file_get01(FAR void **state);
 
 /* cases/fs_mkdir_test.c
  * ************************************************/


### PR DESCRIPTION
## Summary
testing/fs: update api name fs_getfilep/fs_putfilep to file_get/file_put.

DEPENDS ON: https://github.com/apache/nuttx/pull/16499

## Impact
fix compile break

## Testing
CI
