### PR TITLE
benchmarks/osperf/osperf.c: add pipe read-write performance test

### DIFF
--- a/benchmarks/osperf/osperf.c
+++ b/benchmarks/osperf/osperf.c
@@ -188,10 +188,10 @@ static size_t pthread_create_performance(void)
 }
 
 /****************************************************************************
- * Contxt create performance
+ * Context create performance
  ****************************************************************************/
 
-static FAR void *context_swtich_task(FAR void *arg)
+static FAR void *context_switch_task(FAR void *arg)
 {
   FAR struct performance_time_s *time = arg;
   sched_yield();
@@ -204,7 +204,7 @@ static size_t context_switch_performance(void)
   struct performance_time_s time;
   int tid;
 
-  tid = performance_thread_create(context_swtich_task, &time,
+  tid = performance_thread_create(context_switch_task, &time,
                                   CONFIG_INIT_PRIORITY);
   sched_yield();
   performance_start(&time);

--- a/benchmarks/osperf/osperf.c
+++ b/benchmarks/osperf/osperf.c
@@ -71,6 +71,7 @@ static size_t pthread_switch_performance(void);
 static size_t context_switch_performance(void);
 static size_t hpwork_performance(void);
 static size_t poll_performance(void);
+static size_t pipe_performance(void);
 static size_t semwait_performance(void);
 static size_t sempost_performance(void);
 
@@ -85,6 +86,7 @@ static const struct performance_entry_s g_entry_list[] =
   {"context-switch", context_switch_performance},
   {"hpwork", hpwork_performance},
   {"poll-write", poll_performance},
+  {"pipe-rw", pipe_performance},
   {"semwait", semwait_performance},
   {"sempost", sempost_performance},
 };
@@ -285,6 +287,30 @@ static size_t poll_performance(void)
   performance_end(&result);
 
   pthread_join(ret, NULL);
+  close(pipefd[0]);
+  close(pipefd[1]);
+  return performance_gettime(&result);
+}
+
+/****************************************************************************
+ *  pipe performance
+ ****************************************************************************/
+
+static size_t pipe_performance(void)
+{
+  struct performance_time_s result;
+  int pipefd[2];
+  int ret;
+  char r;
+
+  ret = pipe(pipefd);
+  DEBUGASSERT(ret == 0);
+
+  performance_start(&result);
+  write(pipefd[0], "a", 1);
+  read(pipefd[1], &r, 1);
+  performance_end(&result);
+
   close(pipefd[0]);
   close(pipefd[1]);
   return performance_gettime(&result);


### PR DESCRIPTION
## Summary

This adds a simple pip read-write performance test. Also fixes some spelling mistakes in the file.

## Impact

osperf application only, adds new test.

## Testing

Tested on custom board with SAMv7 MCU. osperf output:

```
brcg2> osperf -c 1000
OS performance args: count:1000, detail:false
==============================================================
Describe                                Max        Min        Avg
pthread-create                        29170      18860      20619
pthread-switch                         4156       2386       2918
context-switch                         5966       1876       2274
hpwork                                 8583       3440       4060
poll-write                            48370      40586      43866
pipe-rw                                6983       5123       6014
semwait                                1146        610        675
sempost                                 910        466        523
```
