### PR TITLE
system/fastboot: move usbdev init after help

### DIFF
--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -993,16 +993,8 @@ static int fastboot_open_usb(int index, int flags)
   return -errno;
 }
 
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-int main(int argc, FAR char **argv)
+static int fastboot_usbdev_initialize(void)
 {
-  struct fastboot_ctx_s context;
-  FAR void *buffer = NULL;
-  int ret = OK;
-
 #ifdef CONFIG_SYSTEM_FASTBOOTD_USB_BOARDCTL
   struct boardioc_usbdev_ctrl_s ctrl;
 #  ifdef CONFIG_USBDEV_COMPOSITE
@@ -1011,6 +1003,7 @@ int main(int argc, FAR char **argv)
     uint8_t dev = BOARDIOC_USBDEV_FASTBOOT;
 #  endif
   FAR void *handle;
+  int ret;
 
   ctrl.usbdev   = dev;
   ctrl.action   = BOARDIOC_USBDEV_INITIALIZE;
@@ -1021,7 +1014,7 @@ int main(int argc, FAR char **argv)
   ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
   if (ret < 0)
     {
-      fb_err("boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", ret);
+      fb_err("boardctl(BOARDIOC_USBDEV_INITIALIZE) failed: %d\n", ret);
       return ret;
     }
 
@@ -1034,10 +1027,23 @@ int main(int argc, FAR char **argv)
   ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
   if (ret < 0)
     {
-      fb_err("boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", ret);
+      fb_err("boardctl(BOARDIOC_USBDEV_CONNECT) failed: %d\n", ret);
       return ret;
     }
 #endif /* SYSTEM_FASTBOOTD_USB_BOARDCTL */
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char **argv)
+{
+  struct fastboot_ctx_s context;
+  FAR void *buffer = NULL;
+  int ret = OK;
 
   if (argc > 1)
     {
@@ -1052,6 +1058,12 @@ int main(int argc, FAR char **argv)
   else
     {
       context.wait_ms = 0;
+    }
+
+  ret = fastboot_usbdev_initialize();
+  if (ret < 0)
+    {
+      return ret;
     }
 
   buffer = malloc(CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX);


### PR DESCRIPTION
## Summary
Move initialization of usbdev to after "help()".
This patch fix that even users just run `fastbootd -h`, the usbdev will also be (re)initialized, and if the daemon is running the status will be broken.

## Impact
system/fastboot

## Testing
CI
