### PR TITLE
system/fastboot: add const for memdump_print_t

### DIFF
--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -157,7 +157,7 @@ struct fastboot_cmd_s
                       FAR const char *arg);
 };
 
-typedef void (*memdump_print_t)(FAR void *, FAR char *);
+typedef void (*memdump_print_t)(FAR void *, FAR const char *);
 
 /****************************************************************************
  * Private Function Prototypes
@@ -681,12 +681,13 @@ static void fastboot_memdump_region(memdump_print_t memprint, FAR void *priv)
 #endif
 }
 
-static void fastboot_memdump_syslog(FAR void *priv, FAR char *response)
+static void fastboot_memdump_syslog(FAR void *priv, FAR const char *response)
 {
   fb_err("    %s", response);
 }
 
-static void fastboot_memdump_response(FAR void *priv, FAR char *response)
+static void fastboot_memdump_response(FAR void *priv,
+                                      FAR const char *response)
 {
   fastboot_ack((FAR struct fastboot_ctx_s *)priv, "TEXT", response);
 }


### PR DESCRIPTION
## Summary
Add qualifier "const" to the declaration of `memdump_print_t`, the value of the 2nd argument will not be changed.

## Impact
- system/fastboot

## Testing
- CI
