### PR TITLE
boot/nxboot: fix compile errors caused by nxboot_progress

### DIFF
--- a/boot/nxboot/Kconfig
+++ b/boot/nxboot/Kconfig
@@ -122,9 +122,14 @@ config NXBOOT_PREVENT_DOWNGRADE
 		WARNING: NXboot currently implements preferences only for
 		MAJOR.MINOR.PATCH and ignores prerelease.
 
+config NXBOOT_PROGRESS
+	bool
+	default n
+
 config NXBOOT_PRINTF_PROGRESS
 	bool "Enable progress messages to be sent to STDOUT"
 	default y
+	select NXBOOT_PROGRESS
 	---help---
 		This will display progress during typically lengthy operations:
 			- Calculating checksums

--- a/boot/nxboot/include/nxboot.h
+++ b/boot/nxboot/include/nxboot.h
@@ -168,7 +168,11 @@ enum progress_msg_e
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_NXBOOT_PROGRESS
 void nxboot_progress(enum progress_type_e type, ...);
+#else
+#define nxboot_progress(type, ...) do {} while (0)
+#endif
 
 /****************************************************************************
  * Name: nxboot_get_state

--- a/boot/nxboot/nxboot_main.c
+++ b/boot/nxboot/nxboot_main.c
@@ -41,9 +41,11 @@
  * Public Data
  ****************************************************************************/
 
+#ifdef CONFIG_NXBOOT_PROGRESS
 static bool g_progress_started = false;
 #ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT
 static bool g_progress_percent_started = false;
+#endif
 #endif
 
 /****************************************************************************
@@ -121,6 +123,7 @@ static const char *progress_msgs[] =
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NXBOOT_PROGRESS
 void nxboot_progress(enum progress_type_e type, ...)
 {
 #ifdef CONFIG_NXBOOT_PRINTF_PROGRESS
@@ -242,6 +245,7 @@ void nxboot_progress(enum progress_type_e type, ...)
   va_end(arg);
 #endif /* CONFIG_NXBOOT_PRINTF_PROGRESS */
 }
+#endif
 
 /****************************************************************************
  * Name: nxboot_main


### PR DESCRIPTION
## Summary
Function `nxboot_progress` is located in `nxboot_main.c`, but this file is not compiled when NXboot is used as a library to an existing application and not as a bootloader. Therefore, the declaration of `nxboot_progress` function should be dependent on `NXBOOT_PROGRESS` config option.

## Impact

Fixes NXboot compilation if used as a library without `nxboot_main.c` file.

## Testing
Tested on samv7 custom board. Both bootloader and library now compiles and work as expected.