### PR TITLE
system/fastboot: Add support for TCP network device

### DIFF
--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -6,7 +6,7 @@
 menuconfig SYSTEM_FASTBOOTD
 	bool "fastbootd"
 	default n
-	depends on USBFASTBOOT
+	depends on USBFASTBOOT || NET_TCP
 	---help---
 		support usb fastboot function.
 
@@ -29,6 +29,7 @@ config SYSTEM_FASTBOOTD_USB_BOARDCTL
 	default n
 	depends on BOARDCTL
 	depends on BOARDCTL_USBDEVCTRL
+	depends on USBFASTBOOT
 	---help---
 		Connect usbdev before running fastboot daemon.
 

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -41,9 +41,11 @@
 #include <syslog.h>
 #include <unistd.h>
 
+#include <netinet/in.h>
 #include <sys/boardctl.h>
 #include <sys/ioctl.h>
 #include <sys/param.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
 #include <sys/types.h>
@@ -73,12 +75,27 @@
 #define FASTBOOT_SPARSE_HEADER      sizeof(struct fastboot_sparse_header_s)
 #define FASTBOOT_CHUNK_HEADER       sizeof(struct fastboot_chunk_header_s)
 
+/* Fastboot TCP Protocol v1
+ *
+ *   handshake: chars "FB" followed by a 2-digit base-10 ASCII version number
+ *   data_size: 8-byte big-endian binary value before fastboot packet
+ *
+ *   https://android.googlesource.com/platform/system/core/+/refs/heads/main\
+ *         /fastboot/README.md#tcp-protocol-v1
+ */
+
+#define FASTBOOT_TCP_HANDSHAKE      "FB01"
+#define FASTBOOT_TCP_HANDSHAKE_LEN  4
+#define FASTBOOT_TCP_PORT           5554
+
 #define fb_info(...)                syslog(LOG_INFO, ##__VA_ARGS__);
 #define fb_err(...)                 syslog(LOG_ERR, ##__VA_ARGS__);
 
 /****************************************************************************
  * Private types
  ****************************************************************************/
+
+struct fastboot_ctx_s;
 
 struct fastboot_var_s
 {
@@ -122,19 +139,40 @@ struct fastboot_file_s
   off_t offset;
 };
 
+struct fastboot_transport_ops_s
+{
+  CODE int (*init)(FAR struct fastboot_ctx_s *);
+  CODE void (*deinit)(FAR struct fastboot_ctx_s *);
+  CODE ssize_t (*read)(FAR struct fastboot_ctx_s *, FAR void *, size_t);
+  CODE int (*write)(FAR struct fastboot_ctx_s *, FAR const void *, size_t);
+};
+
 struct fastboot_ctx_s
 {
-  int usbdev_in;
-  int usbdev_out;
+  /* Transport file descriptors
+   *
+   * | idx |    USB   |      TCP      | poll |
+   * |-----|----------|---------------|------|
+   * |   0 |usbdev in |TCP socket     |  Y   |
+   * |   1 |usbdev out|accepted socket|  N   |
+   */
+
+  int tran_fd[2];
   int flash_fd;
   size_t download_max;
   size_t download_size;
   size_t download_offset;
   size_t total_imgsize;
-  int wait_ms;
+
+  /* Store wait_ms argument before poll of fastboot_command_loop, and
+   * TCP transport remaining data size later.
+   */
+
+  uint64_t left;
   FAR void *download_buffer;
   FAR struct fastboot_var_s *varlist;
   CODE int (*upload_func)(FAR struct fastboot_ctx_s *context);
+  FAR const struct fastboot_transport_ops_s *ops;
   struct
     {
       size_t size;
@@ -185,6 +223,27 @@ static void fastboot_shell(FAR struct fastboot_ctx_s *context,
                            FAR const char *arg);
 #endif
 
+/* USB transport */
+
+#ifdef CONFIG_USBFASTBOOT
+static int     fastboot_usbdev_initialize(FAR struct fastboot_ctx_s *ctx);
+static void    fastboot_usbdev_deinit(FAR struct fastboot_ctx_s *ctx);
+static ssize_t fastboot_usbdev_read(FAR struct fastboot_ctx_s *ctx,
+                                    FAR void *buf, size_t len);
+static int     fastboot_usbdev_write(FAR struct fastboot_ctx_s *ctx,
+                                     FAR const void *buf, size_t len);
+#elif defined(CONFIG_NET_TCP)
+
+/* TCP transport */
+
+static int     fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx);
+static void    fastboot_tcp_deinit(FAR struct fastboot_ctx_s *ctx);
+static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
+                                 FAR void *buf, size_t len);
+static int     fastboot_tcp_write(FAR struct fastboot_ctx_s *ctx,
+                                  FAR const void *buf, size_t len);
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -217,6 +276,24 @@ static const struct memory_region_s g_memory_region[] =
 };
 #endif
 
+#ifdef CONFIG_USBFASTBOOT
+static const struct fastboot_transport_ops_s g_tran_ops_usb =
+{
+  .init    = fastboot_usbdev_initialize,
+  .deinit  = fastboot_usbdev_deinit,
+  .read    = fastboot_usbdev_read,
+  .write   = fastboot_usbdev_write,
+};
+#elif defined(CONFIG_NET_TCP)
+static const struct fastboot_transport_ops_s g_tran_ops_tcp =
+{
+  .init    = fastboot_tcp_initialize,
+  .deinit  = fastboot_tcp_deinit,
+  .read    = fastboot_tcp_read,
+  .write   = fastboot_tcp_write,
+};
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -239,9 +316,9 @@ static ssize_t fastboot_read(int fd, FAR void *buf, size_t len)
   return r < 0 ? -errno : r;
 }
 
-static int fastboot_write(int fd, FAR void *buf, size_t len)
+static int fastboot_write(int fd, FAR const void *buf, size_t len)
 {
-  FAR char *data = buf;
+  FAR const char *data = buf;
 
   while (len > 0)
     {
@@ -270,7 +347,7 @@ static void fastboot_ack(FAR struct fastboot_ctx_s *context,
     }
 
   snprintf(response, FASTBOOT_MSG_LEN, "%s%s", code, reason);
-  fastboot_write(context->usbdev_out, response, strlen(response));
+  context->ops->write(context, response, strlen(response));
 }
 
 static void fastboot_fail(FAR struct fastboot_ctx_s *context,
@@ -572,7 +649,7 @@ static void fastboot_download(FAR struct fastboot_ctx_s *context,
     }
 
   snprintf(response, FASTBOOT_MSG_LEN, "DATA%08lx", len);
-  ret = fastboot_write(context->usbdev_out, response, strlen(response));
+  ret = context->ops->write(context, response, strlen(response));
   if (ret < 0)
     {
       fb_err("Reponse error [%d]\n", -ret);
@@ -584,8 +661,7 @@ static void fastboot_download(FAR struct fastboot_ctx_s *context,
 
   while (len > 0)
     {
-      ssize_t r = fastboot_read(context->usbdev_in,
-                                download, len);
+      ssize_t r = context->ops->read(context, download, len);
       if (r < 0)
         {
           context->download_size = 0;
@@ -651,9 +727,8 @@ static void fastboot_reboot_bootloader(FAR struct fastboot_ctx_s *context,
 
 static int fastboot_memdump_upload(FAR struct fastboot_ctx_s *context)
 {
-  return fastboot_write(context->usbdev_out,
-                        context->upload_param.u.mem.addr,
-                        context->upload_param.size);
+  return context->ops->write(context, context->upload_param.u.mem.addr,
+                             context->upload_param.size);
 }
 
 static void fastboot_memdump_region(memdump_print_t memprint, FAR void *priv)
@@ -747,9 +822,8 @@ static int fastboot_filedump_upload(FAR struct fastboot_ctx_s *context)
           break;
         }
       else if (nread < 0 ||
-               fastboot_write(context->usbdev_out,
-                              context->download_buffer,
-                              nread) < 0)
+               context->ops->write(context, context->download_buffer,
+                                   nread) < 0)
         {
           fb_err("Upload failed (%zu bytes left)\n", size);
           close(fd);
@@ -868,7 +942,7 @@ static void fastboot_upload(FAR struct fastboot_ctx_s *context,
   snprintf(response, FASTBOOT_MSG_LEN, "DATA%08zx",
            context->upload_param.size);
 
-  ret = fastboot_write(context->usbdev_out, response, strlen(response));
+  ret = context->ops->write(context, response, strlen(response));
   if (ret < 0)
     {
       fb_err("Reponse error [%d]\n", -ret);
@@ -918,18 +992,22 @@ static void fastboot_oem(FAR struct fastboot_ctx_s *context,
 
 static void fastboot_command_loop(FAR struct fastboot_ctx_s *context)
 {
-  if (context->wait_ms > 0)
+  if (context->left > 0)
     {
       struct pollfd fds[1];
 
-      fds[0].fd = context->usbdev_in;
+      fds[0].fd = context->tran_fd[0];
       fds[0].events = POLLIN;
 
-      if (poll(fds, 1, context->wait_ms) <= 0)
+      if (poll(fds, 1, context->left) <= 0)
         {
           return;
         }
     }
+
+  /* Reinitialize for storing TCP transport remaining data size. */
+
+  context->left = 0;
 
   while (1)
     {
@@ -937,12 +1015,11 @@ static void fastboot_command_loop(FAR struct fastboot_ctx_s *context)
       size_t ncmds = nitems(g_fast_cmd);
       size_t index;
 
-      ssize_t r = fastboot_read(context->usbdev_in,
-                                buffer, FASTBOOT_MSG_LEN);
+      ssize_t r = context->ops->read(context, buffer, FASTBOOT_MSG_LEN);
       if (r < 0)
         {
-          fb_err("USB read error\n");
-          break;
+          fb_err("fastboot transport read() %zd\n", r);
+          continue;
         }
 
       buffer[r] = '\0';
@@ -1006,6 +1083,7 @@ static void fastboot_free_publish(FAR struct fastboot_ctx_s *context)
     }
 }
 
+#ifdef CONFIG_USBFASTBOOT
 static int fastboot_open_usb(int index, int flags)
 {
   int try = FASTBOOT_EP_RETRY_TIMES;
@@ -1070,20 +1148,20 @@ static int fastboot_usbdev_initialize(FAR struct fastboot_ctx_s *ctx)
     }
 #endif /* SYSTEM_FASTBOOTD_USB_BOARDCTL */
 
-  ctx->usbdev_in  =
+  ctx->tran_fd[0]  =
       fastboot_open_usb(FASTBOOT_EP_BULKOUT_IDX, O_RDONLY | O_CLOEXEC);
-  if (ctx->usbdev_in < 0)
+  if (ctx->tran_fd[0] < 0)
     {
-      return ctx->usbdev_in;
+      return ctx->tran_fd[0];
     }
 
-  ctx->usbdev_out =
+  ctx->tran_fd[1] =
       fastboot_open_usb(FASTBOOT_EP_BULKIN_IDX, O_WRONLY | O_CLOEXEC);
-  if (ctx->usbdev_out < 0)
+  if (ctx->tran_fd[1] < 0)
     {
-      close(ctx->usbdev_in);
-      ctx->usbdev_in = -1;
-      return ctx->usbdev_out;
+      close(ctx->tran_fd[0]);
+      ctx->tran_fd[0] = -1;
+      return ctx->tran_fd[1];
     }
 
   return 0;
@@ -1091,11 +1169,192 @@ static int fastboot_usbdev_initialize(FAR struct fastboot_ctx_s *ctx)
 
 static void fastboot_usbdev_deinit(FAR struct fastboot_ctx_s *ctx)
 {
-  close(ctx->usbdev_out);
-  ctx->usbdev_out = -1;
-  close(ctx->usbdev_in);
-  ctx->usbdev_in = -1;
+  int i;
+
+  for (i = 0; i < nitems(ctx->tran_fd); i++)
+    {
+      close(ctx->tran_fd[i]);
+      ctx->tran_fd[i] = -1;
+    }
 }
+
+static ssize_t fastboot_usbdev_read(FAR struct fastboot_ctx_s *ctx,
+                                    FAR void *buf, size_t len)
+{
+  return fastboot_read(ctx->tran_fd[0], buf, len);
+}
+
+static int fastboot_usbdev_write(FAR struct fastboot_ctx_s *ctx,
+                                 FAR const void *buf, size_t len)
+{
+  return fastboot_write(ctx->tran_fd[1], buf, len);
+}
+
+#elif defined(CONFIG_NET_TCP)
+static int fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx)
+{
+  struct sockaddr_in addr;
+
+  ctx->tran_fd[0] = socket(AF_INET, SOCK_STREAM, 0);
+  if (ctx->tran_fd[0] < 0)
+    {
+      fb_err("create socket failed %d", errno);
+      return -errno;
+    }
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(FASTBOOT_TCP_PORT);
+  if (bind(ctx->tran_fd[0], (struct sockaddr *) &addr, sizeof(addr)) < 0)
+    {
+      fb_err("bind() failed %d", errno);
+      goto error;
+    }
+
+  if (listen(ctx->tran_fd[0], 1) < 0)
+    {
+      fb_err("listen() failed %d", errno);
+      goto error;
+    }
+
+  return 0;
+error:
+  close(ctx->tran_fd[0]);
+  ctx->tran_fd[0] = -1;
+  return -errno;
+}
+
+static void fastboot_tcp_disconn(FAR struct fastboot_ctx_s *ctx)
+{
+  close(ctx->tran_fd[1]);
+  ctx->tran_fd[1] = -1;
+}
+
+static void fastboot_tcp_deinit(FAR struct fastboot_ctx_s *ctx)
+{
+  fastboot_tcp_disconn(ctx);
+  close(ctx->tran_fd[0]);
+  ctx->tran_fd[0] = -1;
+}
+
+static ssize_t fastboot_read_all(int fd, FAR void *buf, size_t len)
+{
+  size_t total = 0;
+  ssize_t nread;
+
+  while (total < len)
+    {
+      nread = fastboot_read(fd, buf, len);
+      if (nread <= 0)
+        {
+          if (total == 0)
+            {
+              return nread;
+            }
+
+          break;
+        }
+
+      total += nread;
+    }
+
+  return total;
+}
+
+static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
+                                 FAR void *buf, size_t len)
+{
+  char handshake[FASTBOOT_TCP_HANDSHAKE_LEN];
+  uint64_t data_size;
+  ssize_t nread;
+
+  if (ctx->tran_fd[1] == -1)
+    {
+      while (1)
+        {
+          /* Accept a connection, not care the address of the peer socket */
+
+          ctx->tran_fd[1] = accept(ctx->tran_fd[0], NULL, 0);
+          if (ctx->tran_fd[1] < 0)
+            {
+              continue;
+            }
+
+          /* Handshake */
+
+          memset(handshake, 0, sizeof(handshake));
+          if (fastboot_read_all(ctx->tran_fd[1], handshake,
+                                sizeof(handshake)) != sizeof(handshake) ||
+              strncmp(handshake, FASTBOOT_TCP_HANDSHAKE,
+                      sizeof(handshake)) != 0 ||
+              fastboot_write(ctx->tran_fd[1], handshake,
+                             sizeof(handshake)) < 0)
+            {
+              fb_err("%s err handshake %d 0x%" PRIx32, __func__, errno,
+                     *(FAR uint32_t *)handshake);
+              fastboot_tcp_disconn(ctx);
+              continue;
+            }
+
+          break;
+        }
+    }
+
+  if (ctx->left == 0)
+    {
+      nread =
+          fastboot_read_all(ctx->tran_fd[1], &data_size, sizeof(data_size));
+      if (nread != sizeof(data_size))
+        {
+          /* As normal, end of file if client has closed the connection */
+
+          if (nread != 0)
+            {
+              fb_err("%s err read data_size %zd %d", __func__, nread, errno);
+            }
+
+          fastboot_tcp_disconn(ctx);
+          return nread;
+        }
+
+      ctx->left = be64toh(data_size);
+    }
+
+  if (len > ctx->left)
+    {
+      len = ctx->left;
+    }
+
+  nread = fastboot_read(ctx->tran_fd[1], buf, len);
+  if (nread <= 0)
+    {
+      fastboot_tcp_disconn(ctx);
+      ctx->left = 0;
+    }
+  else
+    {
+      ctx->left -= nread;
+    }
+
+  return nread;
+}
+
+static int fastboot_tcp_write(FAR struct fastboot_ctx_s *ctx,
+                              FAR const void *buf, size_t len)
+{
+  uint64_t data_size = htobe64(len);
+  int ret;
+
+  ret = fastboot_write(ctx->tran_fd[1], &data_size, sizeof(data_size));
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return fastboot_write(ctx->tran_fd[1], buf, len);
+}
+#endif
 
 static int fastboot_context_initialize(FAR struct fastboot_ctx_s *ctx)
 {
@@ -1105,7 +1364,14 @@ static int fastboot_context_initialize(FAR struct fastboot_ctx_s *ctx)
   ctx->flash_fd        = -1;
   ctx->total_imgsize   = 0;
   ctx->varlist         = NULL;
-  ctx->wait_ms         = 0;
+  ctx->left            = 0;
+#ifdef CONFIG_USBFASTBOOT
+  ctx->ops             = &g_tran_ops_usb;
+#elif defined(CONFIG_NET_TCP)
+  ctx->ops             = &g_tran_ops_tcp;
+#endif
+  ctx->tran_fd[0]      = -1;
+  ctx->tran_fd[1]      = -1;
 
   ctx->download_buffer = malloc(CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX);
   if (ctx->download_buffer == NULL)
@@ -1147,10 +1413,13 @@ int main(int argc, FAR char **argv)
           return 0;
         }
 
-      context.wait_ms = atoi(argv[1]);
+      if (sscanf(argv[1], "%" SCNu64 , &context.left) != 1)
+        {
+          return -EINVAL;
+        }
     }
 
-  ret = fastboot_usbdev_initialize(&context);
+  ret = context.ops->init(&context);
   if (ret < 0)
     {
       return ret;
@@ -1159,7 +1428,7 @@ int main(int argc, FAR char **argv)
   fastboot_create_publish(&context);
   fastboot_command_loop(&context);
   fastboot_free_publish(&context);
-  fastboot_usbdev_deinit(&context);
+  context.ops->deinit(&context);
   fastboot_context_deinit(&context);
 
   return ret;

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -1031,7 +1031,7 @@ static int fastboot_open_usb(int index, int flags)
   return -errno;
 }
 
-static int fastboot_usbdev_initialize(void)
+static int fastboot_usbdev_initialize(FAR struct fastboot_ctx_s *ctx)
 {
 #ifdef CONFIG_SYSTEM_FASTBOOTD_USB_BOARDCTL
   struct boardioc_usbdev_ctrl_s ctrl;
@@ -1070,7 +1070,56 @@ static int fastboot_usbdev_initialize(void)
     }
 #endif /* SYSTEM_FASTBOOTD_USB_BOARDCTL */
 
+  ctx->usbdev_in  =
+      fastboot_open_usb(FASTBOOT_EP_BULKOUT_IDX, O_RDONLY | O_CLOEXEC);
+  if (ctx->usbdev_in < 0)
+    {
+      return ctx->usbdev_in;
+    }
+
+  ctx->usbdev_out =
+      fastboot_open_usb(FASTBOOT_EP_BULKIN_IDX, O_WRONLY | O_CLOEXEC);
+  if (ctx->usbdev_out < 0)
+    {
+      close(ctx->usbdev_in);
+      ctx->usbdev_in = -1;
+      return ctx->usbdev_out;
+    }
+
   return 0;
+}
+
+static void fastboot_usbdev_deinit(FAR struct fastboot_ctx_s *ctx)
+{
+  close(ctx->usbdev_out);
+  ctx->usbdev_out = -1;
+  close(ctx->usbdev_in);
+  ctx->usbdev_in = -1;
+}
+
+static int fastboot_context_initialize(FAR struct fastboot_ctx_s *ctx)
+{
+  ctx->download_max    = CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX;
+  ctx->download_offset = 0;
+  ctx->download_size   = 0;
+  ctx->flash_fd        = -1;
+  ctx->total_imgsize   = 0;
+  ctx->varlist         = NULL;
+  ctx->wait_ms         = 0;
+
+  ctx->download_buffer = malloc(CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX);
+  if (ctx->download_buffer == NULL)
+    {
+      fb_err("ERROR: Could not allocate the memory.\n");
+      return -errno;
+    }
+
+  return 0;
+}
+
+static void fastboot_context_deinit(FAR struct fastboot_ctx_s *ctx)
+{
+  free(ctx->download_buffer);
 }
 
 /****************************************************************************
@@ -1080,8 +1129,13 @@ static int fastboot_usbdev_initialize(void)
 int main(int argc, FAR char **argv)
 {
   struct fastboot_ctx_s context;
-  FAR void *buffer = NULL;
-  int ret = OK;
+  int ret;
+
+  ret = fastboot_context_initialize(&context);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   if (argc > 1)
     {
@@ -1095,60 +1149,18 @@ int main(int argc, FAR char **argv)
 
       context.wait_ms = atoi(argv[1]);
     }
-  else
-    {
-      context.wait_ms = 0;
-    }
 
-  ret = fastboot_usbdev_initialize();
+  ret = fastboot_usbdev_initialize(&context);
   if (ret < 0)
     {
       return ret;
     }
 
-  buffer = malloc(CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX);
-  if (buffer == NULL)
-    {
-      fb_err("ERROR: Could not allocate the memory.\n");
-      return -ENOMEM;
-    }
-
-  context.usbdev_in =
-      fastboot_open_usb(FASTBOOT_EP_BULKOUT_IDX, O_RDONLY | O_CLOEXEC);
-  if (context.usbdev_in < 0)
-    {
-      ret = -errno;
-      goto err_with_mem;
-    }
-
-  context.usbdev_out =
-      fastboot_open_usb(FASTBOOT_EP_BULKIN_IDX, O_WRONLY | O_CLOEXEC);
-  if (context.usbdev_out < 0)
-    {
-      ret = -errno;
-      goto err_with_in;
-    }
-
-  context.varlist         = NULL;
-  context.flash_fd        = -1;
-  context.download_buffer = buffer;
-  context.download_size   = 0;
-  context.download_offset = 0;
-  context.download_max    = CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX;
-  context.total_imgsize   = 0;
-
   fastboot_create_publish(&context);
   fastboot_command_loop(&context);
   fastboot_free_publish(&context);
+  fastboot_usbdev_deinit(&context);
+  fastboot_context_deinit(&context);
 
-  close(context.usbdev_out);
-  context.usbdev_out = -1;
-
-err_with_in:
-  close(context.usbdev_in);
-  context.usbdev_in = -1;
-
-err_with_mem:
-  free(buffer);
   return ret;
 }

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -29,6 +29,7 @@
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/version.h>
 
+#include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -71,11 +72,6 @@
 
 #define FASTBOOT_SPARSE_HEADER      sizeof(struct fastboot_sparse_header_s)
 #define FASTBOOT_CHUNK_HEADER       sizeof(struct fastboot_chunk_header_s)
-
-#define FASTBOOT_GETUINT32(p)       (((uint32_t)(p)[3] << 24) | \
-                                     ((uint32_t)(p)[2] << 16) | \
-                                     ((uint32_t)(p)[1] << 8) | \
-                                     (uint32_t)(p)[0])
 
 #define fb_info(...)                syslog(LOG_INFO, ##__VA_ARGS__);
 #define fb_err(...)                 syslog(LOG_ERR, ##__VA_ARGS__);
@@ -437,7 +433,7 @@ fastboot_flash_program(FAR struct fastboot_ctx_s *context, int fd)
             break;
           case FASTBOOT_CHUNK_FILL:
             {
-              uint32_t fill_data = FASTBOOT_GETUINT32(chunk_ptr);
+              uint32_t fill_data = be32toh(*(FAR uint32_t *)chunk_ptr);
               uint32_t chunk_size = chunk->chunk_sz * sparse->blk_sz;
               ret = ffastboot_flash_fill(fd, context->download_offset,
                                          fill_data, sparse->blk_sz,


### PR DESCRIPTION
## Summary
Add TCP network transport support for fastboot, users can add "-s tcp:HOST[:PORT]" option to specify a network device.
1. replace GETUINT32 with be32toh
2. add func for context and usbdev
3. add support for fastboot tcp

## Impact
- system/fastboot

## Testing
### 1. Selftest
#### 1.1 fastboot tcp
config: qemu-armv8a:netnsh
##### getvar
```
$ fastboot -s tcp:192.168.100.2 getvar version
version: 0.0.0
Finished. Total time: 0.042s
```
##### flash

- Host side
```
$ fastboot -s tcp:192.168.100.2 flash virtblk0 fastboot.c
Warning: skip copying virtblk0 image avb footer (virtblk0 partition size: 0, virtblk0 image size: 37142).
Sending 'virtblk0' (36 KB)                         OKAY [  0.084s]
Writing 'virtblk0'                                 OKAY [  0.042s]
Finished. Total time: 0.372s
```
- Device side (hexdump block device)
```
NuttShell (NSH)
nsh> uname -a
NuttX  0.0.0  Jun 16 2025 11:24:06 arm64 qemu-armv8a
nsh>
nsh> ifconfig eth0 192.168.100.2
nsh> echo $?
0
nsh>
nsh> fastbootd &
fastbootd [5:100]
nsh>
nsh> hexdump /dev/virtblk0 count=256
/dev/virtblk0 at 00000000:
0000: 2f 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a /***************
0010: 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a ****************
0020: 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a ****************
0030: 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a ****************
0040: 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 2a 0a 20 2a *************. *
0050: 20 61 70 70 73 2f 73 79 73 74 65 6d 2f 66 61 73  apps/system/fas
0060: 74 62 6f 6f 74 2f 66 61 73 74 62 6f 6f 74 2e 63 tboot/fastboot.c
0070: 0a 20 2a 0a 20 2a 20 53 50 44 58 2d 4c 69 63 65 . *. * SPDX-Lice
0080: 6e 73 65 2d 49 64 65 6e 74 69 66 69 65 72 3a 20 nse-Identifier: 
0090: 41 70 61 63 68 65 2d 32 2e 30 0a 20 2a 0a 20 2a Apache-2.0. *. *
00a0: 20 4c 69 63 65 6e 73 65 64 20 74 6f 20 74 68 65  Licensed to the
00b0: 20 41 70 61 63 68 65 20 53 6f 66 74 77 61 72 65  Apache Software
00c0: 20 46 6f 75 6e 64 61 74 69 6f 6e 20 28 41 53 46  Foundation (ASF
00d0: 29 20 75 6e 64 65 72 20 6f 6e 65 20 6f 72 20 6d ) under one or m
00e0: 6f 72 65 0a 20 2a 20 63 6f 6e 74 72 69 62 75 74 ore. * contribut
00f0: 6f 72 20 6c 69 63 65 6e 73 65 20 61 67 72 65 65 or license agree
nsh>
```
##### oem
```
$ fastboot -s tcp:192.168.100.2 oem shell "uname -a"
NuttX  0.0.0  Jun 16 2025 11:52:52 arm64 qemu-armv8a
OKAY [  0.043s]
Finished. Total time: 0.043s
```
#### 1.2 fastboot usbdev
config: esp32s3-devkit:fastboot
##### getvar
```
$ fastboot -s 1234 getvar version
version: 
Finished. Total time: 0.000s
```
##### flash
- Host side
```
$ fastboot -s 1234 flash console Make.defs 
Warning: skip copying console image avb footer (console partition size: 0, console image size: 1100).
Sending 'console' (1 KB)                           OKAY [  0.002s]
Writing 'console'                                  OKAY [  0.067s]
Finished. Total time: 0.071s
```
- Device side (write to console)
```
nsh> uname -a
NuttX 0.0.0  Jun 12 2025 11:13:32 xtensa lckfb-szpi-esp32s3
nsh> 
nsh> ############################################################################
# apps/system/fastboot/Make.defs
#
# SPDX-License-Identifier: Apache-2.0
#
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.  The
# ASF licenses this file to you under the Apache License, Version 2.0 (the
# "License"); you may not use this file except in compliance with the
# License.  You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
# License for the specific language governing permissions and limitations
# under the License.
#
############################################################################

ifneq ($(CONFIG_SYSTEM_FASTBOOTD),)
CONFIGURED_APPS += $(APPDIR)/system/fastboot
endif

nsh>
```
##### oem
```
$ fastboot -s 1234 oem shell "uname -a"
NuttX 0.0.0  Jun 12 2025 11:13:32 xtensa lckfb-szpi-esp32s3
OKAY [  0.005s]
Finished. Total time: 0.005s
```

### 2. CI
