### PR TITLE
system/fastboot: release resource & disconnect usbdev if need

### DIFF
--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -1008,7 +1008,7 @@ static void fastboot_command_loop(FAR struct fastboot_ctx_s *ctx,
       if (epoll_ctl(epfd, EPOLL_CTL_ADD, c->tran_fd[0], &ev[n]) < 0)
         {
           fb_err("err add poll %d", c->tran_fd[0]);
-          return;
+          goto epoll_close;
         }
     }
 
@@ -1016,7 +1016,7 @@ static void fastboot_command_loop(FAR struct fastboot_ctx_s *ctx,
     {
       if (epoll_wait(epfd, ev, nitems(ev), ctx->left) <= 0)
         {
-          return;
+          goto epoll_close;
         }
     }
 
@@ -1061,6 +1061,14 @@ static void fastboot_command_loop(FAR struct fastboot_ctx_s *ctx,
             }
         }
     }
+
+epoll_close:
+  while (--c >= ctx)
+    {
+      epoll_ctl(epfd, EPOLL_CTL_DEL, c->tran_fd[0], NULL);
+    }
+
+  close(epfd);
 }
 
 static void fastboot_publish(FAR struct fastboot_ctx_s *ctx,

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -109,7 +109,7 @@ struct fastboot_sparse_header_s
 {
   uint32_t magic;           /* 0xed26ff3a */
   uint16_t major_version;   /* (0x1) - reject images with higher major versions */
-  uint16_t minor_version;   /* (0x0) - allow images with higer minor versions */
+  uint16_t minor_version;   /* (0x0) - allow images with higher minor versions */
   uint16_t file_hdr_sz;     /* 28 bytes for first revision of the file format */
   uint16_t chunk_hdr_sz;    /* 12 bytes for first revision of the file format */
   uint32_t blk_sz;          /* block size in bytes, must be a multiple of 4 (4096) */
@@ -652,7 +652,7 @@ static void fastboot_download(FAR struct fastboot_ctx_s *ctx,
   ret = ctx->ops->write(ctx, response, strlen(response));
   if (ret < 0)
     {
-      fb_err("Reponse error [%d]\n", -ret);
+      fb_err("Response error [%d]\n", -ret);
       return;
     }
 
@@ -943,7 +943,7 @@ static void fastboot_upload(FAR struct fastboot_ctx_s *ctx,
   ret = ctx->ops->write(ctx, response, strlen(response));
   if (ret < 0)
     {
-      fb_err("Reponse error [%d]\n", -ret);
+      fb_err("Response error [%d]\n", -ret);
       goto done;
     }
 


### PR DESCRIPTION
## Summary
Add disconnection for usb transport and remove interest list for epoll.
1. Disconnect usbdev when deinit USB transport.
2. Remove fds from the interest list and close epoll if need.

## Impact
- system/fastboot

## Testing
CI