### PR TITLE
system/gcov: Update gcov functionality

### DIFF
--- a/system/gcov/gcov.c
+++ b/system/gcov/gcov.c
@@ -24,6 +24,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <fcntl.h>
 #include <gcov.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -33,17 +34,6 @@
 
 #include <nuttx/crc16.h>
 #include <nuttx/streams.h>
-
-/****************************************************************************
- * Private Types
- ****************************************************************************/
-
-struct gcov_arg
-{
-  FAR const char *name;
-  struct lib_stdoutstream_s stdoutstream;
-  struct lib_hexdumpstream_s hexstream;
-};
 
 /****************************************************************************
  * Private Functions
@@ -66,92 +56,6 @@ static void show_usage(FAR const char *progname)
 }
 
 /****************************************************************************
- * Name: gcov_dump
- ****************************************************************************/
-
-static void gcov_dump(FAR const char * path, FAR const char *strip)
-{
-  if (path == NULL || access(path, F_OK) != 0 || atoi(strip) < 0)
-    {
-      fprintf(stderr, "ERROR: Invalid parameter\n");
-      return;
-    }
-
-  setenv("GCOV_PREFIX_STRIP", strip, 1);
-  setenv("GCOV_PREFIX", path, 1);
-  __gcov_dump();
-}
-
-/****************************************************************************
- * Name: stdout_dump
- ****************************************************************************/
-
-#ifndef CONFIG_COVERAGE_TOOLCHAIN
-static void stdout_dump(FAR const void *buffer, size_t size,
-                        FAR void *arg)
-{
-  FAR struct gcov_arg *args = (FAR struct gcov_arg *)arg;
-  uint16_t checksum = 0;
-  int i;
-
-  if (size == 0)
-    {
-      return;
-    }
-
-  for (i = 0; i < size; i++)
-    {
-      checksum += ((FAR const uint8_t *)buffer)[i];
-    }
-
-  lib_sprintf(&args->stdoutstream.common,
-              "gcov start filename:%s size: %zuByte\n",
-              args->name, size);
-  lib_stream_puts(&args->hexstream, buffer, size);
-  lib_stream_flush(&args->hexstream);
-  lib_sprintf(&args->stdoutstream.common,
-              "gcov end filename:%s checksum: %#0x\n",
-              args->name, checksum);
-  lib_stream_flush(&args->stdoutstream);
-}
-
-/****************************************************************************
- * Name: stdout_filename
- ****************************************************************************/
-
-static void stdout_filename(const char *name, FAR void *arg)
-{
-  FAR struct gcov_arg *args = (FAR struct gcov_arg *)arg;
-  args->name = name;
-  __gcov_filename_to_gcfn(name, NULL, NULL);
-}
-
-/****************************************************************************
- * Name: gcov_stdout_dump
- *
- * Description:
- *   Dump the gcov information of all translation units to stdout.
- *
- ****************************************************************************/
-
-static void gcov_stdout_dump(void)
-{
-  FAR struct gcov_info *info = __gcov_info_start;
-  FAR struct gcov_info *end = __gcov_info_end;
-  struct gcov_arg arg;
-
-  lib_stdoutstream(&arg.stdoutstream, stdout);
-  lib_hexdumpstream(&arg.hexstream, &arg.stdoutstream.common);
-
-  while (info != end)
-    {
-      __gcov_info_to_gcda(info, stdout_filename, stdout_dump, NULL, &arg);
-      info = info->next;
-    }
-}
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -159,14 +63,10 @@ int main(int argc, FAR char *argv[])
 {
   FAR const char *strip = CONFIG_COVERAGE_DEFAULT_PREFIX_STRIP;
   FAR const char *path = NULL;
+  bool onefile = false;
   int option;
 
-  if (argc < 2)
-    {
-      show_usage(argv[0]);
-    }
-
-  while ((option = getopt(argc, argv, "d::t:rh")) != ERROR)
+  while ((option = getopt(argc, argv, "d::t:orh")) != ERROR)
     {
       switch (option)
         {
@@ -191,17 +91,22 @@ int main(int argc, FAR char *argv[])
         }
     }
 
-#ifndef CONFIG_COVERAGE_TOOLCHAIN
-  if (path == NULL)
+  if (access(path, F_OK) == 0)
     {
-      gcov_stdout_dump();
-    }
-  else
-#endif
-    {
-      gcov_dump(path, strip);
+      onefile = true;
     }
 
-  printf("Gcov dump complete\n");
+  if (onefile)
+    {
+      setenv("GCOV_DUMP_ONEFILE", "1", 1);
+    }
+  else
+    {
+      setenv("GCOV_DUMP_ONEFILE", "0", 1);
+    }
+
+  setenv("GCOV_PREFIX_STRIP", strip, 1);
+  setenv("GCOV_PREFIX", path, 1);
+  __gcov_dump();
   return 0;
 }

--- a/system/gcov/gcov.c
+++ b/system/gcov/gcov.c
@@ -71,7 +71,7 @@ static void show_usage(FAR const char *progname)
 
 static void gcov_dump(FAR const char * path, FAR const char *strip)
 {
-  if (path == NULL || access(path, F_OK) != 0 || atoi(strip) <= 0)
+  if (path == NULL || access(path, F_OK) != 0 || atoi(strip) < 0)
     {
       fprintf(stderr, "ERROR: Invalid parameter\n");
       return;
@@ -157,7 +157,7 @@ static void gcov_stdout_dump(void)
 
 int main(int argc, FAR char *argv[])
 {
-  FAR const char *strip = "99";
+  FAR const char *strip = CONFIG_COVERAGE_DEFAULT_PREFIX_STRIP;
   FAR const char *path = NULL;
   int option;
 

--- a/system/gcov/gcov.c
+++ b/system/gcov/gcov.c
@@ -63,7 +63,6 @@ int main(int argc, FAR char *argv[])
 {
   FAR const char *strip = CONFIG_COVERAGE_DEFAULT_PREFIX_STRIP;
   FAR const char *path = NULL;
-  bool onefile = false;
   int option;
 
   while ((option = getopt(argc, argv, "d::t:orh")) != ERROR)
@@ -89,20 +88,6 @@ int main(int argc, FAR char *argv[])
         case 'h':
           show_usage(argv[0]);
         }
-    }
-
-  if (access(path, F_OK) == 0)
-    {
-      onefile = true;
-    }
-
-  if (onefile)
-    {
-      setenv("GCOV_DUMP_ONEFILE", "1", 1);
-    }
-  else
-    {
-      setenv("GCOV_DUMP_ONEFILE", "0", 1);
     }
 
   setenv("GCOV_PREFIX_STRIP", strip, 1);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

All output methods are implemented at the kernel level and passed through environment variables.

## Impact

None

## Testing

1. ci
2. enable CONFIG_COVERAGE_MINI，the usage is the same as before, but when the path is a file, it will output the data to the file, and then it can be converted through nuttx/tools/gcov.py 

