### PR TITLE
system/settings: fix assertion triggered by uninitialized variables

### DIFF
--- a/system/settings/settings.c
+++ b/system/settings/settings.c
@@ -1312,7 +1312,7 @@ errout:
 int settings_type(FAR char *key, FAR enum settings_type_e *stype)
 {
   int ret;
-  FAR setting_t *setting;
+  FAR setting_t *setting = NULL;
 
   if (!g_settings.initialized)
     {
@@ -1360,7 +1360,7 @@ int settings_type(FAR char *key, FAR enum settings_type_e *stype)
 int settings_get(FAR char *key, enum settings_type_e type, ...)
 {
   int ret;
-  FAR setting_t *setting;
+  FAR setting_t *setting = NULL;
 
   if (!g_settings.initialized)
     {
@@ -1458,7 +1458,7 @@ errout:
 int settings_set(FAR char *key, enum settings_type_e type, ...)
 {
   int ret;
-  FAR setting_t *setting;
+  FAR setting_t *setting = NULL;
   uint32_t h;
 
   if (!g_settings.initialized)


### PR DESCRIPTION
Fix non-NULL pointer assertion in `get_setting()` caused by uninitialized pointer variables.

## Summary

system/settings' `get_setting()` function performs non-NULL assertion on non-initialized variables, triggering assertions.

See https://github.com/apache/nuttx-apps/issues/3107 for more details.

## Impact

Fix a bug causing system/settings to be unusable.

## Testing

Tested on a private project making use of `system/settings` on NuttX 12.9.0.

