### PR TITLE
nxplayer: add more error messages

### DIFF
--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -199,7 +199,6 @@ static int _open_with_http(const char *fullurl)
   n = netlib_parsehttpurl(fullurl, &port,
                           hostname, sizeof(hostname) - 1,
                           relurl, sizeof(relurl) - 1);
-
   if (OK != n)
     {
       printf("netlib_parsehttpurl() returned %d\n", n);
@@ -221,18 +220,30 @@ static int _open_with_http(const char *fullurl)
 
   FAR struct hostent *he;
   he = gethostbyname(hostname);
+  if (!he)
+    {
+      close(s);
+
+      // DNS resolution failed
+      return -ENETUNREACH;
+    }
 
   memcpy(&server.sin_addr.s_addr,
          he->h_addr, sizeof(in_addr_t));
-
   n = connect(s,
               (struct sockaddr *)&server,
               sizeof(struct sockaddr_in));
-
   if (-1 == n)
     {
+      int err = errno;
       close(s);
-      return -1;
+      switch (err)
+        {
+          case ETIMEDOUT: return -ETIMEDOUT;
+          case ECONNREFUSED: return -ECONNREFUSED;
+          case ENETUNREACH: return -ENETUNREACH;
+          default: return -1;
+        }
     }
 
   /* Send GET request */
@@ -250,8 +261,24 @@ static int _open_with_http(const char *fullurl)
 
   if (200 != n)
     {
+      int err = errno;
       close(s);
-      return -1;
+      switch (err)
+        {
+          // Unauthorized
+          case 401: return -EACCES;
+
+          // No access
+          case 403: return -EACCES;
+
+          case 404: return -ENOENT;
+
+          // Server internal error
+          case 500: return -EREMOTEIO;
+
+          // Other protocol errors
+          default:  return -EPROTO;
+        }
     }
 
   /* Skip response header */
@@ -1809,11 +1836,15 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
   /* Test that the specified file exists */
 
 #ifdef CONFIG_NXPLAYER_HTTP_STREAMING_SUPPORT
-  if ((pplayer->fd = _open_with_http(pfilename)) == -1)
+  pplayer->fd = _open_with_http(pfilename);
+  if (pplayer->fd < 0)
 #else
-  if ((pplayer->fd = open(pfilename, O_RDONLY)) == -1)
+  pplayer->fd = open(pfilename, O_RDONLY);
+  if (pplayer->fd == -1)
 #endif
     {
+      int err = errno;
+
       /* File not found.  Test if its in the mediadir */
 
 #ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
@@ -1827,19 +1858,21 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
           if (nxplayer_mediasearch(pplayer, pfilename, path,
                                    sizeof(path)) != OK)
             {
-              auderr("ERROR: Could not find file\n");
-              return -ENOENT;
+              auderr("ERROR: Media search failed for %s: %s\n",
+                      pfilename, strerror(err));
+              return -err;
             }
 #else
-          auderr("ERROR: Could not open %s or %s\n", pfilename, path);
-          return -ENOENT;
+          auderr("ERROR: Could not open %s or %s: %s\n",
+                  pfilename, path, strerror(err));
+          return -err;
 #endif /* CONFIG_NXPLAYER_MEDIA_SEARCH */
         }
 
 #else   /* CONFIG_NXPLAYER_INCLUDE_MEDIADIR */
 
-      auderr("ERROR: Could not open %s\n", pfilename);
-      return -ENOENT;
+      auderr("ERROR: Could not open %s: %s\n", pfilename, strerror(err));
+      return -err;
 #endif /* CONFIG_NXPLAYER_INCLUDE_MEDIADIR */
     }
 

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -290,6 +290,22 @@ static int nxplayer_cmd_play(FAR struct nxplayer_s *pplayer, char *parg)
         printf("File %s not found\n", parg);
         break;
 
+      case ENETUNREACH:
+        printf("DNS resolution failed\n");
+        break;
+
+      case ETIMEDOUT:
+        printf("Timeout\n");
+        break;
+
+      case EACCES:
+        printf("No access\n");
+        break;
+
+      case ECONNREFUSED:
+        printf("Connect refused\n");
+        break;
+
       case ENOSYS:
         printf("Unknown audio format\n");
         break;


### PR DESCRIPTION
nxplayer currently only returns directly '-ENOENT', which makes it impossible to know the specific reason for the failure when testing audio with nxplayer.

Therefore, I modified this part of the logic to print out the error as much as possible.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


