### PR TITLE
netutils/thttpd: fix broken cgi and fixup kconfig

### DIFF
--- a/netutils/thttpd/Kconfig
+++ b/netutils/thttpd/Kconfig
@@ -16,7 +16,10 @@ config THTTPD_NFILE_DESCRIPTORS
 	int "the maximum number of file descriptors for thttpd webserver"
 	default 16
 	---help---
-		The maximum number of file descriptors for thttpd webserver
+		The maximum number of file descriptors for thttpd webserver. This is
+		used during CGI application execution to close all file descriptors
+		after stdin, stdout and stderr up to and including this value (with
+		the exception of file descriptor for the open network socket).
 
 config THTTPD_PORT
 	int "THTTPD port number"
@@ -106,6 +109,13 @@ config THTTPD_CGI_TIMELIMIT
 		How many seconds to allow CGI programs to run before killing them.
 		Default: 0 (no time limit)
 
+config THTTPD_CGIDUMP
+	bool "Output Interposed CGI strings to stderr"
+	default n
+	---help---
+		Enabling this will copy sent to and received from CGI tasks
+		to the stderr device.
+
 config THTTPD_CHARSET
 	string "Default character set"
 	default "iso-8859-1"
@@ -137,7 +147,7 @@ config THTTPD_MAXREALLOC
 	---help---
 		Maximum string reallocation size.  Default: 4096
 
-config THTTPD_CGIINBUFFERSIZ
+config THTTPD_CGIINBUFFERSIZE
 	int "CGI interpose input buffer size"
 	default 512
 	---help---
@@ -236,7 +246,7 @@ choice
 		the name of a subdirectory off of the user's actual home dir,
 		something like "public_html".
 
-		3) Niether.  You can also leave both options undefined, and thttpd
+		3) Neither.  You can also leave both options undefined, and thttpd
 		will not do anything special about tildes. Enabling both options
 		is an error.
 

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -1589,9 +1589,7 @@ static void ls_child(int argc, char **argv)
   FAR httpd_conn *hc = (FAR httpd_conn *)strtoul(argv[1], NULL, 16);
   DIR *dirp;
   struct dirent *de;
-  int namlen;
   static int maxnames = 0;
-  int oldmax;
   int nnames;
   static char *names;
   static char **nameptrs;
@@ -1614,6 +1612,18 @@ static void ls_child(int argc, char **argv)
   time_t now;
   char *timestr;
   int i;
+
+  /* Compiler was warning that dirp was not initialised and it wasn't.
+   * But whether this is correct or not I am not sure.
+   */
+
+  dirp = opendir(hc->expnfilename);
+  if (dirp == NULL)
+    {
+      nerr("ERROR: opendir %s: %d\n", hc->expnfilename, errno);
+      httpd_send_err(hc, 404, err404title, "", err404form, hc->encodedurl);
+      return;
+    }
 
   httpd_unlisten(hc->hs);
   send_mime(hc, 200, ok200title, "", "", "text/html; charset=%s",
@@ -1639,11 +1649,11 @@ static void ls_child(int argc, char **argv)
 
   fputs(html_html, fp);
   fputs(html_hdtitle, fp);
-  fprintf(fp, "Index of %s", hc->encodedurl, hc->encodedurl);
+  fprintf(fp, "Index of %s", hc->encodedurl);
   fputs(html_titlehd, fp);
   fputs(html_body, fp);
   fputs(html_hdr2, fp);
-  fprintf(fp, "Index of %s", hc->encodedurl, hc->encodedurl);
+  fprintf(fp, "Index of %s", hc->encodedurl);
   fputs(html_endhdr2, fp);
   fputs(html_crlf, fp);
   fputs("<PRE>\r\nmode  links  bytes  last-changed  name\r\n<HR>", fp);
@@ -1663,7 +1673,6 @@ static void ls_child(int argc, char **argv)
             }
           else
             {
-              oldmax    = maxnames;
               maxnames *= 2;
               names     = RENEW(names, char, oldmax * PATH_MAX,
                                 maxnames * PATH_MAX);
@@ -1833,7 +1842,7 @@ static void ls_child(int argc, char **argv)
       /* And print. */
 
       fprintf(fp,
-              "%s %3ld  %10lld  %s  <A HREF=\"/%.500s%s\">%s</A>%s%s%s\n",
+              "%s %3d  %10d  %s  <A HREF=\"/%.500s%s\">%s</A>%s%s%s\n",
               modestr, 0, (int16_t)sb.st_size, timestr, encrname,
               S_ISDIR(sb.st_mode) ? "/" : "", nameptrs[i], linkprefix,
               link, fileclass);
@@ -1890,7 +1899,8 @@ static int ls(httpd_conn *hc)
       argv[0] = arg;
 
       child = task_create("CGI child", CONFIG_THTTPD_CGI_PRIORITY,
-                          CONFIG_THTTPD_CGI_STACKSIZE, ls_child, argv);
+                          CONFIG_THTTPD_CGI_STACKSIZE, (main_t)ls_child,
+                          argv);
       if (child < 0)
         {
           nerr("ERROR: task_create: %d\n", errno);

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -2354,8 +2354,8 @@ int httpd_get_conn(httpd_server *hs, int listen_fd, httpd_conn *hc)
 
   ninfo("accept() new connection on listen_fd %d\n", listen_fd);
   sz = sizeof(sa);
-  hc->conn_fd = accept4(listen_fd, (struct sockaddr *)&sa, &sz,
-                        SOCK_CLOEXEC);
+  hc->conn_fd = accept4(listen_fd, (struct sockaddr *)&sa, &sz, 0);
+
   if (hc->conn_fd < 0)
     {
       if (errno == EWOULDBLOCK)


### PR DESCRIPTION
## Summary

When trying to enable and use the thttp net utility, it was found that CGI apps didnt send any http responses of data from the CGI app back to the browser client,

Investigation revealed this was due to the net socket being opened with the  O_CLOEXEC flag set.

This is the result, I believe, of a PR last year [here]( https://github.com/apache/nuttx-apps/pull/2595).

See [this](https://github.com/apache/nuttx-apps/issues/3111) issue.

In correcting the issue, some complier warnings were encountered and fixed, along with a Kconfig error and an omission, and the opportunity was taken to improve some help text within Kconfig.

This is why there are two commits in the PR.

### Question

The cgi_child app that is spawned closes all open file descriprors except stdin, stdout, stderr and the socket's descriptor, up to a maximum number of file descriptors as set via Kconfig.

See [here](https://github.com/apache/nuttx-apps/blob/master/netutils/thttpd/thttpd_cgi.c#L773).

Should the Kconfig option be removed and the function use `OPEN_MAX` instead?

## Impact

No impact on existing usage of this netutil, other than to allow it work properly now!

## Testing

This has been tested as part of my own application development, using a custom SAMA5D27C-D1G processor, with the webserver running via CDC-NCM.


