### PR TITLE
examples/xedge: Add Xedge example with BAS integration

### DIFF
--- a/examples/xedge_demo/Kconfig
+++ b/examples/xedge_demo/Kconfig
@@ -1,0 +1,41 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_XEDGE_DEMO
+	tristate "Xedge IoT Toolkit Demo"
+	depends on NETUTILS_XEDGE && ALLOW_GPL_COMPONENTS
+	default n
+	---help---
+		Simple demonstration of the Xedge IoT Toolkit library.
+		
+		This example shows how to integrate and use the Xedge library
+		in your NuttX application. Xedge provides a high-level development
+		environment for creating IoT and industrial device applications
+		using Lua scripting with access to HTTP(S), WebSockets, MQTT,
+		file system, and device I/O.
+
+		Note: This example requires the NETUTILS_XEDGE library to be enabled.
+
+if EXAMPLES_XEDGE_DEMO
+
+config EXAMPLES_XEDGE_DEMO_PROGNAME
+	string "Program name"
+	default "xedge_demo"
+	---help---
+		This is the name of the ELF executable for the Xedge demo application in NSH.
+
+config EXAMPLES_XEDGE_DEMO_PRIORITY
+	int "Xedge demo task priority"
+	default 100
+	---help---
+		Set the task priority for the Xedge demo application.
+
+config EXAMPLES_XEDGE_DEMO_STACKSIZE
+	int "Xedge demo stack size"
+	default 20000
+	---help---
+		Set the stack size for the Xedge demo application.
+
+endif

--- a/examples/xedge_demo/Make.defs
+++ b/examples/xedge_demo/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/xedge_demo/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_XEDGE_DEMO),)
+CONFIGURED_APPS += $(APPDIR)/examples/xedge_demo
+endif

--- a/examples/xedge_demo/Makefile
+++ b/examples/xedge_demo/Makefile
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/xedge_demo/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_XEDGE_DEMO_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_XEDGE_DEMO_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_XEDGE_DEMO_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_XEDGE_DEMO)
+
+MAINSRC = xedge_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/xedge_demo/xedge_main.c
+++ b/examples/xedge_demo/xedge_main.c
@@ -1,0 +1,240 @@
+/***************************************************************************
+ * apps/examples/xedge_demo/xedge_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ***************************************************************************/
+
+/* Xedge NuttX Startup Code (may need adjustments)
+ *
+ * Additional License Note: Xedge, based on the Barracuda
+ * App Server, uses the license options explained here:
+ * https://github.com/RealTimeLogic/BAS#license
+ * This repo does not include Xedge and the Barracuda App Server
+ * library and must be downloaded separately. The dependencies
+ * are automatically downloaded in apps/netutils/xedge/.
+ */
+
+/***************************************************************************
+ * Included Files
+ ***************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <syslog.h>
+#include <pthread.h>
+#include <netutils/ntpclient.h>
+#include <HttpTrace.h>
+#include <BaDiskIo.h>
+#include <BaServerLib.h>
+#include "../../netutils/xedge/BAS/examples/xedge/src/xedge.h"
+
+/***************************************************************************
+ * Pre-processor Definitions
+ ***************************************************************************/
+
+/* The code uses identifiers from the third-party Barracuda App Server
+ * library, which follows a camelCase naming style:
+ * https://realtimelogic.com/ba/doc/en/C/introduction.html#oo_c
+ * These identifiers are used directly and will trigger "Mixed Case"
+ * warnings in tools like nxstyle, which are safe to ignore in this case.
+ */
+
+/***************************************************************************
+ * Private Data
+ ***************************************************************************/
+
+static int running = FALSE; /* Running mode: 2 running, 1 exiting, 0 stopped */
+
+/* BAS is configured to use dlmalloc for NuttX. This is the pool.
+ * 2M : recommended minimum
+ */
+
+static char poolbuf[2 * 1024 * 1024];
+
+extern LThreadMgr ltMgr; /* The LThreadMgr configured in xedge.c */
+
+/***************************************************************************
+ * External Function Prototypes
+ ***************************************************************************/
+
+/* barracuda(): BAS/examples/xedge/src/xedge.c */
+
+extern void barracuda(void);
+extern void init_dlmalloc(char *heapstart, char *heapend); /* dlmalloc.c */
+extern int (*platformInitDiskIo)(DiskIo *io);              /* xedge.c */
+
+/***************************************************************************
+ * Private Functions
+ ***************************************************************************/
+
+/* The following two functions are copied from the example:
+ * https://github.com/RealTimeLogic/BAS/blob/main/examples/xedge/src/led.c
+ * Details:
+ * https://realtimelogic.com/ba/examples/xedge/readme.html#time
+ */
+
+/* This callback is called by one of the threads managed by LThreadMgr
+ * when a job is taken off the queue and executed. The callback
+ * attempts to find the global Lua function '_XedgeEvent', and if the
+ * function is found, it will be executed as follows: _XedgeEvent("sntp")
+ */
+
+static void execevent(ThreadJob *job, int msgh, LThreadMgr *mgr)
+{
+  lua_State *L = job->Lt;
+  lua_pushglobaltable(L);
+  lua_getfield(L, -1, "_XedgeEvent");
+
+  if (lua_isfunction(L, -1))
+    {
+      lua_pushstring(L, "sntp");
+      lua_pcall(L, 1, 0, msgh);
+    }
+}
+
+/* Thread started by xedgeOpenAUX() */
+
+static void *checktimethread(void *arg)
+{
+  ThreadMutex *dm = HttpServer_getMutex(ltMgr.server);
+  const char *d = __DATE__;
+  char buf[50];
+
+  (void)arg;
+
+  if (!(basnprintf(buf, sizeof(buf), "Mon, %c%c %c%c%c %s %s",
+                   d[4], d[5], d[0], d[1], d[2], d + 7, __TIME__) < 0))
+    {
+      BaTime t = baParseDate(buf);
+      if (t)
+        {
+          t -= 24 * 60 * 60;
+          while (baGetUnixTime() < t)
+            {
+              Thread_sleep(500);
+            }
+
+          ThreadJob *job = ThreadJob_lcreate(sizeof(ThreadJob), execevent);
+          ThreadMutex_set(dm);
+          LThreadMgr_run(&ltMgr, job);
+          ThreadMutex_release(dm);
+        }
+    }
+
+  return NULL;
+}
+
+static void panic(BaFatalErrorCodes ecode1,
+                         unsigned int ecode2,
+                         const char *file,
+                         int line)
+{
+  syslog(LOG_ERR, "Fatal error in Barracuda %d %d %s %d\n",
+         ecode1, ecode2, file, line);
+  exit(1);
+}
+
+/* Redirect server's HttpTrace to syslog.
+ * https://realtimelogic.com/ba/doc/en/C/reference/html/structHttpTrace.html
+ */
+
+static void flushtrace(char *buf, int buflen)
+{
+  buf[buflen] = 0;
+  syslog(LOG_INFO, "%s", buf);
+}
+
+static void sighandler(int signo)
+{
+  if (running)
+    {
+      printf("\nGot SIGTERM; exiting...\n");
+      setDispExit();
+
+      /* NuttX feature: Must wait for socket select() to return */
+
+      Thread_sleep(2000);
+    }
+}
+
+/***************************************************************************
+ * Public Functions
+ ***************************************************************************/
+
+/* xedge.c calls this to initialize the IO.
+ * Change "/mnt/lfs" to your preference.
+ */
+
+int xedgeInitDiskIo(DiskIo *io)
+{
+  if (DiskIo_setRootDir(io, "/mnt/lfs"))
+    {
+      syslog(LOG_ERR, "Error: cannot set root to /mnt/lfs\n");
+      return -1;
+    }
+
+  return 0;
+}
+
+/* xedge.c calls this; include your Lua bindings here.
+ * Tutorial: https://tutorial.realtimelogic.com/Lua-Bindings.lsp
+ */
+
+int xedgeOpenAUX(XedgeOpenAUX *aux)
+{
+  pthread_t thread;
+  pthread_attr_t attr;
+  struct sched_param param;
+
+  (void)aux;
+
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, 4096);
+  param.sched_priority = SCHED_PRIORITY_DEFAULT;
+  pthread_attr_setschedparam(&attr, &param);
+  pthread_create(&thread, &attr, checktimethread, NULL);
+
+  return 0;
+}
+
+int main(int argc, FAR char *argv[])
+{
+  if (running)
+    {
+      printf("Already running!\n");
+      return 1;
+    }
+
+  signal(SIGINT, sighandler);
+  signal(SIGTERM, sighandler);
+
+  ntpc_start();
+  init_dlmalloc(poolbuf, poolbuf + sizeof(poolbuf));
+  HttpTrace_setFLushCallback(flushtrace);
+  HttpServer_setErrHnd(panic);
+
+  running = TRUE;
+  barracuda();
+  running = FALSE;
+
+  printf("Exiting Xedge\n");
+  return 0;
+}

--- a/netutils/xedge/.gitignore
+++ b/netutils/xedge/.gitignore
@@ -1,0 +1,3 @@
+/BAS
+/BAS-Resources
+/*.o

--- a/netutils/xedge/Kconfig
+++ b/netutils/xedge/Kconfig
@@ -1,0 +1,23 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NETUTILS_XEDGE
+	tristate "Xedge IoT Toolkit Dependencies"
+	depends on ALLOW_GPL_COMPONENTS
+	default n
+	---help---
+		Download and prepare Xedge IoT Toolkit dependencies (BAS and BAS-Resources).
+		
+		Xedge is an embedded software toolkit designed to enable high-level developers
+		(e.g., web and Lua programmers) to create sophisticated, secure IoT and industrial
+		device applications. It abstracts low-level embedded development through a lightweight
+		runtime built on top of the Barracuda App Server and Lua.
+
+		This option will download the required Barracuda App Server and BAS-Resources
+		repositories during the build process, making them available for applications
+		that want to use Xedge.
+
+		After enabling this, you can use the examples/xedge_demo as a reference
+		for integrating Xedge into your own applications.

--- a/netutils/xedge/Make.defs
+++ b/netutils/xedge/Make.defs
@@ -1,0 +1,35 @@
+############################################################################
+# apps/netutils/xedge/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_NETUTILS_XEDGE),)
+
+CONFIGURED_APPS += $(APPDIR)/netutils/xedge
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/netutils/xedge/BAS/inc
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/netutils/xedge/BAS/inc/arch/Posix
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/netutils/xedge/BAS/inc/arch/NET/Posix
+
+CFLAGS += -DNO_INIT_DISK_IO
+CFLAGS += -DUSE_DBGMON=1
+CFLAGS += -DUSE_IPV6
+
+endif

--- a/netutils/xedge/Makefile
+++ b/netutils/xedge/Makefile
@@ -1,0 +1,95 @@
+############################################################################
+# apps/netutils/xedge/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+include $(APPDIR)/Make.defs
+
+BAS_UNPACKNAME = BAS
+BAS_HASH = 9f74a2f778b002ad8441471b8a7a5b13172dbe76
+BAS_RESOURCES_UNPACKNAME = BAS-Resources
+BAS_RESOURCES_HASH = 227a4b998300fa4cfde871dc7dac92c09e1636c2
+
+BAS_ZIP_URL = https://github.com/RealTimeLogic/BAS/archive/$(BAS_HASH).zip
+BAS_RESOURCES_ZIP_URL = https://github.com/RealTimeLogic/BAS-Resources/archive/$(BAS_RESOURCES_HASH).zip
+
+XEDGEZIP = BAS/examples/xedge/XedgeZip.c
+
+BAS_SRC = $(BAS_UNPACKNAME)$(DELIM)src
+BAS_ARCH_SRC = $(BAS_SRC)$(DELIM)arch$(DELIM)Posix
+BAS_NET_SRC = $(BAS_SRC)$(DELIM)arch$(DELIM)NET$(DELIM)generic
+BAS_DISKIO_SRC = $(BAS_SRC)$(DELIM)DiskIo$(DELIM)posix
+BAS_XEDGE_SRC = $(BAS_UNPACKNAME)$(DELIM)examples$(DELIM)xedge$(DELIM)src
+
+VPATH += $(BAS_SRC)
+VPATH += $(BAS_ARCH_SRC)
+VPATH += $(BAS_NET_SRC)
+VPATH += $(BAS_DISKIO_SRC)
+VPATH += $(BAS_XEDGE_SRC)
+VPATH += $(BAS_UNPACKNAME)/examples/xedge
+
+CSRCS = BAS.c dlmalloc.c ThreadLib.c SoDisp.c BaFile.c xedge.c XedgeZip.c
+
+# Download and prepare BAS and BAS-Resources
+xedge-deps:
+	# ############################################################################
+	# Config and Fetch xedge
+	# ############################################################################
+
+	@if [ ! -d $(BAS_UNPACKNAME) ]; then \
+		echo "Downloading BAS from hash $(BAS_HASH)..."; \
+		curl -f -L $(BAS_ZIP_URL) -o bas-temp.zip || \
+		(echo "Error downloading BAS"; exit 1); \
+		unzip -q bas-temp.zip; \
+		mv BAS-$(BAS_HASH) $(BAS_UNPACKNAME); \
+		rm -f bas-temp.zip; \
+	fi
+
+	@if [ ! -d $(BAS_RESOURCES_UNPACKNAME) ]; then \
+		echo "Downloading BAS-Resources from hash $(BAS_RESOURCES_HASH)..."; \
+		curl -f -L $(BAS_RESOURCES_ZIP_URL) -o resources-temp.zip || \
+		(echo "Error downloading BAS-Resources"; exit 1); \
+		unzip -q resources-temp.zip; \
+		mv BAS-Resources-$(BAS_RESOURCES_HASH) $(BAS_RESOURCES_UNPACKNAME); \
+		rm -f resources-temp.zip; \
+	fi
+
+	# ############################################################################
+	# Library Configuration
+	# ############################################################################
+
+	@if [ ! -f "$(XEDGEZIP)" ]; then \
+		echo "Creating XedgeZip.c"; \
+		cd $(BAS_RESOURCES_UNPACKNAME)/build/ && \
+		printf "n\nl\nn\n" | bash Xedge.sh > /dev/null && \
+		cp XedgeZip.c ../../$(BAS_UNPACKNAME)/examples/xedge/ || exit 1; \
+	fi
+
+$(CSRCS:.c=$(OBJEXT)): xedge-deps
+
+ifeq ($(wildcard $(BAS_UNPACKNAME)/.git),)
+distclean:: xedge-deps
+	$(call DELDIR, $(BAS_UNPACKNAME))
+	$(call DELDIR, $(BAS_RESOURCES_UNPACKNAME))
+
+context:: xedge-deps
+endif
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
examples/xedge_demo: Add Xedge IoT Toolkit with BAS integration
    
    Add support for Xedge, an embedded software toolkit for IoT applications
    using Lua scripting with HTTP(S), WebSockets, MQTT, and device I/O.
    
    * netutils/xedge: Dependency manager that downloads BAS library
     and BAS-Resources, generates XedgeZip.c during build
    
    * examples/xedge_demo: Complete example showing Xedge integration
     with HTTP server, Lua runtime, and SNTP time synchronization

## Summary

I'm supporting @surfskidude to update xedge support with nuttx.

This commit covers conversations: 
https://github.com/apache/nuttx/pull/16352
https://github.com/apache/nuttx-apps/pull/3071

## Impact

``xedge_demo`` a lightweight Lua-based web framework for building secure, real-time IoT applications
=========================================================================

`Xedge <https://realtimelogic.com/products/xedge/>`_ is a robust IoT and web framework that is designed for microcontrollers. It is based on the industrial-grade Barracuda Application Server, designed for seamless OEM integration. Xedge accelerates embedded firmware development by providing a flexible, Lua-based environment and a full stack of industrial-strength protocols, including:

- OPC UA
- Modbus
- MQTT
- SMQ
- WebSockets
- HTTP/HTTPS

This Xedge port for NuttX comes pre-configured and requires:

- TCP/IP v4 and v6 support
- File System support
- 2 MB RAM allocated statically in ``xedge/xedge_main.c``

.. note::
   These instructions set up Xedge in **development mode**. Xedge supports many configuration options that differ between development and production builds. For production settings and optimization, refer to the general Xedge build instructions (details below).

Why Use Lua and Xedge in Embedded Systems
------------------------------------------

Great Lua developers don't treat it as a "better C"; they treat it as a complement. Lua is an extension language, which means it's designed to work alongside C, not replace it. Smart embedded programmers use C for performance-critical, low-level code and Lua for high-level business logic, such as processing sensor data and managing secure cloud connectivity.

Writing embedded business logic purely in C often means hundreds of lines of boilerplate code to manage memory, handle complex APIs, and handle errors. Lua, especially when paired with a framework like Xedge, lifts that burden. It provides high-level libraries and modules out of the box for protocols, networking, file systems, and more.

This shift doesn't just make development easier; it makes it faster. What used to take weeks in C can now be done in days. Lua's simplicity encourages rapid prototyping and quick iteration, which is essential in modern IoT and embedded development, where both time-to-market and security are critical. For a conceptual overview of why this hybrid development model is so powerful, check out the tutorial `Why Smart C Coders Love Lua.

## Testing

Run xedge example with qemu-armv8a board

```bash
 $ ./tools/configure.sh qemu-armv8a:xedge_demo
 $ make
```

Running with QEMU:

```bash
   $ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
     -machine virt,virtualization=on,gic-version=3 \
     -chardev stdio,id=con,mux=on -serial chardev:con \
     -global virtio-mmio.force-legacy=false \
     -netdev user,id=u1,hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,hostfwd=tcp:127.0.0.1:8443-10.0.2.15:443,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23 \
     -device virtio-net-device,netdev=u1,bus=virtio-mmio-bus.0 \
     -mon chardev=con,mode=readline -kernel ./nuttx
```

Running Xedge in NuttX terminal

```bash
   nsh> xedge_demo
    [    3.020000] [CPU0] Error: cannot set root to /mnt/lfs
    [    3.020000] [CPU0] Installing DiskIo failed!
    [    3.070000] [CPU0] Xedge: Server listening on IPv4 port 80
    [    3.080000] [CPU0] Xedge: SharkSSL server listening on IPv4 port 443
    [   13.720000] [CPU0] Xedge: Received invalid browser localStorage
    [   20.090000] [CPU1] 10.0.2.2 GET "rtl/assets/favicon.ico" t
    [   20.090000] [CPU1] Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138
    [   20.090000] [CPU1] .0.0.0 Safari/537.36
    [   20.090000] [CPU1] Host: 127.0.0.1:8080
    [   20.090000] [CPU1] Connection: keep-alive
    [   20.090000] [CPU1] sec-ch-ua-platform: "Linux"
    [   20.090000] [CPU1] User-Agent: a
    [   20.090000] [CPU1] Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138
    [   20.090000] [CPU1] .0.0.0 Safari/537.36
    [   20.090000] [CPU1] sec-ch-ua: "Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"
    [   20.090000] [CPU1] sec-ch-ua-mobile: ?0
    [   20.090000] [CPU1] Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
    [   20.090000] [CPU1] Sec-Fetch-Site: same-origin
    [   20.090000] [CPU1] Sec-Fetch-Mode: no-cors
    [   20.090000] [CPU1] Sec-Fetch-Dest: image
    [   20.090000] [CPU1] Referer: http://127.0.0.1:8080/rtl/
    [   20.090000] [CPU1] Accept-Encoding: gzip, deflate, br, zstd
    [   20.090000] [CPU1] Accept-Language: en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7
    [   20.090000] [CPU1] If-None-Match: 6866b8fe
    [   20.090000] [CPU1] If-Modified-Since: Thu, 03 Jul 2025 17:08:14 GMT
    [   20.090000] [CPU1]
    [   20.090000] [CPU0] 10.0.2.2 Response:
    T
    [   20.090000] [CPU0] Thu, 03 Jul 2025 19:32:12 GMT
    Content-Encoding: gzip
    Vary: Accept-Encoding
    Con
    [   20.090000] [CPU0] tent-Length: 3436
    Keep-Alive: Keep-Alive
```

Launch your web browser and access 127.0.0.1:8080

![image](https://github.com/user-attachments/assets/3910896d-2689-47e9-b4bb-8cffada1c093)
