### PR TITLE
system/dd: portability to non-nuttx platforms

### DIFF
--- a/system/dd/dd_main.c
+++ b/system/dd/dd_main.c
@@ -81,7 +81,7 @@ struct dd_s
   uint32_t     nsectors;   /* Number of sectors to transfer */
   uint32_t     skip;       /* The number of sectors skipped on input */
   uint32_t     seek;       /* The number of sectors seeked on output */
-  int          oflags;     /* The open flags on output deivce */
+  int          oflags;     /* The open flags on output device */
   bool         eof;        /* true: The end of the input or output file has been hit */
   size_t       sectsize;   /* Size of one sector */
   size_t       nbytes;     /* Number of valid bytes in the buffer */

--- a/system/dd/dd_main.c
+++ b/system/dd/dd_main.c
@@ -24,14 +24,14 @@
  * Included Files
  ****************************************************************************/
 
-#if defined(__NuttX__)
+#ifdef __NuttX__
 #include <nuttx/config.h>
 #endif
 
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if defined(__NuttX__)
+#ifdef __NuttX__
 #include <debug.h>
 #endif
 #include <inttypes.h>
@@ -248,7 +248,7 @@ static int dd_verify(FAR struct dd_s *dd)
 
       if (memcmp(dd->buffer, buffer, dd->nbytes) != 0)
         {
-#if defined(__NuttX__)
+#ifdef __NuttX__
           char msg[32];
           snprintf(msg, sizeof(msg), "infile sector %d", sector);
           lib_dumpbuffer(msg, dd->buffer, dd->nbytes);

--- a/system/dd/dd_main.c
+++ b/system/dd/dd_main.c
@@ -31,7 +31,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#if defined(__NuttX__)
 #include <debug.h>
+#endif
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -246,11 +248,15 @@ static int dd_verify(FAR struct dd_s *dd)
 
       if (memcmp(dd->buffer, buffer, dd->nbytes) != 0)
         {
+#if defined(__NuttX__)
           char msg[32];
           snprintf(msg, sizeof(msg), "infile sector %d", sector);
           lib_dumpbuffer(msg, dd->buffer, dd->nbytes);
           snprintf(msg, sizeof(msg), "\noutfile sector %d", sector);
           lib_dumpbuffer(msg, buffer, dd->nbytes);
+#else
+          printf("%s: sector %d differs unexpectedly\n", g_dd, sector);
+#endif
           ret = ERROR;
           break;
         }


### PR DESCRIPTION

## Summary

while this is not a goal for this repository,
it's convenient for me (hopefully for some others too) to be able to build this for other platforms.

an obvious downside is to have a few more ifdefs.

## Impact

## Testing

tested with:
```
/opt/wasi-sdk-25.0/bin/clang -Wall -Oz -s -o dd.wasm dd_main.c
```

