### PR TITLE
system/coredump: Fix missing loglevel to logmask conversion

### DIFF
--- a/system/coredump/coredump.c
+++ b/system/coredump/coredump.c
@@ -418,7 +418,7 @@ static int coredump_now(int pid, FAR char *filename)
 #endif
 
   printf("Start coredump:\n");
-  logmask = setlogmask(LOG_ALERT);
+  logmask = setlogmask(LOG_UPTO(LOG_ALERT));
 
   /* Initialize hex output stream */
 


### PR DESCRIPTION
Companion PR to apache/nuttx#16690, since the same logic is also duplicated in the `coredump` app here.

