### PR TITLE
examples/nximage: Rename program name to nximage

### DIFF
--- a/examples/nximage/Kconfig
+++ b/examples/nximage/Kconfig
@@ -15,7 +15,7 @@ if EXAMPLES_NXIMAGE
 
 config EXAMPLES_NXIMAGE_PROGNAME
 	string "NX Image Program name"
-	default "nxhello"
+	default "nximage"
 	---help---
 		This is the name of the program that will be used when the NSH ELF
 		program is installed.


### PR DESCRIPTION
## Summary
The original name is nxhello, which duplicates in examples/nxhello.

## Impact
Application name in examples/nximage.

## Testing
Build and run nximage command.
