### PR TITLE
graphics/libjpeg: Add JPEG compressor support to Makefile

### DIFF
--- a/graphics/libjpeg/Makefile
+++ b/graphics/libjpeg/Makefile
@@ -24,6 +24,8 @@ include $(APPDIR)/Make.defs
 
 SRC = libjpeg
 
+# Decompressor
+
 CSRCS += $(SRC)/jaricom.c
 CSRCS += $(SRC)/jcomapi.c
 CSRCS += $(SRC)/jdapimin.c
@@ -51,6 +53,29 @@ CSRCS += $(SRC)/jquant2.c
 CSRCS += $(SRC)/jutils.c
 CSRCS += $(SRC)/jmemmgr.c
 CSRCS += $(SRC)/jmemname.c
+
+# Compressor
+
+CSRCS += $(SRC)/jcapimin.c
+CSRCS += $(SRC)/jcapistd.c
+CSRCS += $(SRC)/jcarith.c
+CSRCS += $(SRC)/jccoefct.c
+CSRCS += $(SRC)/jccolor.c
+CSRCS += $(SRC)/jcdctmgr.c
+CSRCS += $(SRC)/jchuff.c
+CSRCS += $(SRC)/jcinit.c
+CSRCS += $(SRC)/jcmainct.c
+CSRCS += $(SRC)/jcmarker.c
+CSRCS += $(SRC)/jcmaster.c
+CSRCS += $(SRC)/jcparam.c
+CSRCS += $(SRC)/jcprepct.c
+CSRCS += $(SRC)/jcsample.c
+CSRCS += $(SRC)/jctrans.c
+
+CSRCS += $(SRC)/jdatadst.c
+CSRCS += $(SRC)/jfdctint.c
+CSRCS += $(SRC)/jfdctfst.c
+CSRCS += $(SRC)/jfdctflt.c
 
 CFLAGS += -DTEMP_DIRECTORY=\"$(CONFIG_EXTERNALS_LIBJPEG_TEMP_DIR)\"
 


### PR DESCRIPTION
## Summary

This PR adds the required JPEG compressor files to the Makefile.
Before this PR, the Makefile contained only the required decompressor files.

## Impact

Users can now use the JPEG compressor. All the required files are added by default.

## Testing

Tested on the STM32H7.
A couple photos were decompressed with 1:8 scaling.
Then compressed again with 20% quality.

JPEG hardware was not used.

```
nsh> resize sd/PROC/11c.jpg sd/PROC/test.jpg 8 20
Resized JPEG written to sd/PROC/test.jpg
nsh> resize sd/PROC/11c.jpg sd/PROC/test.jpg 8 20
Resized JPEG written to sd/PROC/test.jpg
nsh> 
```
And as expected, the output looks correct.
