### PR TITLE
examples/keyboard: Fix compilation warning

### DIFF
--- a/examples/keyboard/kbd_main.c
+++ b/examples/keyboard/kbd_main.c
@@ -141,8 +141,8 @@ int main(int argc, FAR char *argv[])
       else
         {
           printf("Sample  :\n");
-          printf("   code : %d\n",   sample.code);
-          printf("   type : %d\n",   sample.type);
+          printf("   code : %" PRIu32 "\n",   sample.code);
+          printf("   type : %" PRIu32 "\n",   sample.type);
         }
 
       if (nsamples && --nsamples <= 0)


### PR DESCRIPTION
## Summary

Replace %d with %PRIu32 to avoid warning convered in error on CI.

## Impact

Fix CI error

## Testing

stm32f4discovery:sbutton


