### PR TITLE
netutils/nanopb: fix unpack step for MACOS

### DIFF
--- a/netutils/nanopb/Makefile
+++ b/netutils/nanopb/Makefile
@@ -41,7 +41,7 @@ $(NANOPB_TARBALL):
 
 $(NANOPB_UNPACK): $(NANOPB_TARBALL)
 	$(Q) tar zxf $(NANOPB_TARBALL)
-	$(Q) mv nanopb-$(NANOPB_VERSION)-linux-x86 $(NANOPB_UNPACK)
+	$(Q) mv $(NANOPB_NAME) $(NANOPB_UNPACK)
 	$(Q) mv $(NANOPB_TARBALL) $(NANOPB_UNPACK)
 
 ifeq ($(wildcard $(NANOPB_UNPACK)),)


### PR DESCRIPTION
## Summary
Fix unpack step for MACOS

## Impact
Enabling and building `nanopb` works when building on MACOS

## Testing
Tested with local build


