### PR TITLE
system/zlib: expose zlib interface to other applications

### DIFF
--- a/system/zlib/Make.defs
+++ b/system/zlib/Make.defs
@@ -23,4 +23,8 @@
 
 ifneq ($(CONFIG_LIB_ZLIB),)
 CONFIGURED_APPS += $(APPDIR)/system/zlib
+
+CFLAGS +=  ${INCDIR_PREFIX}$(APPDIR)/system/zlib/zlib
+CXXFLAGS +=  ${INCDIR_PREFIX}$(APPDIR)/system/zlib/zlib
+
 endif


### PR DESCRIPTION
## Summary
Expose zlib interface to other applications

## Impact
Other applications may include `zlib.h` and use zlib APIs

## Testing
Tested by using `zlib.h` with other NuttX based application
