### PR TITLE
Nxboot direct access

### DIFF
--- a/boot/nxboot/loader/boot.c
+++ b/boot/nxboot/loader/boot.c
@@ -164,7 +164,7 @@ static int copy_partition(int from, int where, struct nxboot_state *state,
 #ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT
   total_size = remain * 100;
 #endif
-  blocksize = MAX(info_from.blocksize, info_where.blocksize);
+  blocksize = info_where.blocksize;
 
   buf = malloc(blocksize);
   if (!buf)

--- a/boot/nxboot/loader/flash.c
+++ b/boot/nxboot/loader/flash.c
@@ -64,7 +64,7 @@ int flash_partition_open(const char *path)
 {
   int fd;
 
-  fd = open(path, O_RDWR);
+  fd = open(path, O_RDWR | O_DIRECT);
   if (fd < 0)
     {
       syslog(LOG_ERR, "Could not open %s partition: %s\n",


### PR DESCRIPTION
## Summary

**619ea01 boot/nxboot/loader/flash.c: open partition with O_DIRECT flag**

There is no need to use buffers in a bootloader. We expect a sequential
access, therefore we just need to erase the erase page before writing
to it for the first time, which is something FTL layer already takes
care of.

**95e4b0c boot/nxboot/loader/boot.c: copy partition with blocksize large writes**

The previous logic `MAX(info_from.blocksize, info_where.blocksize)` was
incorrect. The most effective access with by writing the entire
size of the block, therefore just decide the size based on the
target page size.

## Impact

Nxboot now utilizes changes presented in https://github.com/apache/nuttx/pull/16642. Should not have impact on current implementation as the additional flags are ignored if changes in https://github.com/apache/nuttx/pull/16642 are not applied.

## Testing

Tested with https://github.com/apache/nuttx/pull/16642 patch applied. Nxboot successfully updates and reverts new image. All works as before, but additional buffering is skipped.
