### PR TITLE
kasantest: -fno-builtin is enabled by default

### DIFF
--- a/testing/mm/kasantest/CMakeLists.txt
+++ b/testing/mm/kasantest/CMakeLists.txt
@@ -22,6 +22,7 @@
 
 if(CONFIG_TESTING_KASAN)
   set(CFLAGS
+      -fno-builtin
       -Wno-error
       -Wno-use-after-free
       -Wno-array-bounds

--- a/testing/mm/kasantest/Makefile
+++ b/testing/mm/kasantest/Makefile
@@ -32,6 +32,6 @@ STACKSIZE = $(CONFIG_TESTING_KASAN_STACKSIZE)
 CFLAGS += -Wno-error -Wno-use-after-free -Wno-stringop-overflow
 CFLAGS += -Wno-array-bounds -Wno-free-nonheap-object
 CFLAGS += -Wno-unused-value -Wno-unused-variable
-CFLAGS += "-O0"
+CFLAGS += -fno-builtin "-O0"
 
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
The strlen function called by kasantest will be optimized by the compiler, and the strlen function implemented in NX will not be called. Adding -fno-builtin can solve the problem.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The strlen function called by kasantest will be optimized by the compiler, and the strlen function implemented in NX will not be called. Adding -fno-builtin can solve the problem.

## Impact

No

## Testing

ci


