### PR TITLE
system/gdbstub: Add depends of LIB_GDBSTUB

### DIFF
--- a/system/gdbstub/Kconfig
+++ b/system/gdbstub/Kconfig
@@ -5,6 +5,7 @@
 
 config SYSTEM_GDBSTUB
 	tristate "GDBSTUB"
+	depends on LIB_GDBSTUB
 	---help---
 		Enable support for gdbstub.
 


### PR DESCRIPTION
## Summary
Add depends of `LIB_GDBSTUB` for gdbstub.
```
in function `gdbstub_main': undefined reference to `gdb_state_init'
undefined reference to `gdb_process'
undefined reference to `gdb_state_uninit'
```

## Impact
- apps/system/gdbstub

## Testing
CI