### PR TITLE
interpreters/python: Fix symbol collision with list_length function

### DIFF
--- a/interpreters/python/Makefile
+++ b/interpreters/python/Makefile
@@ -83,6 +83,7 @@ $(CPYTHON_UNPACKNAME): $(CPYTHON_ZIP)
 	$(Q) patch -p1 -d $(CPYTHON_UNPACKNAME) < patch$(DELIM)0011-avoid-redefinition-warning-if-UNUSED-is-already-defi.patch
 	$(Q) patch -p1 -d $(CPYTHON_UNPACKNAME) < patch$(DELIM)0012-hack-place-_PyRuntime-structure-into-PSRAM-bss-regio.patch
 	$(Q) patch -p1 -d $(CPYTHON_UNPACKNAME) < patch$(DELIM)0013-transform-functions-used-by-NuttX-to-lowercase.patch
+	$(Q) patch -p1 -d $(CPYTHON_UNPACKNAME) < patch$(DELIM)0014-insert-prefix-to-list_length-to-avoid-symbol-collisi.patch
 
 $(HOSTPYTHON):
 	mkdir -p $(HOSTBUILD)

--- a/interpreters/python/patch/0001-workaround-newlib-resource.h-limitations.patch
+++ b/interpreters/python/patch/0001-workaround-newlib-resource.h-limitations.patch
@@ -1,7 +1,7 @@
-From 3917fd37644948096c6bebf53e701b59fa527cf5 Mon Sep 17 00:00:00 2001
+From b96f875c54e2d888413a701eb9727d704b995ce0 Mon Sep 17 00:00:00 2001
 From: Ivan Grokhotkov <ivan@espressif.com>
 Date: Tue, 22 Oct 2024 23:58:17 +0200
-Subject: [PATCH 01/11] workaround newlib resource.h limitations
+Subject: [PATCH 01/14] workaround newlib resource.h limitations
 
 configure script checks if resource.h is available but doesn't check
 if it defines all the necessary functions.
@@ -27,5 +27,5 @@ index b62362f2777..327d883f94e 100644
  
      /* Disable creation of core dump */
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0002-fix-various-uint32_t-unsigned-int-type-mismatch-issu.patch
+++ b/interpreters/python/patch/0002-fix-various-uint32_t-unsigned-int-type-mismatch-issu.patch
@@ -1,7 +1,7 @@
-From 562138b0486ad050b5ce601d434910973ff6f094 Mon Sep 17 00:00:00 2001
+From 2c684af739d366dce8392ee2bb9af8248283e323 Mon Sep 17 00:00:00 2001
 From: Ivan Grokhotkov <ivan@espressif.com>
 Date: Wed, 23 Oct 2024 16:48:49 +0200
-Subject: [PATCH 02/11] fix various uint32_t/'unsigned int' type mismatch
+Subject: [PATCH 02/14] fix various uint32_t/'unsigned int' type mismatch
  issues
 
 In a few places existing code assumes that uint32_t == unsigned int.
@@ -149,5 +149,5 @@ index c911c302003..9c640e0ab65 100644
      assert(_PyASCIIObject_CAST(name)->hash != -1);
      OBJECT_STAT_INC_COND(type_cache_collisions, entry->name != Py_None && entry->name != name);
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0003-reuse-wasm_assets.py-for-generating-an-archive-of-py.patch
+++ b/interpreters/python/patch/0003-reuse-wasm_assets.py-for-generating-an-archive-of-py.patch
@@ -1,7 +1,7 @@
-From dcc6b2b6aa396f96e7c9efe3e793d96c7004ef4f Mon Sep 17 00:00:00 2001
+From 41728277acd7eba4e500d0b4ddd02198b92cf6ac Mon Sep 17 00:00:00 2001
 From: Ivan Grokhotkov <ivan@espressif.com>
 Date: Wed, 23 Oct 2024 16:54:39 +0200
-Subject: [PATCH 03/11] reuse wasm_assets.py for generating an archive of
+Subject: [PATCH 03/14] reuse wasm_assets.py for generating an archive of
  python lib dir
 
 wasm_assets.py is a useful script to prepare the smallest possible
@@ -39,5 +39,5 @@ index ffa5e303412..381d4819c39 100755
      args.wasm_stdlib = args.wasm_root / WASM_STDLIB
      args.wasm_dynload = args.wasm_root / WASM_DYNLOAD
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0004-recognize-nuttx-as-a-supported-OS.patch
+++ b/interpreters/python/patch/0004-recognize-nuttx-as-a-supported-OS.patch
@@ -1,7 +1,7 @@
-From ff067ccb26c91de352de362a25d87bcbabe924dc Mon Sep 17 00:00:00 2001
+From 9965644a9cee6c85a726d21ff2ed6f1e42445941 Mon Sep 17 00:00:00 2001
 From: Ivan Grokhotkov <ivan@espressif.com>
 Date: Wed, 23 Oct 2024 16:55:53 +0200
-Subject: [PATCH 04/11] recognize *-*-nuttx as a supported OS
+Subject: [PATCH 04/14] recognize *-*-nuttx as a supported OS
 
 cpython's configure script bails out when cross-compiling for an
 unknown OS, so we have to add "nuttx" to the list, even though it
@@ -57,5 +57,5 @@ index 24e28a1e2de..80d6738fab5 100644
  		# for now, limit cross builds to known configurations
  		MACHDEP="unknown"
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0005-gh-122907-Fix-Builds-Without-HAVE_DYNAMIC_LOADING-Se.patch
+++ b/interpreters/python/patch/0005-gh-122907-Fix-Builds-Without-HAVE_DYNAMIC_LOADING-Se.patch
@@ -1,7 +1,7 @@
-From 7e646549488f2d3de4cf1e04ad975625342a9218 Mon Sep 17 00:00:00 2001
+From d5c061676d7ee6f1fb963bdf79791e37b5b05a36 Mon Sep 17 00:00:00 2001
 From: Eric Snow <ericsnowcurrently@gmail.com>
 Date: Tue, 13 Aug 2024 14:44:57 -0600
-Subject: [PATCH 05/11] gh-122907: Fix Builds Without HAVE_DYNAMIC_LOADING Set
+Subject: [PATCH 05/14] gh-122907: Fix Builds Without HAVE_DYNAMIC_LOADING Set
  (gh-122952)
 
 As of 529a160 (gh-118204), building with HAVE_DYNAMIC_LOADING stopped working.  This is a minimal fix just to get builds working again.  There are actually a number of long-standing deficiencies with HAVE_DYNAMIC_LOADING builds that need to be resolved separately.
@@ -186,5 +186,5 @@ index 7de35b499da..66b2a262e11 100644
              raise
  
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0006-change-var-name-to-avoid-conflict-with-nuttx-unused_.patch
+++ b/interpreters/python/patch/0006-change-var-name-to-avoid-conflict-with-nuttx-unused_.patch
@@ -1,7 +1,7 @@
-From 82a3c7c021324e4245289c565b2d379b83ed4be3 Mon Sep 17 00:00:00 2001
+From 221e92fa16864f8a590091b643fc40050bab163c Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Wed, 13 Nov 2024 14:20:36 -0300
-Subject: [PATCH 06/11] change var name to avoid conflict with nuttx
+Subject: [PATCH 06/14] change var name to avoid conflict with nuttx
  unused_data macro
 
 Signed-off-by: Tiago Medicci <tiago.medicci@espressif.com>
@@ -165,5 +165,5 @@ index 034a9420b16..595d4ad32e9 100644
      {"needs_input", Py_T_BOOL, offsetof(ZlibDecompressor, needs_input), Py_READONLY,
       ZlibDecompressor_needs_input_doc},
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0007-undef-atexit_register.patch
+++ b/interpreters/python/patch/0007-undef-atexit_register.patch
@@ -1,7 +1,7 @@
-From 7eab2315d75d5e78e67e0b049ebb2fc71914b7ea Mon Sep 17 00:00:00 2001
+From 6ebe2333a7862532aa50e7286db9ea8b9df895c4 Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Wed, 13 Nov 2024 14:22:04 -0300
-Subject: [PATCH 07/11] undef atexit_register
+Subject: [PATCH 07/14] undef atexit_register
 
 Even if not built, nuttx/include/nuttx/atexit.h defines it and this
 causes conflicts.
@@ -27,5 +27,5 @@ index 297a8d74ba3..1fea72fbc99 100644
  atexit_register(PyObject *module, PyObject *args, PyObject *kwargs)
  {
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0008-declare-struct-timeval.patch
+++ b/interpreters/python/patch/0008-declare-struct-timeval.patch
@@ -1,7 +1,7 @@
-From fc042cfa496f37f2a859495ad281583f79af0044 Mon Sep 17 00:00:00 2001
+From ce41aed2d663d6a7278b83bcdc2dc0adb65b9f5c Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Wed, 13 Nov 2024 14:23:34 -0300
-Subject: [PATCH 08/11] declare struct timeval
+Subject: [PATCH 08/14] declare struct timeval
 
 Otherwise, build will fail due to redefinition of _PyTime_FromTimeval
 
@@ -25,5 +25,5 @@ index 205ac5d3781..c30e07f4b4a 100644
  #define _SIZEOF_PYTIME_T 8
  
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0009-include-nuttx-sys-select-header-to-define-FD_SETSIZE.patch
+++ b/interpreters/python/patch/0009-include-nuttx-sys-select-header-to-define-FD_SETSIZE.patch
@@ -1,7 +1,7 @@
-From 3d140751ebec3aedd8ed3cdf2a7eff5009693112 Mon Sep 17 00:00:00 2001
+From 682b331c77974ef5f051b39f30f3a5af4f7789d1 Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Thu, 14 Nov 2024 13:44:49 -0300
-Subject: [PATCH 09/11] include nuttx sys/select header to define FD_SETSIZE
+Subject: [PATCH 09/14] include nuttx sys/select header to define FD_SETSIZE
 
 Signed-off-by: Tiago Medicci <tiago.medicci@espressif.com>
 ---
@@ -24,5 +24,5 @@ index 5bd9b7732a4..e9fab839122 100644
  #  ifndef WIN32_LEAN_AND_MEAN
  #    define WIN32_LEAN_AND_MEAN
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0010-check-for-the-d_ino-member-of-the-structure-dirent.patch
+++ b/interpreters/python/patch/0010-check-for-the-d_ino-member-of-the-structure-dirent.patch
@@ -1,7 +1,7 @@
-From 4191bf1e4505776efa0780ebc4fc5195a6ce79d3 Mon Sep 17 00:00:00 2001
+From 479f4647bf0c5a841af6a916c21fdef1fa1b5cdf Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Tue, 3 Dec 2024 17:18:50 -0300
-Subject: [PATCH 10/11] check for the d_ino member of the structure dirent
+Subject: [PATCH 10/14] check for the d_ino member of the structure dirent
 
 Signed-off-by: Tiago Medicci <tiago.medicci@espressif.com>
 ---
@@ -191,5 +191,5 @@ index 4d8b1d4f254..4a2ba83a872 100644
     */
  #undef HAVE_DIRENT_H
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0011-avoid-redefinition-warning-if-UNUSED-is-already-defi.patch
+++ b/interpreters/python/patch/0011-avoid-redefinition-warning-if-UNUSED-is-already-defi.patch
@@ -1,7 +1,7 @@
-From b82ab44e498a9e9bcdcbbfa1d6161023d8ea8c5b Mon Sep 17 00:00:00 2001
+From deadd332eda6355c6598dc9df5f12b34b870d857 Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Tue, 10 Dec 2024 12:03:47 -0300
-Subject: [PATCH 11/11] avoid redefinition warning if UNUSED is already defined
+Subject: [PATCH 11/14] avoid redefinition warning if UNUSED is already defined
 
 ---
  Parser/pegen.h | 2 ++
@@ -22,5 +22,5 @@ index 32c64e7774b..42574456f23 100644
  #define EXTRA _start_lineno, _start_col_offset, _end_lineno, _end_col_offset, p->arena
  PyObject *_PyPegen_new_type_comment(Parser *, const char *);
 -- 
-2.46.1
+2.50.0
 

--- a/interpreters/python/patch/0012-hack-place-_PyRuntime-structure-into-PSRAM-bss-regio.patch
+++ b/interpreters/python/patch/0012-hack-place-_PyRuntime-structure-into-PSRAM-bss-regio.patch
@@ -1,7 +1,7 @@
-From 79b6142580bad5235588faf38c0a22c7280a2d1b Mon Sep 17 00:00:00 2001
+From 70538c2ec3e59df6ce1e767e53908a9cad361f05 Mon Sep 17 00:00:00 2001
 From: Ivan Grokhotkov <ivan@espressif.com>
 Date: Wed, 23 Oct 2024 16:52:52 +0200
-Subject: [PATCH 12/13] hack: place _PyRuntime structure into PSRAM bss region,
+Subject: [PATCH 12/14] hack: place _PyRuntime structure into PSRAM bss region,
  initialize later
 
 _PyRuntime occupies around 100kB of RAM in .data region, making it
@@ -50,5 +50,5 @@ index 1701a1cd217..93aa808bc03 100644
  _PyRuntime_Initialize(void)
  {
 -- 
-2.48.1
+2.50.0
 

--- a/interpreters/python/patch/0013-transform-functions-used-by-NuttX-to-lowercase.patch
+++ b/interpreters/python/patch/0013-transform-functions-used-by-NuttX-to-lowercase.patch
@@ -1,7 +1,7 @@
-From 914c80b7969d73840bc1b573b478d9148999b7d0 Mon Sep 17 00:00:00 2001
+From 954d39ba94e772940486575e35d586ba1cf738e3 Mon Sep 17 00:00:00 2001
 From: Tiago Medicci <tiago.medicci@espressif.com>
 Date: Fri, 31 Jan 2025 14:06:21 -0300
-Subject: [PATCH 13/13] transform functions used by NuttX to lowercase
+Subject: [PATCH 13/14] transform functions used by NuttX to lowercase
 
 ---
  Include/pylifecycle.h | 10 ++++++++++
@@ -29,5 +29,5 @@ index de1bcb1d2cb..044780ee188 100644
  Py_DEPRECATED(3.11) PyAPI_FUNC(void) Py_SetProgramName(const wchar_t *);
  Py_DEPRECATED(3.13) PyAPI_FUNC(wchar_t *) Py_GetProgramName(void);
 -- 
-2.47.1
+2.50.0
 

--- a/interpreters/python/patch/0014-insert-prefix-to-list_length-to-avoid-symbol-collisi.patch
+++ b/interpreters/python/patch/0014-insert-prefix-to-list_length-to-avoid-symbol-collisi.patch
@@ -1,0 +1,44 @@
+From e908a9a52806768b7546f6a5808eeba1a7862238 Mon Sep 17 00:00:00 2001
+From: Tiago Medicci <tiago.medicci@espressif.com>
+Date: Mon, 21 Jul 2025 12:04:04 -0300
+Subject: [PATCH 14/14] insert prefix to list_length to avoid symbol collision
+ on NuttX
+
+---
+ Objects/listobject.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Objects/listobject.c b/Objects/listobject.c
+index dc9df3c3614..3e5bb33068b 100644
+--- a/Objects/listobject.c
++++ b/Objects/listobject.c
+@@ -627,7 +627,7 @@ list_repr(PyObject *self)
+ }
+ 
+ static Py_ssize_t
+-list_length(PyObject *a)
++py_list_length(PyObject *a)
+ {
+     return PyList_GET_SIZE(a);
+ }
+@@ -3502,7 +3502,7 @@ static PyMethodDef list_methods[] = {
+ };
+ 
+ static PySequenceMethods list_as_sequence = {
+-    list_length,                                /* sq_length */
++    py_list_length,                             /* sq_length */
+     list_concat,                                /* sq_concat */
+     list_repeat,                                /* sq_repeat */
+     list_item,                                  /* sq_item */
+@@ -3768,7 +3768,7 @@ list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
+ }
+ 
+ static PyMappingMethods list_as_mapping = {
+-    list_length,
++    py_list_length,
+     list_subscript,
+     list_ass_subscript
+ };
+-- 
+2.50.0
+


### PR DESCRIPTION
## Summary

* interpreters/python: Fix symbol collision with list_length function

NuttX implements a function with the same name which may end up being included whenever `CONFIG_MM_KERNEL_HEAP` is set. To avoid it, insert a prefix to it on Python's implementation.

Please note that the other patches had their metadata updated too.

## Impact

Impact on user: Yes. Enable using a separate kernel heap with Python interpreter on NuttX.

Impact on build: No.

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

This can be tested by setting `CONFIG_MM_KERNEL_HEAP=y` and building the Python interpreter on a flat build environment. Using `esp32s3-devkit:python`, for instance: 

### Building

Build NuttX and flash it to ESP32-S3-DevKitC-1 v1.1 board (with ESP32-S3-WROOM-2 module):
```
make -j distclean && ./tools/configure.sh esp32s3-devkit:python && kconfig-tweak -e MM_KERNEL_HEAP && make olddefconfig && make flash ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BINDIR=./ -s -j$(nproc)
```

### Running

```
picocom -b 115200 /dev/ttyUSB0
```

### Results

Check the `python` interpreter:
```
NuttShell (NSH) NuttX-10.4.0
nsh> python
Python 3.13.0 (main, Jul 21 2025, 10:58:37) [GCC 14.2.0] on nuttx
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```