### PR TITLE
netutils/esp8266: Fix compile error and some bugs

### DIFF
--- a/include/netutils/esp8266.h
+++ b/include/netutils/esp8266.h
@@ -77,6 +77,7 @@ typedef struct
  ****************************************************************************/
 
 int lesp_initialize(void);
+int lesp_finalize(void);
 int lesp_soft_reset(void);
 
 const char *lesp_security_to_str(lesp_security_t security);

--- a/include/netutils/esp8266.h
+++ b/include/netutils/esp8266.h
@@ -48,19 +48,19 @@
 
 typedef enum
 {
-  lesp_eMODE_AP       = 0,
-  lesp_eMODE_STATION  = 1,
-  lesp_eMODE_BOTH     = 2
+  LESP_MODE_AP       = 0,
+  LESP_MODE_STATION  = 1,
+  LESP_MODE_BOTH     = 2
 } lesp_mode_t;
 
 typedef enum
 {
-  lesp_eSECURITY_NONE = 0,
-  lesp_eSECURITY_WEP,
-  lesp_eSECURITY_WPA_PSK,
-  lesp_eSECURITY_WPA2_PSK,
-  lesp_eSECURITY_WPA_WPA2_PSK,
-  lesp_eSECURITY_NBR
+  LESP_SECURITY_NONE = 0,
+  LESP_SECURITY_WEP,
+  LESP_SECURITY_WPA_PSK,
+  LESP_SECURITY_WPA2_PSK,
+  LESP_SECURITY_WPA_WPA2_PSK,
+  LESP_SECURITY_NBR
 } lesp_security_t;
 
 typedef struct

--- a/include/netutils/esp8266.h
+++ b/include/netutils/esp8266.h
@@ -37,8 +37,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define lespSSID_SIZE 32 /* Number of character max of SSID (null char not included) */
-#define lespBSSID_SIZE 6
+#define LESP_SSID_SIZE 32 /* Number of character max of SSID (null char not included) */
+#define LESP_BSSID_SIZE 6
 
 #define lespIP(x1,x2,x3,x4) ((x1) << 24 | (x2) << 16 | (x3) << 8 | (x4) << 0)
 
@@ -66,8 +66,8 @@ typedef enum
 typedef struct
 {
   lesp_security_t security;
-  char ssid[lespSSID_SIZE + 1];     /* +1 for null char */
-  uint8_t bssid[lespBSSID_SIZE];
+  char ssid[LESP_SSID_SIZE + 1];    /* +1 for null char */
+  uint8_t bssid[LESP_BSSID_SIZE];
   int rssi;
   int channel;
 } lesp_ap_t;

--- a/netutils/esp8266/esp8266.c
+++ b/netutils/esp8266/esp8266.c
@@ -2179,7 +2179,7 @@ int lesp_socket(int domain, int type, int protocol)
  *   close socket creates with lesp_socket.
  *
  * Input Parameters:
- *   sockfd   : socket indentifer.
+ *   sockfd    Socket descriptor returned by socket()
  *
  * Returned Value:
  *   A 0 on success; -1 on error.

--- a/netutils/esp8266/esp8266.c
+++ b/netutils/esp8266/esp8266.c
@@ -315,7 +315,7 @@ static lesp_socket_t *get_sock(int sockfd)
   if (((unsigned int)sockfd) >= SOCKET_NBR)
     {
       errno = EINVAL;
-      ninfo("Esp8266 invalid sockfd\n", sockfd);
+      ninfo("Esp8266 invalid sockfd %d\n", sockfd);
       return NULL;
     }
 
@@ -2283,7 +2283,7 @@ int lesp_connect(int sockfd, FAR const struct sockaddr *addr,
                  socklen_t addrlen)
 {
   int ret = 0;
-  const char *proto_str;
+  const char *proto_str = "";
   lesp_socket_t *sock;
   struct sockaddr_in *in;
   unsigned short port;

--- a/netutils/esp8266/esp8266.c
+++ b/netutils/esp8266/esp8266.c
@@ -1123,6 +1123,7 @@ static int lesp_parse_cwjap_ans_line(char *ptr, lesp_ap_t *ap)
  *    "FreeWifi" => ssid
  *    -90 => rssi
  *    "00:07:cb:07:b6:00" => mac
+ *    1 => channel
  *
  *   Note: Content of ptr is modified and string in ap point into ptr string.
  *
@@ -1218,6 +1219,14 @@ static int lesp_parse_cwlap_ans_line(char *ptr, lesp_ap_t *ap)
                           ptr++;
                         }
                     }
+                }
+              break;
+
+          case 5:
+                {
+                  int i = atoi(ptr);
+
+                  ap->channel = i;
                 }
               break;
         }

--- a/netutils/esp8266/esp8266.c
+++ b/netutils/esp8266/esp8266.c
@@ -1771,7 +1771,7 @@ int lesp_get_net(lesp_mode_t mode, in_addr_t *ip,
     {
       ninfo("Read:%s\n", g_lesp_state.bufans);
 
-      ret = lesp_parse_cipxxx_ans_line(g_lesp_state.bufans, mask);
+      ret = lesp_parse_cipxxx_ans_line(g_lesp_state.bufans, gw);
       if (ret < 0)
         {
           nerr("ERROR: Line badly formed.\n");


### PR DESCRIPTION
## Summary
Fix compile error and nxstyle.
Fix bug to get gateway address.
Fix bug that channel retrieved by lesp_list_access_points is undefined.

## Impact
netutils/esp8266

## Testing
Build CONFIG_NETUTILS_ESP8266=y and run it on esp8266 board.
