### PR TITLE
graphics/jpgresizetool: Add libjpeg resize tool

### DIFF
--- a/graphics/jpgresizetool/Kconfig
+++ b/graphics/jpgresizetool/Kconfig
@@ -1,0 +1,10 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config GRAPHICS_JPGRESIZETOOL
+	bool "JPGResizeTool"
+	default n
+  ---help---
+    Libjpeg JPEG resizer

--- a/graphics/jpgresizetool/Make.defs
+++ b/graphics/jpgresizetool/Make.defs
@@ -1,0 +1,3 @@
+ifneq ($(CONFIG_GRAPHICS_JPGRESIZETOOL),)
+CONFIGURED_APPS += $(APPDIR)/graphics/jpgresizetool
+endif

--- a/graphics/jpgresizetool/Makefile
+++ b/graphics/jpgresizetool/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/graphics/jpgresizetool/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+MAINSRC = resize.c
+
+# built-in application info
+
+PROGNAME = jpgresize
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = 4096
+MODULE = $(CONFIG_GRAPHICS_JPGRESIZETOOL)
+
+include $(APPDIR)/Application.mk

--- a/graphics/jpgresizetool/resize.c
+++ b/graphics/jpgresizetool/resize.c
@@ -1,0 +1,186 @@
+/****************************************************************************
+ * apps/graphics/jpgresizetool/resize.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <jpeglib.h>
+
+/****************************************************************************
+ * Definitions
+ ****************************************************************************/
+
+/* Every N line, report resizing progress */
+#define JPEGRESIZE_PROGRESS_INTERVAL  40
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Usage: jpgresize input.jpg output.jpg scale_denom quality%
+ * (scale_denom = 1, 2, 4, 8)
+ * thumbnail example: jpgresize /sd/PROC/100.jpg /sd/THUMBS/100.jpg 8 20
+ */
+
+int main(int argc, char *argv[])
+{
+  /* Take arguments */
+
+  if (argc != 5)
+    {
+      fprintf(stderr,
+              "Usage: %s input.jpg output.jpg scale_denom quality\n",
+              argv[0]);
+      return -1;
+    }
+
+  const char *input_filename  = argv[1];
+  const char *output_filename = argv[2];
+  int scale_denom = atoi(argv[3]);
+  if (scale_denom != 1 && scale_denom != 2 && scale_denom != 4 &&
+      scale_denom != 8 && scale_denom != 16)
+    {
+      fprintf(stderr, "scale_denom must be 1, 2, 4, 8, or 16\n");
+      return -1;
+    }
+
+  int quality = atoi(argv[4]);
+
+  /* Opening input */
+
+  FILE *infile = fopen(input_filename, "rb");
+  if (!infile)
+    {
+      perror("fopen input");
+      return -1;
+    }
+
+  /* Configuring decompressor */
+
+  struct jpeg_decompress_struct cinfo;
+  struct jpeg_error_mgr jerr;
+  cinfo.err = jpeg_std_error(&jerr);
+  jpeg_create_decompress(&cinfo);
+  jpeg_stdio_src(&cinfo, infile);
+  jpeg_read_header(&cinfo, TRUE);
+
+  cinfo.scale_num = 1;
+  cinfo.scale_denom = scale_denom;
+  jpeg_start_decompress(&cinfo);
+
+  int width = cinfo.output_width;
+  int height = cinfo.output_height;
+  int pixel_size = cinfo.output_components;
+
+  /* Opening output */
+
+  FILE *outfile = fopen(output_filename, "wb");
+  if (!outfile)
+    {
+      perror("fopen output");
+      jpeg_destroy_decompress(&cinfo);
+      fclose(infile);
+      return -1;
+    }
+
+  /* Configuring compressor */
+
+  struct jpeg_compress_struct cinfo_out;
+  struct jpeg_error_mgr jerr_out;
+  cinfo_out.err = jpeg_std_error(&jerr_out);
+  jpeg_create_compress(&cinfo_out);
+  jpeg_stdio_dest(&cinfo_out, outfile);
+
+  cinfo_out.image_width = width;
+  cinfo_out.image_height = height;
+  cinfo_out.input_components = pixel_size;
+  cinfo_out.in_color_space = cinfo.out_color_space;
+  jpeg_set_defaults(&cinfo_out);
+  jpeg_set_quality(&cinfo_out, quality, TRUE);
+  jpeg_start_compress(&cinfo_out, TRUE);
+
+  /* Allocating memory by using JPEG their own allocator. Do not use malloc */
+
+  printf("Allocating... \r");
+  JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)
+      ((j_common_ptr)&cinfo, JPOOL_IMAGE, width * pixel_size, 1);
+
+  /* Start the job */
+
+  printf("Resizing...   \n\r");
+  uint8_t togglechar = 0;
+  while (cinfo.output_scanline < cinfo.output_height)
+    {
+      /* Pretty loading bar... */
+
+      if (cinfo.output_scanline % JPEGRESIZE_PROGRESS_INTERVAL == 1)
+        {
+          printf("\r[%u%%]",
+                 (unsigned)(((float)cinfo.output_scanline
+                 / cinfo.output_height)
+                 * 100));
+          togglechar = !togglechar;
+        }
+
+      if (togglechar)
+        {
+          printf("-");
+        }
+      else
+        {
+          printf("#");
+        }
+
+      fflush(stdout);
+
+      /* Actual work */
+
+      jpeg_read_scanlines(&cinfo, buffer, 1);
+      jpeg_write_scanlines(&cinfo_out, buffer, 1);
+    }
+
+  /* Erase progress bar */
+
+  printf("\r      ");
+  for (size_t i = 0; i < JPEGRESIZE_PROGRESS_INTERVAL; i++)
+    {
+      printf(" ");
+    }
+
+  /* All done */
+
+  printf("\rDone\n\r");
+
+  jpeg_finish_compress(&cinfo_out);
+  jpeg_destroy_compress(&cinfo_out);
+  fclose(outfile);
+
+  jpeg_finish_decompress(&cinfo);
+  jpeg_destroy_decompress(&cinfo);
+  fclose(infile);
+
+  printf("Resized JPEG written to %s\n", output_filename);
+  return 0;
+}


### PR DESCRIPTION

## Summary

Add a libjpeg based JPEG resize tool.
Simple resizer that can resize JPEGs using
"jpgresize input.jpg output.jpg scale_denom(1,2,4,8) quality%". Tries to use little memory by scanning per line.

## Impact

Allows users to quickly resize JPEG images using a simple command. Useful for in scripts to generate thumbnails or experiment with jpeg compression and size ratios.

## Testing

This app is tested during the development of a project where thumbnails are generated from photos.
<img width="525" height="73" alt="image" src="https://github.com/user-attachments/assets/ed2d0989-406b-44ef-a21f-d4ed3d21eeb7" />
<img width="522" height="109" alt="image" src="https://github.com/user-attachments/assets/d7b177dc-99d4-4e3a-be4b-5bb52b550e73" />



