### PR TITLE
nxboot/loader: Fix boot progress calculation.

### DIFF
--- a/boot/nxboot/loader/boot.c
+++ b/boot/nxboot/loader/boot.c
@@ -162,7 +162,7 @@ static int copy_partition(int from, int where, struct nxboot_state *state,
     }
 
 #ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT
-  total_size = remain * 100;
+  total_size = remain;
 #endif
   blocksize = info_where.blocksize;
 
@@ -227,7 +227,7 @@ static int copy_partition(int from, int where, struct nxboot_state *state,
         {
 #ifdef CONFIG_NXBOOT_PRINTF_PROGRESS_PERCENT
           nxboot_progress(nxboot_progress_percent,
-                          ((total_size - remain) * 100) / total_size);
+                          100 - ((100 * remain) / total_size));
 #else
           nxboot_progress(nxboot_progress_dot);
 #endif


### PR DESCRIPTION
## Summary

This patch corrects a mathematical error in the progress reporting function which caused incorrect percentage progress calculations.

This problem was discovered while testing https://github.com/apache/nuttx-apps/pull/3136.

## Impact

None. Just fixes a problem where the reported % went negative and then misbehaved. Schoolboy maths error!

## Testing

On my custom SAMA5D27C-D1G board using NXboot and an 800x480 nLCD with NXboot progress display enabled to view the percentage complete of various NXboot flash operations.

