### PR TITLE
examples: Update ftl_initialize usage in code and Kconfig after kernel side change.

### DIFF
--- a/examples/media/Kconfig
+++ b/examples/media/Kconfig
@@ -24,7 +24,7 @@ config EXAMPLES_MEDIA
 		MTD drivers need an additional wrapper layer, the FTL wrapper must
 		first be used to convert the MTD driver to a block device:
 
-			int ret = ftl_initialize(<N>, mtd);
+			int ret = ftl_initialize(/dev/mtdblock<N>, mtd);
 			ret = bchdev_register(/dev/mtdblock<N>, <path-to-character-driver>,
 			                      false);
 
@@ -45,7 +45,7 @@ config EXAMPLES_MEDIA_DEVPATH
 		MTD drivers need an additional wrapper layer, the FTL wrapper must
 		first be used to convert the MTD driver to a block device:
 
-			int ret = ftl_initialize(<N>, mtd);
+			int ret = ftl_initialize(/dev/mtdblock<N>, mtd);
 			ret = bchdev_register(/dev/mtdblock<N>, <path-to-character-driver>,
 			                      false);
 

--- a/examples/mtdrwb/mtdrwb_main.c
+++ b/examples/mtdrwb/mtdrwb_main.c
@@ -180,7 +180,7 @@ int main(int argc, FAR char *argv[])
    * interesting.
    */
 
-  ret = ftl_initialize(0, mtdrwb);
+  ret = ftl_initialize("/dev/mtdblock0", mtdrwb, 0);
   if (ret < 0)
     {
       printf("ERROR: ftl_initialize /dev/mtdblock0 failed: %d\n", ret);


### PR DESCRIPTION
## Summary

* Follow up FTL kernel side change and update example application.
* Depends on: https://github.com/apache/nuttx/pull/16793.

## Impact

* Examples description and code sync with kernel side change:
  * `examples/media/Kconfig`.
  * `examples/mtdrwb/mtdrwb_main.c`.

## Testing

ci with https://github.com/apache/nuttx/pull/16793

