### PR TITLE
netutils/xedge: refactor Makefile to use git clone instead of zip dow…

### DIFF
--- a/netutils/xedge/Makefile
+++ b/netutils/xedge/Makefile
@@ -22,13 +22,15 @@
 
 include $(APPDIR)/Make.defs
 
+# BAS configuration
 BAS_UNPACKNAME = BAS
 BAS_HASH = 9f74a2f778b002ad8441471b8a7a5b13172dbe76
+BAS_REPO_URL = https://github.com/RealTimeLogic/BAS.git
+
+# BAS-Resources configuration
 BAS_RESOURCES_UNPACKNAME = BAS-Resources
 BAS_RESOURCES_HASH = 227a4b998300fa4cfde871dc7dac92c09e1636c2
-
-BAS_ZIP_URL = https://github.com/RealTimeLogic/BAS/archive/$(BAS_HASH).zip
-BAS_RESOURCES_ZIP_URL = https://github.com/RealTimeLogic/BAS-Resources/archive/$(BAS_RESOURCES_HASH).zip
+BAS_RESOURCES_REPO_URL = https://github.com/RealTimeLogic/BAS-Resources.git
 
 XEDGEZIP = BAS/examples/xedge/XedgeZip.c
 
@@ -47,49 +49,35 @@ VPATH += $(BAS_UNPACKNAME)/examples/xedge
 
 CSRCS = BAS.c dlmalloc.c ThreadLib.c SoDisp.c BaFile.c xedge.c XedgeZip.c
 
-# Download and prepare BAS and BAS-Resources
-xedge-deps:
-	# ############################################################################
-	# Config and Fetch xedge
-	# ############################################################################
+# Clone and setup BAS repository
+$(BAS_UNPACKNAME):
+	$(Q) echo "Cloning BAS repository..."
+	$(Q) git clone $(BAS_REPO_URL) $(BAS_UNPACKNAME)
+	$(Q) cd $(BAS_UNPACKNAME) && git checkout $(BAS_HASH)
 
-	@if [ ! -d $(BAS_UNPACKNAME) ]; then \
-		echo "Downloading BAS from hash $(BAS_HASH)..."; \
-		curl -f -L $(BAS_ZIP_URL) -o bas-temp.zip || \
-		(echo "Error downloading BAS"; exit 1); \
-		unzip -q bas-temp.zip; \
-		mv BAS-$(BAS_HASH) $(BAS_UNPACKNAME); \
-		rm -f bas-temp.zip; \
-	fi
+# Clone and setup BAS-Resources repository
+$(BAS_RESOURCES_UNPACKNAME):
+	$(Q) echo "Cloning BAS-Resources repository..."
+	$(Q) git clone $(BAS_RESOURCES_REPO_URL) $(BAS_RESOURCES_UNPACKNAME)
+	$(Q) cd $(BAS_RESOURCES_UNPACKNAME) && git checkout $(BAS_RESOURCES_HASH)
 
-	@if [ ! -d $(BAS_RESOURCES_UNPACKNAME) ]; then \
-		echo "Downloading BAS-Resources from hash $(BAS_RESOURCES_HASH)..."; \
-		curl -f -L $(BAS_RESOURCES_ZIP_URL) -o resources-temp.zip || \
-		(echo "Error downloading BAS-Resources"; exit 1); \
-		unzip -q resources-temp.zip; \
-		mv BAS-Resources-$(BAS_RESOURCES_HASH) $(BAS_RESOURCES_UNPACKNAME); \
-		rm -f resources-temp.zip; \
-	fi
-
-	# ############################################################################
-	# Library Configuration
-	# ############################################################################
-
-	@if [ ! -f "$(XEDGEZIP)" ]; then \
-		echo "Creating XedgeZip.c"; \
-		cd $(BAS_RESOURCES_UNPACKNAME)/build/ && \
+# Create XedgeZip.c
+$(XEDGEZIP): $(BAS_UNPACKNAME) $(BAS_RESOURCES_UNPACKNAME)
+	$(Q) echo "Creating XedgeZip.c..."
+	$(Q) cd $(BAS_RESOURCES_UNPACKNAME)/build/ && \
 		printf "n\nl\nn\n" | bash Xedge.sh > /dev/null && \
-		cp XedgeZip.c ../../$(BAS_UNPACKNAME)/examples/xedge/ || exit 1; \
-	fi
+		cp XedgeZip.c ../../$(BAS_UNPACKNAME)/examples/xedge/
+
+xedge-deps: $(XEDGEZIP)
 
 $(CSRCS:.c=$(OBJEXT)): xedge-deps
 
 ifeq ($(wildcard $(BAS_UNPACKNAME)/.git),)
-distclean:: xedge-deps
-	$(call DELDIR, $(BAS_UNPACKNAME))
-	$(call DELDIR, $(BAS_RESOURCES_UNPACKNAME))
-
 context:: xedge-deps
 endif
 
 include $(APPDIR)/Application.mk
+
+distclean::
+	$(call DELDIR, $(BAS_UNPACKNAME))
+	$(call DELDIR, $(BAS_RESOURCES_UNPACKNAME))


### PR DESCRIPTION
## Summary

This PR adds the Xedge application to NuttX-Apps, refactoring the Makefile to use git clone instead of zip downloads to resolve CI build failures. Xedge provides a lightweight edge computing platform based on the BAS (Barracuda Application Server) framework, enabling IoT applications and web server capabilities on embedded NuttX systems.

The build system now uses git clone with specific commit hashes for reproducible builds and improved CI compatibility.pendencies, similar problems and solutions), etc.

## Impact

Changes Makefile to use git clone instead of zip downloads.

## Testing

This NuttX-Apps PR depends on the core example created in [NuttX PR #16665](https://github.com/apache/nuttx/pull/16665) which is still under review.

Tested using the official NuttX CI Docker environment:

```bash
sudo docker run -it \
  --name nuttx-ci \
  -v /home/jaga/nuttxspace:/workspace \
  ghcr.io/apache/nuttx/apache-nuttx-ci-linux:latest \
  /bin/bash

# Build xedge application
cd /workspace/nuttx
./tools/configure.sh qemu-armv8a:xedge_demo
make -j

# Running with QEMU:
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
  -machine virt,virtualization=on,gic-version=3 \
  -chardev stdio,id=con,mux=on -serial chardev:con \
  -netdev user,id=u1,hostfwd=tcp:127.0.0.1:8080-10.0.2.15:80,hostfwd=tcp:127.0.0.1:8443-10.0.2.15:443,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23 \
  -device virtio-net-device,netdev=u1 \
  -fsdev local,security_model=none,id=fsdev0,path=/mnt/xxx \
  -device virtio-9p-device,id=fs0,fsdev=fsdev0,mount_tag=host \
  -mon chardev=con,mode=readline -kernel ./nuttx
```
