### PR TITLE
system/uORB: Add flags for gnss satellite format

### DIFF
--- a/system/uorb/sensor/gnss.c
+++ b/system/uorb/sensor/gnss.c
@@ -51,7 +51,8 @@
   ",svid" #idx ":%" PRIu32 \
   ",elevation" #idx ":%" PRIu32 \
   ",azimuth" #idx ":%" PRIu32 \
-  ",snr" #idx ":%" PRIu32 ""
+  ",snr" #idx ":%" PRIu32 \
+  ",flags" #idx ":%" PRIx32 ""
 
 static const char sensor_gnss_format[] =
   UORB_DEBUG_FORMAT_SENSOR_GNSS ",firmware_version:%" PRIu32 "";


### PR DESCRIPTION
## Summary
Add flags for gnss satellite format, some applications require satellite information for positioning using the flag USED_IN_FIX.
Depends on: https://github.com/apache/nuttx/pull/16805

## Impact
- system/uORB

## Testing
CI