### PR TITLE
netutils/dhcpc/dhcpc: add implementation to get renewal (T1) time and rebinding (T2) time from DHCP packet

### DIFF
--- a/include/netutils/dhcpc.h
+++ b/include/netutils/dhcpc.h
@@ -58,6 +58,8 @@ struct dhcpc_state
   struct in_addr dnsaddr;
   struct in_addr default_router;
   uint32_t       lease_time;      /* Lease expires in this number of seconds */
+  uint32_t       renewal_time;    /* Seconds to transition to RENEW state(T1) */
+  uint32_t       rebinding_time;  /* Seconds to transition to REBIND state(T2) */
 };
 
 typedef void (*dhcpc_callback_t)(FAR struct dhcpc_state *presult);

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -96,6 +96,8 @@
 #define DHCP_OPTION_MSG_TYPE    53
 #define DHCP_OPTION_SERVER_ID   54
 #define DHCP_OPTION_REQ_LIST    55
+#define DHCP_OPTION_T1_TIME     58
+#define DHCP_OPTION_T2_TIME     59
 #define DHCP_OPTION_CLIENT_ID   61
 #define DHCP_OPTION_END         255
 
@@ -340,6 +342,7 @@ static uint8_t dhcpc_parseoptions(FAR struct dhcpc_state *presult,
 {
   FAR uint8_t *end = optptr + len;
   uint8_t type = 0;
+  uint16_t tmp[2];
 
   while (optptr < end)
     {
@@ -421,7 +424,6 @@ static uint8_t dhcpc_parseoptions(FAR struct dhcpc_state *presult,
 
             if (optptr + 6 <= end)
               {
-                uint16_t tmp[2];
                 memcpy(tmp, optptr + 2, 4);
                 presult->lease_time = ((uint32_t)ntohs(tmp[0])) << 16 |
                                        (uint32_t)ntohs(tmp[1]);
@@ -429,6 +431,38 @@ static uint8_t dhcpc_parseoptions(FAR struct dhcpc_state *presult,
             else
               {
                 nerr("Packet too short (lease time missing)\n");
+              }
+            break;
+
+          case DHCP_OPTION_T1_TIME:
+
+              /* Get renewal (T1) time (in seconds) in host order */
+
+            if (optptr + 6 <= end)
+              {
+                memcpy(tmp, optptr + 2, 4);
+                presult->renewal_time = ((uint32_t)ntohs(tmp[0])) << 16 |
+                                         (uint32_t)ntohs(tmp[1]);
+              }
+            else
+              {
+                nerr("Packet too short (renewal time missing)\n");
+              }
+            break;
+
+          case DHCP_OPTION_T2_TIME:
+
+              /* Get rebinding (T2) time (in seconds) in host order */
+
+            if (optptr + 6 <= end)
+              {
+                memcpy(tmp, optptr + 2, 4);
+                presult->rebinding_time = ((uint32_t)ntohs(tmp[0])) << 16 |
+                                           (uint32_t)ntohs(tmp[1]);
+              }
+            else
+              {
+                nerr("Packet too short (rebinding time missing)\n");
               }
             break;
 


### PR DESCRIPTION
## Summary

- netutils/dhcpc/dhcpc: add implementation to get renewal (T1) time and rebinding (T2) time from DHCP packet
- According to RFC 2131, T1 and T2 times play a critical role in lease management in DHCP clients.

> 
> T1 Time (Renewal Time)
> Definition: The time at which the client enters the RENEWING state.
> Default Value: 50% of the lease time (0.5 × lease_time).
> 
> T2 Time (Rebinding Time)
> Definition: The time at which the client enters the REBINDING state.
> Default Value: 87.5% of the lease time (0.875 × lease_time).

## Impact
New Feature/Change: Correctly receive and store T1 and T2 time provided by the server
User Impact: Provide a foundation for the implementation of intelligent renewal mechanism in the future
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
#Use tcpdump to capture DHCP traffic
#View options 58 and 59 in DHCP ACK packets
#Option 58: T1 Time
#Option 59: T2 Time

<img width="1381" height="349" alt="图片" src="https://github.com/user-attachments/assets/4bf39495-f7b2-41dd-9ed9-77da2c8260a6" />


