### PR TITLE
apps/unity: Add printf configuration

### DIFF
--- a/include/testing/unity_config.h
+++ b/include/testing/unity_config.h
@@ -47,4 +47,10 @@
 #  define UNITY_OUTPUT_COLOR 1
 #endif
 
+/* Enable Unity TEST_PRINTF */
+
+#ifdef CONFIG_TESTING_UNITY_PRINT_FORMATTED
+#  define UNITY_INCLUDE_PRINT_FORMATTED 1
+#endif
+
 #endif /* UNITY_CONFIG_H */

--- a/testing/unity/Kconfig
+++ b/testing/unity/Kconfig
@@ -29,6 +29,12 @@ config TESTING_UNITY_OUTPUT_COLOR
 	bool "Output color"
 	default n
 	---help---
-		Select this if your want to add some colors to your tests
+		Select this if you want to add some colors to your tests
+
+config TESTING_UNITY_PRINT_FORMATTED
+	bool "Unity printf"
+	default y
+	---help---
+		Select this if you you want to use the Unity TEST_PRINTF macro.
 
 endif # TESTING_UNITY


### PR DESCRIPTION
## Summary

Allows the user to select whether or not they want access to the Unity ``TEST_PRINTF`` commands.

## Impact

Impacts only the build system by adding one more Kconfig option.

## Testing

Verified that adding this definition allowed use of the ``TEST_PRINTF`` Unity macro without compilation issues.