### PR TITLE
[EXPERIMENTAL] Makefile: EXTRA_APPS_LIBS and EXTRA_APPS_INCPATHS vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,28 @@ preconfig: Kconfig
 export:
 ifneq ($(EXPORTDIR),)
 	$(Q) mkdir -p "${EXPORTDIR}"$(DELIM)registry || exit 1;
+	if [ -n "${EXTRA_APPS_LIBS}" ]; then \
+		mkdir -p $(APPDIR)$(DELIM)libcomb; \
+		cp libapps.a $(APPDIR)$(DELIM)libcomb; \
+		for l in ${EXTRA_APPS_LIBS}; do \
+			echo "AR: $$(basename $${l})"; \
+			cp $${l} $(APPDIR)$(DELIM)libcomb; \
+		done; \
+		cd $(APPDIR)$(DELIM)libcomb; \
+		for l in *.a; do \
+			$(AR_EXTRACT) $${l}; \
+		done; \
+		$(AR) libmerged.a *.o; \
+		mv libmerged.a ..$(DELIM)libapps.a; \
+		cd ..; \
+		rm -rf $(APPDIR)$(DELIM)libcomb; \
+	fi; \
+	for d in ${EXTRA_APPS_INCPATHS}; do \
+		if [ -d "$${d}" ]; then \
+			echo "CP: $$(basename $${d})" ; \
+			cp -r "$${d}" "${EXPORTDIR}"$(DELIM)include ; \
+		fi \
+	done
 ifneq ($(CONFIG_BUILD_KERNEL),y)
 ifneq ($(BUILTIN_REGISTRY),)
 	for f in "${BUILTIN_REGISTRY}"$(DELIM)*.bdat "${BUILTIN_REGISTRY}"$(DELIM)*.pdat ; do \


### PR DESCRIPTION
The variables are to be used to mainly by the export rule to export external libraries (.a files) and respective include paths.

The exported external libraries are packed together in the libapps.a library (basically, every .o files are extracted and then packed together).

Signed-off-by: Stepan Pressl <pressl.stepan@gmail.com>

## Summary
Improving the build system with these variables so all the symbols from the external libraries can be packed together within the libapps.a library. This is particularly useful, when we'd like to use this external library and all of its symbols in the nuttx export.

I'm not expecting to be this merged, yet. But I'd like to start a debate over possible solutions and discuss other solutions and improvements. I'm thinking about generalizing the variables over multiple Makefiles, so any directory in the NuttX project would have some kind of a variable. Or possibly only one variable.

A different way of doing this is to just all of these libraries separately, and not withing libapps.a, etc.

Also, external libraries are, in the current state, linked using the EXTRA_LIBS variable. But that is done only in the last stage of the build and the linker only picks symbols that are needed. In the end, the exported library only has a subset of all the symbols.

Also cmake support must be added.





