### PR TITLE
ntpclient/ntpclient.c: NTP client millisecond conversion error

### DIFF
--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -892,7 +892,7 @@ static int ntpc_create_dgram_socket(int domain)
   /* Setup a send timeout on the socket */
 
   tv.tv_sec  = CONFIG_NETUTILS_NTPCLIENT_TIMEOUT_MS / 1000;
-  tv.tv_usec = CONFIG_NETUTILS_NTPCLIENT_TIMEOUT_MS % 1000;
+  tv.tv_usec = (CONFIG_NETUTILS_NTPCLIENT_TIMEOUT_MS % 1000) * 1000;
 
   ret = setsockopt(sd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(struct timeval));
   if (ret < 0)


### PR DESCRIPTION
## Summary
ntpclient/ntpclient.c:fix the NTP client's timeval conversion bug from milliseconds to microseconds.
Avoid premature timeout due to too small microsecond assignment.

## Impact
New Feature/Change:bugfix
User Impact:Avoid premature timeout due to too small microsecond assignment.
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
1. Enable the NTP client in the configuration with the following commands:
   - CONFIG_NETUTILS_NTPCLIENT=y
   - CONFIG_SYSTEM_NTPC=y
2. Request an abnormal NTP service to trigger a timeout, and verify it by packet capture tools such as tcpdump/Wireshark.

