### PR TITLE
examples/tmp112: Add new example for TMP112 temperature sensor

### DIFF
--- a/examples/tmp112/CMakeLists.txt
+++ b/examples/tmp112/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/tmp112/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_TMP112)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_TMP112_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_TMP112_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_TMP112_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_TMP112}
+    SRCS
+    tmp112_main.c)
+endif()

--- a/examples/tmp112/Kconfig
+++ b/examples/tmp112/Kconfig
@@ -1,0 +1,36 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_TMP112
+	tristate "TMP112 temperature sensor example"
+	default n
+	depends on SENSORS_TMP112
+	---help---
+		Enable the TMP112 example
+
+if EXAMPLES_TMP112
+
+config EXAMPLES_TMP112_PROGNAME
+	string "Program name"
+	default "tmp112"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_TMP112_PRIORITY
+	int "TMP112 task priority"
+	default 100
+
+config EXAMPLES_TMP112_STACKSIZE
+	int "TMP112 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+config EXAMPLES_TMP112_DEVPATH
+	string "TMP112 device path"
+	default "/dev/temp0"
+	---help---
+		The default path to the TMP112 temperature sensor device
+
+endif

--- a/examples/tmp112/Make.defs
+++ b/examples/tmp112/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/tmp112/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_TMP112),)
+CONFIGURED_APPS += $(APPDIR)/examples/tmp112
+endif

--- a/examples/tmp112/Makefile
+++ b/examples/tmp112/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/examples/tmp112/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# TMP112 temperature sensor example built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_TMP112_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_TMP112_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_TMP112_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_TMP112)
+
+# TMP112 temperature sensor example
+
+MAINSRC = tmp112_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/tmp112/tmp112_main.c
+++ b/examples/tmp112/tmp112_main.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * apps/examples/tmp112/tmp112_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tmp112_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int fd;
+  int ret;
+  float sample;
+
+  fd = open(CONFIG_EXAMPLES_TMP112_DEVPATH, O_RDONLY);
+  if (fd < 0)
+    {
+      printf("Failed to open TMP112 sensor at %s: %s (%d)\n",
+             CONFIG_EXAMPLES_TMP112_DEVPATH, strerror(errno), errno);
+      return EXIT_FAILURE;
+    }
+
+  ret = read(fd, &sample, sizeof(float));
+  if (ret != sizeof(sample))
+    {
+      perror("Could not read");
+      ret = EXIT_FAILURE;
+    }
+  else
+    {
+      printf("TMP112 = %.03f degrees Celsius\n", sample);
+      ret = EXIT_SUCCESS;
+    }
+
+  close(fd);
+
+  return ret;
+}


### PR DESCRIPTION
## Summary

This is a companion PR to apache/nuttx#16838. It adds a new example that shows how to read the temperature from a TMP112 sensor registered on the I2C bus.

## Impact

N/A

## Testing

These changes were tested on a Linux host, targeting a custom Cortex-M0+ (RP2040) board using today's latest NuttX master as the baseline.


