### PR TITLE
[Litmus] add litmus env

### DIFF
--- a/examples/litmus/Kconfig
+++ b/examples/litmus/Kconfig
@@ -1,0 +1,28 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_Litmus
+	tristate "\"Litmus nuttx !\" example"
+	default n
+	---help---
+		Enable the \"Litmus, Nuttx!\" example
+
+if EXAMPLES_LITMUS
+
+config EXAMPLES_LITMUS_PROGNAME
+	string "Program name"
+	default "litmus"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_LITMUS_PRIORITY
+	int "litmus task priority"
+	default 100
+
+config EXAMPLES_LITMUS_STACKSIZE
+	int "litmus stack size"
+	default DEFAULT_TASK_STACKSIZE
+endif

--- a/examples/litmus/Make.defs
+++ b/examples/litmus/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/litmus/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_LITMUS),)
+CONFIGURED_APPS += $(APPDIR)/examples/litmus
+endif

--- a/examples/litmus/Makefile
+++ b/examples/litmus/Makefile
@@ -1,0 +1,39 @@
+############################################################################
+# apps/examples/litmus/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_LITMUS_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_LITMUS_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_LITMUS_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_LITMUS)
+
+SRC_DIRS := $(CURDIR)/src
+VPATH    += $(SRC_DIRS)
+MAINSRC = "$(CURDIR)/src/run.c"
+
+CSRCS    += $(foreach d,$(SRC_DIRS),$(notdir $(wildcard $(d)/*.c)))
+CSRCS    := $(filter-out $(MAINSRC),$(CSRCS))
+
+CFLAGS+=-D_GNU_SOURCE -DFORCE_AFFINITY -Wall -std=gnu99
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
  Add litmux build env for first draft
  need add symbolink to litmus source code

  EX: ln -s litmus-tests-riscv/hw-tests-src src

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


