### PR TITLE
examples/i2schar: Implement loopback mode check

### DIFF
--- a/examples/i2schar/i2schar.h
+++ b/examples/i2schar/i2schar.h
@@ -73,7 +73,7 @@
 #endif
 
 #ifndef CONFIG_EXAMPLES_I2SCHAR_BUFSIZE
-#   define CONFIG_EXAMPLES_I2SCHAR_BUFSIZE 256
+#  define CONFIG_EXAMPLES_I2SCHAR_BUFSIZE 256
 #endif
 
 /****************************************************************************
@@ -83,6 +83,7 @@
 struct i2schar_state_s
 {
   bool      initialized;
+  bool      loopback;
   FAR char *devpath;
 #ifdef CONFIG_EXAMPLES_I2SCHAR_TX
   int       txcount;


### PR DESCRIPTION
## Summary

* examples/i2schar: Implement loopback mode check
  - Implements the loopback mode for the i2schar example application. This mode - available only when both RX and TX are enabled - allows the user to test the I2S buses when the TX pin is connected to the RX pin. This is done by pre-filling a buffer with known data (additionally, it checks the peripheral's data width to format the data in the buffer accordingly) and passing it for both the transmitter and the receiver threads. This buffer is written to the TX and the received buffer is compared to the known buffer.

Please note that https://github.com/apache/nuttx/pull/16914 should be merged first. Otherwise, the testing application won't be able to fetch the data width (it would use the default value, instead) and the read/write operations would not return the actual values.

## Impact

Impact on user: Yes. It enables automating I2S testing by enabling the loopback mode testing.

Impact on build: No.

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

Please check the testing section of https://github.com/apache/nuttx/pull/16914