### PR TITLE
boot/nxboot/loader/boot.c: avoid unwanted confirm on double update

### DIFF
--- a/boot/nxboot/loader/boot.c
+++ b/boot/nxboot/loader/boot.c
@@ -313,6 +313,8 @@ static enum nxboot_update_type
           nxboot_progress(nxboot_progress_end);
           return NXBOOT_UPDATE_TYPE_UPDATE;
         }
+
+        flash_partition_erase_first_sector(update);
     }
 
   nxboot_progress(nxboot_progress_end);
@@ -643,12 +645,14 @@ int nxboot_get_state(struct nxboot_state *state)
   else if (IS_INTERNAL_MAGIC(primary_header.magic))
     {
       recovery_pointer = primary_header.magic & NXBOOT_RECOVERY_PTR_MASK;
-      if (recovery_pointer == NXBOOT_SECONDARY_SLOT_NUM)
+      if (recovery_pointer == NXBOOT_SECONDARY_SLOT_NUM &&
+          IS_INTERNAL_MAGIC(secondary_header.magic))
         {
           state->primary_confirmed =
             primary_header.crc == secondary_header.crc;
         }
-      else if (recovery_pointer == NXBOOT_TERTIARY_SLOT_NUM)
+      else if (recovery_pointer == NXBOOT_TERTIARY_SLOT_NUM &&
+               IS_INTERNAL_MAGIC(tertiary_header.magic))
         {
           state->primary_confirmed =
             primary_header.crc == tertiary_header.crc;


### PR DESCRIPTION
## Summary
Following steps led to incorrect behavior:
 - upload update image
 - restart device and perform the update
 - upload the same update image again without confirming

This led to the unwanted confirm of the update image. This change ensures the update image is not confirmed by uploading the same image to the update slot. The correct behavior is to perform revert to the last stable image if this occurs.

## Impact
None on current update process, tested with both standard update and revert, works as before.

ping @TimJTi if you want to verify

## Testing
Tested on samv7 custom board for standard update and revert processes + double update described above.

