### PR TITLE
bluetooth/nimble: update to the latest master

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -1,0 +1,2 @@
+      mynewt-nimble/nimble/host/services/ans/src/ble_svc_ans.c
+      mynewt-nimble/nimble/host/services/ans/include

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,10 @@
+[codespell]
+
+# Add complete lines to be ignored to this file.
+# Example for ignoring all current occurrences of (verifiably correct) word usage:
+#   grep -hirw "emac" | sort | uniq >>.codespell-ignore-lines
+exclude-file = .codespell-ignore-lines
+
+# Ignore complete files (e.g. legal text or other immutable material).
+skip =
+  LICENSE,

--- a/wireless/bluetooth/nimble/CMakeLists.txt
+++ b/wireless/bluetooth/nimble/CMakeLists.txt
@@ -48,8 +48,14 @@ if(CONFIG_NIMBLE)
       mynewt-nimble/porting/nimble/src/mem.c
       mynewt-nimble/porting/nimble/src/nimble_port.c
       mynewt-nimble/porting/nimble/src/os_mbuf.c
-      mynewt-nimble/porting/nimble/src/os_mempool.c
-      mynewt-nimble/porting/nimble/src/os_msys_init.c)
+      mynewt-nimble/porting/nimble/src/os_mempool.c)
+
+  # os_msys_init.c is obsolete
+  if(EXISTS mynewt-nimble/porting/nimble/src/os_msys_init.c)
+    list(APPEND SRCS_PORTING mynewt-nimble/porting/nimble/src/os_msys_init.c)
+  else()
+    list(APPEND SRCS_PORTING mynewt-nimble/porting/nimble/src/os_msys.c)
+  endif()
 
   set(SRCS_NPL
       mynewt-nimble/porting/npl/nuttx/src/os_atomic.c

--- a/wireless/bluetooth/nimble/Kconfig
+++ b/wireless/bluetooth/nimble/Kconfig
@@ -15,7 +15,7 @@ if NIMBLE
 
 config NIMBLE_REF
 	string "Version"
-	default "fb15c844542e812ceb49ab5ac8502dc93c167b90"
+	default "b6831813cfe6da9b25c8be7136b40ce060bf9710"
 	---help---
 		Git ref name to use when downloading from NimBLE repo
 


### PR DESCRIPTION
## Summary

Update NimBLE to the latest master. This includes fixing the debug log control, which was broken since:

  https://github.com/apache/mynewt-nimble/commit/da4e2f0f12859079f1bde47cbd69f39026c3cc73

The debug log was always enable and it wasn't possible to disable it.

## Impact

debug log can be disabled again

## Testing

nrf52840-dk/sdc_nimble

