### PR TITLE
system/ntpc: update ntpc messages

### DIFF
--- a/system/ntpc/Kconfig
+++ b/system/ntpc/Kconfig
@@ -9,7 +9,8 @@ config SYSTEM_NTPC
 	select NETUTILS_NTPCLIENT
 	depends on NET_UDP
 	---help---
-		Enable the NTP client 'start' and 'stop' commands
+		Enable the NTP client example. This example provides a command-line
+		interface to manage the NTP client for time synchronization.
 
 if SYSTEM_NTPC
 

--- a/system/ntpc/ntpcstart_main.c
+++ b/system/ntpc/ntpcstart_main.c
@@ -41,13 +41,20 @@
 
 int main(int argc, FAR char *argv[])
 {
-  int pid = ntpc_start();
+  int pid;
+
+  printf("Starting NTP client...\n");
+  printf("Using NTP servers: %s\n", CONFIG_NETUTILS_NTPCLIENT_SERVER);
+
+  pid = ntpc_start();
   if (pid < 0)
     {
       fprintf(stderr, "ERROR: ntpc_start() failed\n");
       return EXIT_FAILURE;
     }
 
-  printf("Started the NTP daemon as PID=%d\n", pid);
+  printf("NTP client started successfully (task ID: %d)\n", pid);
+  printf("NTP client is now running in the background\n");
+
   return EXIT_SUCCESS;
 }

--- a/system/ntpc/ntpcstop_main.c
+++ b/system/ntpc/ntpcstop_main.c
@@ -41,7 +41,11 @@
 
 int main(int argc, FAR char *argv[])
 {
-  int ret = ntpc_stop();
+  int ret = OK;
+
+  printf("Stopping NTP client...\n");
+
+  ret = ntpc_stop();
   if (ret < 0)
     {
       fprintf(stderr, "ERROR: ntpc_stop() failed\n");


### PR DESCRIPTION
## Summary

This PR updates verbosity on ntpc commands. Also updated documentation on NuttX side.

## Impact

No impact for user, build or hardware. Only changes some program outputs.

## Testing

ntpcstart:
```
nsh> ntpcstart
Starting NTP client...
Using NTP servers: 0.pool.ntp.org;1.pool.ntp.org;2.pool.ntp.org
NTP client started successfully (task ID: 10)
NTP client is now running in the background
nsh> date
Fri, Sep 05 18:49:37 2025
```
ntpcstatus:
```
nsh> ntpcstatus
The number of last samples: 5
[0] srv <ip> offset 0.993639955 delay 0.029989675
[1] srv <ip> offset 0.994610567 delay 0.019975724
[2] srv <ip> offset 0.996539219 delay 0.019954988
[3] srv <ip> offset 0.998574000 delay 0.049963876
[4] srv <ip> offset 0.999926716 delay 0.029991036
```

ntpcstop:
```
nsh> ntpcstop
Stopping NTP client...
Stopped the NTP daemon
```
