### PR TITLE
testing/ostest: add nxevent_clear() test cases

### DIFF
--- a/testing/ostest/nxevent.c
+++ b/testing/ostest/nxevent.c
@@ -328,6 +328,34 @@ void nxevent_test(void)
   pthread_join(tid1, NULL);
   pthread_join(tid2, NULL);
 
+  /**************************************************************************/
+
+  /* 4. Event clear Test */
+
+  nxevent_post(&event, 0xff, NXEVENT_POST_SET);
+
+  /* Case 4.1: clear == 0, trywait == 0xf, wait == 0xf */
+
+  nxevent_clear(&event, 0);
+  NXEVENT_TEST(nxevent_wait(&event, 0xf, NXEVENT_WAIT_NOCLEAR), 0xf);
+  NXEVENT_TEST(nxevent_trywait(&event, 0xf, NXEVENT_WAIT_NOCLEAR), 0xf);
+
+  /* Case 4.2: clear == 0xf, trywait == 0xf */
+
+  nxevent_clear(&event, 0xf);
+  NXEVENT_TEST(nxevent_trywait(&event, 0xf, NXEVENT_WAIT_NOCLEAR), 0);
+
+  /* Case 4.3: clear == 0, trywait == 0xf0, wait == 0xf0 */
+
+  nxevent_clear(&event, 0);
+  NXEVENT_TEST(nxevent_wait(&event, 0xf0, NXEVENT_WAIT_NOCLEAR), 0xf0);
+  NXEVENT_TEST(nxevent_trywait(&event, 0xf0, NXEVENT_WAIT_NOCLEAR), 0xf0);
+
+  /* Case 4.4: clear == 0xf0, wait == 0xf0 */
+
+  nxevent_clear(&event, 0xf0);
+  NXEVENT_TEST(nxevent_trywait(&event, 0xf0, NXEVENT_WAIT_NOCLEAR), 0);
+
   nxevent_reset(&event, 0);
   nxevent_destroy(&event);
 }


### PR DESCRIPTION
    Add test cases to verify the new recently added nxevent_clear() api

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add test cases for the new recently added nxevent_clear() api

## Impact

Add new tests, no impact to any other parts

## Testing

**enable events in a2g-tc397-5v-tft**

<img width="653" height="479" alt="image" src="https://github.com/user-attachments/assets/246870a9-2467-47a4-9fd4-32c720d9bbc3" />

**ostest passed on a2g-tc397-5v-tft**

<img width="616" height="710" alt="image" src="https://github.com/user-attachments/assets/76a4745f-8838-4466-b655-f58953f8be9b" />

