### PR TITLE
sched/event: add nxevent_getmask tests

### DIFF
--- a/testing/ostest/nxevent.c
+++ b/testing/ostest/nxevent.c
@@ -356,6 +356,25 @@ void nxevent_test(void)
   nxevent_clear(&event, 0xf0);
   NXEVENT_TEST(nxevent_trywait(&event, 0xf0, NXEVENT_WAIT_NOCLEAR), 0);
 
+  /**************************************************************************/
+
+  /* 5. Event get mask Test */
+
+  /* Case 5.1: post == 0xff */
+
+  nxevent_post(&event, 0xff, NXEVENT_POST_SET);
+  NXEVENT_TEST(nxevent_getmask(&event), 0xff)
+
+  /* Case 5.2: clear == 0xf */
+
+  nxevent_clear(&event, 0xf);
+  NXEVENT_TEST(nxevent_getmask(&event), 0xf0)
+
+  /* Case 5.3: clear == 0xf0 */
+
+  nxevent_clear(&event, 0xf0);
+  NXEVENT_TEST(nxevent_getmask(&event), 0)
+
   nxevent_reset(&event, 0);
   nxevent_destroy(&event);
 }


### PR DESCRIPTION
 add test cases for the new nxevent_getmask() function

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add test cases for nxevent_getmask()

## Impact

New test cases added, no impact to other functions

## Testing

**ostest passed on a2g-tc397-5v-tft board**

<img width="656" height="830" alt="image" src="https://github.com/user-attachments/assets/6b96bd1f-5d61-494a-b473-842fdb002983" />

