### PR TITLE
system/dd: write status/error messages to stderr instead of stdout 

### DIFF
--- a/system/dd/dd_main.c
+++ b/system/dd/dd_main.c
@@ -309,6 +309,7 @@ int main(int argc, FAR char **argv)
   uint32_t sector = 0;
   int ret = ERROR;
   int i;
+  bool show_help = false;
 
   /* Initialize the dd structure */
 
@@ -379,11 +380,23 @@ int main(int argc, FAR char **argv)
               cur = next + 1;
             }
         }
+      else if (strcmp(argv[i], "--help") == 0)
+        {
+          show_help = true;
+        }
       else
         {
           print_usage(stderr);
           goto errout_with_paths;
         }
+    }
+
+  /* Help requested? Emit usage hints and exit. */
+
+  if (show_help)
+    {
+      print_usage(stdout);
+      return 0;
     }
 
   /* If verify enabled, infile and outfile are mandatory */


### PR DESCRIPTION
## Summary

Previously `dd` clobbered its output by writing status messages (e.g. transfer statistics) to stdout.

Thus, `echo foo | dd | md5` produced a different result than `echo foo | md5`.

Now all status messages are written to stderr.

In addition I added the `--help` argument. The code for emitting the usage hints was already there. But it was only accessible by supplying invalid parameters.

## Impact

No more unwanted output for stdout.

## Testing

I tested the result on an rp2040 board.

```
nsh> eecho foo | dd | md5; echo
sh [93:100]
sh [94:100]
4 bytes (1 blocks) copied, 0 usec, 4294967295 KB/s
d3b07384d113edec49eaa6238ad5ff00
nsh> eecho foo | md5; echo
sh [120:100]
d3b07384d113edec49eaa6238ad5ff00
```
