### PR TITLE
system/cdcacm: Support sercon and serdis in CONFIG_BUILD_KERNEL

### DIFF
--- a/system/cdcacm/CMakeLists.txt
+++ b/system/cdcacm/CMakeLists.txt
@@ -21,7 +21,6 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_CDCACM)
-  nuttx_add_application(NAME sercon SRCS cdcacm_main.c)
-
-  nuttx_add_application(NAME serdis)
+  nuttx_add_application(NAME sercon SRCS sercon_main.c)
+  nuttx_add_application(NAME serdis SRCS serdis_main.c)
 endif()

--- a/system/cdcacm/Makefile
+++ b/system/cdcacm/Makefile
@@ -24,7 +24,7 @@ include $(APPDIR)/Make.defs
 
 # USB CDC/ACM serial mass storage add-on
 
-MAINSRC = cdcacm_main.c
+MAINSRC = sercon_main.c serdis_main.c
 
 PROGNAME = sercon serdis
 PRIORITY = SCHED_PRIORITY_DEFAULT

--- a/system/cdcacm/cdcacm.h
+++ b/system/cdcacm/cdcacm.h
@@ -94,24 +94,6 @@
                                  TRACE_TRANSFER_BITS|TRACE_CONTROLLER_BITS|TRACE_INTERRUPT_BITS)
 
 /****************************************************************************
- * Public Types
- ****************************************************************************/
-
-/* All global variables used by this add-on are packed into a structure in
- * order to avoid name collisions.
- */
-
-struct cdcacm_state_s
-{
-  /* This is the handle that references to this particular USB CDC/ACM driver
-   * instance. The value of the driver handle must be remembered between the
-   * 'sercon' and 'msdis' commands.
-   */
-
-  FAR void *handle;
-};
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 

--- a/system/cdcacm/sercon_main.c
+++ b/system/cdcacm/sercon_main.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ * apps/system/cdcacm/sercon_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/boardctl.h>
+
+#include <stdio.h>
+#include <debug.h>
+
+#include <nuttx/usb/usbdev.h>
+#include <nuttx/usb/cdcacm.h>
+
+#include "cdcacm.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * sercon_main
+ *
+ * Description:
+ *   This is the main program that configures the CDC/ACM serial device.
+ *
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct boardioc_usbdev_ctrl_s ctrl;
+  int ret;
+
+  /* Then, in any event, enable trace data collection as configured BEFORE
+   * enabling the CDC/ACM device.
+   */
+
+  usbtrace_enable(TRACE_BITSET);
+
+  /* Initialize the USB CDC/ACM serial driver */
+
+  printf("sercon: Registering CDC/ACM serial driver\n");
+
+  ctrl.usbdev   = BOARDIOC_USBDEV_CDCACM;
+  ctrl.action   = BOARDIOC_USBDEV_CONNECT;
+  ctrl.instance = CONFIG_SYSTEM_CDCACM_DEVMINOR;
+  ctrl.handle   = NULL;
+
+  ret = boardctl(BOARDIOC_USBDEV_CONTROL, (uintptr_t)&ctrl);
+  if (ret < 0)
+    {
+      printf("sercon: ERROR: "
+             "Failed to create the CDC/ACM serial device: %d\n", -ret);
+      return EXIT_FAILURE;
+    }
+
+  printf("sercon: Successfully registered the CDC/ACM serial driver\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION

## Summary

- Put sercon and serdis in separate source files, so that the main functions can be compiled in also in kernel build.
- Don't store the ttyacm handle in the application, it is stored in kernel side in case of the system_cdcacm

## Impact

Only sercon and serdis, but requires https://github.com/apache/nuttx/pull/17010

## Testing

Tested on IMX9 platform, with CONFIG_BUILD_KERNEL
