### PR TITLE
nshlib/reset_cause: Fix format warning for flag

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -510,7 +510,7 @@ int cmd_reset_cause(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   if (cause.cause != BOARDIOC_RESETCAUSE_CPU_SOFT)
     {
-      nsh_output(vtbl, "%s(%lu)\n",
+      nsh_output(vtbl, "%s(%" PRIu32 ")\n",
              g_resetcause[cause.cause], cause.flag);
     }
   else

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -108,7 +108,7 @@ static FAR const char *const g_resetcause[] =
   "cpu_rtc_watchdog",
   "pin",
   "lowpower",
-  "unkown"
+  "unknown"
 };
 #endif
 
@@ -648,7 +648,7 @@ static int cmd_rpmsg_help(FAR struct nsh_vtbl_s *vtbl, int argc,
              "<period(ms)>\n\n", argv[0]);
   nsh_output(vtbl, "<times>      Number of ping operations.\n");
   nsh_output(vtbl, "<length>     The length of each ping packet.\n");
-  nsh_output(vtbl, "<cmd>        Whether the peer acknowlege or "
+  nsh_output(vtbl, "<cmd>        Whether the peer acknowledge or "
              "check data.\n");
   nsh_output(vtbl, "             Bit0 - Request need ack or not.\n");
   nsh_output(vtbl, "             Bit1 - Check the data or not.\n");


### PR DESCRIPTION
## Summary
Fix format string not appropriate warning for cause.flag.
```
nsh_syscmds.c: In function 'cmd_reset_cause':
nsh_syscmds.c:513:24: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'uint32_t' {aka 'unsigned int'} [-Werror=format=]
  513 |       nsh_output(vtbl, "%s(%lu)\n",
      |                        ^~~~~~~~~~~
  514 |              g_resetcause[cause.cause], cause.flag);
      |                                         ~~~~~~~~~~
      |                                              |
      |                                              uint32_t {aka unsigned int}
```
## Impact
- nshlib/reset_cause
## Testing
CI
