### PR TITLE
nshlib/nsh_parse: Fix "e" flag not take effect

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -2936,7 +2936,11 @@ int nsh_parse(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
           /* Parse this command */
 
           ret = nsh_parse_command(vtbl, start);
-          if (ret != OK)
+          if (ret != OK
+#ifndef CONFIG_NSH_DISABLESCRIPT
+              && !(vtbl->np.np_flags & NSH_PFLAG_IGNORE)
+#endif
+             )
             {
               /* nsh_parse_command may return (1) -1 (ERROR) meaning that the
                * command failed or we failed to start the command application


### PR DESCRIPTION
## Summary
The NSH exits when a command exits with a non-zero status, even if the "e" flag is not set. This error does not exist in NSH scripts.
- Comparison with Bash
```bash
$ bash -c "set -e; mkdir /tmp/test; echo $?"
mkdir: cannot create directory ‘/tmp/test’: File exists
$ bash -c "set +e; mkdir /tmp/test; echo $?"
mkdir: cannot create directory ‘/tmp/test’: File exists
1
$ rmdir /tmp/test
$ bash -c "set +e; mkdir /tmp/test; echo $?"
0

$ bash --version
GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
## Impact
nshlib/nsh_parse

## Testing

- Without this patch:
  ```bash
  nsh> sh -c "set -e; mkdir /test; echo $?"
  nsh: /test: mkdir failed: 17
  nsh> sh -c "set +e; mkdir /test; echo $?"
  nsh: /test: mkdir failed: 17
  nsh> rm /test
  nsh> sh -c "set +e; mkdir /test; echo $?"
  0
  ```
- With this patch:
  ```bash
  nsh> sh -c "set -e; mkdir /test; echo $?"
  nsh: /test: mkdir failed: 17
  nsh> sh -c "set +e; mkdir /test; echo $?"
  nsh: /test: mkdir failed: 17
  1
  nsh> rm /test
  nsh> sh -c "set +e; mkdir /test; echo $?"
  0
  ```