### PR TITLE
exclude cxx-oot-build test

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -20,5 +20,5 @@
 #
 # ##############################################################################
 
-nuttx_add_subdirectory()
+nuttx_add_subdirectory(EXCLUDE cxx-oot-build)
 nuttx_generate_kconfig(MENUDESC "Testing")

--- a/testing/cxx-oot-build/CMakeLists.txt
+++ b/testing/cxx-oot-build/CMakeLists.txt
@@ -22,37 +22,29 @@
 
 cmake_minimum_required(VERSION 3.12...3.31)
 
-# --- Guard option ---
-option(BUILD_OOTCPP "Build the Out Of Tree C++ project" OFF)
+project(
+  OOTCpp
+  VERSION 1.0
+  DESCRIPTION "Out Of Tree Build C++ NuttX")
 
-if(BUILD_OOTCPP)
-  project(
-    OOTCpp
-    VERSION 1.0
-    DESCRIPTION "Out Of Tree Build C++ NuttX")
+message(STATUS "Building OOTCpp project")
 
-  message(STATUS "Building OOTCpp project")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/src/HelloWorld.cpp
+                 ${CMAKE_SOURCE_DIR}/src/main.cpp)
 
-  set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/src/HelloWorld.cpp
-                   ${CMAKE_SOURCE_DIR}/src/main.cpp)
+set(EXE_NAME oot)
 
-  set(EXE_NAME oot)
+add_executable(${EXE_NAME} ${SOURCE_FILES})
 
-  add_executable(${EXE_NAME} ${SOURCE_FILES})
+target_include_directories(${EXE_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
-  target_include_directories(${EXE_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include)
-
-  # Generate a .bin file from the ELF after build
-  add_custom_command(
-    TARGET ${EXE_NAME}
-    POST_BUILD
-    COMMAND ${CMAKE_OBJCOPY} -S -O binary ${CMAKE_BINARY_DIR}/${EXE_NAME}
-            ${CMAKE_BINARY_DIR}/${EXE_NAME}.bin
-    COMMENT "Generating binary image ${EXE_NAME}.bin")
-
-else()
-  message(STATUS "Skipping OOTCpp project")
-endif()
+# Generate a .bin file from the ELF after build
+add_custom_command(
+  TARGET ${EXE_NAME}
+  POST_BUILD
+  COMMAND ${CMAKE_OBJCOPY} -S -O binary ${CMAKE_BINARY_DIR}/${EXE_NAME}
+          ${CMAKE_BINARY_DIR}/${EXE_NAME}.bin
+  COMMENT "Generating binary image ${EXE_NAME}.bin")


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR updates the NuttX apps CMake configuration to exclude the cxx-oot-build directory from the build process.

Previously, cxx-oot-build was guarded manually to avoid being included during builds. With the new EXCLUDE support added to nuttx_add_subdirectory() (see https://github.com/apache/nuttx/pull/17105) this PR replaces that guard logic with the cleaner exclusion rule.

This ensures that cxx-oot-build is consistently ignored during app builds, while simplifying the CMake configuration.

## Impact

- Build system: cxx-oot-build is now excluded using the standardized EXCLUDE mechanism. Removes custom guard logic, reducing complexity.

- Compatibility: No impact on users who do not use out-of-tree builds. Transparent to standard builds.

## Testing

1. Built apps with cxx-oot-build present.
2. Confirmed that the directory was excluded via the EXCLUDE mechanism.
3. Verified normal build behavior when no out-of-tree build folder is present.


