### PR TITLE
netutils/libshvc: update to correct reply head for non single element CID array

### DIFF
--- a/netutils/libshvc/Makefile
+++ b/netutils/libshvc/Makefile
@@ -25,7 +25,7 @@ include $(APPDIR)/Make.defs
 SHVDIR := shv-libs4c
 
 # Commit hash of the supported shv-libs4c revision
-SHV_LIBS4C_COMMIT_HASH := a8aa519a85e503a44b819fe3a4919dccc6fd559a
+SHV_LIBS4C_COMMIT_HASH := 149cf26b71c73b9d5f59b5b21d5b079b1a1150c1
 
 SHV_LIBS4C_TARGZ := shv-libs4c-$(SHV_LIBS4C_COMMIT_HASH).tar.gz
 


### PR DESCRIPTION
## Summary

The update enables interoperability with a Silicon-Heaven SHV3 protocol broker implemented in Rust language

  https://github.com/silicon-heaven/shvbroker-rs

New commits from shv-libs4c project

  https://github.com/silicon-heaven/shv-libs4c

- shv_pack_head_reply: correct reply head for non single element CID array

  When servicing request from the SHV3 protocol version broker itself then CID array is empty and missing TAG_CALLER_IDS for empty array breaks encoding scheme.

- shv_process: even in case of unsuccessful attempts to connect respect request to stop

  The request to stop initiate  by signal caused the high priority thread to enter busy-loop and block a system. Check for request to stop (running flag cleared) even in disconnected state after unsuccessful attempt.


## Impact

It has only impact to build with CONFIG_NETUTILS_LIBSHVC enabled and pulls newer version of the library
 
## Testing

The build tested with samv71-xult:netnsh where next options are added

```
+CONFIG_EXAMPLES_SHV_TEST=y
+CONFIG_NETUTILS_LIBSHVC=y
+CONFIG_NETUTILS_LIBULUT=y
+CONFIG_PIPES=y
```
The functionality tested on SaMoCon

https://gitlab.fel.cvut.cz/otrees/motion/samocon

The used host system is Debian/GNU/Linux.