### PR TITLE
examples/shv-nxboot-updater: use downgraded pyshv==0.8.0

### DIFF
--- a/examples/shv-nxboot-updater/update-script/requirements.txt
+++ b/examples/shv-nxboot-updater/update-script/requirements.txt
@@ -1,4 +1,4 @@
-pyshv>=0.10.0
+pyshv==0.8.0
 PyQt6
 argparse
 asyncio

--- a/examples/shv-nxboot-updater/update-script/shvconfirm.py
+++ b/examples/shv-nxboot-updater/update-script/shvconfirm.py
@@ -18,8 +18,7 @@
 #
 ############################################################################
 
-from shv.rpcapi.valueclient import SHVValueClient
-from shv.rpcurl import RpcUrl
+from shv import RpcUrl, SHVValueClient
 
 
 async def shv_confirm(connection: str, path_to_root: str) -> None:

--- a/examples/shv-nxboot-updater/update-script/shvflasher.py
+++ b/examples/shv-nxboot-updater/update-script/shvflasher.py
@@ -22,9 +22,7 @@ import asyncio
 import io
 import zlib
 
-from shv import SHVBytes
-from shv.rpcapi.valueclient import SHVValueClient
-from shv.rpcurl import RpcUrl
+from shv import RpcUrl, SHVBytes, SHVValueClient
 
 
 async def shv_flasher(


### PR DESCRIPTION
The problem probably arises from an incompatibility issue between the shv-libs4c and pyshv libraries. The fix is to downgrade the library for now and then revert back.

## Summary

I failed to test the whole framework properly when I got reviews for my GSoC 2025 Pull request. I was instructed to upgrade the library to the newer version, while all the testing was done before the changes.
Unfortunately, there's some incompatibility between the shv-libs4c and the python library and I'll have to investigate further. For the time being, use version 0.8.0.

## Impact

Makes it actually working :-)

## Testing

Tested on a custom PIC32CA board. I have successfully uploaded a correct NXBoot image to the target device over the SHV network.


