### PR TITLE
examples/fb: Fix error message formatting and accuracy

### DIFF
--- a/examples/fb/fb_main.c
+++ b/examples/fb/fb_main.c
@@ -211,7 +211,7 @@ static int fb_init_mem2(FAR struct fb_state_s *state)
 
   if (pinfo.bpp != state->pinfo.bpp)
     {
-      fprintf(stderr, "ERROR: fbmem2 is incorrect");
+      fprintf(stderr, "ERROR: fbmem2 is incorrect\n");
       return -EINVAL;
     }
 
@@ -622,7 +622,7 @@ int main(int argc, FAR char *argv[])
   if (state.fbmem == MAP_FAILED)
     {
       int errcode = errno;
-      fprintf(stderr, "ERROR: ioctl(FBIOGET_PLANEINFO) failed: %d\n",
+      fprintf(stderr, "ERROR: mmap() failed: %d\n",
               errcode);
       close(state.fd);
       return EXIT_FAILURE;


### PR DESCRIPTION
## Summary

  * **Why change is necessary**: This change fixes two error message issues in the framebuffer example that were causing confusion during debugging. The first issue was a missing newline character in an error message, which could cause output formatting problems. The second issue was an
incorrect error message that referenced the wrong system call, misleading developers about the actual failure point.

  * **What functional part of the code is being changed**: The changes affect the framebuffer example application (`examples/fb/fb_main.c`), specifically error reporting in two functions: `fb_init_mem2()` and `main()`.

  * **How does the change exactly work**:
    - In `fb_init_mem2()` at line 214: Added missing `\n` to the error message "ERROR: fbmem2 is incorrect" to ensure proper line termination
    - In `main()` at line 625: Changed the error message from "ERROR: ioctl(FBIOGET_PLANEINFO) failed: %d\n" to "ERROR: mmap() failed: %d\n" to accurately reflect the actual failing system call

  * **Related NuttX Issue**: No specific issue reference
  * **Related NuttX Apps Issue/PR**: No specific issue reference

## Impact

  * **Is new feature added? Is existing feature changed?**: NO - This is purely a bug fix for error message formatting and accuracy.

  * **Impact on user**: NO - Users will see clearer and more accurate error messages, but no functional behavior changes.

  * **Impact on build**: NO - No build system changes required.

  * **Impact on hardware**: NO - No hardware-specific changes.

  * **Impact on documentation**: NO - No documentation updates required as this is an internal error message fix.

  * **Impact on security**: NO - No security implications.

  * **Impact on compatibility**: NO - Fully backward compatible.

  * **Anything else to consider?**: These changes improve developer experience by providing accurate error information during framebuffer initialization debugging.

## Testing

  I confirm that changes are verified on stm32f746g-disco:fb
 




