### PR TITLE
examples/elf: Fix invalid preprocessor directive syntax

### DIFF
--- a/examples/elf/elf_main.c
+++ b/examples/elf/elf_main.c
@@ -313,7 +313,7 @@ int main(int argc, FAR char *argv[])
     }
 #endif
 #else
-#  Warning "No file system selected"
+#  warning "No file system selected"
 #endif
 
   mm_update(&g_mmstep, "after mount");


### PR DESCRIPTION
## Summary

• Why change is necessary: This change fixes a critical compilation error in the ELF example. The invalid preprocessor directive #  Warning would cause the build to fail when no file system is selected in the configuration, preventing users from building the
ELF example.
• What functional part of the code is being changed: The examples/elf/elf_main.c file, specifically the preprocessor directive section that handles the case when no file system is configured.
• How does the change exactly work: The change corrects the preprocessor directive syntax from #  Warning "No file system selected" to #  warning "No file system selected". The lowercase "warning" is the proper C preprocessor directive that generates a
compiler warning, while the uppercase "Warning" is invalid syntax that causes compilation errors.
• Related NuttX Issue reference: None specific - this is a bug fix discovered during code review.
• Related NuttX Apps Issue/Pull Request reference: None specific - this is a standalone fix.

## Impact

• Is new feature added? Is existing feature changed?: NO - This is purely a bug fix that restores the intended functionality without changing any features.
• Impact on user: NO - Users will not need to adapt to any changes. In fact, this fix improves user experience by allowing the ELF example to compile successfully when no file system is configured.
• Impact on build: NO - The build process remains the same, but this fix prevents build failures in specific configurations.
• Impact on hardware: NO - This change is purely in the application layer and does not affect any hardware, architecture, or driver code.
• Impact on documentation: NO - No documentation changes are required as this is a straightforward syntax correction.
• Impact on security: NO - This change has no security implications.
• Impact on compatibility: NO - This fix maintains backward compatibility and does not affect interoperability.
• Anything else to consider: This fix ensures that the ELF example can be built in configurations where no file system is selected, which is important for testing and minimal configurations.

## Testing

I confirm that changes are verified on local setup and works as intended:
Testing logs before change:

$ make examples/elf
CC:  examples/elf/elf_main.c
examples/elf/elf_main.c:316:3: error: invalid preprocessing directive #Warning
  316 | #  Warning "No file system selected"
      |   ^~~~~~~

Testing logs after change:

$ make examples/elf
CC:  examples/elf/elf_main.c
examples/elf/elf_main.c:316:3: warning: #warning "No file system selected"
  316 | #  warning "No file system selected"
      |   ^~~~~~~
