### PR TITLE
ci: Sync build.yml workflow with NuttX repository.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,51 @@ jobs:
           path: buildartifacts/
         continue-on-error: true
 
+  # Test the out-of-tree build
+  OOT-Build:
+    needs: Linux
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Download Source Artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: source-bundle
+          path: .
+
+      - name: Extract sources
+        run: tar zxf sources.tar.gz
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Export NuttX Repo SHA
+        run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
+
+      - name: Run Out-of-Tree Build Test
+        uses: ./sources/nuttx/.github/actions/ci-container
+        env:
+          BLOBDIR: /tools/blobs
+        with:
+          run: |
+            echo "::add-matcher::sources/nuttx/.github/gcc.json"
+            git config --global --add safe.directory /github/workspace/sources/nuttx
+            git config --global --add safe.directory /github/workspace/sources/apps
+            cd sources/nuttx
+            ./tools/ci/cibuild-oot.sh
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: oot-build-artifacts
+          path: sources/apps/testing/cxx-oot-build
+        continue-on-error: true
+
   # Select the macOS Builds based on PR Arch Label
   macOS-Arch:
     uses: apache/nuttx-apps/.github/workflows/arch.yml@master
@@ -295,7 +340,7 @@ jobs:
             zlib-devel
             cmake
             ninja
-            python-pip 
+            python-pip
             vim
 
       - name: pip3 install


### PR DESCRIPTION
## Summary

This PR synchronizes the build.yml workflow in nuttx-apps with the corresponding workflow in the NuttX repository.
The goal is to ensure both repositories use a consistent CI configuration, as recommended in https://lupyuen.org/articles/ci3#sync-to-nuttx-apps

By keeping both workflows aligned, we ensure better CI behavior, compatibility, and maintenance across NuttX and nuttx-apps.

## Impact

- CI: Ensures both NuttX and nuttx-apps use consistent build workflows.
- Developers: Provides predictable and uniform CI results across both repositories.

## Testing

- [ ] Confirmed that CI jobs run as expected and match behavior in the main NuttX repo.

