### PR TITLE
boot/mcuboot: update MCUBoot version

### DIFF
--- a/boot/mcuboot/CMakeLists.txt
+++ b/boot/mcuboot/CMakeLists.txt
@@ -45,6 +45,9 @@ if(CONFIG_BOOT_MCUBOOT)
 
   set(SRCS
       mcuboot/boot/bootutil/src/boot_record.c
+      mcuboot/boot/bootutil/src/bootutil_area.c
+      mcuboot/boot/bootutil/src/bootutil_img_hash.c
+      mcuboot/boot/bootutil/src/bootutil_loader.c
       mcuboot/boot/bootutil/src/bootutil_misc.c
       mcuboot/boot/bootutil/src/bootutil_public.c
       mcuboot/boot/bootutil/src/caps.c

--- a/boot/mcuboot/Kconfig
+++ b/boot/mcuboot/Kconfig
@@ -22,11 +22,11 @@ config MCUBOOT_REPOSITORY
 
 config MCUBOOT_VERSION
 	string "MCUboot version"
-	default "fefc398cc13ebbc527e297fe9df78cd98a359d75"
+	default "457be0cf3fb03e9e09938728dece8f03309db973"
 	---help---
 		Defines MCUboot version to be downloaded. Either release tag
 		or commit hash should be specified. Using newer MCUboot version
-		may cause compatability issues.
+		may cause compatibility issues.
 
 config MCUBOOT_ENABLE_LOGGING
 	bool "Enable MCUboot logging"

--- a/boot/mcuboot/Makefile
+++ b/boot/mcuboot/Makefile
@@ -44,6 +44,9 @@ endif
 CFLAGS += -Wno-undef -Wno-unused-but-set-variable
 
 CSRCS := $(MCUBOOT_UNPACK)/boot/bootutil/src/boot_record.c \
+         $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_area.c \
+         $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_img_hash.c \
+         $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_loader.c \
          $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_misc.c \
          $(MCUBOOT_UNPACK)/boot/bootutil/src/bootutil_public.c \
          $(MCUBOOT_UNPACK)/boot/bootutil/src/caps.c \


### PR DESCRIPTION
## Summary

- boot/mcuboot: update MCUBoot version
Updates default MCUBoot hash.

This PR updates the default hash for MCUBoot.

Here is a summary of changes (AI assisted).

## MCUboot Changes Summary (fefc398 → 8a07053)

### Overall Statistics
- **404 files changed**
- **19,536 insertions**, **6,494 deletions**

### NuttX-Specific Changes

#### File: `boot/nuttx/include/mcuboot_config/mcuboot_config.h`

**Added configuration definitions:**
- `MCUBOOT_DEV_WITH_ERASE` - Enables flash erase operations with device drivers
- `MCUBOOT_USE_TLV_ALLOW_LIST 1` - Enables non-protected TLV allow list validation

### Core Changes Affecting NuttX

#### New Bootutil APIs
- `boot_get_loader_state()` - Get bootloader state
- `boot_get_image_max_sizes()` - Get image maximum sizes array
- `boot_get_max_app_size()` - Get maximum application size
- `boot_fetch_slot_state_sizes()` - Fetch slot state sizes
- `boot_get_state_secondary_offset()` - Get secondary slot offset from state

#### New Structures
- `struct image_max_size` - Structure to store calculated max size information

#### Boot Serial Encryption
- Added `boot_serial_encryption.h` and `boot_serial_encryption.c`
- Enhanced encrypted image handling in serial recovery mode

#### Other Relevant Changes
- Boot hooks API updates
- Boot record improvements
- Security counter enhancements
- UUID VID/CID support added
- Crypto API improvements (SHA abstraction, ECDSA, RSA)

### Key Commits
- `ae2d0d61` - sys: Add MCUBOOT_USE_TLV_ALLOW_LIST to mcuboot_config.h
- `a13624f0` - bootutil: Add MCUBOOT_USE_TLV_ALLOW_LIST
- `f6e1af89` - doc: Add information on TLV allow list
- `94ad4d44` - boot: Add VID and CID checks
- `82bd4a76` - boot: bootutil: Fix pure image validation check with offset swap

### Impact on NuttX Integration

These changes introduce:
1. **Flash erase control** - `MCUBOOT_DEV_WITH_ERASE` provides better control over flash erase operations
2. **TLV validation** - `MCUBOOT_USE_TLV_ALLOW_LIST` enables allow list checking for non-protected TLV entries
3. **Enhanced APIs** - New bootutil functions for better state and size management
4. **Improved encryption support** - Better handling of encrypted images in serial recovery

## Impact

- Impact on user: No.
- Impact on build: No.
- Impact on hardware: No.
- Impact on documentation: No.
- Impact on security: No.
- Impact on compatibility: No.

## Testing
Tested with mcuboot_update_agent defconfig of ESP32.

### Building
Build the mcuboot_update_agent defconfig or use SD card to locally run an update.
Tested with and without flash encryption.

-  ./tools/configure.sh esp32-devkitc:mcuboot_update_agent
- Enable EXAMPLES_MCUBOOT_LOCAL_AGENT and add SD Card support (this also works the same on OTA).
- make and flash

After flashing, change target slot to slot 1 and build again. Then, I moved the new binary a SD Card and mounted to /mnt.
Used to SD Card update app.

### Results
```
nsh> mcuboot_local_agent /mnt/nuttx.bin
MCUBoot Local Update Agent
Firmware file: /mnt/nuttx.bin
Firmware file size: 1048576 bytes
Erasing secondary flash slot...
Progress: 4096/1048576 bytes [0%]
Progress: 8192/1048576 bytes [0%]
Progress: 12288/1048576 bytes [1%]
Progress: 16384/1048576 bytes [1%]
....
Firmware copy completed successfully!
Firmware successfully copied to secondary slot!
Update scheduled for next boot. Restarting...
reboot status=0
```

