### PR TITLE
Revert "ppp: Fix wrong lcp_state handling on peer reconnection"

### DIFF
--- a/netutils/pppd/lcp.c
+++ b/netutils/pppd/lcp.c
@@ -135,11 +135,7 @@ void lcp_rx(struct ppp_context_s *ctx, uint8_t * buffer, uint16_t count)
       /* In case of new peer connection */
 
       ipcp_init(ctx);
-      
-      /* Clear LCP state to keep it in negotiation phase. LCP_TX_UP will be re-set
-       * once a CONF_ACK is received. */
-      
-      ctx->lcp_state &= ~LCP_TX_UP;
+      ctx->lcp_state &= ~LCP_RX_UP;
 
       DEBUG1(("received [LCP Config Request id %u\n", id));
       if (scan_packet


### PR DESCRIPTION
Reverts apache/nuttx-apps#2571

This patch incorrectly mixed up the LCP state variables.

From:
https://www.eit.lth.se/ppplab/PPPdocs/PPPLCPoverview.htm

> The LCP negotiation is a series of LCP packets exchanged between PPP peers to negotiate a set of options and option values when sending data. The LCP negotiation is actually two separate dialogs between two PPP peers (Peer 1 and Peer 2):
> 
> 1. Peer 1 asks, negotiates, and then receives confirmation of the LCP options that are used when sending data to Peer 2. This dialog starts with Peer 1 sending a Configure-Request message and ends when Peer 2 sends a Configure-Ack message.
> 
> 2. Peer 2 asks, negotiates, and then receives confirmation of the LCP options that are used when sending data to peer 1. This dialog starts with Peer 2 sending a Configure-Request message and ends when Peer 1 sends a Configure-Ack message.

The Nuttx App is peer 1 in this description. We send a CONF_REQ (in lcp_task DEBUG1(("\nSending LCP request packet - "));) and set LCP_TX_UP when we receive a CONF_ACK indicating we are ok to send because peer 2 accepted our CONF_REQ.

We also (in parallel) receive a CONF_REQ from peer 2 and set LCP_RX_UP when we send a CONF_ACK indicating we are good to receive because we accepted the request from peer 2.


The PR I am reverting incorrectly clears LCP_TX_UP when receiving a CONF_REQ claiming: "Clear LCP state to keep it in negotiation phase. LCP_TX_UP will be re-set once a CONF_ACK is received." but this is not true. We are not expecting a CONF_ACK because we are the one to be sending the CONF_ACK in this half of the exchange. It was correct to be clearing LCP_RX_UP.

