### PR TITLE
nshlib/nsh_proccmds.c: fix description for TID and switch order

### DIFF
--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -100,7 +100,7 @@ struct nsh_taskstatus_s
   FAR const char *td_sigmask;      /* Signal mask */
 #endif
   FAR char       *td_cmdline;      /* Command line */
-  int             td_pid;          /* Task ID */
+  int             td_tid;          /* Task ID */
   int             td_ppid;         /* Parent task ID */
 #ifdef NSH_HAVE_CPULOAD
   FAR const char *td_cpuload;      /* CPU load */
@@ -379,7 +379,7 @@ static int ps_record(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
   status->td_sigmask = "";
 #endif
   status->td_cmdline = "";
-  status->td_pid = atoi(entryp->d_name);
+  status->td_tid = atoi(entryp->d_name);
   status->td_ppid = INVALID_PROCESS_ID;
 #ifdef NSH_HAVE_CPULOAD
   status->td_cpuload = "";
@@ -633,7 +633,7 @@ static void ps_title(FAR struct nsh_vtbl_s *vtbl, bool heap)
               "%6s "
 #endif
               "%s\n"
-              , "PID", "PPID", "GROUP"
+              , "TID", "PID", "PPID"
 #ifdef CONFIG_SMP
               , "CPU"
 #endif
@@ -679,7 +679,7 @@ static void ps_output(FAR struct nsh_vtbl_s *vtbl, bool heap,
 #endif
 
   nsh_output(vtbl,
-             "%5d %5d %5s "
+             "%5d %5s %5d "
 #ifdef CONFIG_SMP
              "%3s "
 #endif
@@ -700,7 +700,7 @@ static void ps_output(FAR struct nsh_vtbl_s *vtbl, bool heap,
              "%5s "
 #endif
              "%s\n"
-           , status->td_pid, status->td_ppid, status->td_groupid
+           , status->td_tid, status->td_groupid, status->td_ppid
 #ifdef CONFIG_SMP
            , status->td_cpu
 #endif


### PR DESCRIPTION
## Summary

ID previously marked as PID was in fact TID. PID was hidden under GROUP column. This fixes the description. The order of TID, PPID, PID is also changed to more logical TID, PID, PPID.

## Impact

None except for someone parsing terminal output of `ps` command.

## Testing
Before

```
an2c> ps
  PID  PPID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0001008 Idle_Task
    1     0     0 224 RR       Kthread   - Waiting  Semaphore 0000000000000000 0004032 hpwork 0x20400b98 0x20400be8
    2     0     2 100 RR       Task      - Running            0000000000000000 0004056 startup_main
    3     2     3 100 RR       Task      - Waiting  Signal    0000000000000000 0004056 watchdog
    4     2     4 100 RR       Task      - Waiting  Semaphore 0000000000000000 0004064 broker
    5     2     5 100 RR       Task      - Waiting  Signal    0000000000000000 0008192 ui
    6     2     4 100 RR       pthread   - Waiting  Signal    fffffffffff7fdff 0004080 broker 0x499f61 0x20411090
    7     2     5 100 RR       pthread   - Waiting  Semaphore 0000000000000000 0004080 ui 0x4930c9 0x20429768
```

After
```
an2c> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0001008 Idle_Task
    1     0     0 224 RR       Kthread   - Waiting  Semaphore 0000000000000000 0004032 hpwork 0x20400b98 0x20400be8
    2     2     0 100 RR       Task      - Running            0000000000000000 0004056 startup_main
    3     3     2 100 RR       Task      - Waiting  Signal    0000000000000000 0004056 watchdog
    4     4     2 100 RR       Task      - Waiting  Semaphore 0000000000000000 0004064 broker
    5     5     2 100 RR       Task      - Waiting  Signal    0000000000000000 0008192 ui
    6     4     2 100 RR       pthread   - Waiting  Signal    fffffffffff7fdff 0004080 broker 0x499f61 0x20411090
    7     5     2 100 RR       pthread   - Waiting  Semaphore 0000000000000000 0004080 ui 0x4930c9 0x20429768
```


