### PR TITLE
testing/ostest: align wdog ostest with wdog bugfix

### DIFF
--- a/testing/ostest/wdog.c
+++ b/testing/ostest/wdog.c
@@ -299,6 +299,7 @@ static void wdog_test_run(FAR wdtest_param_t *param)
   /* Maximum */
 
   delay = CLOCK_MAX >> 2;
+  delay -= 1;
   wdtest_assert(wd_start(&test_wdog, delay,
                          wdtest_callback, (wdparm_t)param) == OK);
 


### PR DESCRIPTION
## Summary

https://github.com/apache/nuttx/pull/17293 fixed
wd_start bug, and this patch fixed the related ostest
accordingly

Enables: https://github.com/apache/nuttx/pull/17293.

## Impact

https://github.com/apache/nuttx/pull/17293 can only be merged after this PR

## Testing

**ostest passed on board fvp-armv8r-aarch32**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 c90b48921b-dirty Nov  9 2025 19:11:40 arm fvp-armv8r-aarch32
nsh> ostest

(...)

user_main: vfork() test
[87] ostest: arm_fork: fork context [0x2000f6e0]:
[87] ostest: arm_fork:   r4:20003870 r5:00000000 r6:00000000 r7:00000000
[87] ostest: arm_fork:   r8:00000000 r9:00000000 r10:00000000
[87] ostest: arm_fork:   r11:00000000 sp:2000f708 lr:00055c8c
[87] ostest: nxtask_setup_fork: Child priority=100 start=0x55c8c
[87] ostest: nxtask_setup_fork: parent=0x2000d340, returning child=0x2000fa28
[87] ostest: arm_fork: TCBs: Parent=0x2000d340 Child=0x2000fa28
[87] ostest: arm_fork: Parent: stackutil:152
[87] ostest: arm_fork: Old stack top:2000f7a0 SP:2000f708 FP:00000000
[87] ostest: arm_fork: New stack top:20013880 SP:200137e8 FP:00000000
[87] ostest: nxtask_start_fork: Starting Child TCB=0x2000fa28
[87] ostest: nxtask_activate: ostest pid=168,TCB=0x2000fa28
[168] ostest: nxtask_exit: ostest pid=168,TCB=0x2000fa28
vfork_test: Child 168 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7ff9d2c  7ff9d2c
ordblks         2        6
mxordblk  7fee780  7fec778
uordblks     9504     b52c
fordblks  7ff0828  7fee800
user_main: Exiting
[87] ostest: nxtask_exit: ostest pid=87,TCB=0x2000d340
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
[86] ostest: nxtask_exit: ostest pid=86,TCB=0x2000af20
nsh> 
```
