### PR TITLE
testing/cmoka: fix cmake build

### DIFF
--- a/testing/cmocka/CMakeLists.txt
+++ b/testing/cmocka/CMakeLists.txt
@@ -33,17 +33,17 @@ if(CONFIG_TESTING_CMOCKA)
           ${CMAKE_CURRENT_LIST_DIR}/cmocka BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/testing/cmocka/cmocka
       PATCH_COMMAND
-        patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
+        patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
         ${CMAKE_CURRENT_LIST_DIR}/0001-cmocka.c-Reduce-the-call-stack-consumption-of-printf.patch
-        && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
         ${CMAKE_CURRENT_LIST_DIR}/0002-cmocka-feature-to-forwarding-cmocka-log-message-to-c.patch
-        && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
         ${CMAKE_CURRENT_LIST_DIR}/0003-cmocka-update-method-for-strmatch-to-regex-and-add-list-all-testcases-function.patch
-        && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
-        ${CMAKE_CURRENT_LIST_DIR}/0004-cmocka-xml-report.patch && patch -p0 -d
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
+        ${CMAKE_CURRENT_LIST_DIR}/0004-cmocka-xml-report.patch && patch -p1 -d
         ${CMAKE_CURRENT_LIST_DIR}/cmocka <
         ${CMAKE_CURRENT_LIST_DIR}/0005-cmocka-cmocka_private-fix-warning-in-cmocka_private.patch
-        && patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
         ${CMAKE_CURRENT_LIST_DIR}/0006-fix-linux-risc-v-compile-error-list_initialize.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)


### PR DESCRIPTION
## Summary

fix cmake build for cmoka:
```
   [2/9] No update step for 'cmocka_fetch-populate'
   [3/9] Performing patch step for 'cmocka_fetch-populate'
   can't find file to patch at input line 16
   Perhaps you used the wrong -p or --strip option?
``` 
## Impact

fix build

## Testing
cmoka builds correctly with cmake:

```
[2/9] No update step for 'cmocka_fetch-populate'
[3/9] Performing patch step for 'cmocka_fetch-populate'
patching file src/cmocka.c
patching file src/cmocka.c
patching file src/cmocka.c
patching file include/cmocka.h
patching file src/cmocka.c
patching file include/cmocka_private.h
patching file src/cmocka.c

```


