### PR TITLE
sched/signal: Add support for disabling signals

### DIFF
--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1176,16 +1176,16 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
   int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_KILL
+#if !defined(CONFIG_NSH_DISABLE_KILL) && !defined(CONFIG_DISABLE_SIGNALS)
   int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
   int cmd_pkill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
-#ifndef CONFIG_NSH_DISABLE_SLEEP
+#if !defined(CONFIG_NSH_DISABLE_SLEEP) && !defined(CONFIG_DISABLE_SIGNALS)
   int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
-#ifndef CONFIG_NSH_DISABLE_USLEEP
+#if !defined(CONFIG_NSH_DISABLE_USLEEP) && !defined(CONFIG_DISABLE_SIGNALS)
   int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
@@ -1224,7 +1224,7 @@ int cmd_alias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 int cmd_unalias(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_WATCH
+#if !defined(CONFIG_NSH_DISABLE_WATCH) && !defined(CONFIG_DISABLE_SIGNALS)
 int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -300,11 +300,11 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("irqinfo",  cmd_irqinfo,  1, 1, NULL),
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_KILL
+#if !defined(CONFIG_NSH_DISABLE_KILL) && !defined(CONFIG_DISABLE_SIGNALS)
   CMD_MAP("kill",     cmd_kill,     2, 3, "[-<signal>] <pid>"),
 #endif
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL) && !defined(CONFIG_DISABLE_SIGNALS)
   CMD_MAP("pkill",     cmd_pkill,     2, 3, "[-<signal>] <name>"),
 #endif
 
@@ -571,7 +571,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_SLEEP
+#if !defined(CONFIG_NSH_DISABLE_SLEEP) && !defined(CONFIG_DISABLE_SIGNALS)
   CMD_MAP("sleep",    cmd_sleep,    2, 2, "<sec>"),
 #endif
 
@@ -652,12 +652,11 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("userdel",  cmd_userdel,  2, 2, "<username>"),
 #  endif
 #endif
-
-#ifndef CONFIG_NSH_DISABLE_USLEEP
+#if !defined(CONFIG_NSH_DISABLE_USLEEP) && !defined(CONFIG_DISABLE_SIGNALS)
   CMD_MAP("usleep",   cmd_usleep,   2, 2, "<usec>"),
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_WATCH
+#if !defined(CONFIG_NSH_DISABLE_WATCH) && !defined(CONFIG_DISABLE_SIGNALS)
   CMD_MAP("watch",     cmd_watch,
           2, 6, "[-n] interval [-c] count <command>"),
 #endif

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -993,7 +993,7 @@ int cmd_pidof(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
  * Name: cmd_kill
  ****************************************************************************/
 
-#ifndef CONFIG_NSH_DISABLE_KILL
+#if !defined(CONFIG_NSH_DISABLE_KILL) && !defined(CONFIG_DISABLE_SIGNALS)
 int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *ptr;
@@ -1096,7 +1096,9 @@ invalid_arg:
  * Name: cmd_pkill
  ****************************************************************************/
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
+#if defined(CONFIG_FS_PROCFS) && \
+    !defined(CONFIG_NSH_DISABLE_PKILL) && \
+    !defined(CONFIG_DISABLE_SIGNALS)
 int cmd_pkill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *name;
@@ -1197,7 +1199,7 @@ invalid_arg:
  * Name: cmd_sleep
  ****************************************************************************/
 
-#ifndef CONFIG_NSH_DISABLE_SLEEP
+#if !defined(CONFIG_NSH_DISABLE_SLEEP) && !defined(CONFIG_DISABLE_SIGNALS)
 int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
@@ -1221,7 +1223,7 @@ int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
  * Name: cmd_usleep
  ****************************************************************************/
 
-#ifndef CONFIG_NSH_DISABLE_USLEEP
+#if !defined(CONFIG_NSH_DISABLE_USLEEP) && !defined(CONFIG_DISABLE_SIGNALS)
 int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -550,7 +550,7 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 }
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_WATCH
+#if !defined(CONFIG_NSH_DISABLE_WATCH) && !defined(CONFIG_DISABLE_SIGNALS)
 int cmd_watch(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   int interval = 2;


### PR DESCRIPTION
## Summary

Fix build errors that occur when signals are disabled by excluding `cmd_kill, cmd_sleep, cmd_usleep, and cmd_watch `along with signal support.

## Impact

Disabling signals will depend on this PR.

## Testing

Tested the signal-disable option on the fvp-armv8r-aarch32 board with ostest disabled, based on the changes in https://github.com/apache/nuttx/pull/17352

```
NuttShell (NSH)
nsh> [ 0] Idle_Task: nx_start: CPU0: Beginning Idle Loop
nsh> 
nsh> uname -a
NuttX 0.0.0 cce68d3ead-dirty Nov 20 2025 14:43:39 arm fvp-armv8r-aarch32
nsh> 
nsh> 
nsh> help
help usage:  help [-v] [<cmd>]

    .           cd          exec        ls          pwd         truncate    
    [           cp          exit        mkdir       rm          uname       
    ?           cmp         expr        mkrd        rmdir       umount      
    alias       dirname     false       mount       set         unset       
    unalias     df          fdinfo      mv          source      uptime      
    basename    dmesg       free        pidof       test        xd          
    break       echo        help        printf      time        
    cat         env         hexdump     ps          true        

Builtin Apps:
    dd       nsh      sh       hello    
nsh> 
nsh> 
nsh> hello
[ 2] nsh_main: task_spawn: name=hello entry=0x2f554 file_actions=0x20009a88 attr=0x20009a8c argv=0x20009b48
[ 2] nsh_main: spawn_execattrs: Setting policy=2 priority=100 for pid=3
[ 2] nsh_main: nxtask_activate: hello pid=3,TCB=0x2000a0a0
Hello, World!!
[ 3] hello: nxtask_exit: hello pid=3,TCB=0x2000a0a0
nsh> 
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0 FIFO     Kthread   - Ready                       0008176 0000888  10.8%  Idle_Task
    1     0     0 192 RR       Kthread   - Waiting  Semaphore          0008128 0000432   5.3%  hpwork 0x200002e0 0x20000330
    2     2     0 100 RR       Task      - Running                     0008152 0001840  22.5%  nsh_main
nsh> 
```


