### PR TITLE
examples/elf: fix cmake build error

### DIFF
--- a/examples/elf/CMakeLists.txt
+++ b/examples/elf/CMakeLists.txt
@@ -21,8 +21,7 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_ELF)
-  nuttx_add_application(NAME elf INCLUDES ${CMAKE_CURRENT_SOURCE_DIR} SRCS
-                        elf_main.c)
+  nuttx_add_application(NAME elf SRCS elf_main.c)
 
   # TODO: tests
 


### PR DESCRIPTION
## Summary

fix the cmake build error on examples/elf project

the following are the detailed build error:
```
CMake Error at cmake/nuttx_parse_function_args.cmake:76 (message):
  : unparsed INCLUDES;/home/neo/projects/nuttx/apps/examples/elf
Call Stack (most recent call first):
  cmake/nuttx_add_application.cmake:77 (nuttx_parse_function_args)
  /home/neo/projects/nuttx/apps/examples/elf/CMakeLists.txt:24 (nuttx_add_application)
```

## Impact

has no impact on the other project

## Testing

has passed the ostest


