### PR TITLE
cmake/process-spawn: remove if not required align with Makefile

### DIFF
--- a/system/libuv/CMakeLists.txt
+++ b/system/libuv/CMakeLists.txt
@@ -106,9 +106,12 @@ if(CONFIG_LIBUV)
     ${LIBUV_UNIX_DIR}/fs.c
     ${LIBUV_SRC_DIR}/fs-poll.c
     ${LIBUV_SRC_DIR}/timer.c
-    ${LIBUV_UNIX_DIR}/process-spawn.c
     ${LIBUV_UNIX_DIR}/sysinfo-loadavg.c
     ${LIBUV_UNIX_DIR}/sysinfo-memory.c)
+
+  if(CONFIG_LIBC_EXECFUNCS)
+    list(APPEND SRCS ${LIBUV_UNIX_DIR}/process-spawn.c)
+  endif()
 
   if(CONFIG_LIBC_DLFCN)
     list(APPEND SRCS ${LIBUV_UNIX_DIR}/dl.c)


### PR DESCRIPTION
## Summary
We already fixed the process-spawn.c in Makefile, should align to cmake

## Impact
Before fix, the CMake is not aligned with Makefile, will include not required process-spawn.c.
After fix, the CMake should exactly same with Makefile apps/system/libuv/Makefile.

## Testing
CI-test

