### PR TITLE
testing/pm_smp: add more delay, avoid idle canot run one cycle

### DIFF
--- a/testing/drivers/drivertest/drivertest_pm_smp.c
+++ b/testing/drivers/drivertest/drivertest_pm_smp.c
@@ -46,9 +46,9 @@
 
 #define TEST_PM_LOOP_COUNT   5
 
-#define TEST_STAYTIMEOUT     2   /* in ms */
+#define TEST_STAYTIMEOUT     20   /* in ms */
 
-#define TEST_SNAP_TICK_MAX   3
+#define TEST_SNAP_TICK_MAX   5
 
 #define TEST_TIMEOUT_ENABLED 1
 


### PR DESCRIPTION
## Summary
In current design, we need enter idle thread to allow the power manger process, and if the host performance is too slow, for example qemu run inside docker, etc.
Increase the delay interval to increase compatible

## Impact
The case run time will a little bit increased.

## Testing
CI-test, arm64-v8a pm case

