### PR TITLE
workflows/build.yml: macOS Workflow updated to macos-15-intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,7 +248,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: macOS-Arch
     if: ${{ needs.macOS-Arch.outputs.skip_all_builds != '1' }}
     strategy:


### PR DESCRIPTION
## Summary

The macOS 13 runner image will be retired by December 4th, 2025. To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:

November 4, 14:00 UTC to November 5, 00:00 UTC
November 11, 14:00 UTC to November 12, 00:00 UTC
November 18, 14:00 UTC to November 19, 00:00 UTC
November 25, 14:00 UTC to November 26, 00:00 UTC

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

see https://github.com/apache/nuttx/pull/17390

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub

https://github.com/simbit18/nuttx-testing-ci/actions/runs/19737638856/job/56553486020#logs

