### PR TITLE
import/Make.defs: use _start entry name

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -97,7 +97,7 @@ endif
 ifeq ($(CONFIG_BINFMT_ELF_RELOCATABLE),y)
   LDELFFLAGS += -r
 endif
-LDELFFLAGS += -e __start -Bstatic
+LDELFFLAGS += -e _start -Bstatic
 
 # Remove other ld scripts, just use import ld scripts
 #


### PR DESCRIPTION
## Summary

This reverts crt0 entry name to _start to fix issue#17443 together with [nuttx#17450](https://github.com/apache/nuttx/pull/17450).

## Impact

Bugfix that should not change existing things.

## Testing

See https://github.com/apache/nuttx/pull/17450.

