### PR TITLE
add -f for umount

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -621,7 +621,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT)
 #  ifndef CONFIG_NSH_DISABLE_UMOUNT
-  CMD_MAP("umount",   cmd_umount,   2, 2, "<dir-path>"),
+  CMD_MAP("umount",   cmd_umount,   2, 3, "[-f] <dir-path>"),
 #  endif
 #endif
 

--- a/nshlib/nsh_mntcmds.c
+++ b/nshlib/nsh_mntcmds.c
@@ -363,16 +363,37 @@ int cmd_nfsmount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && !defined(CONFIG_NSH_DISABLE_UMOUNT)
 int cmd_umount(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
-  UNUSED(argc);
-
-  FAR char *fullpath = nsh_getfullpath(vtbl, argv[1]);
+  unsigned int flags = 0;
+  FAR char *fullpath;
   int ret = ERROR;
+  int option;
 
+  while ((option = getopt(argc, argv, "f")) != ERROR)
+    {
+      switch (option)
+        {
+          case 'f':
+            flags |= MNT_FORCE;
+            break;
+
+          default:
+            nsh_error(vtbl, g_fmtarginvalid, argv[0]);
+            return ERROR;
+        }
+    }
+
+  if (optind >= argc)
+    {
+      nsh_error(vtbl, g_fmtargrequired, argv[0]);
+      return ret;
+    }
+
+  fullpath = nsh_getfullpath(vtbl, argv[optind]);
   if (fullpath)
     {
       /* Perform the umount */
 
-      ret = umount(fullpath);
+      ret = umount2(fullpath, flags);
       if (ret < 0)
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], "umount", NSH_ERRNO);


### PR DESCRIPTION
## Summary

This Pull Request adds support for the -f (force) option to the NSH
umount command, allowing users to perform forced unmount
operations when necessary.

## Impact

Users can now force an unmount.


