### PR TITLE
Spitool enhancement

### DIFF
--- a/system/spi/Kconfig
+++ b/system/spi/Kconfig
@@ -78,4 +78,11 @@ config SPITOOL_DEFWORDS
 	---help---
 		Number of words to be transferred (default 1)
 
+config SPITOOL_DEFTRANS
+	int "Number of transfer"
+	default 1
+	range 1 255
+	---help---
+		Number of transfer to be transferred (default 1)
+
 endif # SYSTEM_SPITOOL

--- a/system/spi/spi_common.c
+++ b/system/spi/spi_common.c
@@ -174,12 +174,12 @@ int spitool_common_args(FAR struct spitool_s *spitool, FAR char **arg)
 
       case 'r':
         ret = arg_decimal(arg, &value);
-        if (value < 0)
+        if (value < 0 || value > UINT8_MAX)
           {
             goto out_of_range;
           }
 
-        spitool->count = (uint32_t)value;
+        spitool->trans_count = (uint8_t)value;
         return ret;
 
       case 'u':

--- a/system/spi/spi_main.c
+++ b/system/spi/spi_main.c
@@ -152,6 +152,10 @@ static int spicmd_help(FAR struct spitool_s *spitool, int argc,
                           "Default: %d Current: %" PRIu32 " Max: %d\n",
                  CONFIG_SPITOOL_DEFWORDS, spitool->count, MAX_XDATA);
 
+  spitool_printf(spitool, "  [-r trans_count] Trans to exchange  "
+                          "Default: %d Current: %d Max: %d\n",
+                 CONFIG_SPITOOL_DEFTRANS, spitool->trans_count, UINT8_MAX);
+
   spitool_printf(spitool, "\nNOTES:\n");
 #ifndef CONFIG_DISABLE_ENVIRON
   spitool_printf(spitool, "o An environment variable like $PATH may be used "
@@ -159,7 +163,7 @@ static int spicmd_help(FAR struct spitool_s *spitool, int argc,
 #endif
   spitool_printf(spitool, "o Arguments are \"sticky\".  "
                           "For example, once the SPI address is\n");
-  spitool_printf(spitool, "  specified, that address will be re-used "
+  spitool_printf(spitool, "  specified, that address will be reused "
                           "until it is changed.\n");
   spitool_printf(spitool, "\nWARNING:\n");
   spitool_printf(spitool, "o The SPI commands may have bad side effects "
@@ -398,6 +402,11 @@ int main(int argc, FAR char *argv[])
   if (g_spitool.devtype == 0)
     {
       g_spitool.devtype = SPIDEVTYPE_USER;
+    }
+
+  if (g_spitool.trans_count == 0)
+    {
+      g_spitool.trans_count = CONFIG_SPITOOL_DEFTRANS;
     }
 
   /* Parse and process the command line */

--- a/system/spi/spitool.h
+++ b/system/spi/spitool.h
@@ -140,6 +140,7 @@ struct spitool_s
   bool command;        /* [-c 0|1] Send as command or data?        */
   useconds_t udelay;   /* [-u udelay] Delay in uS after transfer   */
   uint8_t mode;        /* [-m mode] Mode to use for transfer       */
+  uint8_t trans_count; /* [-r trans count] No of trans to exchange */
 
   /* Output streams */
 


### PR DESCRIPTION
## Summary

Adjust the number of parameters in spitool. 
Add the ability to transfer multiple transactions in one spitool seqs.

## Impact

spitool can be used to transfer multiple trans at once.

## Testing

target: tricore device
-w 32 indicates the data transmission width is 32 bits.
-r 2  indicates there are 2 transactions.
-x 1 indicates exchange 1  32bit in each transaction.

```
$ spi exch -b 1 -t 0 -n 0 -f 3000000 -m 1 -w 32 -x 1 -r 2 f001fff1 0000ff35
Sending:        F1FF01F0 35FF0000
Received:       2850C038 38500201
```


