### PR TITLE
apps/system/composite: change cmake build name to conn and disconn

### DIFF
--- a/system/composite/CMakeLists.txt
+++ b/system/composite/CMakeLists.txt
@@ -21,5 +21,6 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_COMPOSITE)
-  nuttx_add_application(NAME composite SRCS composite_main.c)
+  nuttx_add_application(NAME conn SRCS composite_main.c)
+  nuttx_add_application(NAME disconn)
 endif()


### PR DESCRIPTION
## Summary

* The executable file compiled by cmake was named `composite`, while the file compiled by make are named `conn` and `disconn`.
* The executable file compiled by cmake now has the same filename as that compiled by make.

## Impact

Uniform compiled application names between cmake and make.

## Testing

target: sim vela

```
Enabling CDCACM as an example when cmake

before fix:
$ composite 1

after fix:
$ conn 1
```

