### PR TITLE
add a reference count to the TCB to prevent it from being deleted.

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -1,2 +1,6 @@
       mynewt-nimble/nimble/host/services/ans/src/ble_svc_ans.c
       mynewt-nimble/nimble/host/services/ans/include
+#include "crypto/controlse/ccertificate.hxx"
+              object = new Controlse::CCertificate(
+          Controlse::CCertificate cert(se, settings->key_id);
+      auto certificate = Controlse::CCertificate(

--- a/crypto/controlse/controlse_main.cxx
+++ b/crypto/controlse/controlse_main.cxx
@@ -701,8 +701,12 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_STACK_COLORATION
       FAR struct tcb_s *tcb;
       tcb = nxsched_get_tcb(getpid());
-      fprintf(stderr, "\nStack used: %zu / %zu\n", up_check_tcbstack(tcb),
-              tcb->adj_stack_size);
+      if (tcb != NULL)
+        {
+          fprintf(stderr, "\nStack used: %zu / %zu\n", up_check_tcbstack(tcb),
+                  tcb->adj_stack_size);
+          nxsched_put_tcb(tcb);
+        }
 #else
       fprintf(stderr, "\nStack used: unknown"
                       " (STACK_COLORATION must be enabled)\n");


### PR DESCRIPTION
## Summary
add a reference count to the TCB to prevent it from being deleted.

To replace the large lock with smaller ones and reduce the large locks related to the TCB, in many scenarios, we only need to ensure that the TCB won't be released instead of locking, thus reducing the possibility of lock recursion.

should merge with https://github.com/apache/nuttx/pull/17468
## Impact

tcb release

## Testing


esp32s3-devkit:nsh

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8bc 5d8bc
ordblks 7 6
mxordblk 548a0 548a0
uordblks 5014 5014
fordblks 588a8 588a8

Final memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8bc 5d8bc
ordblks 1 6
mxordblk 59238 548a0
uordblks 4684 5014
fordblks 59238 588a8
user_main: Exiting
ostest_main: Exiting with status 0
nsh> u
nsh: u: command not found
nsh>
nsh>
nsh>
nsh> uname -a
NuttX 12.11.0 ef91333e3ac-dirty Dec 10 2025 16:11:04 xtensa esp32s3-devkit
nsh>



