### PR TITLE
apps/testing: Add pthread_mutex_perf created by Anchao

### DIFF
--- a/testing/sched/pthread_mutex_perf/CMakeLists.txt
+++ b/testing/sched/pthread_mutex_perf/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ##############################################################################
+# apps/testing/sched/pthread_mutex_perf/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_TESTING_PTHREAD_MUTEX_PERF)
+
+  set(SRCS pthread_mutex_perf.c)
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_TESTING_PTHREAD_MUTEX_PERF_PROGNMAE}
+    PRIORITY
+    ${CONFIG_TESTING_PTHREAD_MUTEX_PERF_PRIORITY}
+    STACKSIZE
+    ${CONFIG_TESTING_PTHREAD_MUTEX_PERF_STACKSIZE}
+    MODULE
+    ${CONFIG_TESTING_PTHREAD_MUTEX_PERF}
+    COMPILE_FLAGS
+    ${FLAGS}
+    SRCS
+    ${SRCS})
+
+endif()

--- a/testing/sched/pthread_mutex_perf/Kconfig
+++ b/testing/sched/pthread_mutex_perf/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config TESTING_PTHREAD_MUTEX_PERF
+	bool "Pthread Mutex Performance (pmutexp) testing"
+	default n
+	---help---
+		Pthread Mutex Performance (pmp) helps to analyze the pthread
+                mutex performance, by calling the function many times.
+
+if TESTING_PTHREAD_MUTEX_PERF
+
+config TESTING_PTHREAD_MUTEX_PERF_PROGNAME
+	string "Program name"
+	default "pmutexp"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config TESTING_PTHREAD_MUTEX_PERF_PRIORITY
+	int "Priority of pmutexp process"
+	default 100
+
+config TESTING_PTHREAD_MUTEX_PERF_STACKSIZE
+	int "Stack size of pmutexp process"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/testing/sched/pthread_mutex_perf/Make.defs
+++ b/testing/sched/pthread_mutex_perf/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/testing/sched/pthread_mutex_perf/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_TESTING_PTHREAD_MUTEX_PERF),)
+CONFIGURED_APPS += $(APPDIR)/testing/sched/pthread_mutex_perf
+endif

--- a/testing/sched/pthread_mutex_perf/Makefile
+++ b/testing/sched/pthread_mutex_perf/Makefile
@@ -1,0 +1,32 @@
+############################################################################
+# apps/testing/sched/pthread_mutex_perf/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_TESTING_PTHREAD_MUTEX_PERF_PROGNAME)
+PRIORITY  = $(CONFIG_TESTING_PTHREAD_MUTEX_PERF_PRIORITY)
+STACKSIZE = $(CONFIG_TESTING_PTHREAD_MUTEX_PERF_STACKSIZE)
+MODULE    = $(CONFIG_TESTING_PTHREAD_MUTEX_PERF)
+
+MAINSRC = pthread_mutex_perf.c
+
+include $(APPDIR)/Application.mk

--- a/testing/sched/pthread_mutex_perf/pthread_mutex_perf.c
+++ b/testing/sched/pthread_mutex_perf/pthread_mutex_perf.c
@@ -1,0 +1,145 @@
+/****************************************************************************
+ * apps/testing/sched/pthread_mutex_perf/pthread_mutex_perf.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <pthread.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void timespec_diff(const struct timespec *start,
+                          const struct timespec *end,
+                          struct timespec *diff)
+{
+  diff->tv_sec = end->tv_sec - start->tv_sec;
+  diff->tv_nsec = end->tv_nsec - start->tv_nsec;
+
+  if (diff->tv_nsec < 0)
+    {
+      diff->tv_sec--;
+        diff->tv_nsec += 1000000000;
+    }
+}
+
+static void timespec_add(struct timespec *total, const struct timespec *diff)
+{
+  total->tv_sec += diff->tv_sec;
+  total->tv_nsec += diff->tv_nsec;
+
+  if (total->tv_nsec >= 1000000000)
+    {
+      total->tv_sec += total->tv_nsec / 1000000000;
+      total->tv_nsec = total->tv_nsec % 1000000000;
+    }
+}
+
+static void timespec_avg(const struct timespec *total, int count,
+                         struct timespec *avg)
+{
+  uint64_t total_ns = (uint64_t)total->tv_sec * 1000000000 + total->tv_nsec;
+  uint64_t avg_ns = total_ns / count;
+
+  avg->tv_sec = avg_ns / 1000000000;
+  avg->tv_nsec = avg_ns % 1000000000;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * pmp_main
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+  struct timespec start;
+  struct timespec end;
+  struct timespec diff;
+  struct timespec total = {
+                            0, 0
+                          };
+
+  struct timespec avg;
+  int i;
+  int j = 0;
+  const int loop_count = 10;
+
+  while (j < loop_count)
+    {
+      i = 0;
+      j++;
+
+      /* Get the starting time */
+
+      clock_gettime(CLOCK_BOOTTIME, &start);
+
+      /* Do 1 million interactions trying to lock an already locked mutex */
+
+      pthread_mutex_lock(&g_mutex);
+
+      while (i < 1000 * 1000)
+        {
+          i++;
+          pthread_mutex_trylock(&g_mutex);
+        }
+
+      pthread_mutex_unlock(&g_mutex);
+
+      /* Get the finished time */
+
+      clock_gettime(CLOCK_BOOTTIME, &end);
+
+      /* Get the calculated elapsed time */
+
+      timespec_diff(&start, &end, &diff);
+
+      /* Add it to total time for each loop pass */
+
+      timespec_add(&total, &diff);
+
+      /* Get the average time */
+
+      timespec_avg(&total, j, &avg);
+
+      printf("%d: diff = %lu.%09lu s | avg = %lu.%09lu s\n", j,
+             (unsigned long)diff.tv_sec, (unsigned long)diff.tv_nsec,
+             (unsigned long)avg.tv_sec, (unsigned long)avg.tv_nsec);
+    }
+
+  printf("\n===== result =====\n");
+  printf("count: %d\n", loop_count);
+  printf("total: %lu.%09lu s\n", (unsigned long)total.tv_sec,
+         (unsigned long)total.tv_nsec);
+  printf("avg: %lu.%09lu s\n", (unsigned long)avg.tv_sec,
+         (unsigned long)avg.tv_nsec);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

During the discussion about the impact of adding counter to TCB Mr anchao created a pthread mutex performance example: https://github.com/apache/nuttx/pull/17468#issuecomment-3660925314

Because this example can exercise (not ideally) the pthread mutex I decided to add it to apps/testing/sched, the program name will be called "pmutexp" (because "pmp" is not a good name).

## Impact

Another testing tool for NuttX

## Testing

nsh> pmutexp
1: diff = 0.278248977 s | avg = 0.278248977 s
2: diff = 0.277865395 s | avg = 0.278057186 s
3: diff = 0.276913045 s | avg = 0.277675805 s
4: diff = 0.277897198 s | avg = 0.277731153 s
5: diff = 0.278829989 s | avg = 0.277950920 s
6: diff = 0.276655238 s | avg = 0.277734973 s
7: diff = 0.278417236 s | avg = 0.277832439 s
8: diff = 0.276738257 s | avg = 0.277695666 s
9: diff = 0.278345268 s | avg = 0.277767844 s
10: diff = 0.279812201 s | avg = 0.277972280 s

===== result =====
count: 10
total: 2.779722804 s
avg: 0.277972280 s
nsh>

