### PR TITLE
graphics/lvgl: Upgrade LVGL to v9.4.0

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_GRAPHICS_LVGL)
     FetchContent_Declare(
       lvgl_fetch
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://github.com/lvgl/lvgl/archive/refs/tags/v9.2.1.zip" SOURCE_DIR
+      URL "https://github.com/lvgl/lvgl/archive/refs/tags/v9.4.0.zip" SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/lvgl BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/graphics/lvgl/lvgl
       DOWNLOAD_NO_PROGRESS true

--- a/graphics/lvgl/Kconfig
+++ b/graphics/lvgl/Kconfig
@@ -11,7 +11,7 @@ menuconfig GRAPHICS_LVGL
 
 if GRAPHICS_LVGL
 
-# Kconfig file for LVGL v9.2.1
+# Kconfig file for LVGL v9.4.0
 
 menu "LVGL configuration"
 
@@ -156,34 +156,25 @@ menu "LVGL configuration"
 				bool "5: WINDOWS"
 			config LV_OS_MQX
 				bool "6: MQX"
+			config LV_OS_SDL2
+				bool "7: SDL2"
 			config LV_OS_CUSTOM
 				bool "255: CUSTOM"
 		endchoice
-
-		config LV_USE_OS
-			int
-			default 0 if LV_OS_NONE
-			default 1 if LV_OS_PTHREAD
-			default 2 if LV_OS_FREERTOS
-			default 3 if LV_OS_CMSIS_RTOS2
-			default 4 if LV_OS_RTTHREAD
-			default 5 if LV_OS_WINDOWS
-			default 6 if LV_OS_MQX
-			default 255 if LV_OS_CUSTOM
 
 		config LV_OS_CUSTOM_INCLUDE
 			string "Custom OS include header"
 			default "stdint.h"
 			depends on LV_OS_CUSTOM
 
-        config LV_USE_FREERTOS_TASK_NOTIFY
-            bool "Use RTOS task with a direct notification for synchronization"
-            default y
-            depends on LV_OS_FREERTOS
-        help
-            Unblocking an RTOS task with a direct notification is 45% faster and uses less RAM
-            than unblocking a task using an intermediary object such as a binary semaphore.
-            RTOS task notifications can only be used when there is only one task that can be the recipient of the event.
+		config LV_USE_FREERTOS_TASK_NOTIFY
+			bool "Use RTOS task with a direct notification for synchronization"
+			default y
+			depends on LV_OS_FREERTOS
+		help
+			Unblocking an RTOS task with a direct notification is 45% faster and uses less RAM
+			than unblocking a task using an intermediary object such as a binary semaphore.
+			RTOS task notifications can only be used when there is only one task that can be the recipient of the event.
 	endmenu
 
 	menu "Rendering Configuration"
@@ -215,12 +206,38 @@ menu "LVGL configuration"
 				it is buffered into a "simple" layer before rendering. The widget can be buffered in smaller chunks.
 				"Transformed layers" (if `transform_angle/zoom` are set) use larger buffers and can't be drawn in chunks.
 
+		config LV_DRAW_LAYER_MAX_MEMORY
+			int "The maximum amount of memory that can be used for layers"
+			default 0
+			help
+				Limit the max allocated memory for simple and transformed layers.
+				It should be at least `LV_DRAW_LAYER_SIMPLE_BUF_SIZE` sized but if transformed layers are also used
+				it should be enough to store the largest widget too (width x height x 4 area).
+				Set it to 0 to have no limit.
+
 		config LV_DRAW_THREAD_STACK_SIZE
 			int "Stack size of draw thread in bytes"
 			default 8192
-			depends on LV_USE_OS > 0
+			depends on !LV_OS_NONE
 			help
 				If FreeType or ThorVG is enabled, it is recommended to set it to 32KB or more.
+
+		config LV_DRAW_THREAD_PRIO
+			int "Thread priority for the drawing thread"
+			range 0 4
+			default 3
+			depends on !LV_OS_NONE
+			help
+				Thread priority controls the relative importance of the drawing threads.
+				Values correspond to lv_thread_prio_t enum in lv_os.h:
+				0: LV_THREAD_PRIO_LOWEST
+				1: LV_THREAD_PRIO_LOW
+				2: LV_THREAD_PRIO_MID (default)
+				3: LV_THREAD_PRIO_HIGH
+				4: LV_THREAD_PRIO_HIGHEST
+
+				Higher priority can improve rendering performance but might cause
+				starvation of lower priority tasks.
 
 		config LV_USE_DRAW_SW
 			bool "Enable software rendering"
@@ -253,6 +270,11 @@ menu "LVGL configuration"
 			default y
 			depends on LV_USE_DRAW_SW
 
+		config LV_DRAW_SW_SUPPORT_ARGB8888_PREMULTIPLIED
+			bool "Enable support for ARGB8888 premultiplied color format"
+			default y
+			depends on LV_USE_DRAW_SW
+
 		config LV_DRAW_SW_SUPPORT_L8
 			bool "Enable support for L8 color format"
 			default y
@@ -272,6 +294,12 @@ menu "LVGL configuration"
 			bool "Enable support for I1 color format"
 			default y
 			depends on LV_USE_DRAW_SW
+
+		config LV_DRAW_SW_I1_LUM_THRESHOLD
+			int "Luminance threshold for a pixel to be active"
+			default 127
+			range 0 254
+			depends on LV_DRAW_SW_SUPPORT_I1
 
 		config LV_DRAW_SW_DRAW_UNIT_CNT
 			int "Number of draw units"
@@ -359,44 +387,58 @@ menu "LVGL configuration"
 			default ""
 			depends on LV_DRAW_SW_ASM_CUSTOM
 
-		config LV_USE_DRAW_VGLITE
-			bool "Use NXP's VG-Lite GPU on iMX RTxxx platforms"
-			default n
-
-		config LV_USE_VGLITE_BLIT_SPLIT
-			bool "Enable blit quality degradation workaround recommended for screen's dimension > 352 pixels"
-			depends on LV_USE_DRAW_VGLITE
-			default n
-
-		config LV_USE_VGLITE_DRAW_THREAD
-			bool "Use additional draw thread for VG-Lite processing"
-			depends on LV_USE_DRAW_VGLITE && LV_USE_OS > 0
-			default y
-
-		config LV_USE_VGLITE_DRAW_ASYNC
-			bool "Enable VGLite draw async"
-			depends on LV_USE_VGLITE_DRAW_THREAD
-			default y
-			help
-				Queue multiple tasks and flash them once to the GPU. The task ready state will be send asynchronous to dispatcher.
-
-		config LV_USE_VGLITE_ASSERT
-			bool "Enable VGLite asserts"
-			depends on LV_USE_DRAW_VGLITE
-			default n
+		config LV_USE_PXP
+		bool "Use NXP's PXP on iMX RTxxx platforms"
+		default n
 
 		config LV_USE_DRAW_PXP
-			bool "Use NXP's PXP on iMX RTxxx platforms"
+		bool "Use PXP for drawing"
+			depends on LV_USE_PXP
+			default y
+
+		config LV_USE_ROTATE_PXP
+			bool "Use PXP to rotate display"
+			depends on LV_USE_PXP
 			default n
 
 		config LV_USE_PXP_DRAW_THREAD
 			bool "Use additional draw thread for PXP processing"
-			depends on LV_USE_DRAW_PXP && LV_USE_OS > 0
+			depends on LV_USE_DRAW_PXP && !LV_OS_NONE
 			default y
 
 		config LV_USE_PXP_ASSERT
 			bool "Enable PXP asserts"
 			depends on LV_USE_DRAW_PXP
+
+		config LV_USE_G2D
+			bool "Use NXP's G2D on MPU platforms"
+			default n
+		
+		config LV_USE_DRAW_G2D
+			bool "Use G2D for drawing."
+			depends on LV_USE_G2D
+			default y
+		
+		config LV_USE_ROTATE_G2D
+			bool "Use G2D to rotate display."
+			depends on LV_USE_G2D
+			default n
+
+		config LV_G2D_HASH_TABLE_SIZE
+			bool "Maximum number of buffers that can be stored for G2D draw unit."
+			default 50
+			depends on LV_USE_G2D
+			help
+				Includes the frame buffers and assets.
+
+		config LV_USE_G2D_DRAW_THREAD
+			bool "Use additional draw thread for G2D processing"
+			depends on LV_USE_DRAW_G2D && !LV_OS_NONE
+			default y
+
+		config LV_USE_G2D_ASSERT
+			bool "Enable G2D asserts"
+			depends on LV_USE_G2D
 			default n
 
 		config LV_USE_DRAW_DAVE2D
@@ -433,7 +475,7 @@ menu "LVGL configuration"
 
 		config LV_VG_LITE_USE_BOX_SHADOW
 			bool "Enable border to simulate shadow"
-			default n
+			default y
 			depends on LV_USE_DRAW_VG_LITE
 			help
 				which usually improves performance,
@@ -450,7 +492,17 @@ menu "LVGL configuration"
 
 		config LV_VG_LITE_STROKE_CACHE_CNT
 			int "VG-Lite stroke maximum cache number."
-			default 32
+			default 8
+			depends on LV_USE_DRAW_VG_LITE
+
+		config LV_VG_LITE_DISABLE_VLC_OP_CLOSE
+			bool "Remove VLC_OP_CLOSE path instruction (Workaround for NXP)"
+			default n
+			depends on LV_USE_DRAW_VG_LITE
+
+		config LV_VG_LITE_DISABLE_LINEAR_GRADIENT_EXT
+			bool "Disable linear gradient extension for some older versions of drivers."
+			default n
 			depends on LV_USE_DRAW_VG_LITE
 
 		config LV_USE_VECTOR_GRAPHIC
@@ -459,6 +511,56 @@ menu "LVGL configuration"
 			select LV_USE_MATRIX
 			help
 				Enable drawing support vector graphic APIs.
+
+		config LV_USE_DRAW_DMA2D
+			bool "Use DMA2D on the supporting STM32 platforms"
+			default n
+			help
+				Accelerate blends, fills, image decoding, etc. with STM32 DMA2D.
+
+		config LV_DRAW_DMA2D_HAL_INCLUDE
+			string "the header file for LVGL to include for DMA2D"
+			default "stm32h7xx_hal.h"
+			depends on LV_USE_DRAW_DMA2D
+
+		config LV_USE_DRAW_DMA2D_INTERRUPT
+			bool "use the DMA2D transfer complete interrupt"
+			default n
+			depends on LV_USE_DRAW_DMA2D
+			help
+				if enabled, the user is required to call
+				`lv_draw_dma2d_transfer_complete_interrupt_handler`
+				upon receiving the DMA2D global interrupt
+
+		config LV_USE_DRAW_OPENGLES
+			bool "Draw using cached OpenGLES textures"
+			default n
+			depends on LV_USE_OPENGLES
+
+		config LV_USE_PPA
+		bool "Use Espressif's PPA accelerator for ESP SoCs"
+		default n
+
+		config LV_USE_PPA_IMG
+		bool "Use Espressif's PPA accelerator for Image draw"
+		default n
+		depends on LV_USE_PPA
+
+		config LV_USE_DRAW_EVE
+			bool "Use EVE FT81X GPU."
+			default n
+
+		config LV_DRAW_EVE_EVE_GENERATION
+			int "EVE_GEN value"
+			default 4
+			range 2 4
+			depends on LV_USE_DRAW_EVE
+
+		config LV_DRAW_EVE_WRITE_BUFFER_SIZE
+			int "Max bytes to buffer for each SPI transmission or 0 to disable buffering"
+			default 2048
+			depends on LV_USE_DRAW_EVE
+
 	endmenu
 
 	menu "Feature Configuration"
@@ -659,6 +761,10 @@ menu "LVGL configuration"
 				bool "Add id field to obj"
 				default n
 
+			config LV_USE_OBJ_NAME
+				bool "Enable support widget names"
+				default n
+
 			config LV_OBJ_ID_AUTO_ASSIGN
 				bool "Automatically assign an ID when obj is created"
 				default y
@@ -719,6 +825,11 @@ menu "LVGL configuration"
 				bool "Enable multi-thread render"
 				default n
 				depends on LV_USE_VG_LITE_THORVG
+
+			config LV_USE_GESTURE_RECOGNITION
+				bool "Enable the multi-touch gesture recognition feature"
+				depends on LV_USE_FLOAT
+				default n
 		endmenu
 	endmenu
 
@@ -799,10 +910,10 @@ menu "LVGL configuration"
 				bool "Enable Montserrat 28 compressed"
 			config LV_FONT_DEJAVU_16_PERSIAN_HEBREW
 				bool "Enable Dejavu 16 Persian, Hebrew, Arabic letters"
-			config LV_FONT_SIMSUN_14_CJK
-				bool "Enable Simsun 14 CJK"
-			config LV_FONT_SIMSUN_16_CJK
-				bool "Enable Simsun 16 CJK"
+			config LV_FONT_SOURCE_HAN_SANS_SC_14_CJK
+				bool "Enable SourceHanSansSC 14 CJK"
+			config LV_FONT_SOURCE_HAN_SANS_SC_16_CJK
+				bool "Enable SourceHanSansSC 16 CJK"
 
 			config LV_FONT_UNSCII_8
 				bool "Enable UNSCII 8 (Perfect monospace font)"
@@ -887,12 +998,12 @@ menu "LVGL configuration"
 			config LV_FONT_DEFAULT_DEJAVU_16_PERSIAN_HEBREW
 				bool "Dejavu 16 Persian, Hebrew, Arabic letters"
 				select LV_FONT_DEJAVU_16_PERSIAN_HEBREW
-			config LV_FONT_DEFAULT_SIMSUN_14_CJK
-				bool "Simsun 14 CJK"
-				select LV_FONT_SIMSUN_14_CJK
-			config LV_FONT_DEFAULT_SIMSUN_16_CJK
-				bool "Simsun 16 CJK"
-				select LV_FONT_SIMSUN_16_CJK
+			config LV_FONT_DEFAULT_SOURCE_HAN_SANS_SC_14_CJK
+				bool "SourceHanSansSC 14 CJK"
+				select LV_FONT_SOURCE_HAN_SANS_SC_14_CJK
+			config LV_FONT_DEFAULT_SOURCE_HAN_SANS_SC_16_CJK
+				bool "SourceHanSansSC 16 CJK"
+				select LV_FONT_SOURCE_HAN_SANS_SC_16_CJK
 			config LV_FONT_DEFAULT_UNSCII_8
 				bool "UNSCII 8 (Perfect monospace font)"
 				select LV_FONT_UNSCII_8
@@ -914,6 +1025,13 @@ menu "LVGL configuration"
 		config LV_USE_FONT_PLACEHOLDER
 			bool "Enable drawing placeholders when glyph dsc is not found"
 			default y
+
+		menu "Enable static fonts"
+			config LV_DEMO_BENCHMARK_ALIGNED_FONTS
+				depends on LV_USE_DEMO_BENCHMARK
+				bool "Use static aligned fonts"
+				default n
+		endmenu
 	endmenu
 
 	menu "Text Settings"
@@ -955,6 +1073,10 @@ menu "LVGL configuration"
 			help
 				Minimum number of characters in a long word to put on a line after a break
 
+		config LV_TXT_COLOR_CMD
+			string "The control character to use for signalling text recoloring"
+			default "#"
+
 		config LV_USE_BIDI
 			bool "Support bidirectional texts"
 			help
@@ -992,6 +1114,9 @@ menu "LVGL configuration"
 		config LV_USE_ARC
 			bool "Arc"
 			default y if !LV_CONF_MINIMAL
+		config LV_USE_ARCLABEL
+			bool "Arc Label"
+			default y if !LV_CONF_MINIMAL
 		config LV_USE_BAR
 			bool "Bar"
 			default y if !LV_CONF_MINIMAL
@@ -1007,6 +1132,34 @@ menu "LVGL configuration"
 		config LV_CALENDAR_WEEK_STARTS_MONDAY
 			bool "Calendar week starts monday"
 			depends on LV_USE_CALENDAR
+
+		menu "Days name configuration"
+			depends on LV_USE_CALENDAR
+
+		config LV_MONDAY_STR
+			string "Shortened string for Monday"
+			default "Mo"
+		config LV_TUESDAY_STR
+			string "Shortened string for Tuesday"
+			default "Tu"
+		config LV_WEDNESDAY_STR
+			string "Shortened string for Wednesday"
+			default "We"
+		config LV_THURSDAY_STR
+			string "Shortened string for Thursday"
+			default "Th"
+		config LV_FRIDAY_STR
+			string "Shortened string for Friday"
+			default "Fr"
+		config LV_SATURDAY_STR
+			string "Shortened string for Saturday"
+			default "Sa"
+		config LV_SUNDAY_STR
+			string "Shortened string for Sunday"
+			default "Su"
+
+		endmenu
+
 		config LV_USE_CALENDAR_HEADER_ARROW
 			bool "Use calendar header arrow"
 			depends on LV_USE_CALENDAR
@@ -1160,7 +1313,7 @@ menu "LVGL configuration"
 	endmenu
 
 	menu "3rd Party Libraries"
-		config LV_FS_DEFAULT_DRIVE_LETTER
+		config LV_FS_DEFAULT_DRIVER_LETTER
 			int "Default drive letter (e.g. 65 for 'A')"
 			default 0
 			help
@@ -1169,7 +1322,7 @@ menu "LVGL configuration"
 		config LV_USE_FS_STDIO
 			bool "File system on top of stdio API"
 		config LV_FS_STDIO_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
 			depends on LV_USE_FS_STDIO
 		config LV_FS_STDIO_PATH
@@ -1183,7 +1336,7 @@ menu "LVGL configuration"
 		config LV_USE_FS_POSIX
 			bool "File system on top of posix API"
 		config LV_FS_POSIX_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
 			depends on LV_USE_FS_POSIX
 		config LV_FS_POSIX_PATH
@@ -1197,7 +1350,7 @@ menu "LVGL configuration"
 		config LV_USE_FS_WIN32
 			bool "File system on top of Win32 API"
 		config LV_FS_WIN32_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
 			depends on LV_USE_FS_WIN32
 		config LV_FS_WIN32_PATH
@@ -1211,8 +1364,11 @@ menu "LVGL configuration"
 		config LV_USE_FS_FATFS
 			bool "File system on top of FatFS"
 		config LV_FS_FATFS_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
+			depends on LV_USE_FS_FATFS
+		config LV_FS_FATFS_PATH
+			string "Set the working directory"
 			depends on LV_USE_FS_FATFS
 		config LV_FS_FATFS_CACHE_SIZE
 			int ">0 to cache this number of bytes in lv_fs_read()"
@@ -1222,30 +1378,53 @@ menu "LVGL configuration"
 		config LV_USE_FS_MEMFS
 			bool "File system on top of memory-mapped API"
 		config LV_FS_MEMFS_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
 			depends on LV_USE_FS_MEMFS
 
 		config LV_USE_FS_LITTLEFS
 			bool "File system on top of littlefs API"
 		config LV_FS_LITTLEFS_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
+			depends on LV_USE_FS_LITTLEFS
+		config LV_FS_LITTLEFS_PATH
+			string "Set the working directory"
 			depends on LV_USE_FS_LITTLEFS
 
 		config LV_USE_FS_ARDUINO_ESP_LITTLEFS
 			bool "File system on top of Arduino ESP littlefs API"
 		config LV_FS_ARDUINO_ESP_LITTLEFS_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
+			depends on LV_USE_FS_ARDUINO_ESP_LITTLEFS
+		config LV_FS_ARDUINO_ESP_LITTLEFS_PATH
+			string "Set the working directory"
 			depends on LV_USE_FS_ARDUINO_ESP_LITTLEFS
 
 		config LV_USE_FS_ARDUINO_SD
 			bool "File system on top of Arduino SD API"
 		config LV_FS_ARDUINO_SD_LETTER
-			int "Set an upper cased letter on which the drive will accessible (e.g. 65 for 'A')"
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
 			default 0
 			depends on LV_USE_FS_ARDUINO_SD
+		config LV_FS_ARDUINO_SD_PATH
+			string "Set the working directory"
+			depends on LV_USE_FS_ARDUINO_SD
+
+		config LV_USE_FS_UEFI
+			bool "File system on top of the UEFI EFI_SIMPLE_FILE_SYSTEM_PROTOCOL"
+		config LV_USE_FS_UEFI_LETTER
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
+			default 0
+			depends on LV_USE_FS_UEFI
+
+		config LV_USE_FS_FROGFS
+			bool "FrogFS read-only filesystem"
+		config LV_FS_FROGFS_LETTER
+			int "Set an upper-cased driver-identifier letter for this driver (e.g. 65 for 'A')"
+			default 0
+			depends on LV_USE_FS_FROGFS
 
 		config LV_USE_LODEPNG
 			bool "PNG decoder library"
@@ -1272,6 +1451,14 @@ menu "LVGL configuration"
 		config LV_BIN_DECODER_RAM_LOAD
 			bool "Decode whole image to RAM for bin decoder"
 			default n
+
+		config LV_USE_SVG
+			bool "SVG library"
+			depends on LV_USE_VECTOR_GRAPHIC
+
+		config LV_USE_SVG_ANIMATION
+			bool "SVG animation"
+			depends on LV_USE_SVG
 
 		config LV_USE_RLE
 			bool "LVGL's version of RLE compression method"
@@ -1301,7 +1488,12 @@ menu "LVGL configuration"
 			default n
 			depends on LV_USE_TINY_TTF
 		config LV_TINY_TTF_CACHE_GLYPH_CNT
-			bool "Tiny ttf cache entries count"
+			int "Tiny ttf cache entries count"
+			default 128
+			depends on LV_USE_TINY_TTF
+
+		config LV_TINY_TTF_CACHE_KERNING_CNT
+			int "Tiny ttf kerning cache entries count"
 			default 256
 			depends on LV_USE_TINY_TTF
 
@@ -1338,6 +1530,13 @@ menu "LVGL configuration"
 			bool "Dump format"
 			depends on LV_USE_FFMPEG
 			default n
+		config LV_FFMPEG_PLAYER_USE_LV_FS
+			bool "Use lvgl file path in FFmpeg Player widget"
+			depends on LV_USE_FFMPEG
+			default n
+			help
+				You won't be able to open URLs after enabling this feature.
+				Note that FFmpeg image decoder will always use lvgl file system.
 	endmenu
 
 	menu "Others"
@@ -1413,20 +1612,75 @@ menu "LVGL configuration"
 				bool "Center"
 		endchoice
 
-		config LV_USE_PROFILER
+		menuconfig LV_USE_PROFILER
 			bool "Runtime performance profiler"
+
+		if LV_USE_PROFILER
+
 		config LV_USE_PROFILER_BUILTIN
 			bool "Enable the built-in profiler"
-			depends on LV_USE_PROFILER
 			default y
 		config LV_PROFILER_BUILTIN_BUF_SIZE
 			int "Default profiler trace buffer size in bytes"
 			depends on LV_USE_PROFILER_BUILTIN
 			default 16384
+		config LV_PROFILER_BUILTIN_DEFAULT_ENABLE
+			bool "Enable built-in profiler by default"
+			depends on LV_USE_PROFILER_BUILTIN
+			default y
+		config LV_USE_PROFILER_BUILTIN_POSIX
+			bool "Enable POSIX profiler port"
+			depends on LV_USE_PROFILER_BUILTIN
+			default n
 		config LV_PROFILER_INCLUDE
 			string "Header to include for the profiler"
-			depends on LV_USE_PROFILER
 			default "lvgl/src/misc/lv_profiler_builtin.h"
+
+		config LV_PROFILER_LAYOUT
+			bool "Enable layout profiler"
+			default y
+
+		config LV_PROFILER_REFR
+			bool "Enable disp refr profiler"
+			default y
+
+		config LV_PROFILER_DRAW
+			bool "Enable draw profiler"
+			default y
+
+		config LV_PROFILER_INDEV
+			bool "Enable indev profiler"
+			default y
+
+		config LV_PROFILER_DECODER
+			bool "Enable decoder profiler"
+			default y
+
+		config LV_PROFILER_FONT
+			bool "Enable font profiler"
+			default y
+
+		config LV_PROFILER_FS
+			bool "Enable fs profiler"
+			default y
+
+		config LV_PROFILER_STYLE
+			bool "Enable style profiler"
+			default n
+
+		config LV_PROFILER_TIMER
+			bool "Enable timer profiler"
+			default y
+
+		config LV_PROFILER_CACHE
+			bool "Enable cache profiler"
+			default y
+
+		config LV_PROFILER_EVENT
+			bool "Enable event profiler"
+			default y
+
+		endif # LV_USE_PROFILER
 
 		config LV_USE_MONKEY
 			bool "Enable Monkey test"
@@ -1487,15 +1741,34 @@ menu "LVGL configuration"
 			help
 				This can save some memory, but not much. After the quick access bar is created, it can be hidden by clicking the button at the top left corner of the browsing area, which is very useful for small screen devices.
 
+		config LV_USE_FONT_MANAGER
+			bool "Enable Font manager"
+			default n
+		config LV_FONT_MANAGER_NAME_MAX_LEN
+			int "Font manager name max length"
+			depends on LV_USE_FONT_MANAGER
+			default 32
+		config LV_USE_TEST
+			bool "Enable emulated input devices, time emulation, and screenshot compares."
+		config LV_USE_TEST_SCREENSHOT_COMPARE
+			bool "Enable `lv_test_screenshot_compare`. Requires libpng and a few MB of extra RAM."
+			depends on LV_USE_TEST
+		config LV_USE_TRANSLATION
+			bool "Enable text translation support"
+		config LV_USE_XML
+			bool "Enable loading XML UIs runtime"
+		config LV_USE_COLOR_FILTER
+			bool "Enable color filter style"
+			default n
 		config LVGL_VERSION_MAJOR
 			int
 			default 9 # LVGL_VERSION_MAJOR
 		config LVGL_VERSION_MINOR
 			int
-			default 2 # LVGL_VERSION_MINOR
+			default 4 # LVGL_VERSION_MINOR
 		config LVGL_VERSION_PATCH
 			int
-			default 1 # LVGL_VERSION_PATCH
+			default 0 # LVGL_VERSION_PATCH
 	endmenu
 
 	menu "Devices"
@@ -1621,10 +1894,31 @@ menu "LVGL configuration"
 			bool "Draw client side window decorations, only necessary on Mutter (GNOME)"
 			depends on LV_USE_WAYLAND
 			default n
-		config LV_WAYLAND_WL_SHELL
-			bool "Support the legacy wl_shell instead of the default XDG Shell protocol"
+		config LV_WAYLAND_BUF_COUNT
+			int "Use 1 for single buffer with partial render mode or 2 for double buffer with full render mode"
 			depends on LV_USE_WAYLAND
-			default n
+			default 1
+		choice
+			prompt "Wayland rendering mode"
+			depends on LV_USE_WAYLAND
+			default LV_WAYLAND_RENDER_MODE_PARTIAL
+
+			config LV_WAYLAND_RENDER_MODE_PARTIAL
+				bool "Use the buffer(s) to render the screen is smaller parts"
+				depends on !LV_WAYLAND_USE_DMABUF
+
+			config LV_WAYLAND_RENDER_MODE_DIRECT
+				bool "Only the changed areas will be updated with 2 screen sized buffers"
+				depends on LV_WAYLAND_USE_DMABUF
+
+			config LV_WAYLAND_RENDER_MODE_FULL
+				bool "Always redraw the whole screen even if only one pixel has been changed with 2 screen sized buffers"
+				depends on LV_WAYLAND_USE_DMABUF
+		endchoice
+
+		config LV_WAYLAND_USE_DMABUF
+			bool "Use DMA buffers for frame buffers"
+			depends on LV_USE_WAYLAND && LV_USE_G2D
 
 		config LV_USE_LINUX_FBDEV
 			bool "Use Linux framebuffer device"
@@ -1686,8 +1980,23 @@ menu "LVGL configuration"
 			depends on LV_USE_LINUX_FBDEV && LV_LINUX_FBDEV_CUSTOM_BUFFER
 			default 60
 
+		config LV_LINUX_FBDEV_MMAP
+			bool "Framebuffer device supports mmap"
+			depends on LV_USE_LINUX_FBDEV
+			default y
+
 		config LV_USE_NUTTX
 			bool "Use Nuttx to open window and handle touchscreen"
+			default n
+
+		config LV_USE_NUTTX_INDEPENDENT_IMAGE_HEAP
+			bool "Use independent image heap"
+			depends on LV_USE_NUTTX
+			default n
+
+		config LV_NUTTX_DEFAULT_DRAW_BUF_USE_INDEPENDENT_IMAGE_HEAP
+			bool "Use independent image heap for default draw buffer"
+			depends on LV_USE_NUTTX_INDEPENDENT_IMAGE_HEAP
 			default n
 
 		config LV_USE_NUTTX_LIBUV
@@ -1738,6 +2047,37 @@ menu "LVGL configuration"
 			depends on LV_USE_NUTTX
 			default n
 
+		config LV_NUTTX_TOUCHSCREEN_CURSOR_SIZE
+			int "Touchscreen cursor size in pixels"
+			depends on LV_USE_NUTTX_TOUCHSCREEN
+			default 0
+			help
+				Set to 0 to disable cursor, or set to a value greater than 0 to set the cursor size in pixels.
+
+		config LV_USE_NUTTX_MOUSE
+			bool "Use NuttX mouse driver"
+			depends on LV_USE_NUTTX
+			default n
+
+		config LV_USE_NUTTX_MOUSE_MOVE_STEP
+			int "Mouse movement step (pixels)"
+			depends on LV_USE_NUTTX_MOUSE
+			range 1 10
+			default 1
+			help
+				Set the step size of the mouse movement in pixels.
+
+		config LV_USE_NUTTX_TRACE_FILE
+			bool "Use NuttX trace file"
+			depends on LV_USE_NUTTX
+			depends on LV_USE_PROFILER_BUILTIN
+			default n
+
+		config LV_NUTTX_TRACE_FILE_PATH
+			depends on LV_USE_NUTTX_TRACE_FILE
+			string "NuttX trace file path"
+			default "/data/lvgl-trace.log"
+
 		config LV_USE_LINUX_DRM
 			bool "Use Linux DRM device"
 			default n
@@ -1745,6 +2085,14 @@ menu "LVGL configuration"
 		config LV_USE_TFT_ESPI
 			bool "Use TFT_eSPI driver"
 			default n
+
+		config LV_USE_LOVYAN_GFX
+			bool "Use LovyanGFX driver"
+			default n
+		config LV_LGFX_USER_INCLUDE
+			string "Header for LovyanGFX user configuration"
+			default "lv_lgfx_user.hpp"
+			depends on LV_USE_LOVYAN_GFX
 
 		config LV_USE_EVDEV
 			bool "Use evdev input driver"
@@ -1767,30 +2115,65 @@ menu "LVGL configuration"
 		config LV_USE_ST7735
 			bool "Use ST7735 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_ST7789
 			bool "Use ST7789 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_ST7796
 			bool "Use ST7796 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_ILI9341
 			bool "Use ILI9341 LCD driver"
 			default n
+			select LV_USE_GENERIC_MIPI
 
 		config LV_USE_GENERIC_MIPI
 			bool "Generic MIPI driver"
 			default y if LV_USE_ST7735 || LV_USE_ST7789 || LV_USE_ST7796 || LV_USE_ILI9341
 
+		config LV_USE_NXP_ELCDIF
+			bool "Use NXP ELCDIF to generate display"
+			default n
+
 		config LV_USE_RENESAS_GLCDC
 			bool "Use Renesas GLCDC driver"
+			default n
+
+		config LV_USE_ST_LTDC
+			bool "Driver for ST LTDC"
+			default n
+
+		config LV_ST_LTDC_USE_DMA2D_FLUSH
+			bool "Only used for created partial mode LTDC displays"
+			default n
+			depends on LV_USE_ST_LTDC && !LV_USE_DRAW_DMA2D
+
+		config LV_USE_FT81X
+			bool "Use ft81x EVE driver"
 			default n
 
 		config LV_USE_WINDOWS
 			bool "Use LVGL Windows backend"
 			depends on LV_OS_WINDOWS
+			default n
+
+		config LV_USE_UEFI
+			bool "Use LVGL UEFI backend"
+			default n
+
+		config LV_USE_UEFI_INCLUDE
+			string "Header that hides the actual framework (EDK2, gnu-efi, ...)"
+			depends on LV_USE_UEFI
+			default "myefi.h"
+
+		config LV_UEFI_USE_MEMORY_SERVICES
+			bool "Use the memory services from the boot services table"
+			depends on LV_USE_UEFI
 			default n
 
 		config LV_USE_OPENGLES
@@ -1819,69 +2202,88 @@ menu "LVGL configuration"
 	endmenu
 
 	menu "Demos"
-		config LV_USE_DEMO_WIDGETS
-			bool "Show some widget"
-			default n
+		config LV_BUILD_DEMOS
+			bool "Build demos"
+			default y if !LV_CONF_MINIMAL
 
-		config LV_USE_DEMO_KEYPAD_AND_ENCODER
-			bool "Demonstrate the usage of encoder and keyboard"
-			default n
+		if LV_BUILD_DEMOS
+			config LV_USE_DEMO_WIDGETS
+				bool "Show some widget"
+				default n
 
-		config LV_USE_DEMO_BENCHMARK
-			bool "Benchmark your system"
-			default n
-			depends on LV_FONT_MONTSERRAT_14 && LV_FONT_MONTSERRAT_24 && LV_USE_DEMO_WIDGETS
-		config LV_USE_DEMO_RENDER
-			bool "Render test for each primitives. Requires at least 480x272 display"
-			default n
+			config LV_USE_DEMO_KEYPAD_AND_ENCODER
+				bool "Demonstrate the usage of encoder and keyboard"
+				default n
 
-		config LV_USE_DEMO_SCROLL
-			bool "Scroll settings test for LVGL"
-			default n
+			config LV_USE_DEMO_BENCHMARK
+				bool "Benchmark your system"
+				default n
+				select LV_FONT_MONTSERRAT_14
+				select LV_FONT_MONTSERRAT_20
+				select LV_FONT_MONTSERRAT_24
+				select LV_FONT_MONTSERRAT_26
+				select LV_USE_DEMO_WIDGETS
+			config LV_USE_DEMO_RENDER
+				bool "Render test for each primitives. Requires at least 480x272 display"
+				default n
 
-		config LV_USE_DEMO_STRESS
-			bool "Stress test for LVGL"
-			default n
+			config LV_USE_DEMO_SCROLL
+				bool "Scroll settings test for LVGL"
+				default n
 
-		config LV_USE_DEMO_TRANSFORM
-			bool "Transform test for LVGL"
-			default n
-			depends on LV_FONT_MONTSERRAT_18
+			config LV_USE_DEMO_STRESS
+				bool "Stress test for LVGL"
+				default n
 
-		config LV_USE_DEMO_MUSIC
-			bool "Music player demo"
-			default n
-		config LV_DEMO_MUSIC_SQUARE
-			bool "Enable Square"
-			depends on LV_USE_DEMO_MUSIC
-			default n
-		config LV_DEMO_MUSIC_LANDSCAPE
-			bool "Enable Landscape"
-			depends on LV_USE_DEMO_MUSIC
-			default n
-		config LV_DEMO_MUSIC_ROUND
-			bool "Enable Round"
-			depends on LV_USE_DEMO_MUSIC
-			default n
-		config LV_DEMO_MUSIC_LARGE
-			bool "Enable Large"
-			depends on LV_USE_DEMO_MUSIC
-			default n
-		config LV_DEMO_MUSIC_AUTO_PLAY
-			bool "Enable Auto play"
-			depends on LV_USE_DEMO_MUSIC
-			default n
+			config LV_USE_DEMO_TRANSFORM
+				bool "Transform test for LVGL"
+				default n
+				depends on LV_FONT_MONTSERRAT_18
 
-		config LV_USE_DEMO_FLEX_LAYOUT
-			bool "Flex layout previewer"
-			default n
-		config LV_USE_DEMO_MULTILANG
-			bool "multi-language demo"
-			default n
-		config LV_USE_DEMO_VECTOR_GRAPHIC
-			bool "vector graphic demo"
-			default n
-			depends on LV_USE_VECTOR_GRAPHIC
+			config LV_USE_DEMO_MUSIC
+				bool "Music player demo"
+				default n
+			config LV_DEMO_MUSIC_SQUARE
+				bool "Enable Square"
+				depends on LV_USE_DEMO_MUSIC
+				default n
+			config LV_DEMO_MUSIC_LANDSCAPE
+				bool "Enable Landscape"
+				depends on LV_USE_DEMO_MUSIC
+				default n
+			config LV_DEMO_MUSIC_ROUND
+				bool "Enable Round"
+				depends on LV_USE_DEMO_MUSIC
+				default n
+			config LV_DEMO_MUSIC_LARGE
+				bool "Enable Large"
+				depends on LV_USE_DEMO_MUSIC
+				default n
+			config LV_DEMO_MUSIC_AUTO_PLAY
+				bool "Enable Auto play"
+				depends on LV_USE_DEMO_MUSIC
+				default n
+
+			config LV_USE_DEMO_FLEX_LAYOUT
+				bool "Flex layout previewer"
+				default n
+			config LV_USE_DEMO_MULTILANG
+				bool "multi-language demo"
+				default n
+			config LV_USE_DEMO_VECTOR_GRAPHIC
+				bool "vector graphic demo"
+				default n
+				depends on LV_USE_VECTOR_GRAPHIC
+			config LV_USE_DEMO_SMARTWATCH
+				bool "Smartwatch demo"
+				default n
+			config LV_USE_DEMO_EBIKE
+				bool "Ebike demo"
+				default n
+			config LV_USE_DEMO_HIGH_RES
+				bool "High resolution demo"
+				default n
+		endif
 	endmenu
 
 endmenu

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -58,7 +58,7 @@ WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
 CONFIG_GRAPH_LVGL_URL ?= "https://github.com/lvgl/lvgl/archive/refs/tags"
 
-LVGL_VERSION = 9.2.1
+LVGL_VERSION = 9.4.0
 LVGL_TARBALL = v$(LVGL_VERSION).zip
 
 LVGL_UNPACKNAME = lvgl


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

- Update CMakeLists.txt to use LVGL v9.4.0
- Update Kconfig with new v9.4.0 configuration options
- Update Makefile with new LVGL version

## Impact

LVGL

## Testing

test with rv-virt:lvgl64_vector created by another PR in nuttx repo (https://github.com/apache/nuttx/pull/17532)

Verified LVGL demo


