### PR TITLE
apps/netutils: Modify the MQTT compilation file to enable MQTT testing

### DIFF
--- a/netutils/mqttc/CMakeLists.txt
+++ b/netutils/mqttc/CMakeLists.txt
@@ -1,24 +1,24 @@
-############################################################################
+# ##############################################################################
 # apps/netutils/mqttc/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_NETUTILS_MQTTC)
 
@@ -123,5 +123,25 @@ if(CONFIG_NETUTILS_MQTTC)
         DEPENDS
         mqttc)
     endif()
+  endif()
+
+  if(CONFIG_NETUTILS_MQTTC_TEST)
+    set(MQTT_TEST_CFLAGS ${CFLAGS} -Dopen_nb_socket=test_open_nb_socket
+                         -Dpublish_callback=test_publish_callback)
+
+    nuttx_add_application(
+      NAME
+      cmocka_mqttc_test
+      STACKSIZE
+      ${CONFIG_NETUTILS_MQTTC_TEST_STACKSIZE}
+      PRIORITY
+      ${SCHED_PRIORITY_DEFAULT}
+      SRCS
+      ${MQTTC_DIR}/tests.c
+      COMPILE_FLAGS
+      ${MQTT_TEST_CFLAGS}
+      DEPENDS
+      cmocka
+      mqttc)
   endif()
 endif()

--- a/netutils/mqttc/Kconfig
+++ b/netutils/mqttc/Kconfig
@@ -17,9 +17,21 @@ config NETUTILS_MQTTC_EXAMPLE
 	---help---
 		Enable MQTT-C example
 
+config NETUTILS_MQTTC_TEST
+	tristate "Enable MQTT-C test"
+	default n
+
 if NETUTILS_MQTTC_EXAMPLE
 
 config NETUTILS_MQTTC_EXAMPLE_STACKSIZE
+	int "Task's stack size"
+	default 8192
+
+endif
+
+if NETUTILS_MQTTC_TEST
+
+config NETUTILS_MQTTC_TEST_STACKSIZE
 	int "Task's stack size"
 	default 8192
 

--- a/netutils/mqttc/Makefile
+++ b/netutils/mqttc/Makefile
@@ -83,4 +83,17 @@ endif
 
 endif
 
+ifneq ($(CONFIG_NETUTILS_MQTTC_TEST),)
+$(MQTTC_UNPACK)$(DELIM)tests.c_CFLAGS += \
+            -I$(APPDIR)$(DELIM)testing$(DELIM)cmocka$(DELIM)cmocka$(DELIM)include \
+            -Dopen_nb_socket=test_open_nb_socket \
+            -Dpublish_callback=test_publish_callback
+
+PRIORITY  = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_NETUTILS_MQTTC_TEST_STACKSIZE)
+MODULE    = $(CONFIG_NETUTILS_MQTTC_TEST)
+MAINSRC  += $(MQTTC_UNPACK)$(DELIM)tests.c
+PROGNAME += cmocka_mqttc_test
+endif
+
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary

Modify the build and test files to make the MQTT test cases run. 
Previously, native MQTT test cases were not compiled. Now, these native test cases are compiled in to make them run. However, some test cases do have issues that were not introduced by this patch but existed in the original test cases.

## Impact

Only affects MQTT testing

## Testing

The compilation is successful and the test commands can be executed normally.
`nsh> cmocka_mqttc_test
Staring MQTT-C unit-tests.
Using broker: "test.mosquitto.org:1883"

[MQTT Packet Serialization/Deserialization Tests]
[==========] framing_tests: Running 11 test(s).
[ RUN      ] TEST__framing__fixed_header
[       OK ] TEST__framing__fixed_header
[ RUN      ] TEST__framing__connect
[       OK ] TEST__framing__connect
[ RUN      ] TEST__framing__connack
[       OK ] TEST__framing__connack
[ RUN      ] TEST__framing__publish
[       OK ] TEST__framing__publish
[ RUN      ] TEST__framing__pubxxx
[       OK ] TEST__framing__pubxxx
[ RUN      ] TEST__framing__subscribe
[       OK ] TEST__framing__subscribe
[ RUN      ] TEST__framing__suback
[       OK ] TEST__framing__suback
[ RUN      ] TEST__framing__unsubscribe
[       OK ] TEST__framing__unsubscribe
[ RUN      ] TEST__framing__unsuback
[       OK ] TEST__framing__unsuback
[ RUN      ] TEST__framing__ping
[       OK ] TEST__framing__ping
[ RUN      ] TEST__framing__disconnect
[       OK ] TEST__framing__disconnect
[==========] framing_tests: 11 test(s) run.
[  PASSED  ] 11 test(s).

[MQTT-C Utilities Tests]
[==========] util_tests: Running 4 test(s).
[ RUN      ] TEST__utility__message_queue
[       OK ] TEST__utility__message_queue
[ RUN      ] TEST__utility__pid_lfsr
[       OK ] TEST__utility__pid_lfsr
[ RUN      ] TEST__utility__connect_disconnect
Failed to open socket (getaddrinfo): EAI_AGAIN
[  ERROR   ] --- client.socketfd != -1
[   LINE   ] --- MQTT-C/tests.c:280: error: Failure!
[  FAILED  ] TEST__utility__connect_disconnect
[ RUN      ] TEST__utility__ping
Failed to open socket (getaddrinfo): EAI_AGAIN
[  ERROR   ] --- client.socketfd != -1
[   LINE   ] --- MQTT-C/tests.c:482: error: Failure!
[  FAILED  ] TEST__utility__ping
[==========] util_tests: 4 test(s) run.
[  PASSED  ] 2 test(s).
[  FAILED  ] util_tests: 2 test(s), listed below:
[  FAILED  ] TEST__utility__connect_disconnect
[  FAILED  ] TEST__utility__ping

 2 FAILED TEST(S)

[MQTT-C API Tests]
[==========] api_tests: Running 3 test(s).
[ RUN      ] TEST__api__connect_ping_disconnect
Failed to open socket (getaddrinfo): EAI_AGAIN
[  ERROR   ] --- __mqtt_send(&client) > 0
[   LINE   ] --- MQTT-C/tests.c:640: error: Failure!
[  FAILED  ] TEST__api__connect_ping_disconnect
[ RUN      ] TEST__api__publish_subscribe__single
Failed to open socket (getaddrinfo): EAI_AGAIN
Failed to open socket (getaddrinfo): EAI_AGAIN
[  ERROR   ] --- __mqtt_send(&sender) > 0
[   LINE   ] --- MQTT-C/tests.c:687: error: Failure!
[  FAILED  ] TEST__api__publish_subscribe__single
[ RUN      ] TEST__api__publish_subscribe__multiple
Failed to open socket (getaddrinfo): EAI_AGAIN
Failed to open socket (getaddrinfo): EAI_AGAIN
error: MQTT_ERROR_SOCKET_ERROR
[  ERROR   ] --- rv > 0
[   LINE   ] --- MQTT-C/tests.c:758: error: Failure!
[  FAILED  ] TEST__api__publish_subscribe__multiple
[==========] api_tests: 3 test(s) run.
[  PASSED  ] 0 test(s).
[  FAILED  ] api_tests: 3 test(s), listed below:
[  FAILED  ] TEST__api__connect_ping_disconnect
[  FAILED  ] TEST__api__publish_subscribe__single
[  FAILED  ] TEST__api__publish_subscribe__multiple

 3 FAILED TEST(S)
`