### PR TITLE
netutils/netlib: add interface for cleardnsaddr

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -492,6 +492,10 @@ int netlib_del_ipv6dnsaddr(FAR const struct in6_addr *inaddr);
 int netlib_del_ipv6dnsaddr_by_index(int index);
 #endif
 
+#ifdef CONFIG_NETDB_DNSCLIENT
+void netlib_clear_dnsaddr(void);
+#endif
+
 int netlib_set_mtu(FAR const char *ifname, int mtu);
 
 #if defined(CONFIG_NETDEV_STATISTICS)

--- a/netutils/netlib/CMakeLists.txt
+++ b/netutils/netlib/CMakeLists.txt
@@ -83,6 +83,12 @@ if(CONFIG_NETUTILS_NETLIB)
     endif()
   endif()
 
+  # DNS client support
+
+  if(CONFIG_NETDB_DNSCLIENT)
+    list(APPEND SRCS netlib_cleardnsaddr.c)
+  endif()
+
   # Device support
 
   if(CONFIG_NETLINK_ROUTE)

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -84,6 +84,10 @@ CSRCS += netlib_ip6tables.c
 endif
 endif
 
+ifeq ($(CONFIG_NETDB_DNSCLIENT),y)
+CSRCS += netlib_cleardnsaddr.c
+endif
+
 # Device support
 
 ifeq ($(CONFIG_NETLINK_ROUTE),y)

--- a/netutils/netlib/netlib_cleardnsaddr.c
+++ b/netutils/netlib/netlib_cleardnsaddr.c
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_cleardnsaddr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/net/dns.h>
+
+#include "netutils/netlib.h"
+
+#ifdef CONFIG_NETDB_DNSCLIENT
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_clear_dnsaddr
+ *
+ * Description:
+ *   Clear the DNS server address
+ *
+ * Parameters:
+ *   void
+ *
+ * Return:
+ *  void
+ *
+ ****************************************************************************/
+
+void netlib_clear_dnsaddr(void)
+{
+  dns_default_nameserver();
+}
+
+#endif /* CONFIG_NETDB_DNSCLIENT */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

In some wearable devices, the saved DNS address is not deleted when the tun network card is logged off, which leads to a check for the existence of the DNS address when the tun network card is created next time, resulting in the failure of tun network card creation

## Impact

dns interface

## Testing

It has passed self-testing in true machine(wearable devices)


