### PR TITLE
netutils/dhcpc: avoid setting IP to stack when oldaddr matches presult->ipaddr

### DIFF
--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -817,11 +817,16 @@ int dhcpc_request(FAR void *handle, FAR struct dhcpc_state *presult)
                   pdhcpc->serverid.s_addr = presult->serverid.s_addr;
 
                   /* Temporarily use the address offered by the server
-                   * and break out of the loop.
+                   * if it differs from the current address, then break
+                   * out of the loop.
                    */
 
-                  netlib_set_ipv4addr(pdhcpc->interface,
-                                      &presult->ipaddr);
+                  if (oldaddr.s_addr != presult->ipaddr.s_addr)
+                    {
+                      netlib_set_ipv4addr(pdhcpc->interface,
+                                          &presult->ipaddr);
+                    }
+
                   state = STATE_HAVE_OFFER;
                 }
             }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

when processing DHCP offer messages in dhcp_dequest, netlib_set_ipv4addr is used to set the IP regardless of whether the IP has changed, resulting in disconnection between the two communication devices

## Impact

dhcpc setting ip addr

## Testing
It has passed self-testing in true machine(speaker equipment)


