### PR TITLE
sched/signal: Add support to disable partial signals

### DIFF
--- a/examples/buttons/buttons_main.c
+++ b/examples/buttons/buttons_main.c
@@ -219,9 +219,11 @@ static int button_daemon(int argc, char *argv[])
       goto errout_with_fd;
     }
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   /* Ignore the default signal action */
 
   signal(CONFIG_EXAMPLES_BUTTONS_SIGNO, SIG_IGN);
+#endif /* CONFIG_ENABLE_ALL_SIGNALS */
 #endif
 
   /* Now loop forever, waiting BUTTONs events */

--- a/examples/chrono/chrono_main.c
+++ b/examples/chrono/chrono_main.c
@@ -165,9 +165,11 @@ static int chrono_daemon(int argc, char *argv[])
       goto errout_with_fd;
     }
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   /* Ignore the default signal action */
 
   signal(BUTTON_SIGNO, SIG_IGN);
+#endif
 
   /* Now loop forever, waiting BUTTONs events */
 

--- a/netutils/dhcpc/dhcpc.c
+++ b/netutils/dhcpc/dhcpc.c
@@ -533,8 +533,16 @@ static void *dhcpc_run(void *args)
   struct dhcpc_state result;
   int ret;
 
+#ifndef CONFIG_ENABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   while (1)
     {
+#ifndef CONFIG_ENABLE_ALL_SIGNALS
+      pthread_testcancel();
+#endif
       ret = dhcpc_request(pdhcpc, &result);
       if (ret == OK)
         {
@@ -701,7 +709,9 @@ void dhcpc_close(FAR void *handle)
 void dhcpc_cancel(FAR void *handle)
 {
   struct dhcpc_state_s *pdhcpc = (struct dhcpc_state_s *)handle;
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   sighandler_t old;
+#endif
   int ret;
 
   if (pdhcpc)
@@ -710,6 +720,7 @@ void dhcpc_cancel(FAR void *handle)
 
       if (pdhcpc->thread)
         {
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
           old = signal(SIGQUIT, SIG_IGN);
 
           /* Signal the dhcpc_run */
@@ -719,6 +730,9 @@ void dhcpc_cancel(FAR void *handle)
             {
               nerr("ERROR: pthread_kill DHCPC thread\n");
             }
+#else
+          pthread_cancel(pdhcpc->thread);
+#endif
 
           /* Wait for the end of dhcpc_run */
 
@@ -729,7 +743,9 @@ void dhcpc_cancel(FAR void *handle)
             }
 
           pdhcpc->thread = 0;
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
           signal(SIGQUIT, old);
+#endif
         }
     }
 }

--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -1555,6 +1555,7 @@ static pid_t dhcpd_get_pid(void)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
 static void
 dhcpd_signal_handler(int signo, FAR siginfo_t *info, FAR void *ctx)
 {
@@ -1562,6 +1563,7 @@ dhcpd_signal_handler(int signo, FAR siginfo_t *info, FAR void *ctx)
 
   g_dhcpd_daemon.ds_state = DHCPD_STOP_REQUESTED;
 }
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -1573,7 +1575,9 @@ dhcpd_signal_handler(int signo, FAR siginfo_t *info, FAR void *ctx)
 
 int dhcpd_run(FAR const char *interface)
 {
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   struct sigaction act;
+#endif
   int sockfd = -1;
   int nbytes;
 
@@ -1602,11 +1606,12 @@ int dhcpd_run(FAR const char *interface)
 
   /* Install signal handler for CONFIG_NETUTILS_DHCPD_SIGWAKEUP */
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   memset(&act, 0, sizeof(act));
   act.sa_sigaction = dhcpd_signal_handler;
   act.sa_flags = SA_SIGINFO;
   sigaction(CONFIG_NETUTILS_DHCPD_SIGWAKEUP, &act, NULL);
-
+#endif
   /* Indicate that we have started */
 
   g_dhcpd_daemon.ds_state = DHCPD_RUNNING;

--- a/netutils/ping/icmp_ping.c
+++ b/netutils/ping/icmp_ping.c
@@ -91,6 +91,7 @@ static volatile bool g_exiting;
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
 /****************************************************************************
  * Name: sigexit
  ****************************************************************************/
@@ -99,6 +100,7 @@ static void sigexit(int signo)
 {
   g_exiting = true;
 }
+#endif
 
 /****************************************************************************
  * Name: ping_newid
@@ -199,7 +201,9 @@ void icmp_ping(FAR const struct ping_info_s *info)
   int i;
 
   g_exiting = false;
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   signal(SIGINT, sigexit);
+#endif
 
   /* Initialize result structure */
 

--- a/netutils/telnetd/telnetd_daemon.c
+++ b/netutils/telnetd/telnetd_daemon.c
@@ -74,7 +74,7 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
 #endif
   } addr;
 
-#ifdef CONFIG_SCHED_HAVE_PARENT
+#if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_ENABLE_ALL_SIGNALS)
   struct sigaction sa;
   sigset_t blockset;
 #endif
@@ -85,7 +85,7 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
   int optval;
 #endif
 
-#ifdef CONFIG_SCHED_HAVE_PARENT
+#if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_ENABLE_ALL_SIGNALS)
   /* Call sigaction with the SA_NOCLDWAIT flag so that we do not transform
    * children into "zombies" when they terminate:  Child exit status will
    * not be retained.
@@ -113,7 +113,7 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       nerr("ERROR: sigprocmask failed: %d\n", errno);
       goto errout;
     }
-#endif /* CONFIG_SCHED_HAVE_PARENT */
+#endif /* CONFIG_SCHED_HAVE_PARENT && CONFIG_ENABLE_ALL_SIGNALS */
 
   /* Create a new TCP socket to use to listen for connections */
 

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -74,10 +74,14 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                 FAR char **argv,
                 FAR const struct nsh_param_s *param)
 {
-#if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS)
+#if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS) && \
+    defined(CONFIG_ENABLE_ALL_SIGNALS)
   struct sigaction act;
   struct sigaction old;
-#endif
+#endif /* !CONFIG_NSH_DISABLEBG && CONFIG_SCHED_CHILD_STATUS &&
+        * CONFIG_ENABLE_ALL_SIGNALS
+        */
+
   int ret = OK;
 
   /* Lock the scheduler in an attempt to prevent the application from
@@ -86,7 +90,8 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
   sched_lock();
 
-#if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS)
+#if !defined(CONFIG_NSH_DISABLEBG) && \
+    defined(CONFIG_SCHED_CHILD_STATUS) && defined(CONFIG_ENABLE_ALL_SIGNALS)
   /* Ignore the child status if run the application on background. */
 
   if (vtbl->np.np_bg == true)
@@ -98,7 +103,9 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
       sigaction(SIGCHLD, &act, &old);
     }
 
-#endif /* CONFIG_NSH_DISABLEBG */
+#endif /* !CONFIG_NSH_DISABLEBG && !CONFIG_SCHED_CHILD_STATUS &&
+        * CONFIG_ENABLE_ALL_SIGNALS
+        */
 
   /* Try to find and execute the command within the list of builtin
    * applications.
@@ -230,7 +237,8 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
 #if !defined(CONFIG_SCHED_WAITPID) || !defined(CONFIG_NSH_DISABLEBG)
         {
-#if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS)
+#if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS) && \
+    defined(CONFIG_ENABLE_ALL_SIGNALS)
 
           /* Restore the old actions */
 
@@ -241,7 +249,10 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
               sigaction(SIGCHLD, &old, NULL);
             }
 
-#  endif
+#  endif /* !CONFIG_NSH_DISABLEBG && CONFIG_SCHED_CHILD_STATUS && \
+          * CONFIG_ENABLE_ALL_SIGNALS
+          */
+
           struct sched_param sched;
           sched_getparam(ret, &sched);
           nsh_output(vtbl, "%s [%d:%d]\n", cmd, ret, sched.sched_priority);

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -873,6 +873,7 @@ static int top_cmpcpuload(FAR const void *item1, FAR const void *item2)
     }
 }
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
 /****************************************************************************
  * Name: top_exit
  ****************************************************************************/
@@ -881,6 +882,7 @@ static void top_exit(int signo, FAR siginfo_t *siginfo, FAR void *context)
 {
   *(FAR bool *)siginfo->si_user = true;
 }
+#endif /* CONFIG_ENABLE_ALL_SIGNALS */
 
 #endif
 
@@ -1357,7 +1359,9 @@ int cmd_top(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   FAR char *pidlist = NULL;
   size_t num = SIZE_MAX;
   size_t i;
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   struct sigaction act;
+#endif
   bool quit = false;
   int delay = 3;
   int ret = 0;
@@ -1393,6 +1397,7 @@ int cmd_top(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         }
     }
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   act.sa_user = &quit;
   act.sa_sigaction = top_exit;
   sigemptyset(&act.sa_mask);
@@ -1402,6 +1407,7 @@ int cmd_top(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       nsh_error(vtbl, g_fmtcmdfailed, "top", "sigaction", NSH_ERRNO);
       return ERROR;
     }
+#endif
 
   if (vtbl->isctty)
     {

--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -124,10 +124,12 @@ static FAR void *cu_listener(FAR void *parameter)
   return NULL;
 }
 
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
 static void sigint(int sig)
 {
   g_cu.force_exit = true;
 }
+#endif
 
 #ifdef CONFIG_SERIAL_TERMIOS
 static int set_termios(FAR struct cu_globals_s *cu, int rate,
@@ -275,7 +277,9 @@ static int cu_cmd(FAR struct cu_globals_s *cu, char bcmd)
 int main(int argc, FAR char *argv[])
 {
   pthread_attr_t attr;
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   struct sigaction sa;
+#endif
   FAR const char *devname = CONFIG_SYSTEM_CUTERM_DEFAULT_DEVICE;
   FAR struct cu_globals_s *cu = &g_cu;
 #ifdef CONFIG_SERIAL_TERMIOS
@@ -295,13 +299,13 @@ int main(int argc, FAR char *argv[])
 
   memset(cu, 0, sizeof(*cu));
   cu->escape = '~';
-
+#ifdef CONFIG_ENABLE_ALL_SIGNALS
   /* Install signal handlers */
 
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sigint;
   sigaction(SIGINT, &sa, NULL);
-
+#endif
   optind = 0;   /* Global that needs to be reset in FLAT mode */
   while ((option = getopt(argc, argv, "l:s:ceE:fho?")) != ERROR)
     {


### PR DESCRIPTION
## Summary

sched/signal: Add support to disable partial signals
    
    Fix dependency issue when signals are only partially enabled
    
 Co-authored-by: guoshichao <guoshichao@xiaomi.com>
 Signed-off-by: Chengdong Wang <wangchengdong@lixiang.com>

## Impact

Fix dependency issue when signals are only partially enabled

## Testing

**ostest passed on rv-virt:smp64 when CONFIG_ENABLE_PARTIAL_SIGNALS=y**

```
nsh> uname -a
NuttX 0.0.0 3503bbec44-dirty Dec 23 2025 11:32:43 risc-v rv-virt
nsh> ostest

(...)

smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc23e0  1fc23e0
ordblks         1        7
mxordblk  1fb72f0  1fa4140
uordblks     b0f0    14df8
fordblks  1fb72f0  1fad5e8
user_main: Exiting
ostest_main: Exiting with status 0
```


