### PR TITLE
net/ping: utils ping should depends on ipv4

### DIFF
--- a/system/ping/Kconfig
+++ b/system/ping/Kconfig
@@ -6,6 +6,7 @@
 config SYSTEM_PING
 	tristate "ICMP 'ping' command"
 	default n
+	depends on NET_IPv4
 	select NETUTILS_PING
 	---help---
 		Enable support for the ICMP 'ping' command.


### PR DESCRIPTION
## Summary

ping tool depends on NET-IPV4, and all dependencies should be added in Kconfig.

## Impact

ping tool compile.

## Testing

Enable the 'system ping' compilation configuration, disable the 'NET-IPV4' compilation configuration, and then start compiling. The following error message appears:
`icmp/icmp_sockif.c:387:14: warning: implicit declaration of function ‘ipv4_getsockopt’; did you mean ‘ipv6_getsockopt’? [-Wimplicit-function-declaration]
  387 |       return ipv4_getsockopt(psock, option, value, value_len);
      |              ^~~~~~~~~~~~~~~
      |              ipv6_getsockopt
icmp/icmp_sockif.c: In function ‘icmp_setsockopt’:
icmp/icmp_sockif.c:490:14: warning: implicit declaration of function ‘ipv4_setsockopt’; did you mean ‘ipv6_setsockopt’? [-Wimplicit-function-declaration]
  490 |       return ipv4_setsockopt(psock, option, value, value_len);
      |              ^~~~~~~~~~~~~~~
      |              ipv6_setsockopt
CC:  icmp/icmp_sendmsg.c icmp/icmp_sendmsg.c: In function ‘sendto_request’:
icmp/icmp_sendmsg.c:110:56: error: ‘IPv4_HDRLEN’ undeclared (first use in this function); did you mean ‘IPv6_HDRLEN’?
  110 |   devif_send(dev, pstate->snd_buf, pstate->snd_buflen, IPv4_HDRLEN);
      |                                                        ^~~~~~~~~~~
      |                                                        IPv6_HDRLEN
icmp/icmp_sendmsg.c:110:56: note: each undeclared identifier is reported only once for each function it appears in
icmp/icmp_sendmsg.c:126:3: warning: implicit declaration of function ‘ipv4_build_header’; did you mean ‘ipv6_build_header’? [-Wimplicit-function-declaration]
  126 |   ipv4_build_header(IPv4BUF, dev->d_len, IP_PROTO_ICMP,
      |   ^~~~~~~~~~~~~~~~~
      |   ipv6_build_header
icmp/icmp_sendmsg.c:127:27: error: ‘struct net_driver_s’ has no member named ‘d_ipaddr’; did you mean ‘d_ipv6addr’?
  127 |                     &dev->d_ipaddr, &pstate->snd_toaddr,
      |                           ^~~~~~~~
      |                           d_ipv6addr
icmp/icmp_sendmsg.c: In function ‘icmp_sendmsg’:
icmp/icmp_sendmsg.c:322:13: warning: implicit declaration of function ‘netdev_findby_ripv4addr’; did you mean ‘netdev_findby_ripv6addr’? [-Wimplicit-function-declaration]
  322 |       dev = netdev_findby_ripv4addr(INADDR_ANY, inaddr->sin_addr.s_addr);
      |             ^~~~~~~~~~~~~~~~~~~~~~~
      |             netdev_findby_ripv6addr
icmp/icmp_sendmsg.c:322:11: warning: assignment to ‘struct net_driver_s *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  322 |       dev = netdev_findby_ripv4addr(INADDR_ANY, inaddr->sin_addr.s_addr);
      |           ^
icmp/icmp_sendmsg.c:335:57: error: ‘IPv4_HDRLEN’ undeclared (first use in this function); did you mean ‘IPv6_HDRLEN’?
  335 |   if (len > NETDEV_PKTSIZE(dev) - (NET_LL_HDRLEN(dev) + IPv4_HDRLEN))
      |                                                         ^~~~~~~~~~~
      |                                                         IPv6_HDRLEN
icmp/icmp_sendmsg.c:420:20: warning: implicit declaration of function ‘net_ipv4addr_maskcmp’; did you mean ‘net_ipv6addr_maskcmp’? [-Wimplicit-function-declaration]
  420 |               if (!net_ipv4addr_maskcmp(state.snd_toaddr, dev->d_ipaddr,
      |                    ^~~~~~~~~~~~~~~~~~~~
      |                    net_ipv6addr_maskcmp
icmp/icmp_sendmsg.c:420:64: error: ‘struct net_driver_s’ has no member named ‘d_ipaddr’; did you mean ‘d_ipv6addr’?
  420 |               if (!net_ipv4addr_maskcmp(state.snd_toaddr, dev->d_ipaddr,
      |                                                                ^~~~~~~~
      |                                                                d_ipv6addr
icmp/icmp_sendmsg.c:421:46: error: ‘struct net_driver_s’ has no member named ‘d_netmask’; did you mean ‘d_ipv6netmask’?
  421 |                                         dev->d_netmask))
      |                                              ^~~~~~~~~
   `



Add relationship for SYSTEM_PING, then these error information disapeared.


