### PR TITLE
netutils/dhcpc.h: fix the compilation error caused by undefined

### DIFF
--- a/include/netutils/dhcpc.h
+++ b/include/netutils/dhcpc.h
@@ -39,12 +39,21 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
 #include <stdint.h>
 #include <netinet/in.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+/* Provide a default value for CONFIG_NETDB_DNSSERVER_NAMESERVERS if
+ * CONFIG_NETDB_DNSCLIENT is not enabled.
+ */
+
+#if !defined(CONFIG_NETDB_DNSSERVER_NAMESERVERS)
+#  define CONFIG_NETDB_DNSSERVER_NAMESERVERS 1
+#endif
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary
netutils/dhcpc.h: fix the compilation error caused by undefined CONFIG_NETDB_DNSSERVER_NAMESERVERS.
Provide a default value for CONFIG_NETDB_DNSSERVER_NAMESERVERS if CONFIG_NETDB_DNSCLIENT is not enabled.

Issue link：https://github.com/apache/nuttx-apps/pull/3206#issuecomment-3681046048

## Impact
New Feature/Change: Yes
User Impact: No
Build Impact:No new Kconfig options or build system changes.
Hardware Impact: No
Security: No
Compatibility: Backward-compatible; no breaking changes.

## Testing
After re-running make, the dhcpc-related compilation errors have disappeared and the build has now progressed smoothly to the linking stage.

