### PR TITLE
ostest/hrtimer: Fix typos

### DIFF
--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -304,7 +304,7 @@ int sem_nfreeholders(void);
 void nxevent_test(void);
 #endif
 
-#if defined(CONFIG_SCHED_EVENTS) && defined(CONFIG_BUILD_FLAT)
+#if defined(CONFIG_HRTIMER) && defined(CONFIG_BUILD_FLAT)
 void hrtimer_test(void);
 #endif
 


### PR DESCRIPTION
## Summary

The current code incorrectly used the CONFIG_SCHED_EVENTS 
macro in ostest.h for hrtimer_test(). This has been corrected to use CONFIG_HRTIMER.

## Impact

Fix typos for hrtimer api tests

## Testing

**ostest passed on rv-virt:smp64 with https://github.com/apache/nuttx/pull/17573 applied and HRTIMER enabled.**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 26f4bbc328-dirty Dec 25 2025 12:56:52 risc-v rv-virt
nsh> 
nsh> ostest

(...)

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fbdea0  1fbdea0
ordblks        10       10
mxordblk  1f9a7d8  1f9a7d8
uordblks    14c68    16868
fordblks  1fa9238  1fa7638

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fbdea0  1fbdea0
ordblks         1       10
mxordblk  1fb2cc0  1f9a7d8
uordblks     b1e0    16868
fordblks  1fb2cc0  1fa7638
user_main: Exiting
ostest_main: Exiting with status 0

```

