### PR TITLE
dhcpd: Align makefile implementation

### DIFF
--- a/examples/dhcpd/CMakeLists.txt
+++ b/examples/dhcpd/CMakeLists.txt
@@ -25,10 +25,28 @@ if(CONFIG_EXAMPLES_DHCPD)
     NAME
     dhcpd
     SRCS
-    host.c
     target.c
+    dhcpd_daemon.c
     STACKSIZE
-    2048)
+    ${CONFIG_DEFAULT_TASK_STACKSIZE})
+
+  nuttx_add_application(
+    NAME
+    dhcpd_start
+    SRCS
+    dhcpd_start.c
+    dhcpd_daemon.c
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE})
+
+  nuttx_add_application(
+    NAME
+    dhcpd_stop
+    SRCS
+    dhcpd_stop.c
+    dhcpd_daemon.c
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE})
 
   add_definitions(-DCONFIG_NETUTILS_DHCPD_HOST=1 -DHAVE_SO_REUSEADDR=1
                   -DHAVE_SO_BROADCAST=1)


### PR DESCRIPTION
## Summary

Improve the CMakeLists.txt to achieve the same compilation results as Makefile.

## Impact

CMake compilation affecting dhcpd

## Testing

CMake compiles successfully, and the daemon process can be managed using dhcpd_start & dhcpd_stop.
The local test results are as follows:
```
nsh> dhcpd_start eth0
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069568 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 hpwork 0x400cb020 0x400cb0a0
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 lpwork 0x400cb0e0 0x400cb160
    3     3     0 100 FIFO     Task      - Running            0000000000000000 0067488 nsh_main
    5     5     4 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0067464 DHCPD_daemon eth0
nsh> dhcpd_stop eth0
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069568 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 hpwork 0x400cb020 0x400cb0a0
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 lpwork 0x400cb0e0 0x400cb160
    3     3     0 100 FIFO     Task      - Running            0000000000000000 0067488 nsh_main
nsh> 
```


