### PR TITLE
apps/net: add ip address connectivity check API

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -508,6 +508,10 @@ int netlib_getifstatistics(FAR const char *ifname,
 int netlib_check_ifconflict(FAR const char *ifname);
 #endif
 
+#ifdef CONFIG_NETUTILS_PING
+int netlib_check_ipconnectivity(FAR const char *ip, int timeout, int retry);
+#endif
+
 #ifdef CONFIG_MM_IOB
 int netlib_get_iobinfo(FAR struct iob_stats_s *iob);
 #endif

--- a/netutils/netlib/CMakeLists.txt
+++ b/netutils/netlib/CMakeLists.txt
@@ -153,6 +153,10 @@ if(CONFIG_NETUTILS_NETLIB)
     list(APPEND SRCS netlib_getiobinfo.c)
   endif()
 
+  if(CONFIG_NETUTILS_PING)
+    list(APPEND SRCS netlib_checkipconnectivity.c)
+  endif()
+
   target_sources(apps PRIVATE ${SRCS})
 
 endif()

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -152,4 +152,8 @@ ifeq ($(CONFIG_MM_IOB),y)
 CSRCS += netlib_getiobinfo.c
 endif
 
+ifeq ($(CONFIG_NETUTILS_PING),y)
+CSRCS += netlib_checkipconnectivity.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/netutils/netlib/netlib_checkipconnectivity.c
+++ b/netutils/netlib/netlib_checkipconnectivity.c
@@ -1,0 +1,135 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_checkipconnectivity.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <arpa/inet.h>
+#include <nuttx/net/ip.h>
+
+#include "netutils/icmp_ping.h"
+#include "netutils/netlib.h"
+
+#ifdef CONFIG_NETUTILS_PING
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#define PING_IPADDR_DATALEN  80
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ping_ipaddr_callback
+ *
+ * Description:
+ *   ping ipaddr callback
+ *
+ * Parameters:
+ *   result  The result of ping
+ *
+ ****************************************************************************/
+
+static void ping_ipaddr_callback(FAR const struct ping_result_s *result)
+{
+  FAR int *count = result->info->priv;
+
+  if (result->code == ICMP_I_FINISH)
+    {
+      *count = result->nreplies;
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_check_ipconnectivity
+ *
+ * Description:
+ *   Get the network dns status
+ *
+ * Parameters:
+ *   ip       The ipv4 address to check
+ *   timeout  The max timeout of each ping
+ *   retry    The retry times of ping
+ *
+ * Return:
+ *   nums of remote reply of ping; a nagtive on failure
+ *
+ ****************************************************************************/
+
+int netlib_check_ipconnectivity(FAR const char *ip, int timeout, int retry)
+{
+  int replies = 0;
+#ifdef CONFIG_NETDB_DNSSERVER_IPv4ADDR
+  char ip_str[INET_ADDRSTRLEN];
+  struct in_addr addr;
+#endif
+  struct ping_info_s info;
+
+  info.count    = retry;
+  info.datalen  = PING_IPADDR_DATALEN;
+  info.delay    = 0;
+  info.timeout  = timeout;
+  info.callback = ping_ipaddr_callback;
+  info.priv     = &replies;
+
+  /* if ip is NULL we use default DNS server */
+
+  if (ip == NULL)
+    {
+#ifdef CONFIG_NETDB_DNSSERVER_IPv4ADDR
+      addr.s_addr = HTONL(CONFIG_NETDB_DNSSERVER_IPv4ADDR);
+      inet_ntop(AF_INET, &addr, ip_str, INET_ADDRSTRLEN);
+      info.hostname = ip_str;
+#else
+      nerr("ERROR: IP is NULL and no DNS server configured\n");
+      return -EINVAL;
+#endif
+    }
+  else
+    {
+      info.hostname = ip;
+    }
+
+  ninfo("ping ipaddr test %s \n", info.hostname);
+  icmp_ping(&info);
+
+  return replies;
+}
+
+#endif /* CONFIG_NETUTILS_PING */


### PR DESCRIPTION
## Summary

The system checks connectivity with the input IP address; if no IP address is provided, it defaults to checking DNS server connectivity.

## Impact

N/A

## Testing

Use the following test cases for testing.
```
/****************************************************************************
 * apps/examples/hello/hello_main.c
 *
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.  The
 * ASF licenses this file to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance with the
 * License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 ****************************************************************************/

/****************************************************************************
 * Included Files
 ****************************************************************************/

#include <nuttx/config.h>
#include <stdio.h>

#ifdef CONFIG_NETUTILS_PING
#include "netutils/netlib.h"
#endif

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

int main(int argc, FAR char *argv[])
{
  printf("Hello, World!!\n");

#ifdef CONFIG_NETUTILS_PING
  int replies;
  int timeout = 100;  /* 1 second in milliseconds */
  int retry = 10;        /* 3 ping attempts */

  printf("\n=== Network Connectivity Test ===\n");
  
  /* Test case 1: Ping a specific IP address */
  replies = netlib_check_ipconnectivity("223.5.5.5", timeout, retry);
  
  if (replies > 0)
    {
      printf("SUCCESS - Received %d/%d replies\n", replies, retry);
    }
  else if (replies == 0)
    {
      printf("FAILED - No replies received\n");
    }
  else
    {
      printf("ERROR - Error code: %d\n", replies);
    }

#ifdef CONFIG_NETDB_DNSSERVER_IPv4ADDR
  /* Test case 2: Ping default DNS server (from config) */
  printf("\n=== Test Default DNS Server ===\n");
  replies = netlib_check_ipconnectivity(NULL, timeout, retry);
  
  if (replies > 0)
    {
      printf("SUCCESS - Received %d/%d replies\n", replies, retry);
    }
  else if (replies == 0)
    {
      printf("FAILED - No replies received\n");
    }
  else
    {
      printf("ERROR - Error code: %d\n", replies);
    }
#else
  printf("\nDefault DNS server test skipped (CONFIG_NETDB_DNSSERVER_IPv4ADDR not configured)\n");
#endif

#else
  printf("\nNetwork connectivity test is not available\n");
  printf("(CONFIG_NETUTILS_PING is not enabled)\n");
#endif

  return 0;
}

```
The execution results are as follows
```
nsh> hello
Hello, World!!

=== Network Connectivity Test ===
SUCCESS - Received 10/10 replies

=== Test Default DNS Server ===
SUCCESS - Received 10/10 replies

```


