### PR TITLE
dhcpd: Supports kernel mode compilation

### DIFF
--- a/examples/dhcpd/CMakeLists.txt
+++ b/examples/dhcpd/CMakeLists.txt
@@ -30,23 +30,27 @@ if(CONFIG_EXAMPLES_DHCPD)
     STACKSIZE
     ${CONFIG_DEFAULT_TASK_STACKSIZE})
 
-  nuttx_add_application(
-    NAME
-    dhcpd_start
-    SRCS
-    dhcpd_start.c
-    dhcpd_daemon.c
-    STACKSIZE
-    ${CONFIG_DEFAULT_TASK_STACKSIZE})
+  if(NOT CONFIG_BUILD_KERNEL)
+    nuttx_add_application(
+      NAME
+      dhcpd_start
+      SRCS
+      dhcpd_start.c
+      dhcpd_daemon.c
+      STACKSIZE
+      ${CONFIG_DEFAULT_TASK_STACKSIZE})
+  endif()
 
-  nuttx_add_application(
-    NAME
-    dhcpd_stop
-    SRCS
-    dhcpd_stop.c
-    dhcpd_daemon.c
-    STACKSIZE
-    ${CONFIG_DEFAULT_TASK_STACKSIZE})
+  if(CONFIG_SCHED_WAITPID)
+    nuttx_add_application(
+      NAME
+      dhcpd_stop
+      SRCS
+      dhcpd_stop.c
+      dhcpd_daemon.c
+      STACKSIZE
+      ${CONFIG_DEFAULT_TASK_STACKSIZE})
+  endif()
 
   add_definitions(-DCONFIG_NETUTILS_DHCPD_HOST=1 -DHAVE_SO_REUSEADDR=1
                   -DHAVE_SO_BROADCAST=1)

--- a/examples/dhcpd/Makefile
+++ b/examples/dhcpd/Makefile
@@ -26,13 +26,23 @@ include $(APPDIR)/Make.defs
 
 CSRCS = dhcpd_daemon.c
 
-MAINSRC = dhcpd_start.c dhcpd_stop.c target.c
+MAINSRC = target.c
 
 # DHCPD built-in application info
 
-PROGNAME = dhcpd_start dhcpd_stop dhcpd
+PROGNAME = dhcpd
 PRIORITY = SCHED_PRIORITY_DEFAULT
 STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
 MODULE = $(CONFIG_EXAMPLES_DHCPD)
+
+ifneq ($(CONFIG_BUILD_KERNEL),y)
+MAINSRC += dhcpd_start.c
+PROGNAME += dhcpd_start
+endif
+
+ifeq ($(CONFIG_SCHED_WAITPID),y)
+MAINSRC += dhcpd_stop.c
+PROGNAME += dhcpd_stop
+endif
 
 include $(APPDIR)/Application.mk

--- a/examples/dhcpd/dhcpd_daemon.c
+++ b/examples/dhcpd/dhcpd_daemon.c
@@ -128,10 +128,12 @@ int dhcpd_daemon(int argc, FAR char *argv[], bool daemon)
 
   /* Then start the dhcpd */
 
-  if (daemon)
+#ifndef CONFIG_BUILD_KERNEL
+  if (!daemon)
     {
-      return dhcpd_run(devname);
+      return dhcpd_start(devname);
     }
+#endif
 
-  return dhcpd_start(devname);
+  return dhcpd_run(devname);
 }


### PR DESCRIPTION
## Summary

The previous method of terminating the dhcp daemon via a global variable has been removed; instead, the `kill pid` command is used. Also, because the original `dhcp_start` method creates tasks via `task_create`, which is not supported in kernel mode, `dhcp_start` is not compiled in kernel mode. The daemon can be started in kernel mode using `dhcpd xxx &`.

## Impact

The dhcpd_start and dhcpd_stop functions

## Testing

Tested normally in flat mode
```
nsh> dhcpd_start eth0
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069568 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 hpwork 0x400b8020 0x400b80a0
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 lpwork 0x400b80e0 0x400b8160
    3     3     0 100 FIFO     Task      - Running            0000000000000000 0067488 nsh_main
    5     5     4 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0067464 dhcpd eth0
nsh> dhcpd_stop
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069568 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 hpwork 0x400b8020 0x400b80a0
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 lpwork 0x400b80e0 0x400b8160
    3     3     0 100 FIFO     Task      - Running            0000000000000000 0067488 nsh_main
nsh> 
```

The build process works correctly in kernel mode and also functions properly on the internal QEMU platform.

```
ap> dhcpd wlan0 &
dhcpd [15:255]
ap> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0008104 0000492   6.0%  39.0% CPU0 IDLE
    1     0 254 FIFO     Kthread   - Ready              0000000000000000 0008056 0000720   8.9%   0.8% hpwork 0x402009c0 0x40200a18
    2     0  90 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008056 0000584   7.2%   0.0% lpwork 0x40200940 0x40200998
    4     4 255 FIFO     Task      - Running            0000000000000000 0032656 0001664   5.0%   0.9% /bin/init
    6     6 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102296 0001872   1.8%   0.0% kvdbd
    7     7 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102288 0001496   1.4%  57.7% servicemanager
    9     9 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102296 0007080   6.9%   0.0% mediad
   10    10 100 FIFO     Task      - Ready              0000000000000000 0102296 0004620   4.5%   1.3% systemd
   11    11 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102296 0001072   1.0%   0.0% opteed
   12    12 100 FIFO     Task      - Waiting  Semaphore 0000000000020000 0102296 0000624   0.6%   0.0% telnetd
   13     6 100 FIFO     pthread   - Waiting  Semaphore 0000000000000000 0008104 0000544   6.7%   0.0% kvdbd 0x800010cd 0x820194ac
   14    14 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102264 0024880  24.3%   0.0% vappxms com.application.x4b.init
   15    15 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102288 0000624   0.6%   0.0% dhcpd wlan0
ap> dhcpd_stop
ap> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0008104 0000492   6.0%  89.4% CPU0 IDLE
    1     0 254 FIFO     Kthread   - Ready              0000000000000000 0008056 0000720   8.9%   3.5% hpwork 0x402009c0 0x40200a18
    2     0  90 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008056 0000584   7.2%   0.0% lpwork 0x40200940 0x40200998
    4     4 255 FIFO     Task      - Running            0000000000000000 0032656 0001664   5.0%   0.8% /bin/init
    6     6 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102296 0001872   1.8%   0.0% kvdbd
    7     7 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102288 0001496   1.4%   0.0% servicemanager
    9     9 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102296 0007080   6.9%   0.0% mediad
   10    10 100 FIFO     Task      - Ready              0000000000000000 0102296 0004620   4.5%   6.1% systemd
   11    11 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102296 0001072   1.0%   0.0% opteed
   12    12 100 FIFO     Task      - Waiting  Semaphore 0000000000020000 0102296 0000624   0.6%   0.0% telnetd
   13     6 100 FIFO     pthread   - Waiting  Semaphore 0000000000000000 0008104 0000544   6.7%   0.0% kvdbd 0x800010cd 0x820194ac
   14    14 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0102264 0024880  24.3%   0.0% vappxms com.application.x4b.init

```

