### PR TITLE
 netlib: Add support for adding/removing VLAN device

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -329,6 +329,11 @@ int netlib_getessid(FAR const char *ifname, FAR char *essid, size_t idlen);
 int netlib_setessid(FAR const char *ifname, FAR const char *essid);
 #endif
 
+#ifdef CONFIG_NET_VLAN
+int netlib_add_vlan(FAR const char *ifname, int vlanid);
+int netlib_del_vlan(FAR const char *vlanif);
+#endif
+
 #ifdef CONFIG_NET_ARP
 /* ARP Table Support */
 

--- a/netutils/netlib/CMakeLists.txt
+++ b/netutils/netlib/CMakeLists.txt
@@ -118,6 +118,10 @@ if(CONFIG_NETUTILS_NETLIB)
     list(APPEND SRCS netlib_setmacaddr.c netlib_getmacaddr.c)
   endif()
 
+  if(CONFIG_NET_VLAN)
+    list(APPEND SRCS netlib_addvlan.c netlib_delvlan.c)
+  endif()
+
   list(APPEND SRCS netlib_setmtu.c)
 
   if(CONFIG_WIRELESS_IEEE802154)

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -123,6 +123,10 @@ ifeq ($(CONFIG_NET_ETHERNET),y)
 CSRCS += netlib_setmacaddr.c netlib_getmacaddr.c
 endif
 
+ifeq ($(CONFIG_NET_VLAN),y)
+CSRCS += netlib_addvlan.c netlib_delvlan.c
+endif
+
 CSRCS += netlib_setmtu.c
 
 ifeq ($(CONFIG_WIRELESS_IEEE802154),y)

--- a/netutils/netlib/netlib_addvlan.c
+++ b/netutils/netlib/netlib_addvlan.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_addvlan.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#ifdef CONFIG_NET_VLAN
+
+#include <nuttx/net/vlan.h>
+
+#include "netutils/netlib.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_add_vlan
+ *
+ * Description:
+ *   Add a VLAN interface to an existing network device.
+ *
+ * Parameters:
+ *   ifname - The name of the existing network device
+ *   vlanid - The VLAN identifier to be added
+ *
+ * Return:
+ *   0 on success; -1 on failure
+ *
+ ****************************************************************************/
+
+int netlib_add_vlan(FAR const char *ifname, int vlanid)
+{
+  int ret = ERROR;
+
+  if (ifname && vlanid > 0)
+    {
+      int sockfd = socket(NET_SOCK_FAMILY, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+      if (sockfd >= 0)
+        {
+          struct vlan_ioctl_args ifv;
+
+          strlcpy(ifv.device1, ifname, sizeof(ifv.device1));
+          ifv.u.VID = vlanid;
+          ifv.cmd = ADD_VLAN_CMD;
+
+          ret = ioctl(sockfd, SIOCSIFVLAN, &ifv);
+          close(sockfd);
+        }
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_NET_VLAN */

--- a/netutils/netlib/netlib_delvlan.c
+++ b/netutils/netlib/netlib_delvlan.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_delvlan.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#ifdef CONFIG_NET_VLAN
+
+#include <nuttx/net/vlan.h>
+
+#include "netutils/netlib.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_del_vlan
+ *
+ * Description:
+ *   Remove a VLAN interface from an existing network device.
+ *
+ * Parameters:
+ *   vlanif - The name of the VLAN network device
+ *
+ * Return:
+ *   0 on success; -1 on failure
+ *
+ ****************************************************************************/
+
+int netlib_del_vlan(FAR const char *vlanif)
+{
+  int ret = ERROR;
+
+  if (vlanif)
+    {
+      int sockfd = socket(NET_SOCK_FAMILY, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+      if (sockfd >= 0)
+        {
+          struct vlan_ioctl_args ifv;
+
+          strlcpy(ifv.device1, vlanif, sizeof(ifv.device1));
+          ifv.cmd = DEL_VLAN_CMD;
+
+          ret = ioctl(sockfd, SIOCSIFVLAN, &ifv);
+          close(sockfd);
+        }
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_NET_VLAN */


### PR DESCRIPTION

## Summary

The Nuttx network protocol stack supports the Vlan module, and netlib needs to support Vlan related apis.

## Impact

Users can add or delete Vlan interfaces through the netlib api interface.

## Testing

`
#include <stdio.h>
#include <string.h>
#include <unistd.h>
#include <errno.h>
#include <netutils/netlib.h>

#define TEST_IFNAME "eth0"   // Change to your actual base interface name
#define TEST_VLANID 100      // VLAN ID to test
#define TEST_VLANIF "eth0.100" // Expected VLAN interface name

int main(void)
{
    int ret;

    printf("Testing netlib_add_vlan()...\n");
    ret = netlib_add_vlan(TEST_IFNAME, TEST_VLANID);
    if (ret == 0)
    {
        printf("netlib_add_vlan: SUCCESS (added VLAN %d to %s)\n", TEST_VLANID, TEST_IFNAME);
    }
    else
    {
        printf("netlib_add_vlan: FAILED (errno=%d: %s)\n", errno, strerror(errno));
        return 1;
    }

    // Optionally, you can check if the VLAN interface exists here
    // For simplicity, we just try to delete it

//    printf("Testing netlib_del_vlan()...\n");
//    ret = netlib_del_vlan(TEST_VLANIF);
//    if (ret == 0)
//    {
//        printf("netlib_del_vlan: SUCCESS (deleted VLAN interface %s)\n", TEST_VLANIF);
//    }
//    else
//    {
//        printf("netlib_del_vlan: FAILED (errno=%d: %s)\n", errno, strerror(errno));
//        return 1;
//    }

    printf("VLAN add/delete test completed.\n");
    return 0;
}
`


