### PR TITLE
 net/pkt: Set `sll_protocol` for raw socket to `ETH_P_ALL`

### DIFF
--- a/examples/netpkt/netpkt_ethercat.c
+++ b/examples/netpkt/netpkt_ethercat.c
@@ -30,6 +30,8 @@
 #include <time.h>
 
 #include <net/if.h>
+#include <netinet/if_ether.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netpacket/packet.h>
 #include <sys/socket.h>
@@ -66,7 +68,7 @@ int main(int argc, FAR const char *argv[])
   int num_packets = 0;
   int len;
   int ifindex;
-  int sockfd = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW);
+  int sockfd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 
   if (sockfd == -1)
     {
@@ -96,6 +98,7 @@ int main(int argc, FAR const char *argv[])
 
   addr.sll_family = AF_PACKET;
   addr.sll_ifindex = ifindex;
+  addr.sll_protocol = htons(ETH_P_ALL);
   if (bind(sockfd, (FAR const struct sockaddr *)&addr, sizeof(addr)) < 0)
     {
       perror("ERROR: binding socket failed");

--- a/system/tcpdump/tcpdump.c
+++ b/system/tcpdump/tcpdump.c
@@ -30,6 +30,8 @@
 #include <fcntl.h>
 #include <net/if.h>
 #include <net/if_arp.h>
+#include <netinet/if_ether.h>
+#include <netinet/in.h>
 #include <netpacket/packet.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -201,6 +203,7 @@ static int socket_open(int ifindex)
 
   addr.sll_family = AF_PACKET;
   addr.sll_ifindex = ifindex;
+  addr.sll_protocol = htons(ETH_P_ALL);
   if (bind(sd, (FAR const struct sockaddr *)&addr, sizeof(addr)) < 0)
     {
       perror("ERROR: binding socket failed");


### PR DESCRIPTION

## Summary

Ref: https://man7.org/linux/man-pages/man7/packet.7.html

We should either set protocal when creating socket or binding, otherwise
we cannot capture any packet.

## Impact

The netpkt tool will receive all types of Ethernet messages.
## Testing

Open the compilation option CONFIG_EXAMPLES_NETPKT and set up the SIM environment. Use `netpkt - vr` to receive messages at the SIM and send messages to the SIM at the host. Check the reception of SIM terminal. The result verifies that netpkt receives normally.


