### PR TITLE
apps/testing: add cmock_test for enet in order to test send and receive pkt

### DIFF
--- a/testing/enet/CMakeLists.txt
+++ b/testing/enet/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# apps/testing/enet/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ENET_TEST)
+
+  set(ENETTEST_INCDIR ${CMAKE_CURRENT_LIST_DIR}/include
+                      ${CMAKE_CURRENT_LIST_DIR}/util)
+  file(GLOB ENETTEST_CSRC ${CMAKE_CURRENT_LIST_DIR}/src/*.c
+       ${CMAKE_CURRENT_LIST_DIR}/util/*.c)
+
+  nuttx_add_application(
+    NAME
+    cmocka_enet
+    SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/enet_entry.c
+    ${ENETTEST_CSRC}
+    STACKSIZE
+    ${CONFIG_ENET_TEST_STACKSIZE}
+    PRIORITY
+    ${CONFIG_ENET_TEST_PRIORITY}
+    INCLUDE_DIRECTORIES
+    ${ENETTEST_INCDIR}
+    DEPENDS
+    cmocka)
+
+endif()

--- a/testing/enet/Kconfig
+++ b/testing/enet/Kconfig
@@ -1,0 +1,32 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config ENET_TEST
+	tristate "cmocka enet test"
+	default n
+	depends on TESTING_CMOCKA
+	---help---
+		Enable the cmocka enet test
+
+if ENET_TEST
+config ENET_TEST_PROGNAME
+	string "Program name"
+	default "enet_test"
+	---help---
+		This is the name of the cmocka program that will be used as enet test.
+
+config ENET_TEST_PRIORITY
+	int "Task priority"
+	default 100
+
+config ENET_TEST_STACKSIZE
+	int "Stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+config ENET_TEST_DEV
+	string "Dev Node"
+	default "eth0"
+
+endif

--- a/testing/enet/Make.defs
+++ b/testing/enet/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# testing/enet/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_ENET_TEST),)
+CONFIGURED_APPS += $(APPDIR)/testing/enet
+endif

--- a/testing/enet/Makefile
+++ b/testing/enet/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# testing/enet/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+CFLAGS += -I$(APPDIR)/testing/enet/util
+CSRCS  += $(wildcard $(APPDIR)/testing/enet/util/*.c)
+
+CFLAGS += -I$(APPDIR)/testing/enet/include
+CSRCS  += $(wildcard $(APPDIR)/testing/enet/src/*.c)
+
+PRIORITY  = $(CONFIG_ENET_TEST_PRIORITY)
+STACKSIZE = $(CONFIG_ENET_TEST_STACKSIZE)
+MODULE    = $(CONFIG_ENET_TEST)
+
+PROGNAME += CONFIG_ENET_TEST_PROGNAME
+MAINSRC  += $(CURDIR)/enet_entry.c
+
+include $(APPDIR)/Application.mk

--- a/testing/enet/enet_entry.c
+++ b/testing/enet/enet_entry.c
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * apps/testing/enet/enet_entry.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "enettest.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cmocka_test_main
+ ****************************************************************************/
+
+int main(int argc, char * argv[])
+{
+  /* Add Test Cases */
+
+  const struct CMUnitTest enettestsuite[] =
+  {
+    cmocka_unit_test_setup_teardown(test_enet_loopwr_datacheck,
+                                    enet_test_setup,
+                                    enet_test_teardown),
+  };
+
+  /* Run Test cases */
+
+  cmocka_run_group_tests(enettestsuite, NULL, NULL);
+  return 0;
+}

--- a/testing/enet/include/enettest.h
+++ b/testing/enet/include/enettest.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * apps/testing/enet/include/enettest.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _H_ENET_TEST_H_
+#define  H_ENET_TEST_H_
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "enet_util.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* TEST CASES FUNCTIONS */
+
+void test_enet_loopwr_datacheck(void **state);
+
+#endif //_H_ENET_TEST_H_

--- a/testing/enet/src/test_enet_loopwr_datacheck.c
+++ b/testing/enet/src/test_enet_loopwr_datacheck.c
@@ -1,0 +1,98 @@
+/****************************************************************************
+ * apps/testing/enet/src/test_enet_loopwr_datacheck.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "enettest.h"
+#include <sys/socket.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define DATA_SIZE 200
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_enet_loopwr_datacheck
+ * Description:
+ *   This function tests the ENET loop write function and reads the frame
+ *   from the ENET interface without using poll.
+ ****************************************************************************/
+
+void test_enet_loopwr_datacheck(void **state)
+{
+  struct senet_testsuites_params *enet_if = *state;
+  uint8_t recv_data[DATA_SIZE];
+  ssize_t bytes_received;
+  int loop_count = 0;
+  const int LOOP_MAX = 20;
+  const uint8_t expected_mac[6] =
+  {
+    0x58,
+    0x32,
+    0x31,
+    0x32,
+    0x39,
+    0x37
+  };
+
+  /* Send frames */
+
+  sleep(10);
+  enet_loop_send_frame(state);
+
+  /* Read loop */
+
+  while (loop_count < LOOP_MAX)
+    {
+      /* Directly read data */
+
+      bytes_received = read(enet_if->enet_dev.fd, recv_data, DATA_SIZE);
+      assert_true(bytes_received >= 0);
+
+      if (bytes_received > 0)
+        {
+          /* Verify ethernet type (0x88f7) */
+
+          uint16_t eth_type = (recv_data[12] << 8) | recv_data[13];
+          assert_true(eth_type == 0x88f7);
+
+          /* Verify frame length matches expected size */
+
+          assert_true(bytes_received == DATA_SIZE);
+
+          /* Verify source MAC address */
+
+          assert_memory_equal(&recv_data[6], expected_mac, 6);
+          loop_count++;
+        }
+    }
+
+  /* Verify we received expected number of frames */
+
+  assert_true(loop_count == LOOP_MAX);
+}

--- a/testing/enet/util/enet_util.c
+++ b/testing/enet/util/enet_util.c
@@ -1,0 +1,284 @@
+/****************************************************************************
+ * apps/testing/enet/util/enet_util.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "enet_util.h"
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netpacket/packet.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define DATA_SIZE 200
+
+#define ETH_PTP_TYPE 0x88f7
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: enet_test_setup
+ ****************************************************************************/
+
+int enet_test_setup(void **state)
+{
+  struct senet_testsuites_params *enet_p;
+  int ret;
+
+  enet_p = zalloc(sizeof(struct senet_testsuites_params));
+  assert_true(enet_p != NULL);
+  enet_p->enet_dev.if_name = strdup(CONFIG_ENET_TEST_DEV);
+  *state = enet_p;
+
+  /* ifup enet interface */
+
+  ret = netlib_ifup(enet_p->enet_dev.if_name);
+  assert_true(ret == 0);
+  enet_p->enet_dev.fd = enet_test_init(enet_p->enet_dev.if_name);
+  assert_true(enet_p->enet_dev.fd > 0);
+  return 0;
+}
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: enet_test_init
+ ****************************************************************************/
+
+int enet_test_init(const char *enetif)
+{
+  int ret;
+  int pkt_fd;
+  struct sockaddr_ll sll;
+  struct timeval timeout;
+  struct ifreq ifr;
+  int ifindex;
+  int optval;
+
+  /* Create raw socket */
+
+  pkt_fd = socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK, HTONS(ETH_PTP_TYPE));
+  assert_true(pkt_fd > 0);
+
+  /* Initialize socket address structure */
+
+  memset(&sll, 0, sizeof(struct sockaddr_ll));
+
+  /* Set socket timeout options */
+
+  timeout.tv_sec = 0;
+  timeout.tv_usec = 1;
+
+  ret = setsockopt(pkt_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                   sizeof(timeout));
+  assert_true(ret == 0);
+
+  ret = setsockopt(pkt_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout,
+                   sizeof(timeout));
+  assert_true(ret == 0);
+
+  /* Set don't route option */
+
+  optval = 1;
+  ret = setsockopt(pkt_fd, SOL_SOCKET, SO_DONTROUTE, &optval,
+                   sizeof(optval));
+  assert_true(ret == 0);
+
+  /* Get interface index */
+
+  strlcpy(ifr.ifr_name, enetif, IFNAMSIZ);
+  ret = ioctl(pkt_fd, SIOCGIFINDEX, &ifr);
+  assert_true(ret == 0);
+
+  ifindex = ifr.ifr_ifindex;
+
+  /* Get interface flags */
+
+  ret = ioctl(pkt_fd, SIOCGIFFLAGS, &ifr);
+  assert_true(ret == 0);
+
+  /* Set interface broadcast flag */
+
+  ifr.ifr_flags |= IFF_BROADCAST;
+  ret = ioctl(pkt_fd, SIOCSIFFLAGS, &ifr);
+  assert_true(ret == 0);
+
+  /* Prepare and bind socket */
+
+  sll.sll_family = AF_PACKET;
+  sll.sll_protocol = HTONS(ETH_PTP_TYPE);
+  sll.sll_ifindex = ifindex;
+
+  ret = bind(pkt_fd, (struct sockaddr *)&sll,
+             sizeof(struct sockaddr_ll));
+  assert_true(ret == 0);
+
+  return pkt_fd;
+
+errout_with_socket:
+  close(pkt_fd);
+  return -1;
+}
+
+/****************************************************************************
+ * Name: enet_loop_send_frame
+ * Description:
+ *   Test sending ethernet frames in a loop (20 times)
+ ****************************************************************************/
+
+void enet_loop_send_frame(void **state)
+{
+  struct senet_testsuites_params *enet_if = *state;
+  uint8_t data[DATA_SIZE];
+  const char *message = "Hello, World!";
+  uint16_t ip_checksum;
+  int ret;
+  size_t message_len;
+  int i;
+  const int LOOP_COUNT = 20;  /* Number of frames to send */
+
+  /* Initialize test data */
+
+  memset(data, 0, DATA_SIZE);
+
+  /* Setup ethernet header */
+
+  /* Destination MAC address (broadcast) */
+
+  data[0] = 0x01; data[1] = 0x00; data[2] = 0x5e;
+  data[3] = 0x00; data[4] = 0x00; data[5] = 0x00;
+
+  /* Source MAC address: 58:32:31:32:39:37 */
+
+  data[6] = 0x58; data[7] = 0x32; data[8] = 0x31;
+  data[9] = 0x32; data[10] = 0x39; data[11] = 0x37;
+
+  /* Ethernet type (IPv4) */
+
+  data[12] = 0x88; data[13] = 0xf7;
+
+  /* Setup IP header */
+
+  data[14] = 0x45;                    /* Version 4, IHL 5 (20 bytes) */
+  data[15] = 0x00;                    /* DSCP/ECN */
+  data[16] = 0x00; data[17] = 0x4e;   /* Total Length: 78 bytes */
+  data[18] = 0x00; data[19] = 0x00;   /* Identification */
+  data[20] = 0x00; data[21] = 0x00;   /* Flags and Fragment Offset */
+  data[22] = 0x40;                    /* TTL: 64 */
+  data[23] = 0x11;                    /* Protocol: UDP */
+  data[24] = 0x00; data[25] = 0x00;   /* Header Checksum (initial 0) */
+
+  /* Source IP: 10.0.0.2 */
+
+  data[26] = 0x0a; data[27] = 0x00;
+  data[28] = 0x00; data[29] = 0x02;
+
+  /* Destination IP: 255.255.255.255 (broadcast) */
+
+  data[30] = 0xff; data[31] = 0xff;
+  data[32] = 0xff; data[33] = 0xff;
+
+  /* Copy payload message */
+
+  message_len = strlen(message);
+  memcpy(data + 42, message, message_len);
+
+  /* Calculate IP header checksum */
+
+  ip_checksum = 0;
+  for (int i = 14; i < 34; i += 2)
+    {
+      ip_checksum += (data[i] << 8) | data[i + 1];
+    }
+
+  if (ip_checksum >> 16)
+    {
+      ip_checksum = (ip_checksum & 0xffff) + (ip_checksum >> 16);
+    }
+
+  ip_checksum = ~ip_checksum;
+  data[24] = (ip_checksum >> 8) & 0xff;
+  data[25] = ip_checksum & 0xff;
+
+  /* Send frames in a loop */
+
+  for (i = 0; i < LOOP_COUNT; i++)
+    {
+      ret = send(enet_if->enet_dev.fd, data, DATA_SIZE, 0);
+      assert_true(ret > 0);
+
+      /* Add a small delay between sends */
+
+      usleep(100000);  /* 100ms delay */
+    }
+
+  /* Verify we completed all sends */
+
+  assert_true(i == LOOP_COUNT);
+}
+
+/****************************************************************************
+ * Name: enet_test_teardown
+ ****************************************************************************/
+
+int enet_test_teardown(void **state)
+{
+  int ret;
+  struct senet_testsuites_params *enet_p;
+
+  if (state == NULL || *state == NULL)
+    {
+      return -1;
+    }
+
+  enet_p = *state;
+
+  /* close enet interface */
+
+  ret = close(enet_p->enet_dev.fd);
+  assert_true(ret == 0);
+  ret = netlib_ifdown(enet_p->enet_dev.if_name);
+  assert_true(ret >= 0);
+
+  /* free memory */
+
+  free(enet_p->enet_dev.if_name);
+
+  /* free structure */
+
+  free(enet_p);
+  *state = NULL;
+  return 0;
+}

--- a/testing/enet/util/enet_util.h
+++ b/testing/enet/util/enet_util.h
@@ -1,0 +1,68 @@
+/****************************************************************************
+ * apps/testing/enet/util/enet_util.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _H_CM_ENETTEST_UTIL_H
+#define _H_CM_ENETTEST_UTIL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <nuttx/config.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include "netutils/netlib.h"
+#include <poll.h>
+#include <pthread.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct enet_if
+{
+  int fd;
+  char *if_name;
+};
+struct senet_testsuites_params
+{
+  struct enet_if enet_dev;
+  int loopmax;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int enet_test_init (const char *enetif);
+int enet_test_teardown (void **state);
+int enet_test_setup (void **state);
+void enet_loop_send_frame(void **state);
+
+#endif /* CM_MYTEST_UTIL_H */


### PR DESCRIPTION
## Summary

add cmock_test for enet in order to test send and receive pkt

## Impact

Added basic packet sending and receiving tests for Ethernet drivers.

## Testing

1. Enable the following configuration:

CONFIG_TESTING_CMOCKA=y
CONFIG_LIBC_REGEX=y
CONFIG_ALLOW_MIT_COMPONENTS=y
CONFIG_ENET_TEST=y

2. Execute commands on the device： “cmocka --test test_enet_loopwr_datacheck”

The log information after the test passed is as follows:
```
core1> cmocka --test test_enet_loopwr_datacheck
[core1] Cmocka Test Start.
[core1] [==========] enettestsuite: Running 1 test(s).
[core1] [ RUN      ] test_enet_loopwr_datacheck
core1> [core1] [       OK ] test_enet_loopwr_datacheck
[core1] [==========] enettestsuite: 1 test(s) run.
[core1] [  PASSED  ] 1 test(s).
[core1] Cmocka Test Completed.
```




