### PR TITLE
apps/examples/udp: Update CMAKEList.txt for UDP tests under CMAKE

### DIFF
--- a/examples/udp/CMakeLists.txt
+++ b/examples/udp/CMakeLists.txt
@@ -21,5 +21,60 @@
 # ##############################################################################
 
 if(CONFIG_EXAMPLES_UDP)
-  nuttx_add_application(NAME udp)
+
+  # Basic UDP networking test
+
+  set(CSRCS udp_cmdline.c)
+
+  if(CONFIG_EXAMPLES_UDP_NETINIT)
+    list(APPEND CSRCS udp_netinit.c)
+  endif()
+
+  # Target 1 Files
+
+  if(CONFIG_EXAMPLES_UDP_SERVER1)
+    list(APPEND CSRCS udp_server.c)
+  else()
+    list(APPEND CSRCS udp_client.c)
+  endif()
+
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_UDP_PROGNAME1}
+    PRIORITY
+    ${CONFIG_EXAMPLES_UDP_PRIORITY1}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_UDP_STACKSIZE1}
+    MODULE
+    ${CONFIG_EXAMPLES_UDP}
+    INCLUDE_DIRECTORIES
+    ${CMAKE_BINARY_DIR}/include/nuttx
+    SRCS
+    udp_target1.c
+    ${CSRCS})
+
+  # Target 2 Files
+
+  if(CONFIG_EXAMPLES_UDP_TARGET2)
+    if(CONFIG_EXAMPLES_UDP_SERVER1)
+      list(APPEND CSRCS udp_client.c)
+    else()
+      list(APPEND CSRCS udp_server.c)
+    endif()
+
+    nuttx_add_application(
+      NAME
+      ${CONFIG_EXAMPLES_UDP_PROGNAME2}
+      PRIORITY
+      ${CONFIG_EXAMPLES_UDP_PRIORITY2}
+      STACKSIZE
+      ${CONFIG_EXAMPLES_UDP_STACKSIZE2}
+      MODULE
+      ${CONFIG_EXAMPLES_UDP}
+      INCLUDE_DIRECTORIES
+      ${CMAKE_BINARY_DIR}/include/nuttx
+      SRCS
+      udp_target2.c
+      ${CSRCS})
+  endif()
 endif()


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Fixed examples/udp/CMakeLists.txt in order to build example with CMake correctly.

## Impact

CMake build of apps/examples/udp is now fixed.

## Testing

Verify using the app's built-in UDP test: As a client, the peer device starts a UDP server and listens for packets. The local client tests the following:

1. Socket creation successful;

2. Packets can be sent to the peer device normally;

3. Packets with a single packet length (UDP payload) of 1460 can be successfully sent to the peer device;

Test results are as follows:
```
core1> udpclient
client: 0. Sending 96 bytes
client: 0. Sent 96 bytes
client: 1. Sending 96 bytes
client: 1. Sent 96 bytes
```




