### PR TITLE
github/ci: add support for NTFC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,31 @@ jobs:
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
 
+      - name: Install NTFC
+        uses: ./sources/nuttx/.github/actions/ci-container
+        env:
+          BLOBDIR: /tools/blobs
+        with:
+          run: |
+            # install venv
+            apt-get update
+            apt install -y python3-dev
+            apt install -y python3-venv
+
+            # get NTFC sources
+            git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-ntfc
+            cd /github/workspace/nuttx-ntfc
+
+            # install NTFC with venv
+            python3 -m venv /github/workspace/nuttx-ntfc/venv
+            source /github/workspace/nuttx-ntfc/venv/bin/activate
+            pip3 install .
+            deactivate
+
+            # get NTFC test cases
+            cd external
+            git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-testing
+
       - name: Run builds
         uses: ./sources/nuttx/.github/actions/ci-container
         env:
@@ -183,6 +208,7 @@ jobs:
           run: |
             echo "::add-matcher::sources/nuttx/.github/gcc.json"
             export ARTIFACTDIR=`pwd`/buildartifacts
+            export NTFCDIR=/github/workspace/nuttx-ntfc
             git config --global --add safe.directory /github/workspace/sources/nuttx
             git config --global --add safe.directory /github/workspace/sources/apps
             cd sources/nuttx/tools/ci


### PR DESCRIPTION
## Summary
Add support for NTFC testing framework.

At the moment NTFC is downloaded from a private repo, and installed with pip and venv. In the future NTFC repositories will be migrated to Apache organization.

It must be merged with https://github.com/apache/nuttx/pull/17728 to not break CI.
First step to solve https://github.com/apache/nuttx/issues/17717

## Impact
NTFC will be available for nuttx-apps CI, so `sim/citest` can be executed after https://github.com/apache/nuttx/pull/17728 is merged

## Testing
CI only. The real test will be done after merging this PR and https://github.com/apache/nuttx/pull/17728



