### PR TITLE
system/iptables: avoid trap when run "iptables -L" if configured CONF…

### DIFF
--- a/system/iptables/iptables.c
+++ b/system/iptables/iptables.c
@@ -506,7 +506,7 @@ int main(int argc, FAR char *argv[])
   else
 #endif
 #ifdef CONFIG_NET_NAT
-  if (strcmp(args.table, TABLE_NAME_NAT) == 0)
+  if (args.table != NULL && strcmp(args.table, TABLE_NAME_NAT) == 0)
     {
       ret = iptables_apply(&args, iptables_nat_command);
       if (ret < 0)


### PR DESCRIPTION
avoid trap when run "iptables -L" if configured CONFIG_NET_NAT while not configured CONFIG_NET_IPFILTER
It's a trap happen everytime.

It's a trap happen everytime.

it can fix issue: https://github.com/apache/nuttx-apps/issues/3294