### PR TITLE
ostest: sync hrtimer ostest with hrtimer updates

### DIFF
--- a/testing/ostest/hrtimer.c
+++ b/testing/ostest/hrtimer.c
@@ -120,18 +120,22 @@ static void hrtimer_test_init(FAR struct hrtimer_test_s *hrtimer_test,
  *
  * Input Parameters:
  *   hrtimer - Pointer to the expired HRTimer instance
+ *   expired - The expired value of hrtimer
  *
  * Returned Value:
  *   Timer period in nanoseconds (NSEC_PER_50MS)
  *
  ****************************************************************************/
 
-static uint32_t test_hrtimer_callback(FAR hrtimer_t *hrtimer)
+static uint64_t
+test_hrtimer_callback(FAR hrtimer_t *hrtimer, uint64_t expired)
 {
   struct timespec ts;
   uint32_t diff;
   uint64_t now;
   int ret;
+
+  UNUSED(expired);
 
   FAR struct hrtimer_test_s *test =
     (FAR struct hrtimer_test_s *)hrtimer;
@@ -207,9 +211,7 @@ void hrtimer_test(void)
 
   /* Initialize the high-resolution timer */
 
-  hrtimer_init(&hrtimer_test.timer,
-               test_hrtimer_callback,
-               NULL);
+  hrtimer_init(&hrtimer_test.timer, test_hrtimer_callback);
 
   /* Start the timer with 500ms relative timeout */
 


### PR DESCRIPTION
## Summary

sync hrtimer ostest with hrtimer updates by  https://github.com/apache/nuttx/pull/17642

## Impact

this PR depends on https://github.com/apache/nuttx/pull/17642

## Testing

**ostest passed with hrtimer enabled on rv-virt:smp64**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 a93f8254ea-dirty Jan  6 2026 12:19:18 risc-v rv-virt
nsh> 
nsh> ostest

(...)

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fbddc0  1fbddc0
ordblks         9        8
mxordblk  1fa06b8  1fa06b8
uordblks    14d68    16560
fordblks  1fa9058  1fa7860

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fbddc0  1fbddc0
ordblks         1        8
mxordblk  1fb2be0  1fa06b8
uordblks     b1e0    16560
fordblks  1fb2be0  1fa7860
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 
```

