### PR TITLE
netlib/ping: fix the stack variable not initialized.

### DIFF
--- a/netutils/netlib/netlib_checkipconnectivity.c
+++ b/netutils/netlib/netlib_checkipconnectivity.c
@@ -107,6 +107,9 @@ int netlib_check_ipconnectivity(FAR const char *ip, int timeout, int retry)
   info.timeout  = timeout;
   info.callback = ping_ipaddr_callback;
   info.priv     = &replies;
+#ifdef CONFIG_NET_BINDTODEVICE
+  info.devname  = NULL;
+#endif
 
   /* if ip is NULL we use default DNS server */
 


### PR DESCRIPTION
## Summary

We add devname in ping_info_s, but not initializeed, cause
data abort as value in stack possible not NULL.

## Impact

Only affects the connectivity detection API

## Testing

The following code was successfully tested on the sim.

```
/****************************************************************************
 * apps/examples/hello/hello_main.c
 *
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.  The
 * ASF licenses this file to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance with the
 * License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 ****************************************************************************/

/****************************************************************************
 * Included Files
 ****************************************************************************/

#include <nuttx/config.h>
#include <stdio.h>
#include <stdlib.h>
#include <errno.h>

#ifdef CONFIG_NETUTILS_PING
#include <netutils/netlib.h>
#endif

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

int main(int argc, FAR char *argv[])
{
  printf("Hello, World!!\n");

#ifdef CONFIG_NETUTILS_PING
  const char *ip = "10.0.1.1";
  int timeout = 5000;  /* 5 seconds (in milliseconds) */
  int retry = 3;        /* 3 times */
  int replies;

  /* Optional: timeout and retry from command line */
  if (argc > 1)
    {
      timeout = atoi(argv[1]);
    }

  if (argc > 2)
    {
      retry = atoi(argv[2]);
    }

  printf("\n=== Network IP Connectivity Test ===\n");
  printf("Target IP: %s\n", ip);
  printf("Timeout: %d ms\n", timeout);
  printf("Retry: %d times\n", retry);
  printf("Checking connectivity by pinging %s...\n\n", ip);

  replies = netlib_check_ipconnectivity(ip, timeout, retry);

  if (replies > 0)
    {
      printf("SUCCESS: IP %s is reachable!\n", ip);
      printf("Received %d ping reply(ies) from %s.\n", replies, ip);
      return 0;
    }
  else if (replies == 0)
    {
      printf("FAILED: IP %s is not reachable.\n", ip);
      printf("No ping replies received from %s.\n", ip);
      return 1;
    }
  else
    {
      printf("ERROR: Failed to check connectivity for %s.\n", ip);
      printf("Error code: %d (errno: %d)\n", replies, errno);
      return 1;
    }
#else
  printf("\nNote: Network connectivity check is disabled.\n");
  printf("Enable CONFIG_NETUTILS_PING to use this feature.\n");
  return 0;
#endif
}

```
The execution result is as follows

```
nsh> hello
Hello, World!!

=== Network IP Connectivity Test ===
Target IP: 10.0.1.1
Timeout: 5000 ms
Retry: 3 times
Checking connectivity by pinging 10.0.1.1...

SUCCESS: IP 10.0.1.1 is reachable!
Received 3 ping reply(ies) from 10.0.1.1.

```

