### PR TITLE
interpreters: Add mquickjs JavaScript interpreter integration

### DIFF
--- a/interpreters/mquickjs/.gitignore
+++ b/interpreters/mquickjs/.gitignore
@@ -1,0 +1,2 @@
+*.d
+mquickjs/

--- a/interpreters/mquickjs/CMakeLists.txt
+++ b/interpreters/mquickjs/CMakeLists.txt
@@ -1,0 +1,123 @@
+# ##############################################################################
+# apps/interpreters/mquickjs/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_INTERPRETERS_MQJS)
+  set(MQJS_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/mquickjs)
+
+  # Prefer local git repo if it exists, otherwise download tarball
+  if(EXISTS ${MQJS_SOURCE_DIR}/.git)
+    # Use local git-managed mquickjs
+    set(MQJS_DIR ${MQJS_SOURCE_DIR})
+    message(STATUS "Using local mquickjs git repo: ${MQJS_DIR}")
+  else()
+    # Download mquickjs to build directory
+    FetchContent_Declare(
+      mquickjs_fetch
+      URL https://github.com/bellard/mquickjs/archive/refs/heads/main.zip
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_MakeAvailable(mquickjs_fetch)
+
+    # The source directory after FetchContent_MakeAvailable
+    set(MQJS_DIR ${mquickjs_fetch_SOURCE_DIR})
+    message(STATUS "Using downloaded mquickjs: ${MQJS_DIR}")
+  endif()
+
+  # Detect target architecture for header generation
+  if(CONFIG_ARCH_64BIT)
+    set(MQJS_BUILD_FLAGS "-m64")
+  else()
+    set(MQJS_BUILD_FLAGS "-m32")
+  endif()
+
+  include(ExternalProject)
+
+  # Build mqjs_stdlib host tool using mquickjs Makefile
+  ExternalProject_Add(
+    mqjs_stdlib_host
+    SOURCE_DIR ${MQJS_DIR}
+    BINARY_DIR ${MQJS_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND make mqjs_stdlib
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS ${MQJS_DIR}/mqjs_stdlib)
+
+  # Generate mqjs_stdlib.h
+  add_custom_command(
+    OUTPUT ${MQJS_DIR}/mqjs_stdlib.h
+    COMMAND ${MQJS_DIR}/mqjs_stdlib ${MQJS_BUILD_FLAGS} >
+            ${MQJS_DIR}/mqjs_stdlib.h
+    DEPENDS mqjs_stdlib_host
+    COMMENT "Generating mqjs_stdlib.h")
+
+  # Generate mquickjs_atom.h
+  add_custom_command(
+    OUTPUT ${MQJS_DIR}/mquickjs_atom.h
+    COMMAND ${MQJS_DIR}/mqjs_stdlib -a ${MQJS_BUILD_FLAGS} >
+            ${MQJS_DIR}/mquickjs_atom.h
+    DEPENDS mqjs_stdlib_host
+    COMMENT "Generating mquickjs_atom.h")
+
+  # Custom target for header generation
+  add_custom_target(mqjs_headers_gen DEPENDS ${MQJS_DIR}/mqjs_stdlib.h
+                                             ${MQJS_DIR}/mquickjs_atom.h)
+
+  # Create mquickjs library
+  nuttx_add_library(libmquickjs)
+  target_sources(
+    libmquickjs
+    PRIVATE ${MQJS_DIR}/mquickjs.c ${MQJS_DIR}/dtoa.c ${MQJS_DIR}/libm.c
+            ${MQJS_DIR}/cutils.c ${MQJS_DIR}/readline.c
+            ${MQJS_DIR}/readline_tty.c)
+  target_include_directories(libmquickjs PRIVATE ${MQJS_DIR})
+  nuttx_export_header(TARGET libmquickjs INCLUDE_DIRECTORIES ${MQJS_DIR})
+
+  # Ensure headers are generated before building library
+  add_dependencies(libmquickjs mqjs_headers_gen)
+
+  # Add mquickjs include directory to global include paths
+  set_property(
+    TARGET nuttx
+    APPEND
+    PROPERTY NUTTX_INCLUDE_DIRECTORIES ${NUTTX_APPS_DIR}/interpreters/mquickjs)
+
+  # Create mqjs NSH application
+  set(MQJS_PRIORITY ${CONFIG_INTERPRETERS_MQJS_PRIORITY})
+  set(MQJS_STACKSIZE ${CONFIG_INTERPRETERS_MQJS_STACKSIZE})
+
+  nuttx_add_application(
+    NAME
+    mqjs
+    PRIORITY
+    ${MQJS_PRIORITY}
+    STACKSIZE
+    ${MQJS_STACKSIZE}
+    SRCS
+    ${MQJS_DIR}/mqjs.c
+    INCLUDE_DIRECTORIES
+    ${MQJS_DIR}
+    DEPENDS
+    libmquickjs
+    mqjs_headers_gen)
+
+endif()

--- a/interpreters/mquickjs/Kconfig
+++ b/interpreters/mquickjs/Kconfig
@@ -1,0 +1,24 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config INTERPRETERS_MQJS
+	tristate "MicroQuickJS JavaScript interpreter"
+	default n
+
+if INTERPRETERS_MQJS
+
+config INTERPRETERS_MQJS_PRIORITY
+	int "MicroQuickJS interpreter priority"
+	default 100
+	---help---
+		Task priority of the MicroQuickJS interpreter.
+
+ config INTERPRETERS_MQJS_STACKSIZE
+ 	int "MicroQuickJS interpreter stack size"
+ 	default 8192
+ 	---help---
+ 		Size of the stack allocated for MicroQuickJS interpreter.
+
+ endif # INTERPRETERS_MQJS

--- a/interpreters/mquickjs/Make.defs
+++ b/interpreters/mquickjs/Make.defs
@@ -1,0 +1,30 @@
+############################################################################
+# apps/interpreters/mquickjs/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_INTERPRETERS_MQJS),)
+CONFIGURED_APPS += $(APPDIR)/interpreters/mquickjs
+
+# It allows `<mquickjs.h>` import.
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/mquickjs/mquickjs
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/interpreters/mquickjs/mquickjs
+
+endif

--- a/interpreters/mquickjs/Makefile
+++ b/interpreters/mquickjs/Makefile
@@ -1,0 +1,92 @@
+############################################################################
+# apps/interpreters/mquickjs/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+MQJS_UNPACK = mquickjs
+MQJS_ARCHIVE = mquickjs-master.zip
+MQJS_URL = https://github.com/bellard/mquickjs/archive/refs/heads/master.zip
+
+# Determine target word size for header generation
+ifeq ($(CONFIG_ARCH_64BIT),y)
+MQJS_BUILD_FLAGS = -m64
+else
+MQJS_BUILD_FLAGS = -m32
+endif
+
+CSRCS = $(MQJS_UNPACK)/mquickjs.c \
+        $(MQJS_UNPACK)/dtoa.c \
+        $(MQJS_UNPACK)/libm.c \
+        $(MQJS_UNPACK)/cutils.c \
+        $(MQJS_UNPACK)/readline.c \
+        $(MQJS_UNPACK)/readline_tty.c
+
+PROGNAME = mqjs
+PRIORITY = $(CONFIG_INTERPRETERS_MQJS_PRIORITY)
+STACKSIZE = $(CONFIG_INTERPRETERS_MQJS_STACKSIZE)
+MODULE = $(CONFIG_INTERPRETERS_MQJS)
+MAINSRC = $(MQJS_UNPACK)/mqjs.c
+
+# Download archive
+$(MQJS_ARCHIVE):
+	$(Q) echo "Downloading $(MQJS_ARCHIVE)"
+	$(Q) curl -L $(MQJS_URL) -o $(MQJS_ARCHIVE)
+
+# Unpack archive
+$(MQJS_UNPACK): $(MQJS_ARCHIVE)
+	$(Q) echo "Unpacking $(MQJS_ARCHIVE) to $(MQJS_UNPACK)"
+	$(Q) unzip -q -o $(MQJS_ARCHIVE)
+	$(Q) mv bellard-mquickjs-* $(MQJS_UNPACK)
+	$(Q) touch $(MQJS_UNPACK)
+
+# Build host tool via upstream Makefile
+$(MQJS_UNPACK)/mqjs_stdlib:
+	$(Q) echo "Building mquickjs host tool via upstream Makefile"
+	$(Q) rm -f $(MQJS_UNPACK)/mqjs_stdlib
+	$(Q) $(MAKE) -C $(MQJS_UNPACK) HOSTCC=$(HOSTCC) mqjs_stdlib
+
+# Generate stdlib header using built host tool
+$(MQJS_UNPACK)/mqjs_stdlib.h: $(MQJS_UNPACK)/mqjs_stdlib
+	$(Q) echo "Generating mquickjs stdlib header"
+	$(MQJS_UNPACK)/mqjs_stdlib $(MQJS_BUILD_FLAGS) > $@
+
+# Generate atom header using built host tool
+$(MQJS_UNPACK)/mquickjs_atom.h: $(MQJS_UNPACK)/mqjs_stdlib
+	$(Q) echo "Generating mquickjs atom header"
+	$(MQJS_UNPACK)/mqjs_stdlib -a $(MQJS_BUILD_FLAGS) > $@
+
+# Download and unpack only if not a git repository
+context:: $(MQJS_UNPACK)/mqjs_stdlib.h $(MQJS_UNPACK)/mquickjs_atom.h
+
+# Clean up on distclean
+distclean::
+ifneq ($(wildcard $(MQJS_UNPACK)/.git),)
+	$(Q) $(MAKE) -C $(MQJS_UNPACK) clean
+else
+	$(call DELDIR, $(MQJS_UNPACK))
+endif
+	$(call DELFILE, $(MQJS_ARCHIVE))
+
+# Dependencies
+$(MQJS_UNPACK)/mquickjs.c: $(MQJS_UNPACK)/mquickjs_atom.h
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION

## Summary

 * **Why change is necessary?** New feature - adds MicroQuickJS JavaScript interpreter support to NuttX
  * **What functional part of the code is being changed?** New interpreter module added in `interpreters/mquickjs/` directory.
  * **How does the change exactly work?** 
    - FetchContent automatically downloads mquickjs source from bellard/mquickjs if not present locally
    - Builds mqjs_stdlib host tool to generate required headers (mqjs_stdlib.h, mquickjs_atom.h) during build
    - Creates libmquickjs library with proper dependency handling for parallel builds
    - Provides mqjs NSH command for interactive JavaScript execution
    - Supports both CMake and Make build systems


## Impact

  * **Is new feature added?** YES - New MicroQuickJS JavaScript interpreter integration
  * **Impact on user?** YES - Users can now enable and use JavaScript interpreter by enabling `CONFIG_INTERPRETERS_MQJS` in Kconfig
  * **Impact on build?** YES - Adds new build target and configuration option
  * **Impact on hardware?** NO - Works across architectures (32-bit and 64-bit)
  * **Impact on documentation?** YES - Documentation should be added in nuttx repository (separate PR)
  * **Impact on security?** NO - Standard JavaScript interpreter integration
  * **Impact on compatibility?** NO - Pure addition, no breaking changes

## Testing

stm32f7 disco:
```
Builtin Apps:
    mqjs    dd      nsh     sh
nsh> mqjs --memory-limit 65536 -d -e "print('Run 1')"
Run 1
            TAG    COUNT AVG_SIZE     SIZE    RATIO
           free        6        7       44       1%
         object       60       14      836      25%
        float64        1       12       12       0%
         string        3       13       40       1%
  func_bytecode        1       40       40       1%
    value_array       12      158     1900      57%
     byte_array        8       10       84       3%
         varref       44        8      352      11%
heap size=3308/65164 stack_size=0
```

