### PR TITLE
apps/net: add if network conntivity check API

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -515,6 +515,8 @@ int netlib_check_ifconflict(FAR const char *ifname);
 
 #ifdef CONFIG_NETUTILS_PING
 int netlib_check_ipconnectivity(FAR const char *ip, int timeout, int retry);
+int netlib_check_ifconnectivity(FAR const char *ifname,
+                                int timeout, int retry);
 #endif
 
 #ifdef CONFIG_MM_IOB

--- a/netutils/netlib/CMakeLists.txt
+++ b/netutils/netlib/CMakeLists.txt
@@ -158,7 +158,7 @@ if(CONFIG_NETUTILS_NETLIB)
   endif()
 
   if(CONFIG_NETUTILS_PING)
-    list(APPEND SRCS netlib_checkipconnectivity.c)
+    list(APPEND SRCS netlib_checkipconnectivity.c netlib_checkifconnectivity.c)
   endif()
 
   target_sources(apps PRIVATE ${SRCS})

--- a/netutils/netlib/Makefile
+++ b/netutils/netlib/Makefile
@@ -157,7 +157,7 @@ CSRCS += netlib_getiobinfo.c
 endif
 
 ifeq ($(CONFIG_NETUTILS_PING),y)
-CSRCS += netlib_checkipconnectivity.c
+CSRCS += netlib_checkipconnectivity.c netlib_checkifconnectivity.c
 endif
 
 include $(APPDIR)/Application.mk

--- a/netutils/netlib/netlib_checkifconnectivity.c
+++ b/netutils/netlib/netlib_checkifconnectivity.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * apps/netutils/netlib/netlib_checkifconnectivity.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <arpa/inet.h>
+#include <nuttx/net/ip.h>
+
+#include "netutils/netlib.h"
+
+#ifdef CONFIG_NETUTILS_PING
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netlib_check_ifconnectivity
+ *
+ * Description:
+ *   Check network interface connectivity by pinging the gateway
+ *
+ * Parameters:
+ *   ifname   The name of the interface to use
+ *   timeout  The timeout of ping
+ *   retry    The retry times of ping
+ *
+ * Return:
+ *   nums of gateway reply of ping; a nagtive on failure.
+ *
+ ****************************************************************************/
+
+int netlib_check_ifconnectivity(FAR const char *ifname,
+                                int timeout, int retry)
+{
+  int ret;
+  char destip[INET_ADDRSTRLEN];
+  struct in_addr addr;
+
+  ret = netlib_get_dripv4addr(ifname, &addr);
+  if (ret < 0)
+    {
+      nerr("ERROR: failed to get gateway ip %s\n", ifname);
+      return ret;
+    }
+
+  if (net_ipv4addr_cmp(&addr, INADDR_ANY))
+    {
+      nerr("ERROR: failed to get gateway ip %s\n", ifname);
+      return -EINVAL;
+    }
+
+  inet_ntop(AF_INET, &addr, destip, sizeof(destip));
+  ninfo("ping gateway %s \n", destip);
+
+  return netlib_check_ipconnectivity(destip, timeout, retry);
+}
+
+#endif /* CONFIG_NETUTILS_PING */


### PR DESCRIPTION
## Summary

Perform connectivity testing on the specified network interface card.

## Impact

Adding new APIs will not affect existing functionality.

## Testing

Use the following code to test.

```
/****************************************************************************
 * apps/examples/hello/hello_main.c
 *
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.  The
 * ASF licenses this file to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance with the
 * License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 ****************************************************************************/

/****************************************************************************
 * Included Files
 ****************************************************************************/

#include <nuttx/config.h>
#include <stdio.h>
#include <stdlib.h>
#include <errno.h>

#ifdef CONFIG_NETUTILS_PING
#include <netutils/netlib.h>
#endif

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

int main(int argc, FAR char *argv[])
{
  printf("Hello, World!!\n");

#ifdef CONFIG_NETUTILS_PING
  const char *ifname = "eth0";  /* Default network interface */
  int timeout = 5000;            /* 5 seconds (in milliseconds) */
  int retry = 3;                 /* 3 times */
  int replies;

  /* Optional: interface name, timeout and retry from command line */
  if (argc > 1)
    {
      ifname = argv[1];
    }

  if (argc > 2)
    {
      timeout = atoi(argv[2]);
    }

  if (argc > 3)
    {
      retry = atoi(argv[3]);
    }

  printf("\n=== Network Interface Connectivity Test ===\n");
  printf("Interface: %s\n", ifname);
  printf("Timeout: %d ms\n", timeout);
  printf("Retry: %d times\n", retry);
  printf("Checking connectivity by pinging gateway of %s...\n\n", ifname);

  replies = netlib_check_ifconnectivity(ifname, timeout, retry);

  if (replies > 0)
    {
      printf("SUCCESS: Interface %s is reachable!\n", ifname);
      printf("Received %d ping reply(ies) from gateway.\n", replies);
      return 0;
    }
  else if (replies == 0)
    {
      printf("FAILED: Interface %s is not reachable.\n", ifname);
      printf("No ping replies received from gateway.\n");
      return 1;
    }
  else
    {
      printf("ERROR: Failed to check connectivity for %s.\n", ifname);
      printf("Error code: %d (errno: %d)\n", replies, errno);
      return 1;
    }
#else
  printf("\nNote: Network connectivity check is disabled.\n");
  printf("Enable CONFIG_NETUTILS_PING to use this feature.\n");
  return 0;
#endif
}
```
The execution results are as follows，Test results show that the API works correctly.
```
nsh> hello
Hello, World!!

=== Network Interface Connectivity Test ===
Interface: eth0
Timeout: 5000 ms
Retry: 3 times
Checking connectivity by pinging gateway of eth0...

SUCCESS: Interface eth0 is reachable!
Received 3 ping reply(ies) from gateway.
```

