### PR TITLE
nsh_syscmds/rpmsg: add rpmsg test command support

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -535,7 +535,7 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #if defined(CONFIG_RPTUN) && !defined(CONFIG_NSH_DISABLE_RPTUN)
   CMD_MAP("rptun",    cmd_rptun,    2, 7,
-    "<start|stop|reset|panic|dump|ping> <path|all>"
+    "<start|stop|reset|panic|dump|ping|test> <path|all>"
     " [value|times length ack sleep]"),
 #endif
 

--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -592,6 +592,12 @@ static int cmd_rpmsg_once(FAR struct nsh_vtbl_s *vtbl,
       val = (unsigned long)&ping;
     }
 #endif
+#ifdef CONFIG_RPMSG_TEST
+  else if (strcmp(argv[1], "test") == 0)
+    {
+      cmd = RPMSGIOC_TEST;
+    }
+#endif
   else if (rpmsg_cb && rpmsg_cb(&cmd, &val, argv) == OK)
     {
       /* Nothing */
@@ -642,7 +648,7 @@ static int cmd_rpmsg_recursive(FAR struct nsh_vtbl_s *vtbl,
 static int cmd_rpmsg_help(FAR struct nsh_vtbl_s *vtbl, int argc,
                           FAR char **argv)
 {
-  nsh_output(vtbl, "%s <panic|dump> <path>\n", argv[0]);
+  nsh_output(vtbl, "%s <panic|dump|test> <path>\n", argv[0]);
 #ifdef CONFIG_RPMSG_PING
   nsh_output(vtbl, "%s ping <path> <times> <length> <cmd> "
              "<period(ms)>\n\n", argv[0]);


### PR DESCRIPTION
## Summary
This commit adds RPMSG test command support to the NuttX Shell (NSH), enabling users to test RPMSG channels directly from the command line.

Command syntax: rpmsg test /dev/rpmsg/<cpuname>
Allows convenient testing of RPMSG communication channels without custom applications

Depends-on: https://github.com/apache/nuttx/pull/17807.

## Impact
nsh

## Testing
```c
❯ ./nuttx/cmake_out/sim_server/nuttx

NuttShell (NSH) NuttX-12.10.0
server> 
server> 
server> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     4   0 FIFO     Kthread   - Ready              0000000000000000 0069616 Idle_Task
    1     0     4 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067504 rpmsgdev_server 0xe6617850 0xe6617898
    2     0     4 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067520 hpwork 0x400ee0c0 0x400ee108
    3     0     4 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067520 lpwork 0x400ee140 0x400ee188
    4     4     0 100 FIFO     Task      - Running            0000000000000000 0067528 nsh_main
    5     0     4 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0069560 rptun proxy 0xe677ae20
    6     4     0  80 FIFO     pthread   - Waiting  Semaphore 0000000000000000 0067560 netinit 0x400751d2 0
server> 
server> 
server> 
server> 
server> 
server> cu

NuttShell (NSH) NuttX-12.10.0
proxy> 
proxy> 
proxy> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     2   0 FIFO     Kthread   - Ready              0000000000000000 0069616 Idle_Task
    1     0     2 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067512 hpwork 0x400bf0c0 0x400bf108
    2     2     0 100 FIFO     Task      - Running            0000000000000000 0067536 nsh_main
    3     0     2 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0069560 rptun server 0xe5e98050
proxy> 
proxy> 
proxy> server> 
server> 
server> 
server> rptun ping all 1 1 1 1
[   16.370000] [server] ping times: 1
[   16.370000] [server] buffer_len: 2032, send_len: 17
[   16.370000] [server] avg: 0 s, 19969287 ns
[   16.370000] [server] min: 0 s, 19969287 ns
[   16.370000] [server] max: 0 s, 19969287 ns
[   16.370000] [server] rate: 0.006810 Mbits/sec
server> 
server> 
server> rptun ping all 1 1 1 1
[   17.510000] [server] ping times: 1
[   17.510000] [server] buffer_len: 2032, send_len: 17
[   17.510000] [server] avg: 0 s, 19946854 ns
[   17.510000] [server] min: 0 s, 19946854 ns
[   17.510000] [server] max: 0 s, 19946854 ns
[   17.510000] [server] rate: 0.006818 Mbits/sec
server> rptun ping all 1 1 1 1
[   17.890000] [server] ping times: 1
[   17.890000] [server] buffer_len: 2032, send_len: 17
[   17.890000] [server] avg: 0 s, 9969876 ns
[   17.890000] [server] min: 0 s, 9969876 ns
[   17.890000] [server] max: 0 s, 9969876 ns
[   17.890000] [server] rate: 0.013641 Mbits/sec
server> 
server> 
server> rpmsg test /dev/rptun/proxy
[   28.900000] [server] Rpmsg Test: start send
[   28.900000] [server] Rpmsg Test: tx buffer num=8 space=2032
[   28.900000] [server] Rpmsg Test: send finish
server> [   25.810000] [proxy] Rpmsg Test: hold rx buffer finish
[   25.830000] [proxy] Rpmsg Test: release rx buffers start
[   25.830000] [proxy] Rpmsg Test: release rx buffers end

server> 
server> 
server> 
server> 
server> uname -a
NuttX server 12.10.0 80e35af3960-dirty Jan  8 2026 17:20:30 sim sim
```


