### PR TITLE
netlib: Add an empty macro definition to the two connectivity functions

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -517,6 +517,9 @@ int netlib_check_ifconflict(FAR const char *ifname);
 int netlib_check_ipconnectivity(FAR const char *ip, int timeout, int retry);
 int netlib_check_ifconnectivity(FAR const char *ifname,
                                 int timeout, int retry);
+#else
+#define netlib_check_ipconnectivity(i, t, r) 1
+#define netlib_check_ifconnectivity(i, t, r) 1
 #endif
 
 #ifdef CONFIG_MM_IOB


### PR DESCRIPTION
## Summary

The `netlib_check_ipconnectivity` and `netlib_check_ifconnectivity` functions depend on the `NETUTILS PING` configuration item. When `NETUTILS PING` is not enabled, a compilation error will occur; therefore, an empty macro definition is added.

## Impact

It only affects the compilation of `netlib_check_ipconnectivity` &  `netlib_check_ifconnectivity` .

## Testing

Calling netlib_check_ipconnectivity & netlib_check_ifconnectivity without enabling NETUTILS_PING did not result in a compilation error. Use the following code to test.
```
/****************************************************************************
 * apps/examples/hello/hello_main.c
 *
 * SPDX-License-Identifier: Apache-2.0
 *
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
 * this work for additional information regarding copyright ownership.  The
 * ASF licenses this file to you under the Apache License, Version 2.0 (the
 * "License"); you may not use this file except in compliance with the
 * License.  You may obtain a copy of the License at
 *
 *   http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 ****************************************************************************/

/****************************************************************************
 * Included Files
 ****************************************************************************/

#include <nuttx/config.h>
#include <stdio.h>
#include <errno.h>
#include <string.h>

#include <netutils/netlib.h>

/****************************************************************************
 * Pre-processor Definitions
 ****************************************************************************/

#define DEFAULT_IFNAME  "eth0"
#define DEFAULT_TEST_IP "10.0.1.1"
#define PING_TIMEOUT_MS 5000  /* 5 seconds */
#define PING_RETRY      3     /* 3 retries */

/****************************************************************************
 * Public Functions
 ****************************************************************************/

/****************************************************************************
 * hello_main
 ****************************************************************************/

int main(int argc, FAR char *argv[])
{
  const char *ifname;
  const char *test_ip;
  int ret;
  int replies;

  printf("Hello, World!!\n");
  printf("\n");
  printf("========================================\n");
  printf("Network Interface Connectivity Test\n");
  printf("========================================\n");
  printf("\n");

  /* Get interface name from command line or use default */

  if (argc > 1)
    {
      ifname = argv[1];
    }
  else
    {
      ifname = DEFAULT_IFNAME;
    }

  /* Get test IP address from command line or use default */

  if (argc > 2)
    {
      test_ip = argv[2];
    }
  else
    {
      test_ip = DEFAULT_TEST_IP;
    }

  printf("Testing interface: %s\n", ifname);
  printf("Timeout: %d ms\n", PING_TIMEOUT_MS);
  printf("Retry: %d times\n", PING_RETRY);
  printf("\n");

  /* Test 1: Check interface connectivity by pinging the gateway */

  printf("========================================\n");
  printf("Test 1: netlib_check_ifconnectivity\n");
  printf("========================================\n");
  printf("Checking interface connectivity (pinging gateway)...\n");
  ret = netlib_check_ifconnectivity(ifname, PING_TIMEOUT_MS, PING_RETRY);

  if (ret < 0)
    {
      printf("ERROR: Failed to check interface connectivity: %d (%s)\n",
             ret, strerror(-ret));
      printf("\n");
      printf("Possible reasons:\n");
      printf("  1. Interface '%s' does not exist\n", ifname);
      printf("  2. Interface has no gateway configured\n");
      printf("  3. Gateway is unreachable\n");
      printf("  4. Network stack not initialized\n");
    }
  else
    {
      replies = ret;
      printf("Result: Received %d ping reply(ies) from gateway\n", replies);
      if (replies > 0)
        {
          printf("SUCCESS: Interface '%s' is connected!\n", ifname);
        }
      else
        {
          printf("WARNING: No ping replies received from gateway\n");
          printf("Interface '%s' may not be properly connected\n", ifname);
        }
    }

  printf("\n");

  /* Test 2: Check IP connectivity by pinging a specific IP address */

  printf("========================================\n");
  printf("Test 2: netlib_check_ipconnectivity\n");
  printf("========================================\n");
  printf("Testing IP connectivity: %s\n", test_ip);
  printf("Timeout: %d ms\n", PING_TIMEOUT_MS);
  printf("Retry: %d times\n", PING_RETRY);
  printf("\n");
  printf("Pinging %s...\n", test_ip);
  ret = netlib_check_ipconnectivity(test_ip, PING_TIMEOUT_MS, PING_RETRY);

  if (ret < 0)
    {
      printf("ERROR: Failed to ping %s: %d (%s)\n",
             test_ip, ret, strerror(-ret));
      printf("\n");
      printf("Possible reasons:\n");
      printf("  1. IP address '%s' is unreachable\n", test_ip);
      printf("  2. Network stack not initialized\n");
      printf("  3. No route to host\n");
    }
  else
    {
      replies = ret;
      printf("Result: Received %d ping reply(ies) from %s\n", replies, test_ip);
      if (replies > 0)
        {
          printf("SUCCESS: IP address '%s' is reachable!\n", test_ip);
        }
      else
        {
          printf("WARNING: No ping replies received from %s\n", test_ip);
          printf("IP address '%s' may be unreachable\n", test_ip);
        }
    }

  printf("\n");
  printf("========================================\n");
  printf("All tests completed\n");
  printf("========================================\n");

  return 0;
}

```
The output is as follows
```
nsh> hello
Hello, World!!

========================================
Network Interface Connectivity Test
========================================

Testing interface: eth0
Timeout: 5000 ms
Retry: 3 times

========================================
Test 1: netlib_check_ifconnectivity
========================================
Checking interface connectivity (pinging gateway)...
Result: Received 1 ping reply(ies) from gateway
SUCCESS: Interface 'eth0' is connected!

========================================
Test 2: netlib_check_ipconnectivity
========================================
Testing IP connectivity: 10.0.1.1
Timeout: 5000 ms
Retry: 3 times

Pinging 10.0.1.1...
Result: Received 1 ping reply(ies) from 10.0.1.1
SUCCESS: IP address '10.0.1.1' is reachable!

========================================
All tests completed
========================================
```

