### PR TITLE
net/vlan: fix issue of vlan pcp config

### DIFF
--- a/netutils/netlib/netlib_addvlan.c
+++ b/netutils/netlib/netlib_addvlan.c
@@ -42,13 +42,14 @@
  * Parameters:
  *   ifname - The name of the existing network device
  *   vlanid - The VLAN identifier to be added
+ *   prio   - The default VLAN priority (PCP)
  *
  * Return:
  *   0 on success; -1 on failure
  *
  ****************************************************************************/
 
-int netlib_add_vlan(FAR const char *ifname, int vlanid)
+int netlib_add_vlan(FAR const char *ifname, int vlanid, int prio)
 {
   int ret = ERROR;
 
@@ -60,8 +61,9 @@ int netlib_add_vlan(FAR const char *ifname, int vlanid)
           struct vlan_ioctl_args ifv;
 
           strlcpy(ifv.device1, ifname, sizeof(ifv.device1));
-          ifv.u.VID = vlanid;
-          ifv.cmd = ADD_VLAN_CMD;
+          ifv.u.VID    = vlanid;
+          ifv.vlan_qos = prio;
+          ifv.cmd      = ADD_VLAN_CMD;
 
           ret = ioctl(sockfd, SIOCSIFVLAN, &ifv);
           close(sockfd);


### PR DESCRIPTION
## Summary

Fix a issue of vlan pcp config [3305](https://github.com/apache/nuttx-apps/issues/3305)

## Impact

User can config vlan pcp when add it, and default  pcp is 0
`vconfig add eth0 10` will create eth0.10 with VID=10 and no PCP(0)
 `vconfig add eth0 10 3` will create eth0.10 with VID=10 and PCP=3

## Testing
Open the compilation options CONFIG_NET_VLAN and CONFIG_NSH_DISABLE_VCONFIG. 
Add a vlan interface withc comand: `vconfig add eth0 10 3; ifconfig eth0.10 192.168.10.2/24`, config host vlan interface and ping from sim to host , then check pcp in packet.

Change a pcp and check agin.