### PR TITLE
apps/testing: update nvs testcases for struct nvs_ate changed

### DIFF
--- a/testing/fs/mtd_config_fs/mtd_config_fs_test_main.c
+++ b/testing/fs/mtd_config_fs/mtd_config_fs_test_main.c
@@ -1293,35 +1293,35 @@ static void test_nvs_gc_3sectors(struct mtdnvs_ctx_s *ctx)
   ret = write_content(max_id, max_writes, max_writes_2);
   if (ret < 0)
     {
-      printf("%s:2st GC write failed, ret=%d\n", __func__, ret);
+      printf("%s:2nd GC write failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = check_content(max_id);
   if (ret < 0)
     {
-      printf("%s:2st GC check failed, ret=%d\n", __func__, ret);
+      printf("%s:2nd GC check failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = mtdconfig_unregister();
   if (ret < 0)
     {
-      printf("%s:2st mtdconfig_unregister failed, ret=%d\n", __func__, ret);
+      printf("%s:2nd mtdconfig_unregister failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = setup(ctx);
   if (ret < 0)
     {
-      printf("%s:2st setup failed, ret=%d\n", __func__, ret);
+      printf("%s:2nd setup failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = check_content(max_id);
   if (ret < 0)
     {
-      printf("%s:2st GC check failed, ret=%d\n", __func__, ret);
+      printf("%s:2nd GC check failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
@@ -1330,35 +1330,35 @@ static void test_nvs_gc_3sectors(struct mtdnvs_ctx_s *ctx)
   ret = write_content(max_id, max_writes_2, max_writes_3);
   if (ret < 0)
     {
-      printf("%s:3st GC write failed, ret=%d\n", __func__, ret);
+      printf("%s:3rd GC write failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = check_content(max_id);
   if (ret < 0)
     {
-      printf("%s:3st GC check failed, ret=%d\n", __func__, ret);
+      printf("%s:3rd GC check failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = mtdconfig_unregister();
   if (ret < 0)
     {
-      printf("%s:3st mtdconfig_unregister failed, ret=%d\n", __func__, ret);
+      printf("%s:3rd mtdconfig_unregister failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = setup(ctx);
   if (ret < 0)
     {
-      printf("%s:3st setup failed, ret=%d\n", __func__, ret);
+      printf("%s:3rd setup failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
   ret = check_content(max_id);
   if (ret < 0)
     {
-      printf("%s:3st GC check failed, ret=%d\n", __func__, ret);
+      printf("%s:3rd GC check failed, ret=%d\n", __func__, ret);
       goto test_fail;
     }
 
@@ -2471,7 +2471,7 @@ static void test_nvs_gc_not_touched_expired_ate(struct mtdnvs_ctx_s *ctx)
       goto test_fail;
     }
 
-  /* Now udpate A again.
+  /* Now update A again.
    * We should trigger gc for once, and we won't need to search for
    * the old one again after gc.
    */
@@ -2576,7 +2576,7 @@ int main(int argc, FAR char *argv[])
   ctx = malloc(sizeof(struct mtdnvs_ctx_s));
   if (ctx == NULL)
     {
-      printf("malloc ctx feild,exit!\n");
+      printf("malloc ctx field, exit!\n");
       exit(1);
     }
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. The original test cases were designed based on struct nvs_ate, but now the struct nvs_ate has been changed. The expired field is dynamically adjusted according to the size of the page size, and the test cases also need to be changed accordingly
2. The special_id of NVS should be changed from fixed ffff to dynamically adjusted based on erase value, and the test cases should also be adjusted accordingly

## Impact

testcases for nvs module

## Testing

This has been tested and passed in qemu

test_nvs_mount: test begin
test_nvs_mount: success
test_nvs_write: test begin
test_nvs_write: success
test_nvs_corrupt_expire: test begin
test_nvs_corrupt_expire: success
test_nvs_corrupted_write: test begin
test_nvs_corrupted_write: success
test_nvs_gc: test begin
test_nvs_gc: success
test_nvs_gc_3sectors: test begin
test_nvs_gc_3sectors: success
test_nvs_corrupted_sector_close: test begin
test_nvs_corrupted_sector_close: success
test_nvs_full_sector: test begin
test_nvs_full_sector: success
test_nvs_gc_corrupt_close_ate: test begin
test_nvs_gc_corrupt_close_ate: success
test_nvs_gc_corrupt_ate: test begin
test_nvs_gc_corrupt_ate: success
test_nvs_gc_touched_deleted_ate: test begin
test_nvs_gc_touched_deleted_ate: success
test_nvs_gc_touched_expired_ate: test begin
test_nvs_gc_touched_expired_ate: success
test_nvs_gc_not_touched_expired_ate: test begin
test_nvs_gc_not_touched_expired_ate: success

Final memory usage:
VARIABLE BEFORE AFTER DELTA
arena 4294 4294 0
ordblks 1 1 0
mxordblk eb0 eb0 0
uordblks 33e4 33e4 0
fordblks eb0 eb0 0
nsh>


