### PR TITLE
github/build.yml: fix python venv installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,10 +181,9 @@ jobs:
           BLOBDIR: /tools/blobs
         with:
           run: |
-            # install venv
+            # install python venv
             apt-get update
-            apt install -y python3-dev
-            apt install -y python3-venv
+            apt-get install -y python3 python3-dev python3-venv
 
             # get NTFC sources
             git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-ntfc


### PR DESCRIPTION
## Summary

install venv package in one command to avoid issues with ubuntu mirrors

## Impact
fix broken CI after the python3.10-venv package was updated in ubuntu mirrors

## Testing
CI


