### PR TITLE
system/uorb: add a new uorb topic ENG

### DIFF
--- a/system/uorb/sensor/eng.c
+++ b/system/uorb/sensor/eng.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/eng.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sensor/eng.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_UORB
+static const char sensor_eng_format[] =
+  "timestamp:%" PRIu64 ",eng0:%hf,eng1:%hf,eng2:%hf,eng3:%hf,"
+  "status:0x%" PRIx32 "";
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+ORB_DEFINE(sensor_eng, struct sensor_eng, sensor_eng_format);

--- a/system/uorb/sensor/eng.h
+++ b/system/uorb/sensor/eng.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * apps/system/uorb/sensor/eng.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_UORB_SENSOR_ENG_H
+#define __APPS_SYSTEM_UORB_SENSOR_ENG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <uORB/uORB.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* register this as object request broker structure */
+
+ORB_DECLARE(sensor_eng);
+
+#endif

--- a/system/uorb/sensor/topics.c
+++ b/system/uorb/sensor/topics.c
@@ -38,6 +38,7 @@
 #include <sensor/co2.h>
 #include <sensor/dust.h>
 #include <sensor/ecg.h>
+#include <sensor/eng.h>
 #include <sensor/force.h>
 #include <sensor/gas.h>
 #include <sensor/gnss.h>
@@ -87,6 +88,7 @@ static FAR const struct orb_metadata *g_sensor_list[] =
   ORB_ID(sensor_device_orientation),
   ORB_ID(sensor_dust),
   ORB_ID(sensor_ecg),
+  ORB_ID(sensor_eng),
   ORB_ID(sensor_force),
   ORB_ID(sensor_gas),
   ORB_ID(sensor_glance_gesture),
@@ -157,7 +159,7 @@ FAR const struct orb_metadata *orb_get_meta(FAR const char *name)
   int fd;
   int i;
 
-  /* Fisrt search built-in topics */
+  /* First search built-in topics */
 
   for (i = 0; g_sensor_list[i]; i++)
     {


### PR DESCRIPTION
## Summary

- add a new sensor type ENG (Electroneurography).

Depends-on: https://github.com/apache/nuttx/pull/17837.

## Impact

- uorb / new sensor type.

## Testing

We have conducted tests on the following platforms:
Simulator  - single core:pass
BES Platform - multi-core:pass;

```
grass:/ # uor
uorb_advertise_demo  uorb_downsample      uorb_listener        uorb_rpmsg_test      uorb_unit_test
grass:/ # uorb_listener -n 10 sensor_eng0

Mointor objects num:1
object_name:sensor_eng, object_instance:0
sensor_eng(now:2942986005):timestamp:1555925885,eng0:-0.283753,eng1:4.146453,eng2:-10.340199,eng3:0.000000,status:0x7
sensor_eng(now:2942988113):timestamp:1555930885,eng0:2.807018,eng1:-0.033562,eng2:-3.261632,eng3:0.000000,status:0x7
sensor_eng(now:2942989815):timestamp:1555935885,eng0:4.707857,eng1:0.018306,eng2:-2.935164,eng3:0.000000,status:0x7
sensor_eng(now:2942991548):timestamp:1555940885,eng0:1.281465,eng1:2.248665,eng2:-6.340199,eng3:0.000000,status:0x7
sensor_eng(now:2942993269):timestamp:1555945885,eng0:-5.714722,eng1:2.709382,eng2:-7.572845,eng3:0.000000,status:0x7
sensor_eng(now:2942994463):timestamp:1555950885,eng0:-3.078566,eng1:0.073226,eng2:-4.173913,eng3:0.000000,status:0x7
sensor_eng(now:2942994755):timestamp:1555955885,eng0:2.556827,eng1:-0.070175,eng2:-3.682685,eng3:0.000000,status:0x7
sensor_eng(now:2942995046):timestamp:1555960885,eng0:-0.189169,eng1:1.809306,eng2:-6.468345,eng3:0.000000,status:0x7
sensor_eng(now:2942995230):timestamp:1555965885,eng0:-6.599542,eng1:2.245614,eng2:-7.139588,eng3:0.000000,status:0x7
sensor_eng(now:2942995411):timestamp:1555970885,eng0:-3.130435,eng1:-0.427155,eng2:-3.240275,eng3:0.000000,status:0x7
Object name:sensor_eng0, recieved:10
Total number of received Message:10/10
grass:/ #
```