### PR TITLE
ping4:Set the filter for reply packet.

### DIFF
--- a/include/netutils/icmp_ping.h
+++ b/include/netutils/icmp_ping.h
@@ -51,6 +51,7 @@
 #define ICMP_E_RECVFROM    -13 /* extra: error code    */
 #define ICMP_E_RECVSMALL   -15 /* extra: recv bytes    */
 #define ICMP_E_BINDDEV     -17 /* extra: error bind    */
+#define ICMP_E_FILTER      -19 /* extra: error filter  */
 
 /* Negative even number represent warning(recoverable) */
 

--- a/netutils/ping/icmp_ping.c
+++ b/netutils/ping/icmp_ping.c
@@ -53,6 +53,7 @@
  ****************************************************************************/
 
 #define ICMP_IOBUFFER_SIZE(x) (sizeof(struct icmp_hdr_s) + (x))
+#define ICMP_SET_FILTER(t) (~(1U << (t)))
 
 /****************************************************************************
  * Private Types
@@ -197,6 +198,9 @@ void icmp_ping(FAR const struct ping_info_s *info)
   int ret;
   int ch;
   int i;
+#ifdef CONFIG_NET_SOCKOPTS
+  int filter;
+#endif
 
   g_exiting = false;
   signal(SIGINT, sigexit);
@@ -243,6 +247,19 @@ void icmp_ping(FAR const struct ping_info_s *info)
           free(priv);
           return;
         }
+    }
+#endif
+
+#ifdef CONFIG_NET_SOCKOPTS
+  filter = ICMP_SET_FILTER(ICMP_ECHO_REPLY);
+  ret = setsockopt(priv->sockfd, IPPROTO_ICMP, ICMP_FILTER,
+                   &filter, sizeof(filter));
+  if (ret < 0)
+    {
+      icmp_callback(&result, ICMP_E_FILTER, errno);
+      close(priv->sockfd);
+      free(priv);
+      return;
     }
 #endif
 


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

- Why : When using icmp_ping , there is no filter set for the socket. This might cause the socket to receive unwanted ICMP packets or fail to filter out packets that are not Echo Replies, potentially interfering with the ping logic or causing performance issues in noisy network environments.
- What : This commit adds logic to set the ICMP_FILTER socket option for the ping socket. It introduces a macro ICMP_SET_FILTER and uses setsockopt to configure the filter to only allow ICMP_ECHO_REPLY packets, blocking all other ICMP types.

## Impact

- Users : Users of the ping command will experience more robust behavior as the socket will only process relevant ICMP Echo Reply packets.
- Build : No impact on build configuration.
- Hardware : No specific hardware dependency. Depends on the TCP/IP stack implementation of ICMP_FILTER socket option.
- Compatibility : Backward compatible.

## Testing

- Verification :
- Verified that the code compiles successfully.
- Verified that checkpatch.sh passes for the modified files.
- Target : Verified on local hardware platform.


