### PR TITLE
net/ptpd: Change the dynamic memory allocation method to a static allocation method

### DIFF
--- a/netutils/ptpd/ptpd.c
+++ b/netutils/ptpd/ptpd.c
@@ -758,10 +758,12 @@ static int ptp_sendmsg(FAR struct ptp_state_s *state, FAR const void *buf,
         0x01, 0x80, 0xc2, 0x00, 0x00, 0x0e
       };
 
-      char raw[sizeof(struct ether_header) + buflen];
+      char raw[sizeof(struct ether_header) + sizeof(struct ptp_announce_s)];
       FAR struct ether_header *header;
       struct msghdr msg;
       struct iovec iov;
+
+      DEBUGASSERT(sizeof(struct ptp_announce_s) >= buflen);
 
       header = (FAR struct ether_header *)&raw;
       memcpy(header->ether_dhost, ptp_multicast_mac, ETHER_ADDR_LEN);


### PR DESCRIPTION
## Summary

In some scenarios, dynamic memory allocation is not allowed, so it is modified to a static allocation method.
By reading through the code, in the `ptp_sendmsg` function, the maximum value of `buflen` is `sizeof (struct ptp_announce_s)`, so the  `char raw [sizeof (struct ether_ceader)+buflen];  ` is changed to `char raw [sizeof (struct ether_ceader)+sizeof (struct ptp_announce_s);`

## Impact

No modification of user interface, no impact on functionality.

## Testing
Use the development board to set up the GPTP runtime environment and test the clock synchronization function. After testing, gptp function is normal.

