### PR TITLE
libuv: fix sendmsg parameter type in NuttX port

### DIFF
--- a/system/libuv/0001-libuv-port-for-nuttx.patch
+++ b/system/libuv/0001-libuv-port-for-nuttx.patch
@@ -424,7 +424,7 @@ index 00000000..298bd2f8
 +    return 0;
 +  }
 +
-+  /* Make sure the memory is initiallized to zero using calloc() */
++  /* Make sure the memory is initialized to zero using calloc() */
 +  *addresses = uv__calloc(*count, sizeof(**addresses));
 +  if (*addresses == NULL) {
 +    freeifaddrs(addrs);
@@ -3972,3 +3972,15 @@ diff --color -ur libuv_back/src/unix/thread.c libuv/src/unix/thread.c
  # include <sched.h>
  # define uv__cpu_set_t cpu_set_t
  #elif defined(__FreeBSD__)
+diff --git a/src/unix/nuttx.c b/src/unix/nuttx.c
+index d0e110a..e1c962e 100644
+--- a/src/unix/nuttx.c
++++ b/src/unix/nuttx.c
+@@ -222,7 +222,7 @@ ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags) {
+   return UV_ENOTSUP;
+ }
+ 
+-ssize_t sendmsg(int sockfd, struct msghdr *msg, int flags) {
++ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags) {
+   return UV_ENOTSUP;
+ }


### PR DESCRIPTION
## Summary

Update the sendmsg() stub implementation in the libuv NuttX port (src/unix/nuttx.c) to match the POSIX‑compliant signature by changing the msg parameter from struct msghdr * to const struct msghdr *. This change synchronizes the libuv port with the recent NuttX socket API update.

## Impact

1. Ensures the libuv NuttX port compiles cleanly with the updated NuttX socket headers.
2. Maintains type consistency between libuv and the underlying NuttX socket API.
3. No functional change—the stub still returns UV_ENOTSUP as before.

## Testing

Verified that the modified libuv patch applies successfully and compiles without type‑mismatch warnings.


