### PR TITLE
iptables: fix the ipv4 mask conversion error

### DIFF
--- a/system/iptables/iptables_utils.c
+++ b/system/iptables/iptables_utils.c
@@ -546,7 +546,7 @@ int iptables_parse_ip(FAR const char *str, FAR void *addr, FAR void *mask,
               return -EINVAL;
             }
 
-          *mask4 <<= 32 - prefixlen;
+          *mask4 >>= 32 - prefixlen;
         }
 #endif
 


### PR DESCRIPTION
## Summary
the configured mask should be in network byte order, but the logic here calculates it as host byte order.

## Impact
iptable filter.

## Testing
infineon board.


