### PR TITLE
netlib: fixed compilation issues

### DIFF
--- a/include/netutils/netlib.h
+++ b/include/netutils/netlib.h
@@ -56,6 +56,11 @@
 #include <nuttx/net/netdev.h>
 #include <nuttx/net/netconfig.h>
 
+#ifdef CONFIG_NET_IPTABLES
+#  include <nuttx/net/netfilter/ip_tables.h>
+#  include <nuttx/net/netfilter/ip6_tables.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Using certain compilers for compilation, there is an alarm message: 

ctc E295: ["/home/gaohd/Public/code/dev-system/apps/include/netutils/netlib.h" 1118/45] reference to incomplete enum type
ctc E295: ["/home/gaohd/Public/code/dev-system/apps/include/netutils/netlib.h" 1133/46] reference to incomplete enum type
ctc E295: ["/home/gaohd/Public/code/dev-system/apps/include/netutils/netlib.h" 1151/23] reference to incomplete enum type
ctc E295: ["/home/gaohd/Public/code/dev-system/apps/include/netutils/netlib.h" 1169/23] reference to incomplete enum type
ctc E295: ["/home/gaohd/Public/code/dev-system/apps/include/netutils/netlib.h" 1187/23] reference to incomplete enum type

To address these alarm messages, reference files have been added to the header file.

## Impact
Include  header files in netlib.h

#ifdef CONFIG_NET_IPTABLES
    #include <nuttx/net/netfilter/ip_tables.h>
    #include <nuttx/net/netfilter/ip6_tables.h>
#endif

## Testing
Compile alarm information cleared, compilation passed, Ethernet communication is normal


