### PR TITLE
iptables: add file lock to prevent concurrent overwrite

### DIFF
--- a/system/iptables/Kconfig
+++ b/system/iptables/Kconfig
@@ -29,4 +29,9 @@ config SYSTEM_IPTABLES_STACKSIZE
 	int "iptables & ip6tables stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config SYSTEM_IPTABLES_LOCK_FILE_PATH
+	string "File lock path to prevent concurrent overwrite"
+	default "/tmp/iptables.lock"
+	depends on FS_LOCK_BUCKET_SIZE > 0
+
 endif


### PR DESCRIPTION
## Summary
the kernel can only prevent the concurrency of s/getsockopt, but iptables will call these interfaces multiple times at a time. We need to wait for one iptables to complete before executing the second one, otherwise the data will be overwritten.

iptables flow:
get current iptables entries [1] -> add new entry 2 [1,2] -> set to kernel [1,2]
get current iptables entries [1] -> add new entry 3 [1,3] -> set to kernel [1,3]
then, entry 2 is missing.

## Impact
iptables

## Testing
sim:matter, enable iptables
NuttX test log:
```
NuttShell (NSH) NuttX-12.12.0
MOTD: username=admin password=Administrator
nsh> iptables -L
Chain INPUT (policy ACCEPT)
target        prot  idev  odev  source              destination        

Chain FORWARD (policy ACCEPT)
target        prot  idev  odev  source              destination        

Chain OUTPUT (policy ACCEPT)
target        prot  idev  odev  source              destination        

nsh> iptables -A INPUT -i eth0 -s 172.16.46.0/24 -d 172.16.46.0/24 -j ACCEPT
nsh> iptables -A INPUT -i eth0 -s 172.16.47.0/24 -d 172.16.47.0/24 -j ACCEPT
nsh> iptables -A INPUT -i eth0 -s 172.16.48.0/24 -d 172.16.48.0/24 -j ACCEPT
nsh> iptables -L
Chain INPUT (policy ACCEPT)
target        prot  idev  odev  source              destination        
ACCEPT        all   eth0  any   172.16.46.0/24      172.16.46.0/24     
ACCEPT        all   eth0  any   172.16.47.0/24      172.16.47.0/24     
ACCEPT        all   eth0  any   172.16.48.0/24      172.16.48.0/24     

Chain FORWARD (policy ACCEPT)
target        prot  idev  odev  source              destination        

Chain OUTPUT (policy ACCEPT)
target        prot  idev  odev  source              destination        

nsh> 
```