### PR TITLE
netlib_setarp.c: add ATF_PERM to mark arp entry as permanent

### DIFF
--- a/netutils/netlib/netlib_setarp.c
+++ b/netutils/netlib/netlib_setarp.c
@@ -78,6 +78,7 @@ int netlib_set_arpmapping(FAR const struct sockaddr_in *inaddr,
 
           req.arp_ha.sa_family = ARPHRD_ETHER;
           memcpy(&req.arp_ha.sa_data, macaddr, ETHER_ADDR_LEN);
+          req.arp_flags = ATF_PERM;
           if (ifname != NULL)
             {
                strlcpy((FAR char *)&req.arp_dev, ifname,


### PR DESCRIPTION
## Summary
Improve the behavior of the ARP table so that the manually configured ARP table has the highest priority, can only be manually modified to other values, otherwise will never change again, and will not time out.

## Impact
command ```arp -s```

## Testing
sim:matter
```
NuttShell (NSH) NuttX-12.12.0
MOTD: username=admin password=Administrator
nsh> arp
IP Address   Ethernet Address  Interface
nsh> arp -s 10.0.1.1 11:22:33:44:55:66
nsh> arp
IP Address   Ethernet Address  Interface
10.0.1.1     11:22:33:44:55:66 eth0
nsh> arp -s 10.0.1.1 11:22:33:44:55:67
nsh> arp
IP Address   Ethernet Address  Interface
10.0.1.1     11:22:33:44:55:67 eth0
nsh> arp
IP Address   Ethernet Address  Interface
10.0.1.1     11:22:33:44:55:67 eth0
nsh> 
nsh> 
```


