### PR TITLE
benchmarks/ramspeed: add cmake build support

### DIFF
--- a/benchmarks/ramspeed/CMakeLists.txt
+++ b/benchmarks/ramspeed/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/benchmarks/ramspeed/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BENCHMARK_RAMSPEED)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_BENCHMARK_RAMSPEED_PROGNAME}
+    SRCS
+    ramspeed_main.c
+    STACKSIZE
+    ${CONFIG_BENCHMARK_RAMSPEED_STACKSIZE}
+    PRIORITY
+    ${CONFIG_BENCHMARK_RAMSPEED_PRIORITY})
+endif()


### PR DESCRIPTION
## Summary

Add a CMakeLists.txt file for the benchmarks/ramspeed application, enabling it to be built with the CMake build system. This provides build‑system parity between CMake and the existing Makefile‑based approach.

## Impact

1. Allows the RAMSpeed benchmark to be compiled and linked when using the CMake build infrastructure.
2. No effect on runtime behavior or generated binaries; only build‑system support is added.

## Testing

Verified that benchmarks/ramspeed builds successfully using CMake

