### PR TITLE
signals: fix dependency issues when signals are all disabled

### DIFF
--- a/canutils/candump/Kconfig
+++ b/canutils/candump/Kconfig
@@ -6,7 +6,7 @@
 config CANUTILS_CANDUMP
 	tristate "SocketCAN candump tool"
 	default n
-	depends on NET_CAN && CANUTILS_LIBCANUTILS
+	depends on NET_CAN && CANUTILS_LIBCANUTILS && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the SocketCAN candump tool ported from
 		https://github.com/linux-can/can-utils

--- a/examples/chrono/Kconfig
+++ b/examples/chrono/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_CHRONO
 	tristate "Chronometer example to use with STM32LDiscover"
 	default n
-	depends on SLCD
+	depends on SLCD && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the Chronometer example
 

--- a/examples/djoystick/Kconfig
+++ b/examples/djoystick/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_DJOYSTICK
 	tristate "Discrete joystick example"
 	default n
-	depends on INPUT_DJOYSTICK
+	depends on INPUT_DJOYSTICK && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the discrete joystick example
 

--- a/examples/i2sloop/Kconfig
+++ b/examples/i2sloop/Kconfig
@@ -6,6 +6,6 @@
 config EXAMPLES_I2SLOOP
 	tristate "I2S loopback test"
 	default n
-	depends on I2S && AUDIO && DRIVERS_AUDIO && AUDIO_I2SCHAR
+	depends on I2S && AUDIO && DRIVERS_AUDIO && AUDIO_I2SCHAR && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the I2S loopback test

--- a/examples/oneshot/Kconfig
+++ b/examples/oneshot/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_ONESHOT
 	tristate "Oneshot timer example"
 	default n
-	depends on ONESHOT
+	depends on ONESHOT && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the oneshot timer driver example
 

--- a/examples/shv-nxboot-updater/Kconfig
+++ b/examples/shv-nxboot-updater/Kconfig
@@ -5,7 +5,7 @@
 
 menuconfig EXAMPLES_SHV_NXBOOT_UPDATER
 	bool "Silicon Heaven Firmware updates for NXBoot"
-	depends on NETUTILS_LIBSHVC
+	depends on NETUTILS_LIBSHVC && ENABLE_ALL_SIGNALS
 	default n
 	---help---
 		Enable the shv-nxboot-updater application.

--- a/examples/usrsocktest/usrsocktest_wake_with_signal.c
+++ b/examples/usrsocktest/usrsocktest_wake_with_signal.c
@@ -146,10 +146,19 @@ static void do_usrsock_blocking_socket_thread(FAR void *param)
   TEST_ASSERT_TRUE(test_hang);
   TEST_ASSERT_TRUE(test_abort);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Allow main thread to hang usrsock daemon at this point. */
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt hanging open socket. */
 
@@ -176,6 +185,11 @@ static void do_usrsock_blocking_close_thread(FAR void *param)
   TEST_ASSERT_TRUE(test_hang);
   TEST_ASSERT_TRUE(test_abort);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -189,6 +203,10 @@ static void do_usrsock_blocking_close_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt hanging close socket. */
 
@@ -214,6 +232,11 @@ static void do_usrsock_blocking_connect_thread(FAR void *param)
 
   TEST_ASSERT_TRUE(test_hang || !test_hang);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -227,6 +250,10 @@ static void do_usrsock_blocking_connect_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt blocking connect. */
 
@@ -257,6 +284,11 @@ static void do_usrsock_blocking_setsockopt_thread(FAR void *param)
   bool test_abort = !!(test_flags & TEST_FLAG_DAEMON_ABORT);
   bool test_hang = !!(test_flags & TEST_FLAG_PAUSE_USRSOCK_HANDLING);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -273,6 +305,10 @@ static void do_usrsock_blocking_setsockopt_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt hanging setsockopt. */
 
@@ -304,6 +340,11 @@ static void do_usrsock_blocking_getsockopt_thread(FAR void *param)
   bool test_abort = !!(test_flags & TEST_FLAG_DAEMON_ABORT);
   bool test_hang = !!(test_flags & TEST_FLAG_PAUSE_USRSOCK_HANDLING);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -320,6 +361,10 @@ static void do_usrsock_blocking_getsockopt_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt hanging getsockopt. */
 
@@ -352,6 +397,11 @@ static void do_usrsock_blocking_send_thread(FAR void *param)
 
   TEST_ASSERT_TRUE(test_hang || !test_hang);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -371,6 +421,10 @@ static void do_usrsock_blocking_send_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt blocking send. */
 
@@ -401,6 +455,11 @@ static void do_usrsock_blocking_recv_thread(FAR void *param)
 
   TEST_ASSERT_TRUE(test_hang || !test_hang);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -420,6 +479,10 @@ static void do_usrsock_blocking_recv_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt blocking recv. */
 
@@ -454,6 +517,11 @@ static void do_usrsock_blocking_poll_thread(FAR void *param)
   TEST_ASSERT_TRUE(test_abort);
   TEST_ASSERT_TRUE(test_hang || !test_hang);
 
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+  pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
+#endif
+
   /* Open socket. */
 
   test_sd[tidx] = socket(AF_INET, SOCK_STREAM, 0);
@@ -473,6 +541,10 @@ static void do_usrsock_blocking_poll_thread(FAR void *param)
 
   sem_post(&tid_startsem);
   sem_wait(&tid_releasesem);
+
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+  pthread_testcancel();
+#endif
 
   /* Attempt poll. */
 
@@ -560,8 +632,11 @@ static void do_wake_test(enum e_test_type type, int flags)
 
       for (tidx = 0; tidx < nthreads; tidx++)
         {
+#ifdef CONFIG_DISABLE_ALL_SIGNALS
+          pthread_cancel(tid[tidx]);
+#else
           pthread_kill(tid[tidx], SIGUSR1);
-
+#endif
           /* Wait threads to complete work. */
 
           ret = pthread_join(tid[tidx], NULL);

--- a/examples/xedge_demo/Kconfig
+++ b/examples/xedge_demo/Kconfig
@@ -5,11 +5,11 @@
 
 config EXAMPLES_XEDGE_DEMO
 	tristate "Xedge IoT Toolkit Demo"
-	depends on NETUTILS_XEDGE && ALLOW_GPL_COMPONENTS
+	depends on NETUTILS_XEDGE && ALLOW_GPL_COMPONENTS && ENABLE_ALL_SIGNALS
 	default n
 	---help---
 		Simple demonstration of the Xedge IoT Toolkit library.
-		
+
 		This example shows how to integrate and use the Xedge library
 		in your NuttX application. Xedge provides a high-level development
 		environment for creating IoT and industrial device applications

--- a/examples/zerocross/Kconfig
+++ b/examples/zerocross/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_ZEROCROSS
 	tristate "Zero Cross Detection example"
 	default n
-	depends on SENSORS_ZEROCROSS
+	depends on SENSORS_ZEROCROSS && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the zero cross detection example
 

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -1179,6 +1179,7 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
   int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 
+#ifndef CONFIG_DISABLE_ALL_SIGNALS
 #ifndef CONFIG_NSH_DISABLE_KILL
   int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
@@ -1191,6 +1192,7 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #ifndef CONFIG_NSH_DISABLE_USLEEP
   int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
+#endif /* !CONFIG_DISABLE_ALL_SIGNALS */
 
 #ifndef CONFIG_NSH_DISABLE_UPTIME
   int cmd_uptime(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -304,14 +304,6 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("irqinfo",  cmd_irqinfo,  1, 1, NULL),
 #endif
 
-#ifndef CONFIG_NSH_DISABLE_KILL
-  CMD_MAP("kill",     cmd_kill,     2, 3, "[-<signal>] <pid>"),
-#endif
-
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
-  CMD_MAP("pkill",     cmd_pkill,     2, 3, "[-<signal>] <name>"),
-#endif
-
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #  if defined(CONFIG_DEV_LOOP) && !defined(CONFIG_NSH_DISABLE_LOSETUP)
   CMD_MAP("losetup",  cmd_losetup,  3, 6,
@@ -575,8 +567,22 @@ static const struct cmdmap_s g_cmdmap[] =
 #endif
 #endif
 
+#ifndef CONFIG_DISABLE_ALL_SIGNALS
+#ifndef CONFIG_NSH_DISABLE_KILL
+  CMD_MAP("kill",     cmd_kill,     2, 3, "[-<signal>] <pid>"),
+#endif
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
+  CMD_MAP("pkill",     cmd_pkill,     2, 3, "[-<signal>] <name>"),
+#endif
+
 #ifndef CONFIG_NSH_DISABLE_SLEEP
   CMD_MAP("sleep",    cmd_sleep,    2, 2, "<sec>"),
+#endif
+
+#ifndef CONFIG_NSH_DISABLE_USLEEP
+  CMD_MAP("usleep",   cmd_usleep,   2, 2, "<usec>"),
+#endif
 #endif
 
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_SOURCE)
@@ -655,10 +661,6 @@ static const struct cmdmap_s g_cmdmap[] =
 #  ifndef CONFIG_NSH_DISABLE_USERDEL
   CMD_MAP("userdel",  cmd_userdel,  2, 2, "<username>"),
 #  endif
-#endif
-
-#ifndef CONFIG_NSH_DISABLE_USLEEP
-  CMD_MAP("usleep",   cmd_usleep,   2, 2, "<usec>"),
 #endif
 
 #ifndef CONFIG_NSH_DISABLE_WATCH

--- a/nshlib/nsh_proccmds.c
+++ b/nshlib/nsh_proccmds.c
@@ -995,7 +995,8 @@ int cmd_pidof(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
  * Name: cmd_kill
  ****************************************************************************/
 
-#ifndef CONFIG_NSH_DISABLE_KILL
+#if !defined(CONFIG_NSH_DISABLE_KILL) && \
+    !defined(CONFIG_DISABLE_ALL_SIGNALS)
 int cmd_kill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *ptr;
@@ -1098,7 +1099,8 @@ invalid_arg:
  * Name: cmd_pkill
  ****************************************************************************/
 
-#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL)
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_NSH_DISABLE_PKILL) && \
+    !defined(CONFIG_DISABLE_ALL_SIGNALS)
 int cmd_pkill(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR const char *name;
@@ -1199,7 +1201,8 @@ invalid_arg:
  * Name: cmd_sleep
  ****************************************************************************/
 
-#ifndef CONFIG_NSH_DISABLE_SLEEP
+#if !defined(CONFIG_NSH_DISABLE_SLEEP) && \
+    !defined(CONFIG_DISABLE_ALL_SIGNALS)
 int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);
@@ -1222,8 +1225,8 @@ int cmd_sleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 /****************************************************************************
  * Name: cmd_usleep
  ****************************************************************************/
-
-#ifndef CONFIG_NSH_DISABLE_USLEEP
+#if !defined(CONFIG_NSH_DISABLE_USLEEP) && \
+    !defined(CONFIG_DISABLE_ALL_SIGNALS)
 int cmd_usleep(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);

--- a/system/sensortest/Kconfig
+++ b/system/sensortest/Kconfig
@@ -6,7 +6,7 @@
 config SYSTEM_SENSORTEST
 	tristate "Sensor driver test"
 	default n
-	depends on SENSORS
+	depends on SENSORS && ENABLE_ALL_SIGNALS
 	---help---
 		Enable the Sensor driver test
 

--- a/testing/drivers/nand_sim/Kconfig
+++ b/testing/drivers/nand_sim/Kconfig
@@ -5,7 +5,7 @@
 
 config TESTING_NAND_SIM
 	boolean "NAND Flash Simulator"
-	depends on MTD_NAND_RAM
+	depends on MTD_NAND_RAM && ENABLE_ALL_SIGNALS
 	default n
 	---help---
 		Enable the NAND Flash Simulator device.

--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -22,14 +22,15 @@
 
 if(CONFIG_TESTING_OSTEST)
 
-  set(SRCS
-      getopt.c
-      libc_memmem.c
-      restart.c
-      sigprocmask.c
-      sighand.c
-      signest.c
-      sighelper.c)
+  set(SRCS getopt.c libc_memmem.c restart.c sighelper.c)
+
+  if(CONFIG_ENABLE_ALL_SIGNALS)
+    list(APPEND SRCS sighand.c signest.c)
+  endif()
+
+  if(NOT CONFIG_DISABLE_ALL_SIGNALS)
+    list(APPEND SRCS sigprocmask.c)
+  endif()
 
   if(CONFIG_DEV_NULL)
     list(APPEND SRCS dev_null.c)
@@ -124,7 +125,10 @@ if(CONFIG_TESTING_OSTEST)
 
   if(NOT CONFIG_DISABLE_MQUEUE)
     if(NOT CONFIG_DISABLE_PTHREAD)
-      list(APPEND SRCS mqueue.c timedmqueue.c)
+      list(APPEND SRCS timedmqueue.c)
+      if(NOT CONFIG_DISABLE_ALL_SIGNALS)
+        list(APPEND SRCS mqueue.c)
+      endif()
     endif() # CONFIG_DISABLE_PTHREAD
   endif() # CONFIG_DISABLE_MQUEUE
 

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -31,8 +31,16 @@ MODULE = $(CONFIG_TESTING_OSTEST)
 
 # NuttX OS Test
 
-CSRCS   = getopt.c libc_memmem.c restart.c sigprocmask.c sighand.c \
+CSRCS   = getopt.c libc_memmem.c restart.c \
           signest.c sighelper.c
+
+ifeq ($(CONFIG_ENABLE_ALL_SIGNALS),y)
+CSRCS += sighand.c signest.c
+endif
+
+ifneq ($(CONFIG_DISABLE_ALL_SIGNALS),y)
+CSRCS += sigprocmask.c
+endif
 
 MAINSRC = ostest_main.c
 
@@ -119,7 +127,10 @@ endif # CONFIG_DISABLE_PTHREAD
 
 ifneq ($(CONFIG_DISABLE_MQUEUE),y)
 ifneq ($(CONFIG_DISABLE_PTHREAD),y)
-CSRCS += mqueue.c timedmqueue.c
+CSRCS += timedmqueue.c
+ifneq ($(CONFIG_DISABLE_ALL_SIGNALS),y)
+CSRCS += mqueue.c
+endif
 endif # CONFIG_DISABLE_PTHREAD
 endif # CONFIG_DISABLE_MQUEUE
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -499,14 +499,6 @@ static int user_main(int argc, char *argv[])
 #if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_PTHREAD)
       /* Verify pthreads and message queues */
 
-      printf("\nuser_main: message queue test\n");
-      mqueue_test();
-      check_test_memory_usage();
-#endif
-
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_PTHREAD)
-      /* Verify pthreads and message queues */
-
       printf("\nuser_main: timed message queue test\n");
       timedmqueue_test();
       check_test_memory_usage();
@@ -518,6 +510,14 @@ static int user_main(int argc, char *argv[])
       printf("\nuser_main: sigprocmask test\n");
       sigprocmask_test();
       check_test_memory_usage();
+
+#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_PTHREAD)
+      /* Verify pthreads and message queues */
+
+      printf("\nuser_main: message queue test\n");
+      mqueue_test();
+      check_test_memory_usage();
+#endif
 
 #if defined(CONFIG_SIG_SIGSTOP_ACTION) && defined(CONFIG_SIG_SIGKILL_ACTION) && \
     !defined(CONFIG_BUILD_KERNEL)


### PR DESCRIPTION
Fix build and runtime issues when signals all disabled.

## Summary

This PR fixes dependency issues when signals are all disabled

## Impact

Fix dependency issues when signals are all disabled, no impact to any existing functions

## Testing

**ostest passed on rv-virt:smp64**

**disable all signals**

<img width="798" height="410" alt="image" src="https://github.com/user-attachments/assets/ded9d6ab-05cd-470d-ada3-1d38bf6bc853" />

**ostest passed log**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 02cfe5cf75-dirty Jan 15 2026 16:37:47 risc-v rv-virt
nsh> 
nsh> ostest

(...)

smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc2d20  1fc2d20
ordblks         1        7
mxordblk  1fb7c78  1f709c0
uordblks     b0a8    16278
fordblks  1fb7c78  1facaa8
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```



