### PR TITLE
testing/watchdog: disable the drivertest_watchdog_api testcase on some platform

### DIFF
--- a/testing/drivers/drivertest/drivertest_watchdog.c
+++ b/testing/drivers/drivertest/drivertest_watchdog.c
@@ -57,7 +57,11 @@
 #define WDG_DEFAULT_TIMEOUT 2000
 #define WDG_DEFAULT_TESTCASE 0
 #define WDG_DEFAULT_DEVIATION 20
+#if defined(CONFIG_ARCH_ARMV7A) && defined(CONFIG_ARCH_HAVE_TRUSTZONE)
+#define WDG_COUNT_TESTCASE 3
+#else
 #define WDG_COUNT_TESTCASE 4
+#endif
 
 #define OPTARG_TO_VALUE(value, type, base)                            \
   do                                                                  \
@@ -544,7 +548,9 @@ int main(int argc, FAR char *argv[])
     cmocka_unit_test_prestate(drivertest_watchdog_feeding, &wdg_state),
     cmocka_unit_test_prestate(drivertest_watchdog_interrupts, &wdg_state),
     cmocka_unit_test_prestate(drivertest_watchdog_loop, &wdg_state),
+#if !defined(CONFIG_ARCH_ARMV7A) || !defined(CONFIG_ARCH_HAVE_TRUSTZONE)
     cmocka_unit_test_prestate(drivertest_watchdog_api, &wdg_state)
+#endif
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary

When we support the watchdog interrupt on the Armv7-A platform with the TEE enabled, the watchdog interrupt needs to be configured as a FIQ to avoid the impact of interrupt disabling in the AP. In this case, the `drivertest_watchdog_api` testcase cannot pass the test in such a scenario.

This is because the `drivertest_watchdog_api` itself requires calling a specified callback after the watchdog interrupt is triggered, instead of directly dumping the AP's context and then asserting the system.

Therefore, when both `CONFIG_ARCH_ARMV7A` and `CONFIG_ARCH_HAVE_TRUSTZONE` are enabled, we need to skip the current `drivertest_watchdog_api` testcase.

## Impact

1. Maintains test‑suite reliability – Skips the drivertest_watchdog_api test only when both CONFIG_ARCH_ARMV7A and CONFIG_ARCH_HAVE_TRUSTZONE are set, ensuring the test does not fail due to hardware/security constraints.
2. Preserves watchdog testing coverage – All other watchdog tests (feeding, interrupts, loop operation) continue to run, providing meaningful driver validation.
3. No effect on other platforms – The test remains fully enabled on all non‑Armv7‑A‑with‑TrustZone configurations.

## Testing

Verified that on Armv7‑A + TrustZone platforms, the watchdog test suite compiles and runs without the drivertest_watchdog_api test.

