### PR TITLE
usrsocktest: fix TEST_ASSERT_EQUAL fail for POLLIN

### DIFF
--- a/examples/usrsocktest/usrsocktest_remote_disconnect.c
+++ b/examples/usrsocktest/usrsocktest_remote_disconnect.c
@@ -871,7 +871,6 @@ static void remote_disconnect_poll2(struct usrsocktest_daemon_conf_s *dconf)
       TEST_ASSERT_EQUAL(1, ret);
       TEST_ASSERT_EQUAL(0, pfd.revents & POLLERR);
       TEST_ASSERT_EQUAL(POLLHUP, pfd.revents & POLLHUP);
-      TEST_ASSERT_EQUAL(*events & POLLIN, pfd.revents & POLLIN);
       TEST_ASSERT_EQUAL(0, pfd.revents & POLLOUT);
       TEST_ASSERT_EQUAL(1, usrsocktest_daemon_get_num_active_sockets());
       TEST_ASSERT_EQUAL(0, usrsocktest_daemon_get_num_connected_sockets());


### PR DESCRIPTION
This assertion should be removed because the POLLIN event is now only raised when there is data pending to be received. Previously, POLLIN was incorrectly set as soon as the connection was established, even when no data was available, which was not consistent with the expected behavior.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

usrsocktest: fix TEST_ASSERT_EQUAL fail for POLLIN

This PR removes a specific `POLLIN` assertion in `usrsocktest` to align with the kernel changes introduced in https://github.com/apache/nuttx/pull/17877.

The kernel change prevents `POLLIN` from being set when a remote connection is closed (`POLLHUP`) unless there is actual data available to read (`USRSOCK_EVENT_RECVFROM_AVAIL`). This was done to fix an issue where `usrsock` would repeatedly report `POLLIN` in a loop, causing high CPU usage or system hangs under certain conditions (e.g., interface down during connection).

Since the kernel logic now conditionally filters `POLLIN` in this scenario, the test case expectation must be updated to reflect that `POLLIN` is no longer guaranteed to be set alongside `POLLHUP` when no data is buffered.

## Impact

*   **Users:** Users running `usrsocktest` to verify user socket implementations.
*   **Build:** No impact on build configuration.
*   **Compatibility:** Updates test expectations to match the corrected kernel behavior where POLLIN is only set when data is actually available.

## Testing

*   **Verification:** Verified that `usrsocktest` now passes with the updated kernel changes.
*   **Target:** Sim/QEMU with usrsock enabled.


