### PR TITLE
ostest/hrtimer: sync hrtimer test with latest updates

### DIFF
--- a/testing/ostest/hrtimer.c
+++ b/testing/ostest/hrtimer.c
@@ -211,11 +211,12 @@ void hrtimer_test(void)
 
   /* Initialize the high-resolution timer */
 
-  hrtimer_init(&hrtimer_test.timer, test_hrtimer_callback);
+  hrtimer_init(&hrtimer_test.timer);
 
   /* Start the timer with 500ms relative timeout */
 
   ret = hrtimer_start(&hrtimer_test.timer,
+                      test_hrtimer_callback,
                       hrtimer_test.period,
                       HRTIMER_MODE_REL);
 


### PR DESCRIPTION
## Summary

Synchronize the hrtimer ostest with the latest hrtimer changes

## Impact

Synchronize the hrtimer ostest with the latest hrtimer changes

## Testing

depends on https://github.com/apache/nuttx/pull/18002

**ostest passed on rv-virt:smp64 when hrtimer is enabled**

```
NuttShell (NSH)
nsh> 
nsh> 
nsh> uname -a
NuttX 0.0.0 a8c1583552-dirty Jan 19 2026 13:12:31 risc-v rv-virt
nsh> ostest

(...)

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc0c20  1fc0c20
ordblks         6        6
mxordblk  1fab270  1fab270
uordblks    10898    12080
fordblks  1fb0388  1faeba0

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc0c20  1fc0c20
ordblks         1        6
mxordblk  1fb5b30  1fab270
uordblks     b0f0    12080
fordblks  1fb5b30  1faeba0
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 
```

**ostest passed on a2g-tc397-5v-tft:nsh when hrtimer is enabled**

```
NuttShell (NSH)
nsh>
nsh>
nsh>
nsh> uname -a
NuttX 0.0.0 a8c1583552-dirty Jan 19 2026 13:16:08 tricore a2g-tc397-5v-tft
nsh>
nsh> ostest

(...)

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         6        6
mxordblk    1f890    1f890
uordblks     5574     5574
fordblks    23888    23888

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28dfc    28dfc
ordblks         1        6
mxordblk    24208    1f890
uordblks     4bf4     5574
fordblks    24208    23888
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```


