### PR TITLE
system/cu: Fix ci error

### DIFF
--- a/system/cu/cu_main.c
+++ b/system/cu/cu_main.c
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <debug.h>
+#include <nuttx/sched.h>
 
 #include "system/readline.h"
 
@@ -125,6 +126,7 @@ static FAR void *cu_listener(FAR void *parameter)
 #ifdef CONFIG_ENABLE_ALL_SIGNALS
 static void sigint(int sig)
 {
+  FAR siginfo_t *siginfo = nxsched_self()->sigunbinfo;
   FAR struct cu_globals_s *cu = siginfo->si_user;
   cu->force_exit = true;
 }


### PR DESCRIPTION
## Summary

fix ci build error:

```
Configuration/Tool: qemu-armv8a/rpproxy
2026-01-20 04:26:55
------------------------------------------------------------------------------------
  Cleaning...
/github/workspace/sources/apps/Application.mk:238: target 'signest.c.github.workspace.sources.apps.testing.ostest.o' given more than once in the same rule
/github/workspace/sources/apps/Application.mk:238: target 'signest.c.github.workspace.sources.apps.testing.ostest.o' given more than once in the same rule
  Configuring...
  Building NuttX...
cu_main.c: In function 'sigint':
Error: cu_main.c:128:33: error: 'siginfo' undeclared (first use in this function)
  128 |   FAR struct cu_globals_s *cu = siginfo->si_user;
```

## Impact

Fix CI build error

## Testing

since this PR is to fix CI error, CI will verify it


