### PR TITLE
netutils/nng: Update help for NETUTILS_NNG

### DIFF
--- a/netutils/nng/Kconfig
+++ b/netutils/nng/Kconfig
@@ -11,6 +11,12 @@ config NETUTILS_NNG
 		offering a simple API to solve common recurring messaging problems,
 		such as publish/subscribe, RPC-style request/reply, or service discovery.
 
+		Consider the following configuration when enabling NNG:
+		- CONFIG_LIBC_NETDB=y
+		- CONFIG_DEV_URANDOM=y
+		- CONFIG_NET_LOCAL=y
+		- CONFIG_NET_LOCAL_STREAM=y
+
 if NETUTILS_NNG
 
 config NETUTILS_NNG_VERSION


### PR DESCRIPTION
## Summary

NNG depends on options that, if not enabled, makes compilation or runtime crashes. Noting these options in help helps to find out which are such options.

## Impact

Improve documentation.

## Testing

I have tried to build and run without and with these configurations enabled.


