### PR TITLE
testing/ostest: fix build issue

### DIFF
--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -31,8 +31,7 @@ MODULE = $(CONFIG_TESTING_OSTEST)
 
 # NuttX OS Test
 
-CSRCS   = getopt.c libc_memmem.c restart.c \
-          signest.c sighelper.c
+CSRCS   = getopt.c libc_memmem.c restart.c sighelper.c
 
 ifeq ($(CONFIG_ENABLE_ALL_SIGNALS),y)
 CSRCS += sighand.c signest.c


### PR DESCRIPTION
## Summary

**this PR fix CI build isse:**
```
  Building NuttX...

  /d/a/nuttx-apps/nuttx-apps/sources/apps/Application.mk:238: target 'signest.c.d.a.nuttx-apps.nuttx-  apps.sources.apps.testing.ostest.o' given more than once in the same rule
```

## Impact

Fix CI build issue

## Testing

This PR is to fix CI build issue, so CI itself can verify it


