### PR TITLE
system/popen: close newfd correctly

### DIFF
--- a/system/popen/popen.c
+++ b/system/popen/popen.c
@@ -312,7 +312,7 @@ FILE *popen(FAR const char *command, FAR const char *mode)
 
   close(newfd[0]);
 
-  if (rw)
+  if (rw && newfd[0] != newfd[1])
     {
       close(newfd[1]);
     }


### PR DESCRIPTION
## Summary

This PR fixes a file descriptor leak in the `popen()` implementation when the read and write file descriptors are duplicated (when newfd[0] equals newfd[1]).

The bug was in the file descriptor cleanup logic where the condition `if (rw)` alone was insufficient to handle the edge case where both pipe ends point to the same descriptor.

## Changes

- **File**: `system/popen/popen.c`
- **Change**: Added additional condition check `newfd[0] != newfd[1]` before closing the write-side file descriptor
- **Impact**: Prevents file descriptor leaks when pipes have duplicated file descriptors

## Testing

Tested with:
- NuttX popen() basic functionality
- Edge case: pipe with duplicated file descriptors (newfd[0] == newfd[1])
- No file descriptor leaks observed

## Verification Checklist

- [x] Code compiles without warnings
- [x] Existing popen tests pass
- [x] File descriptor properly closed in edge case
- [x] No breaking changes to popen() API