### PR TITLE
apps/examples/popen: Modify kconfig file

### DIFF
--- a/examples/popen/Kconfig
+++ b/examples/popen/Kconfig
@@ -7,6 +7,7 @@ config EXAMPLES_POPEN
 	tristate "popen() example"
 	default n
 	depends on SYSTEM_POPEN
+	depends on !DISABLE_POSIX_TIMERS
 	---help---
 		Enable the popen() example
 


### PR DESCRIPTION
This test depends on !DISABLE_POSIX_TIMERS.

arm-none-eabi/bin/ld:
apps/examples/popen/libapps_popen.a(popen_main.c.obj): in function `popen_main':
apps/examples/popen/popen_main.c:62:(.text.popen_main+0x1c): undefined reference to `timer_create'

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


