### PR TITLE
system/uorb: uorb listener bug fix.

### DIFF
--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -427,7 +427,7 @@ static int listener_generate_object_list(FAR struct listen_list_s *objlist,
                         }
                     }
 
-                  if (orb_exists(object.meta, object.instance++) < 0)
+                  if (orb_exists(object.meta, ++object.instance) < 0)
                     {
                       break;
                     }


### PR DESCRIPTION
Fixed the issue that instance+1 subscription will be triggered when topic exists in this core

## Summary

This patch fixes a critical bug in the uORB listener that caused incorrect instance numbering when iterating through topic instances.

In the listener_generate_object_list() function, when checking for the existence of the next topic instance, the code incorrectly used post-increment (instance++) instead of pre-increment (++instance). This caused the following issues:

When a topic exists in the current core (e.g., instance 0), the orb_exists() check would use the current instance value first, then increment it
This resulted in checking instance 0 twice and skipping to instance 2, missing instance 1 entirely
The subscription would incorrectly trigger for instance+1 instead of the expected next instance

## Impact

Fixed: Correct instance enumeration when listening to multi-instance topics

## Testing
~~~
ap> uorb_listener sensor_accel0

Mointor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:37453857):timestamp:37451171,x:0.430533,y:0.287640,z:9.751862,temperature:26.849609
sensor_accel(now:37493591):timestamp:37491516,x:0.408985,y:0.261304,z:9.854813,temperature:26.849609
sensor_accel(now:37535339):timestamp:37531860,x:0.413774,y:0.297217,z:9.799746,temperature:26.849609
sensor_accel(now:37574340):timestamp:37572143,x:0.413774,y:0.242151,z:9.871572,temperature:26.849609
sensor_accel(now:37614685):timestamp:37612487,x:0.406591,y:0.237362,z:9.838053,temperature:26.849609
sensor_accel(now:37654968):timestamp:37652832,x:0.392226,y:0.292429,z:9.754255,temperature:26.849609
sensor_accel(now:37695251):timestamp:37693115,x:0.380255,y:0.234968,z:9.725525,temperature:26.849609
sensor_accel(now:37735595):timestamp:37733459,x:0.464052,y:0.266093,z:9.761438,temperature:26.849609
sensor_accel(now:37775878):timestamp:37773742,x:0.399408,y:0.261304,z:9.766227,temperature:26.849609
sensor_accel(now:37816040):timestamp:37814086,x:0.341948,y:0.256516,z:9.787775,temperature:26.849609
sensor_accel(now:37856567):timestamp:37854370,x:0.397014,y:0.316371,z:9.830871,temperature:26.849609
sensor_accel(now:37896850):timestamp:37894714,x:0.332371,y:0.287640,z:9.737496,temperature:26.849609
sensor_accel(now:37937194):timestamp:37934997,x:0.428139,y:0.258910,z:9.737496,temperature:26.849609
sensor_accel(now:37977539):timestamp:37975341,x:0.382649,y:0.311582,z:9.766227,temperature:26.849609
sensor_accel(now:38017822):timestamp:38015686,x:0.437716,y:0.246939,z:9.787775,temperature:26.849609
sensor_accel(now:38058105):timestamp:38055969,x:0.452081,y:0.275669,z:9.842841,temperature:26.849609
sensor_accel(now:38098449):timestamp:38096313,x:0.358707,y:0.325948,z:9.756650,temperature:26.849609
sensor_accel(now:38138732):timestamp:38136657,x:0.420956,y:0.352284,z:9.933821,temperature:26.849609
sensor_accel(now:38179077):timestamp:38176940,x:0.382649,y:0.234968,z:9.782987,temperature:26.849609
sensor_accel(now:38219299):timestamp:38217285,x:0.425745,y:0.246939,z:9.816505,temperature:26.849609
sensor_accel(now:38259765):timestamp:38257568,x:0.416168,y:0.273275,z:9.909879,temperature:26.849609
sensor_accel(now:38300109):timestamp:38297912,x:0.435322,y:0.287640,z:9.766227,temperature:26.849609
sensor_accel(now:38340454):timestamp:38338256,x:0.404197,y:0.299611,z:9.739890,temperature:26.849609
sensor_accel(now:38380798):timestamp:38378601,x:0.435322,y:0.282852,z:9.835659,temperature:26.849609
Object name:sensor_accel0, recieved:24
Total number of received Message:24/24
ap>  ls /dev/uorb
/dev/uorb:
 sensor_accel0

ap> uorb_listener sensor_accel1
Mointor objects num:1
object_name:sensor_accel, object_instance:1
Object name:sensor_accel1, recieved:0
Total number of received Message:0/0

ap> ls /dev/uorb
/dev/uorb:
 sensor_accel0
 sensor_accel1
ap>

~~~


