### PR TITLE
nsh: fix nsh redirect fd double close

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -726,6 +726,8 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
       if (vtbl->np.np_redir_out || vtbl->np.np_redir_in)
         {
           nsh_undirect(vtbl, save);
+          fd_out = -1;
+          fd_in = -1;
         }
     }
 


### PR DESCRIPTION
avoid double-close of redirection fds


## Summary

*Fix a double close() in foreground redirection. nsh_undirect() already closes the redirected fd_in/fd_out, but close_redir would close them again. Reset fd_in/fd_out to -1 after nsh_undirect() to avoid closing the same fd twice.*

## Impact

*nsh_redirect.*

## Testing

```
# NSH Script
echo "start" > /tmp/test.log
help >> /tmp/test.log
cat < /tmp/test.log
```


