### PR TITLE
fix(macro): fix CAPIO_FREQUENCY macro typo

### DIFF
--- a/examples/capture/cap_main.c
+++ b/examples/capture/cap_main.c
@@ -351,11 +351,11 @@ int main(int argc, FAR char *argv[])
 
       /* Get the frequency data using the ioctl */
 
-      ret = ioctl(fd, CAPIOC_FREQUENCE,
+      ret = ioctl(fd, CAPIOC_FREQUENCY,
                   (unsigned long)((uintptr_t)&frequency));
       if (ret < 0)
         {
-          printf("cap_main: ioctl(CAPIOC_FREQUENCE) failed: %d\n", errno);
+          printf("cap_main: ioctl(CAPIOC_FREQUENCY) failed: %d\n", errno);
           exitval = EXIT_FAILURE;
           goto errout_with_dev;
         }


### PR DESCRIPTION
Going from CAPIOC_FREQUENCE to CAPIO_FREQUENCY according to https://github.com/apache/nuttx/pull/16925

## Summary

CAPIOC_FREQUENCE is a typo, should be FREQUENCY. nuttx/pull/16925 fixes this, so the app side should be fixed too.