### PR TITLE
mtdconfig: support ram_mtdconfig device && lomtdconfig device

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -322,9 +322,15 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 #  if defined(CONFIG_MTD_LOOP) && !defined(CONFIG_NSH_DISABLE_LOMTD)
+#    ifdef CONFIG_MTD_CONFIG
+  CMD_MAP("lomtd",    cmd_lomtd,    3, 10,
+    "[-d <dev-path>] | [[-o <offset>] [-e <erase-size>] "
+    "[-b <sect-size>] [-c <configdata>] <dev-path> <file-path>]]"),
+#    else
   CMD_MAP("lomtd",    cmd_lomtd,    3, 9,
     "[-d <dev-path>] | [[-o <offset>] [-e <erase-size>] "
     "[-b <sect-size>] <dev-path> <file-path>]]"),
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
[For nvs test in qemu](mtdconfig: support ram_mtdconfig device && lomtdconfig device)

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

mtdconfig: support ram_mtdconfig device && lomtdconfig device

## Impact

register mtdconfig device

## Testing
CONFIG_DISABLE_MOUNTPOINT=n
CONFIG_NSH_DISABLE_LOMTD=n
CONFIG_MTD_LOOP=y
CONFIG_MTD_CONFIG=y

goldfish-armv7a-ap> ls /dev
/dev:
 audio/
 binder
 charge/
 console
 crypto
 fb0
 goldfish_pipe
 input0
 kbd0
 kmsg
 log
 loopmtd
 loopmtd1
 lra0
 mtdnvs_flash

