### PR TITLE
uorb_listener add flush and getinfo.

### DIFF
--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -559,13 +559,13 @@ static void listener_flush_topic(FAR const struct listen_list_s *objlist,
   int ret;
 
   fds = calloc(nb_objects, sizeof(struct pollfd));
-  if (!fds)
+  if (fds == NULL)
     {
       return;
     }
 
   result = calloc(nb_objects, sizeof(int8_t));
-  if (!result)
+  if (result == NULL)
     {
       free(fds);
       return;
@@ -598,6 +598,8 @@ static void listener_flush_topic(FAR const struct listen_list_s *objlist,
       if (ret < 0)
         {
           result[i] = ret;
+          uorbinfo_raw("topic [%s%d] call flush failed! return:%d\n",
+                       tmp->object.meta->o_name, tmp->object.instance, ret);
         }
       else
         {


### PR DESCRIPTION

## Summary

**1. Sensor Device Information Query (Commit: 81edbcf95)**
- Added `-i` option to retrieve and display sensor device information based on topic
- Displays comprehensive sensor metadata including name, vendor, version, power consumption, measurement ranges, resolution, delay parameters, and FIFO capacity

**2. Sensor Flush Functionality (Commit: 415ed6c4b)**
- Implemented `-f` option to flush sensor driver data
- Changed record-to-file option from `-f` to `-s` to avoid conflict
- Supports flushing multiple topics simultaneously with comma-separated topic names
- Uses `poll()` with `POLLPRI` events to wait for `SENSOR_EVENT_FLUSH_COMPLETE` notification
- Provides detailed result reporting showing success/failure status for each flushed topic
- Includes timeout mechanism (default: 5 seconds) to prevent indefinite waiting

**3. Flush Error Reporting Enhancement (Commit: c62dd4038)**
- Added detailed error messages when flush operation fails
- Reports topic name, instance, and error code for failed flush attempts
- Improves debugging experience by providing immediate failure feedback


## Impact

**User Impact:**
- **New command-line options:**
  - `-i`: Get sensor device information
  - `-f`: Flush sensor data (previously used for file recording)
  - `-s`: Record to file (moved from `-f`)
- **Breaking change:** Users relying on `-f` for file recording must switch to `-s`

**Functionality Impact:**
- Enables runtime sensor capability inspection
- Provides explicit flush control for sensor data pipelines
- Improves observability with detailed error messages
- No impact on existing subscription/listening functionality

**Build Impact:**
- No new dependencies introduced
- All changes are within `system/uorb/listener.c`
- Memory allocations use standard `calloc()` with proper cleanup

**Documentation Impact:**
- Help text updated to reflect new options and option changes
- Usage examples provided in commit messages


## Testing
~~~
ap> uorb_listener -i sensor_accel
Topic [sensor_accel0] info:
        name:BMI270 Accelerometer
        vendor:Bosch
        version:3
        power:0.010000
        max_range:78.480003
        resolution:0.002400
        min_delay:20000
        max_delay:40000
        fifo_reserved_event_count:40
        fifo_max_event_count:40

ap> uorb_listener -f sensor_accel
Result:
        Topic [sensor_accel0] flush: SUCCESS.
Total number of flush topics: 1
ap> uorb_listener -f sensor_accel,sensor_gyro
Result:
        Topic [sensor_gyro0] flush: SUCCESS.
        Topic [sensor_accel0] flush: SUCCESS.
Total number of flush topics: 2
ap> uorb_listener -i sensor_accel,sensor_gyro
Topic [sensor_gyro0] info:
        name:BMI270 Gyroscope
        vendor:Bosch
        version:3
        power:0.410000
        max_range:34.910000
        resolution:0.001060
        min_delay:20000
        max_delay:40000
        fifo_reserved_event_count:40
        fifo_max_event_count:40

Topic [sensor_accel0] info:
        name:BMI270 Accelerometer
        vendor:Bosch
        version:3
        power:0.010000
        max_range:78.480003
        resolution:0.002400
        min_delay:20000
        max_delay:40000
        fifo_reserved_event_count:40
        fifo_max_event_count:40

ap>
~~~


