### PR TITLE
system/ymodem: fix send err when partial write

### DIFF
--- a/system/ymodem/ymodem.c
+++ b/system/ymodem/ymodem.c
@@ -98,7 +98,7 @@ static int ymodem_send_buffer(FAR struct ymodem_ctx_s *ctx,
   ymodem_debug("send buffer data, write size is %zu\n", size);
   while (i < size)
     {
-      ssize_t ret = write(ctx->sendfd, buf, size);
+      ssize_t ret = write(ctx->sendfd, buf + i, size - i);
       if (ret >= 0)
         {
           ymodem_debug("send buffer data, size %zd\n", ret);


### PR DESCRIPTION
## Summary

Fix buffer offset calculation in ymodem_send_buffer() to correctly handle partial writes by advancing the buffer pointer and adjusting the remaining size on each retry.

### Changes:
- Fix buffer offset in write retry logic: change `write(fd, buf, size)` to `write(fd, buf + i, size - i)`

## Impact

- **Features**: Fixes YMODEM transfer corruption on partial writes
- **API Changes**: None
- **Build**: No changes
- **Hardware**: Affects UART devices with buffer constraints
- **Documentation**: No changes needed
- **Security**: No security implications
- **Compatibility**: Fully backward compatible

## Testing

Tested on UART with small write buffers. YMODEM file transfers complete successfully without corruption.