### PR TITLE
apps: Add spinlock.h include for critical section support

### DIFF
--- a/benchmarks/osperf/osperf.c
+++ b/benchmarks/osperf/osperf.c
@@ -39,6 +39,7 @@
 #include <sys/poll.h>
 
 #include <nuttx/sched.h>
+#include <nuttx/spinlock.h>
 
 /****************************************************************************
  * Private Types
@@ -129,7 +130,7 @@ static size_t performance_gettime(FAR struct performance_time_s *result)
 }
 
 /****************************************************************************
- * Pthread swtich performance
+ * Pthread switch performance
  ****************************************************************************/
 
 static FAR void *pthread_switch_task(FAR void *arg)

--- a/testing/ostest/wdog.c
+++ b/testing/ostest/wdog.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
 #include <nuttx/wdog.h>
+#include <nuttx/spinlock.h>
 
 #include <assert.h>
 #include <pthread.h>


### PR DESCRIPTION
## Summary

This pull request adds necessary header includes to NuttX applications to support inlined critical section operations. The changes enable the kernel-side optimization of `enter_critical_section` by providing access to spinlock definitions in application code paths that require fine-grained synchronization.

should merge before https://github.com/apache/nuttx/pull/18135

### Changes Made

1. **benchmarks/osperf/osperf.c** - Added `#include <nuttx/spinlock.h>` to support performance measurement of critical section operations with inlining capability.

2. **testing/ostest/wdog.c** - Added `#include <nuttx/spinlock.h>` to enable watchdog timer tests to access inlined synchronization primitives.

### Related Issues

This commit is part of the critical section refactoring series in NuttX kernel that consolidates synchronization mechanisms using rspinlock_t foundation.

## Impact

- **Compatibility**: Fully backward compatible with existing applications
- **Performance**: Enables kernel-side inlining optimizations for applications using critical sections
- **Build**: No changes to build system or configuration
- **API**: No public API changes

### Files Modified

**Applications Layer:**
- `benchmarks/osperf/osperf.c` - Performance benchmark tool
- `testing/ostest/wdog.c` - Watchdog timer tests

## Testing

1. **Build Test**: Verify applications build successfully with new includes
2. **Functionality Test**: Run osperf and ostest to confirm normal operation
3. **Performance Test**: Verify osperf measurements remain consistent
4. **Integration Test**: Test with critical section refactoring (NuttX kernel changes)

### Verification Checklist

- [x] Code builds without warnings
- [x] Includes are necessary and used by kernel optimizations
- [x] No circular dependencies introduced
- [x] Existing tests pass
- [x] Applications run correctly
- [x] Performance metrics remain stable