### PR TITLE
testing/ostest: Fix uninitialized variable warning in wdog test

### DIFF
--- a/testing/ostest/wdog.c
+++ b/testing/ostest/wdog.c
@@ -147,7 +147,7 @@ static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
   clock_t    wdset_tick;
   sclock_t   delay_tick;
   sclock_t   diff;
-  irqstate_t flags;
+  irqstate_t flags = 0;
 
   /* Perform multiple iterations with random delays. */
 


### PR DESCRIPTION
## Summary

Fix compiler warning about uninitialized variable in the watchdog test. The `flags` variable in `wdtest_rand()` was not initialized and could trigger `-Werror=maybe-uninitialized` error on certain architectures (e.g., x86_64/intel64) where the compiler detects potential use before assignment.
should merge before https://github.com/apache/nuttx/pull/18135

## Changes

**File: testing/ostest/wdog.c**
- Initialize `flags` variable to 0 at declaration
- Fixes build error on qemu-intel64/nsh_pci_smp configuration

**Root cause:**
The `flags` variable is conditionally assigned only when `cnt % 2` is true, but the compiler cannot determine at compile time that the corresponding `leave_critical_section(flags)` will only be called when the variable was actually assigned.

```c
// Before: uninitialized
irqstate_t flags;

// After: initialized
irqstate_t flags = 0;