### PR TITLE
nshlib: Add stderr redirection support

### DIFF
--- a/include/nshlib/nshlib.h
+++ b/include/nshlib/nshlib.h
@@ -69,21 +69,24 @@
 
 struct nsh_param_s
 {
-  /* Redirect input/output through `fd` OR `path_name`
+  /* Redirect input/output/error through `fd` OR `path_name`
    *
    * Select one:
-   * 1. Using fd_in/fd_out as oldfd for dup2() if greater than -1.
-   * 2. Using file_in/file_out as full path to the file if it is
-   *    not NULL, and oflags_in/oflags_out as flags for open().
+   * 1. Using fd_in/fd_out/fd_err as oldfd for dup2() if greater than -1.
+   * 2. Using file_in/file_out/file_err as full path to the file if it is
+   *    not NULL, and oflags_in/oflags_out/oflags_err as flags for open().
    */
 
   int fd_in;
   int fd_out;
+  int fd_err;
 
   int oflags_in;
   int oflags_out;
+  int oflags_err;
   FAR const char *file_in;
   FAR const char *file_out;
+  FAR const char *file_err;
 };
 
 /****************************************************************************

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -655,6 +655,7 @@ struct nsh_parser_s
 #endif
   bool     np_redir_out; /* true: Output from the last command was re-directed */
   bool     np_redir_in;  /* true: Input from the last command was re-directed */
+  bool     np_redir_err; /* true: Error from the last command was re-directed */
   bool     np_fail;      /* true: The last command failed */
   pid_t    np_lastpid;   /* Pid of the last command executed */
 #ifdef NSH_HAVE_VARS

--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -76,7 +76,7 @@ static int nsh_erroroutput(FAR struct nsh_vtbl_s *vtbl,
 #endif
 static FAR char *nsh_consolelinebuffer(FAR struct nsh_vtbl_s *vtbl);
 static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd_in,
-                                int fd_out, FAR uint8_t *save);
+                                int fd_out, int fd_err, FAR uint8_t *save);
 static void nsh_consoleundirect(FAR struct nsh_vtbl_s *vtbl,
                                 FAR uint8_t *save);
 static void nsh_consoleexit(FAR struct nsh_vtbl_s *vtbl,
@@ -332,7 +332,7 @@ static void nsh_consolerelease(FAR struct nsh_vtbl_s *vtbl)
  ****************************************************************************/
 
 static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd_in,
-                                int fd_out, FAR uint8_t *save)
+                                int fd_out, int fd_err, FAR uint8_t *save)
 {
   FAR struct console_stdio_s *pstate = (FAR struct console_stdio_s *)vtbl;
   FAR struct serialsave_s *ssave  = (FAR struct serialsave_s *)save;
@@ -354,6 +354,7 @@ static void nsh_consoleredirect(FAR struct nsh_vtbl_s *vtbl, int fd_in,
 
   OUTFD(pstate) = fd_out;
   INFD(pstate) = fd_in;
+  ERRFD(pstate) = fd_err;
 }
 
 /****************************************************************************

--- a/nshlib/nsh_console.h
+++ b/nshlib/nsh_console.h
@@ -43,15 +43,15 @@
 
 /* Method access macros */
 
-#define nsh_clone(v)            (v)->clone(v)
-#define nsh_release(v)          (v)->release(v)
-#define nsh_write(v,b,n)        (v)->write(v,b,n)
-#define nsh_read(v,b,n)         (v)->read(v,b,n)
-#define nsh_ioctl(v,c,a)        (v)->ioctl(v,c,a)
-#define nsh_linebuffer(v)       (v)->linebuffer(v)
-#define nsh_redirect(v,fi,fo,s) (v)->redirect(v,fi,fo,s)
-#define nsh_undirect(v,s)       (v)->undirect(v,s)
-#define nsh_exit(v,s)           (v)->exit(v,s)
+#define nsh_clone(v)               (v)->clone(v)
+#define nsh_release(v)             (v)->release(v)
+#define nsh_write(v,b,n)           (v)->write(v,b,n)
+#define nsh_read(v,b,n)            (v)->read(v,b,n)
+#define nsh_ioctl(v,c,a)           (v)->ioctl(v,c,a)
+#define nsh_linebuffer(v)          (v)->linebuffer(v)
+#define nsh_redirect(v,fi,fo,fe,s) (v)->redirect(v,fi,fo,fe,s)
+#define nsh_undirect(v,s)          (v)->undirect(v,s)
+#define nsh_exit(v,s)              (v)->exit(v,s)
 
 #ifdef CONFIG_CPP_HAVE_VARARGS
 #  define nsh_error(v, ...)     (v)->error(v, ##__VA_ARGS__)
@@ -127,7 +127,7 @@ struct nsh_vtbl_s
       printf_like(2, 3);
   FAR char *(*linebuffer)(FAR struct nsh_vtbl_s *vtbl);
   void (*redirect)(FAR struct nsh_vtbl_s *vtbl, int fd_in, int fd_out,
-                   FAR uint8_t *save);
+                   int fd_err, FAR uint8_t *save);
   void (*undirect)(FAR struct nsh_vtbl_s *vtbl, FAR uint8_t *save);
   void (*exit)(FAR struct nsh_vtbl_s *vtbl, int status) noreturn_function;
 

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -64,7 +64,7 @@ static int nsh_script_redirect(FAR struct nsh_vtbl_s *vtbl,
       fd = open(CONFIG_NSH_SCRIPT_REDIRECT_PATH, 0666);
       if (fd > 0)
         {
-          nsh_redirect(vtbl, 0, fd, save);
+          nsh_redirect(vtbl, 0, fd, fd, save);
         }
     }
 


### PR DESCRIPTION
## Summary

This PR implements stderr redirection support in NSH (NuttShell), enabling Bash-like syntax for redirecting standard error output. This enhancement improves NSH compatibility with standard Unix shells and provides better error handling capabilities.

### Features Added:
- Support `2>` operator for stderr redirection (overwrite mode)
- Support `2>>` operator for stderr redirection (append mode)
- Support `2>&1` syntax to redirect stderr to stdout
- Works with both foreground and background commands

### Usage Examples:
```bash
nsh> ls noexists 2> err.log           # Redirect stderr to file
nsh> ls noexists 2> err.log &         # Background with stderr redirect
nsh> ls noexists 2>> err.log          # Append stderr to file
nsh> sh < /dev/ttyS0 > /dev/ttyS0 2> /dev/ttyS1 &    # Multiple redirections
nsh> sh < /dev/ttyS0 > /dev/ttyS0 2>&1 &             # Merge stderr to stdout
```

### Implementation Details:
- Added stderr file descriptor field to `nsh_vtbl_s` structure
- Extended redirection parsing logic in `nsh_parse.c` to handle stderr operators
- Implemented `nsh_redirect_stderr()` function in `nsh_fileapps.c`
- Updated console and script handlers to support stderr redirection

## Impact

- **Features**: Adds stderr redirection capability to NSH shell, enhancing compatibility with standard Unix shell syntax
- **API Changes**: Modified `nsh_vtbl_s` structure to include stderr file descriptor (internal API only, no user-facing changes)
- **User Experience**: Users can now redirect error messages separately from standard output, improving script debugging and error logging
- **Security**: No security implications
- **Compatibility**: Fully backward compatible - existing NSH commands and scripts continue to work unchanged

## Testing

### Test Configuration:
- **Platform**: Simulation (sim:nsh)
- **Config**: sim:nsh

### Runtime Test Results:

**Test 1: Basic stderr redirection (overwrite mode)**
```bash
nsh> ll 2> err.log
nsh> cat err.log
nsh: ll: command not found
```

**Test 2: Stderr append mode**
```bash
nsh> ll 2> err.log
nsh> cat err.log
nsh: ll: command not found
nsh> ls noexists 2>> err.log
nsh> cat err.log
nsh: ll: command not found
nsh: ls: stat failed: 2
```

**Test 3: Redirect stderr to stdout (2>&1)**
```bash
nsh> ll > log 2>&1
nsh> cat log
nsh: ll: command not found
```
