### PR TITLE
ostest/hrtimer: sync hrtimer ostest with latest hritmer update

### DIFF
--- a/testing/ostest/hrtimer.c
+++ b/testing/ostest/hrtimer.c
@@ -223,7 +223,7 @@ static void * hrtimer_test_thread(void *arg)
       /* Cancel timer */
 
       ret = hrtimer_cancel(&timer);
-      HRTIMER_TEST(ret, OK);
+      HRTIMER_TEST(ret >= 0, true);
 
       /* Start timer with fixed period */
 
@@ -241,7 +241,7 @@ static void * hrtimer_test_thread(void *arg)
   /* Cancel the timer synchronously */
 
   ret = hrtimer_cancel_sync(&timer);
-  HRTIMER_TEST(ret, OK);
+  HRTIMER_TEST(ret >= 0, true);
 
   return NULL;
 }


### PR DESCRIPTION
  ## Summary

sync hrtimer ostest with latest hritmer update

## Impact

sync hrtimer ostest implementation, this change is isolated in hrtimer module

## Testing

depends on  https://github.com/apache/nuttx/pull/18174

**ostest passed on rv-virt:smp64 with hrtimer enabled**

```
NuttShell (NSH)
nsh> 
nsh> uname -a
NuttX 0.0.0 d819e61456-dirty Jan 27 2026 11:19:53 risc-v rv-virt
nsh> 
nsh> ostest

(...)

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

user_main: hrtimer test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc11e0  1fc11e0
ordblks         6       11
mxordblk  1f77500  1f77500
uordblks     dd58    1dbf8
fordblks  1fb3488  1fa35e8

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc11e0  1fc11e0
ordblks         1       11
mxordblk  1fb60d0  1f77500
uordblks     b110    1dbf8
fordblks  1fb60d0  1fa35e8
user_main: Exiting
ostest_main: Exiting with status 0
```




