### PR TITLE
Application.mk: Add missing preconfig target

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -400,3 +400,5 @@ distclean:: clean
 
 # Include Wasm specific definitions
 include $(APPDIR)/tools/Wasm.mk
+
+preconfig:


### PR DESCRIPTION
### Summary
This PR adds a default `preconfig` target to `Application.mk`. This ensures that the `make preconfig` command (used to generate/update `apps/Kconfig` and sub-Kconfigs) can execute successfully across all subdirectories, even those that do not manage their own `Kconfig` files (e.g., `modbus`, `nshlib`).

### Impact
This fix improves the robustness of the NuttX build system, specifically for environment reconfiguration scenarios. Without this fix, users cannot easily regenerate stale Kconfig files if their directory structure changes, as the recursive make process is blocked by subdirectories missing the `preconfig` target.

### Testing
- **Scenario**: Moved the `apps` and `nuttx` directories to a new parent location, invalidating existing Kconfig absolute/relative paths.
- **Before Fix**: Running `make preconfig TOPDIR=...` in `apps/` failed with:

`make[1]: Entering directory '/path/to/apps/modbus'
make[1]: *** No rule to make target 'preconfig'. Stop.`

- **After Fix**: `make preconfig` completes successfully. The `apps/Kconfig` is correctly regenerated with valid absolute paths, restoring build functionality.