### PR TITLE
crypto/openssl_mbedtls_wrapper: Fix compat with Mbed TLS 3.6.2

### DIFF
--- a/crypto/openssl_mbedtls_wrapper/Makefile
+++ b/crypto/openssl_mbedtls_wrapper/Makefile
@@ -22,4 +22,5 @@
 
 include $(APPDIR)/Make.defs
 CSRCS += $(wildcard $(APPDIR)/crypto/openssl_mbedtls_wrapper/mbedtls/*.c)
+CFLAGS += -DMBEDTLS_ALLOW_PRIVATE_ACCESS
 include $(APPDIR)/Application.mk


### PR DESCRIPTION
crypto/openssl_mbedtls_wrapper: Fix compat with Mbed TLS 3.6.2

## Summary
This updates the `openssl_mbedtls_wrapper` to fix compilation errors and logic issues when building against Mbed TLS 3.6.2.

## Details
Mbed TLS 3.x introduced breaking changes, including hiding struct members and refactoring state machine enums. This patch adjusts the wrapper to accommodate these changes.

### Changes
1.  **Allow Private Access**:
    -   Added `-DMBEDTLS_ALLOW_PRIVATE_ACCESS` to `Makefile`. The wrapper relies on direct struct access which is now private in Mbed TLS 3.x.

2.  **Update State Machine Mappings (`ssl_pm.c`)**:
    -   Removed the obsolete `MBEDTLS_SSL_SERVER_NEW_SESSION_TICKET` enum usage in `ssl_pm_get_state()`.

3.  **Fix Error Codes & Versioning**:
    -   Replaced removed `MBEDTLS_ERR_SSL_NO_USABLE_CIPHERSUITE` with `MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE`.
    -   Updated `ssl_pm_new` to use correct version macros compatible with Mbed TLS 3.x.

## Testing
-   Verified compilation validation with Mbed TLS 3.6.2.