### PR TITLE
netlib_xarp: remove redundant cast

### DIFF
--- a/netutils/netlib/netlib_delarp.c
+++ b/netutils/netlib/netlib_delarp.c
@@ -76,8 +76,7 @@ int netlib_del_arpmapping(FAR const struct sockaddr_in *inaddr,
           memset(&req.arp_ha, 0, sizeof(struct sockaddr_in));
           if (ifname != NULL)
             {
-               strlcpy((FAR char *)&req.arp_dev, ifname,
-                       sizeof(req.arp_dev));
+               strlcpy(req.arp_dev, ifname, sizeof(req.arp_dev));
             }
           else
             {

--- a/netutils/netlib/netlib_getarp.c
+++ b/netutils/netlib/netlib_getarp.c
@@ -77,8 +77,7 @@ int netlib_get_arpmapping(FAR const struct sockaddr_in *inaddr,
           memcpy(&req.arp_pa, inaddr, sizeof(struct sockaddr_in));
           if (ifname != NULL)
             {
-               strlcpy((FAR char *)&req.arp_dev, ifname,
-                       sizeof(req.arp_dev));
+               strlcpy(req.arp_dev, ifname, sizeof(req.arp_dev));
             }
           else
             {

--- a/netutils/netlib/netlib_setarp.c
+++ b/netutils/netlib/netlib_setarp.c
@@ -81,8 +81,7 @@ int netlib_set_arpmapping(FAR const struct sockaddr_in *inaddr,
           req.arp_flags = ATF_PERM;
           if (ifname != NULL)
             {
-               strlcpy((FAR char *)&req.arp_dev, ifname,
-                       sizeof(req.arp_dev));
+               strlcpy(req.arp_dev, ifname, sizeof(req.arp_dev));
             }
           else
             {

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -1310,7 +1310,7 @@ int cmd_arp(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
           FAR uint8_t *ptr;
 
           if (ifname != NULL &&
-              strcmp(ifname, (FAR char *)arptab[i].arp_dev) != 0)
+              strcmp(ifname, arptab[i].arp_dev) != 0)
             {
               continue;
             }


### PR DESCRIPTION
## Summary
removes redundant type casts in ARP-related network library functions. The casts from req.arp_dev (already a char array) to (FAR char *) are unnecessary and can be safely removed.

## Impact
Code cleanup only, no functional changes;
Improves code readability by removing unnecessary casts.

## Testing
sim:matter
- [*] Build tested
- [*] Functional testing of ARP commands
NuttX test log
```
NuttShell (NSH) NuttX-12.12.0
MOTD: username=admin password=Administrator
nsh> 
nsh> arp
IP Address   Ethernet Address  Interface
nsh> help arp
arp usage:  arp [-i <ifname>] [-a <ipaddr>|-d <ipaddr>|-s <ipaddr> <hwaddr>]
nsh> arp -i eth0 -s 10.0.1.3 00:11:22:33:44:55
nsh> arp
IP Address   Ethernet Address  Interface
10.0.1.3     00:11:22:33:44:55 eth0
nsh> arp -i eth0
IP Address   Ethernet Address  Interface
10.0.1.3     00:11:22:33:44:55 eth0
nsh> arp -a 10.0.1.3
HWaddr: 00:11:22:33:44:55
nsh> arp -d 10.0.1.3
nsh> arp -a 10.0.1.3
nsh: arp: no such ARP entry: 10.0.1.3
nsh> arp -i eth0
IP Address   Ethernet Address  Interface
nsh> arp
IP Address   Ethernet Address  Interface
nsh> 
```

