### PR TITLE
netutils/rexecd: fix rpname mismatch with rexec when using AF_RPMSG

### DIFF
--- a/netutils/rexecd/rexecd.c
+++ b/netutils/rexecd/rexecd.c
@@ -223,7 +223,7 @@ int main(int argc, FAR char **argv)
       case AF_RPMSG:
         ((FAR struct sockaddr_rpmsg *)&addr)->rp_family = AF_RPMSG;
         snprintf(((FAR struct sockaddr_rpmsg *)&addr)->rp_name,
-                 RPMSG_SOCKET_NAME_SIZE, "%d", REXECD_PORT);
+                 RPMSG_SOCKET_NAME_SIZE, "%d", htons(REXECD_PORT));
         ret = sizeof(struct sockaddr_rpmsg);
     }
 


### PR DESCRIPTION
## Summary

When using AF_RPMSG (-r option), rexecd was setting the rp_name to the raw port number, while rexec was using htons(port). This caused a mismatch where rexec couldn't connect to rexecd.

This commit fixes the issue by applying htons() to REXECD_PORT when setting rp_name in the AF_RPMSG case, making it consistent with the rexec client implementation.

The issue was introduced in #2839 commit de8080d which added htons() for AF_INET and AF_INET6 but missed the AF_RPMSG case.

## Impact

- Fixes rexec connection failure when using AF_RPMSG(-r option)
- No impact on AF_INET and AF_INET6 cases

## Testing

**Build Host:** Linux x86_64, GCC
**Targets:** sim:rpproxy and sim:rpserver

**Configuration:**
```CONFIG_NETUTILS_REXEC=y     
CONFIG_NETUTILS_REXECD=y
CONFIG_PIPES=y
CONFIG_SYSTEM_POPEN=y 
CONFIG_NET_LOCAL=y
CONFIG_NET_LOCAL_STREAM=y
CONFIG_NET_RPMSG=y
```

- Server: `./tools/configure.sh sim:rpserver && make -j4`
- Proxy: `./tools/configure.sh sim:rpproxy && make -j4`

**Test procedure:**
1. Start rpserver and rpproxy in separate terminals
2. On proxy: `rexecd -r &`
3. On server: `rexec -H proxy -r ls` and `rexec -H proxy -r ps`

**Results:**
- Before fix: Connection failed due to rpname mismatch
- After fix: Commands execute successfully, output received correctly

Test logs show successful execution of remote commands via RPMSG.
```$ ./rpproxy```

```
$ ./rpserver  

NuttShell (NSH) NuttX-12.12.0
server> 
server> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069600 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067488 sim_loop_wq 0xf2800218 0xf2800260
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067480 rpmsgdev_server 0xf28131b0 0xf28131f8
    3     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067504 hpwork 0x40100020 0x40100068
    4     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 lpwork 0x401000a0 0x401000e8
    5     5     0 100 FIFO     Task      - Running            0000000000000000 0067520 nsh_main
    7     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 rpmsg-virtio proxy 0xf2988168
    8     5     0  80 FIFO     pthread   - Waiting  Semaphore 0000000000000000 0067552 netinit 0x40037482 0
server> cu
NuttShell (NSH) NuttX-12.12.0
proxy> 
proxy> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069600 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067488 sim_loop_wq 0xf3a001f8 0xf3a00240
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 hpwork 0x400d2020 0x400d2068
    3     3     0 100 FIFO     Task      - Running            0000000000000000 0067520 nsh_main
    5     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 rpmsg-virtio server 0xf3a46838
proxy> 
proxy> rexecd -r &
rexecd [6:100]
proxy> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069600 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067488 sim_loop_wq 0xf3a001f8 0xf3a00240
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 hpwork 0x400d2020 0x400d2068
    3     3     0 100 FIFO     Task      - Running            0000000000000000 0067520 nsh_main
    5     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 rpmsg-virtio server 0xf3a46838
    6     6     3 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0067512 rexecd -r
proxy> server> 
server> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069600 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067488 sim_loop_wq 0xf2800218 0xf2800260
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067480 rpmsgdev_server 0xf28131b0 0xf28131f8
    3     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067504 hpwork 0x40100020 0x40100068
    4     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 lpwork 0x401000a0 0x401000e8
    5     5     0 100 FIFO     Task      - Running            0000000000000000 0067520 nsh_main
    7     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 rpmsg-virtio proxy 0xf2988168
server> rexec -H proxy -r ls
/:
 dev/
 proc/
 var/
server> rexec -H proxy -r ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069600 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067488 sim_loop_wq 0xf3a001f8 0xf3a00240
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 hpwork 0x400d2020 0x400d2068
    3     3     0 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0067520 nsh_main
    5     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067496 rpmsg-virtio server 0xf3a46838
    6     6     3 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0067512 rexecd -r
    9     6     3 100 FIFO     pthread   - Ready              0000000000000000 0067544 rexecd 0x4006f85d 0x4
   10    10     6 100 FIFO     Task      - Running            0000000000000000 0067512 popen -c ps
server> 
```

