### PR TITLE
testing/{ostest,sched/smp}: Remove BOARD_LOOPSPERMSEC references

### DIFF
--- a/testing/ostest/sporadic.c
+++ b/testing/ostest/sporadic.c
@@ -65,13 +65,19 @@ static time_t g_start_time;
 
 static void my_mdelay(unsigned int milliseconds)
 {
-  volatile unsigned int i;
-  volatile unsigned int j;
+  struct timespec start;
+  struct timespec cur;
+  struct timespec diff;
 
-  for (i = 0; i < milliseconds; i++)
+  clock_gettime(CLOCK_MONOTONIC, &start);
+
+  for (; ; )
     {
-      for (j = 0; j < CONFIG_BOARD_LOOPSPERMSEC; j++)
+      clock_gettime(CLOCK_MONOTONIC, &cur);
+      clock_timespec_subtract(&cur, &start, &diff);
+      if (diff.tv_sec * 1000 + diff.tv_nsec / 1000000 > milliseconds)
         {
+          break;
         }
     }
 }

--- a/testing/ostest/sporadic2.c
+++ b/testing/ostest/sporadic2.c
@@ -80,13 +80,19 @@ static int32_t g_ms_cnt2[2] =
 
 static void my_mdelay(unsigned int milliseconds)
 {
-  volatile unsigned int i;
-  volatile unsigned int j;
+  struct timespec start;
+  struct timespec cur;
+  struct timespec diff;
 
-  for (i = 0; i < milliseconds; i++)
+  clock_gettime(CLOCK_MONOTONIC, &start);
+
+  for (; ; )
     {
-      for (j = 0; j < CONFIG_BOARD_LOOPSPERMSEC; j++)
+      clock_gettime(CLOCK_MONOTONIC, &cur);
+      clock_timespec_subtract(&cur, &start, &diff);
+      if (diff.tv_sec * 1000 + diff.tv_nsec / 1000000 > milliseconds)
         {
+          break;
         }
     }
 }
@@ -172,7 +178,7 @@ static void sporadic_test_case(int32_t budget_1_ns, int32_t budget_2_ns)
 
   sem_init(&g_sporadic_sem, 0, 0);
 
-  /* initilize global worker-thread millisecons-counters */
+  /* Initialize global worker-thread milliseconds-counters */
 
   g_ms_cnt1[PRIO_HI_NDX] = 0;
   g_ms_cnt1[PRIO_LO_NDX] = 0;

--- a/testing/sched/smp/smp_main.c
+++ b/testing/sched/smp/smp_main.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <string.h>
@@ -87,13 +88,19 @@ static void show_cpu_conditional(FAR const char *caller, int threadno)
 
 static void hog_milliseconds(unsigned int milliseconds)
 {
-  volatile unsigned int i;
-  volatile unsigned int j;
+  struct timespec start;
+  struct timespec cur;
+  struct timespec diff;
 
-  for (i = 0; i < milliseconds; i++)
+  clock_gettime(CLOCK_MONOTONIC, &start);
+
+  for (; ; )
     {
-      for (j = 0; j < CONFIG_BOARD_LOOPSPERMSEC; j++)
+      clock_gettime(CLOCK_MONOTONIC, &cur);
+      clock_timespec_subtract(&cur, &start, &diff);
+      if (diff.tv_sec * 1000 + diff.tv_nsec / 1000000 > milliseconds)
         {
+          break;
         }
     }
 }


### PR DESCRIPTION
## Summary

In an effort to avoid unexpected behaviour from users not calibrating BOARD_LOOPSPERMSEC, a compilation error occurs when it is undefined. On some systems, this is allowed (those that use timer implementations instead of busy-looping for delays). In these cases, we should busy-loop using the clock time instead of relying on a possibly undefined/uncalibrated macro.

Closes #3345

## Impact

Impacts the OSTest cases `sporadic` and `sporadic2`, as well as the `sched/smp`
test.

## Testing

Compilation for `qemu-armv8a:nsh_smp` now passes (this is the configuration
failing due to missing symbol `CONFIG_BOARDLOOPSPERMSEC` in https://github.com/apache/nuttx/pull/17011).

<details>

```console
$ ./tools/configure.sh qemu-armv8a:nsh_smp
$ make -j
Create version.h
LN: platform/board to /home/linguini/coding/nuttx-space/apps/platform/dummy
Register: getprime
Register: hello
Register: taskset
Register: gcov
Register: nsh
Register: sh
Register: ostest
Register: osperf
Register: smp
Register: dd
CPP:  /home/linguini/coding/nuttx-space/nuttx/boards/arm64/qemu/qemu-armv8a/scripts/dramboot.ld-> /home/linguini/coding/nuttx-space/nuttx/boards/arm64/qemu/qemu-armv8a/scriptLD: nuttx
Memory region         Used Size  Region Size  %age Used
CP: nuttx.hex
CP: nuttx.bin
```

</details>

Running the SMP test on this configuration as-is passes:

<details>

```console
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
- Ready to Boot Primary CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize
- Ready to Boot Second CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize

NuttShell (NSH) NuttX-12.12.0
nsh> smp
  Main[0]: Running on CPU1
  Main[0]: Initializing barrier
  Main[0]: Thread 1 created
Thread[1]: Started
  Main[0]: Thread 2 created
Thread[2]: Started
Thread[1]: Running on CPU0
  Main[0]: Now running on CPU0
Thread[2]: Running on CPU0
  Main[0]: Thread 3 created
Thread[3]: Started
Thread[2]: Now running on CPU1
Thread[1]: Now running on CPU1
  Main[0]: Thread 4 created
Thread[3]: Running on CPU1
Thread[4]: Started
  Main[0]: Thread 5 created
Thread[5]: Started
Thread[4]: Running on CPU0
Thread[1]: Now running on CPU0
Thread[2]: Now running on CPU0
  Main[0]: Thread 6 created
Thread[5]: Running on CPU0
Thread[6]: Started
Thread[3]: Now running on CPU0
Thread[4]: Now running on CPU1
  Main[0]: Now running on CPU1
Thread[1]: Now running on CPU1
Thread[6]: Running on CPU0
Thread[5]: Now running on CPU1
  Main[0]: Thread 7 created
Thread[7]: Started
Thread[3]: Now running on CPU1
Thread[2]: Now running on CPU1
Thread[4]: Now running on CPU0
Thread[1]: Now running on CPU0
  Main[0]: Now running on CPU0
Thread[7]: Running on CPU1
Thread[6]: Now running on CPU1
  Main[0]: Thread 8 created
Thread[3]: Now running on CPU0
Thread[1]: Now running on CPU1
Thread[8]: Started
Thread[5]: Now running on CPU0
Thread[2]: Now running on CPU0
Thread[4]: Now running on CPU1
  Main[0]: Now running on CPU1
Thread[8]: Running on CPU0
Thread[6]: Now running on CPU0
Thread[7]: Now running on CPU0
Thread[1]: Now running on CPU0
Thread[3]: Now running on CPU1
Thread[2]: Now running on CPU1
Thread[4]: Now running on CPU0
Thread[5]: Now running on CPU1
Thread[1]: Now running on CPU1
Thread[7]: Now running on CPU1
Thread[8]: Now running on CPU1
Thread[6]: Now running on CPU1
Thread[3]: Now running on CPU0
Thread[4]: Now running on CPU1
Thread[2]: Now running on CPU0
Thread[1]: Now running on CPU0
Thread[5]: Now running on CPU0
Thread[6]: Now running on CPU0
Thread[3]: Now running on CPU1
Thread[2]: Calling pthread_barrier_wait()
Thread[8]: Now running on CPU0
Thread[5]: Now running on CPU1
Thread[7]: Now running on CPU0
Thread[1]: Calling pthread_barrier_wait()
Thread[3]: Now running on CPU0
Thread[6]: Now running on CPU1
Thread[4]: Calling pthread_barrier_wait()
Thread[2]: Now running on CPU1
Thread[5]: Calling pthread_barrier_wait()
Thread[7]: Now running on CPU1
Thread[3]: Calling pthread_barrier_wait()
Thread[6]: Calling pthread_barrier_wait()
Thread[4]: Now running on CPU0
Thread[8]: Now running on CPU1
Thread[5]: Now running on CPU0
Thread[7]: Calling pthread_barrier_wait()
Thread[8]: Now running on CPU0
Thread[8]: Calling pthread_barrier_wait()
Thread[8]: Back with ret=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
Thread[1]: Back with ret=0 (I am not special)
Thread[2]: Back with ret=0 (I am not special)
Thread[3]: Back with ret=0 (I am not special)
Thread[4]: Back with ret=0 (I am not special)
Thread[6]: Back with ret=0 (I am not special)
Thread[5]: Back with ret=0 (I am not special)
Thread[7]: Back with ret=0 (I am not special)
Thread[1]: Now running on CPU1
Thread[2]: Now running on CPU0
Thread[3]: Now running on CPU1
Thread[4]: Now running on CPU1
Thread[6]: Now running on CPU0
Thread[8]: Now running on CPU1
Thread[5]: Now running on CPU1
Thread[7]: Now running on CPU0
Thread[1]: Now running on CPU0
Thread[4]: Now running on CPU0
Thread[2]: Now running on CPU1
Thread[3]: Now running on CPU0
Thread[5]: Now running on CPU0
Thread[6]: Now running on CPU1
Thread[7]: Now running on CPU1
Thread[1]: Now running on CPU1
Thread[8]: Now running on CPU0
Thread[4]: Now running on CPU1
Thread[5]: Now running on CPU1
Thread[2]: Now running on CPU0
Thread[6]: Now running on CPU0
Thread[3]: Now running on CPU1
Thread[1]: Now running on CPU0
Thread[7]: Now running on CPU0
Thread[4]: Now running on CPU0
Thread[2]: Now running on CPU1
Thread[5]: Now running on CPU0
Thread[8]: Now running on CPU1
Thread[1]: Now running on CPU1
Thread[6]: Now running on CPU1
Thread[3]: Now running on CPU0
Thread[2]: Now running on CPU0
Thread[7]: Now running on CPU1
Thread[4]: Now running on CPU1
Thread[8]: Now running on CPU0
Thread[6]: Now running on CPU0
Thread[5]: Now running on CPU1
Thread[1]: Now running on CPU0
Thread[7]: Now running on CPU0
Thread[2]: Now running on CPU1
Thread[8]: Done
Thread[3]: Done
Thread[4]: Now running on CPU0
Thread[1]: Now running on CPU1
Thread[6]: Now running on CPU1
Thread[5]: Done
Thread[2]: Done
Thread[8]: Now running on CPU1
Thread[7]: Now running on CPU1
Thread[4]: Done
Thread[1]: Now running on CPU0
Thread[7]: Done
Thread[5]: Now running on CPU0
Thread[6]: Done
Thread[4]: Now running on CPU1
Thread[1]: Done
  Main[0]: Now running on CPU0
  Main[0]: Thread 1 completed with result=0
  Main[0]: Thread 2 completed with result=0
  Main[0]: Thread 3 completed with result=0
  Main[0]: Thread 4 completed with result=0
  Main[0]: Thread 5 completed with result=0
  Main[0]: Thread 6 completed with result=0
  Main[0]: Thread 7 completed with result=0
  Main[0]: Thread 8 completed with result=0
```

</details>

With `CONFIG_SCHED_SPORADIC=y` (so modified code is compiled into ostest), ostest passes:

<details>

```console
$ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
   -machine virt,virtualization=on,gic-version=3 \
   -net none -chardev stdio,id=con,mux=on -serial chardev:con \
   -mon chardev=con,mode=readline -kernel ./nuttx
- Ready to Boot Primary CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize
- Ready to Boot Second CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize

NuttShell (NSH) NuttX-12.12.0
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=5

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        2
mxordblk  7b7be30  7b7be30
uordblks    12198    12198
fordblks  7b7be68  7b7be68

user_main: getopt() test
getopt():  Simple test
getopt():  Invalid argument
getopt():  Missing optional argument
getopt_long():  Simple test
getopt_long():  No short options
getopt_long():  Argument for --option=argument
getopt_long():  Invalid long option
getopt_long():  Mixed long and short options
getopt_long():  Invalid short option
getopt_long():  Missing optional arguments
getopt_long_only():  Mixed long and short options
getopt_long_only():  Single hyphen long options

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        2
mxordblk  7b7be30  7b7be30
uordblks    12198    12198
fordblks  7b7be68  7b7be68

user_main: libc tests

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        2
mxordblk  7b7be30  7b7be30
uordblks    12198    12198
fordblks  7b7be68  7b7be68
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        3
mxordblk  7b7be30  7b7be30
uordblks    12198    12178
fordblks  7b7be68  7b7be88
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         3        2
mxordblk  7b7be30  7b7be30
uordblks    12178    12068
fordblks  7b7be88  7b7bf98

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        2
mxordblk  7b7be30  7b7be30
uordblks    12068    12068
fordblks  7b7bf98  7b7bf98

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        2
mxordblk  7b7be30  7b7be30
uordblks    12068    12068
fordblks  7b7bf98  7b7bf98

user_main: FPU test
Starting task FPU#1
fpu_test: Started task FPU#1 at PID=6
FPU#1: pass 1
Starting task FPU#2
fpu_test: Started task FPU#2 at PID=7
FPU#2: pass 1
FPU#1: pass 2
FPU#2: pass 2
FPU#1: pass 3
FPU#2: pass 3
FPU#1: pass 4
FPU#2: pass 4
FPU#1: pass 5
FPU#2: pass 5
FPU#1: pass 6
FPU#2: pass 6
FPU#1: pass 7
FPU#2: pass 7
FPU#1: pass 8
FPU#2: pass 8
FPU#1: pass 9
FPU#2: pass 9
FPU#1: pass 10
FPU#2: pass 10
FPU#1: pass 11
FPU#2: pass 11
FPU#1: pass 12
FPU#2: pass 12
FPU#1: pass 13
FPU#2: pass 13
FPU#1: pass 14
FPU#2: pass 14
FPU#1: pass 15
FPU#2: pass 15
FPU#1: pass 16
FPU#2: pass 16
FPU#1: Succeeded
FPU#2: Succeeded
fpu_test: Returning

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        4
mxordblk  7b7be30  7b73298
uordblks    12068    1a358
fordblks  7b7bf98  7b73ca8

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=8
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: I am still here
restart_main: I am still here
restart_main: Started with argc=4
restart_main: Started restart_main at PID=8
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         4        5
mxordblk  7b73298  7b73298
uordblks    1a358    1a3b0
fordblks  7b73ca8  7b73c50

user_main: waitpid test

Test waitpid()
waitpid_start_child: Started waitpid_main at PID=9
waitpid_main: PID 9 Started
waitpid_start_child: Started waitpid_main at PID=10
waitpid_main: PID 10 Started
waitpid_start_child: Started waitpid_main at PID=11
waitpid_main: PID 11 Started
waitpid_test: Waiting for PID=9 with waitpid()
waitpid_main: PID 9 exitting with result=14
waitpid_test: PID 9 waitpid succeeded with stat_loc=0e00
waitpid_main: PID 10 exitting with result=14
waitpid_last: Waiting for PID=11 with waitpid()
waitpid_main: PID 11 exitting with result=14
waitpid_last: PASS: PID 11 waitpid succeeded with stat_loc=0e00

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         5        6
mxordblk  7b73298  7b6a998
uordblks    1a3b0    226c0
fordblks  7b73c50  7b6b940

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
                Thread1 Thread2
        Loops   32      32
        Errors  0       0

Testing moved mutex
Starting moved mutex thread 1
Starting moved mutex thread 2
                Thread1 Thread2
        Moved Loops     32      32
        Moved Errors    0       0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         6        4
mxordblk  7b6a998  7b73ab0
uordblks    226c0    1a3d8
fordblks  7b6b940  7b73c28

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread:  Started
pthread:  Waiting for lock or timeout
mutex_test: Unlocking
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the timeout.  Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         4        5
mxordblk  7b73ab0  7b6f8f8
uordblks    1a3d8    1e560
fordblks  7b73c28  7b6faa0

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffffffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffffffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         5        3
mxordblk  7b6f8f8  7b77c78
uordblks    1e560    16248
fordblks  7b6faa0  7b77db8

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         3        4
mxordblk  7b77c78  7b73ab0
uordblks    16248    1a3d8
fordblks  7b77db8  7b73c28

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
sem_test: Starting waiter thread 2
waiter_func: Thread 1 Started
sem_test: Set thread 2 priority to 128
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
poster_func: Thread 3 new semaphore value = -1
waiter_func: Thread 1 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
poster_func: Thread 3 new semaphore value = 0
waiter_func: Thread 2 new semaphore value = 0
poster_func: Thread 3 done
waiter_func: Thread 2 done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         4        6
mxordblk  7b73ab0  7b6b730
uordblks    1a3d8    1e568
fordblks  7b73c28  7b6fa98

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1646092844 sec, 650381344 nsec)
AFTER:  (1646092846 sec, 650926128 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1646092846 sec, 651638672 nsec)
AFTER:  (1646092847 sec, 653312784 nsec)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         6        3
mxordblk  7b6b730  7b77c78
uordblks    1e568    16248
fordblks  7b6fa98  7b77db8

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test:      Waiter  Signaler
cond_test: Loops        32      32
cond_test: Errors       0       0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         3        5
mxordblk  7b77c78  7b6f8f8
uordblks    16248    1a3d0
fordblks  7b77db8  7b73c30

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=39
pthread_exit_main 39: Starting pthread_exit_thread
pthread_exit_main 39: Sleeping for 5 seconds
pthread_exit_thread 40: Sleeping for 10 second
pthread_exit_thread 40: Still running...
pthread_exit_main 39: Calling pthread_exit()

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         5        6
mxordblk  7b6f8f8  7b6b730
uordblks    1a3d0    226f0
fordblks  7b73c30  7b6b910

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 40: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         6        7
mxordblk  7b6b730  7b633b0
uordblks    226f0    268b0
fordblks  7b6b910  7b67750

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         7        6
mxordblk  7b633b0  7b633b0
uordblks    268b0    22720
fordblks  7b67750  7b6b8e0

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
timedwait_test: Joining
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         6        7
mxordblk  7b633b0  7b633b0
uordblks    22720    268b0
fordblks  7b6b8e0  7b67750

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 64
receiver_thread: Starting
mqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_send succeeded on msg 0
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 9
receiver_thread: mq_receive succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         7        6
mxordblk  7b633b0  7b6b730
uordblks    268b0    16330
fordblks  7b67750  7b77cd0

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         6        5
mxordblk  7b6b730  7b73900
uordblks    16330    16330
fordblks  7b77cd0  7b77cd0

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         5        5
mxordblk  7b73900  7b73900
uordblks    16330    16330
fordblks  7b77cd0  7b77cd0

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=58
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=58 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         5        4
mxordblk  7b73900  7b73900
uordblks    16330    16350
fordblks  7b77cd0  7b77cb0

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
signest_test: Started waiter_main pid=59
waiter_main: Waiter started
signest_test: Starting interfering task at priority 102
waiter_main: Setting signal mask
waiter_main: Registering signal handler
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=60
waiter_main: Waiting on semaphore
signest_test: Simple case:
  Total signalled 1240  Odd=620 Even=620
  Total handled   1240  Odd=620 Even=620
  Total nested    0    Odd=0   Even=0
signest_test: With task locking
  Total signalled 2480  Odd=1240 Even=1240
  Total handled   2480  Odd=1240 Even=1240
  Total nested    0    Odd=0   Even=0
signest_test: With intefering thread
  Total signalled 3720  Odd=1860 Even=1860
  Total handled   3720  Odd=1860 Even=1860
  Total nested    0    Odd=0   Even=0
signest_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         4        7
mxordblk  7b73900  7b6f8f8
uordblks    16350    1a590
fordblks  7b77cb0  7b73a70

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wdtest_recursive 1000000ns
wdtest_recursive 1000000ns
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 4611686018427387900
wdtest_recursive 1000000ns
wdtest_recursive 1000000ns
wdtest_recursive 1000000ns
wdtest_recursive 1000000ns
wdtest_recursive 1000000ns
recursive wdog triggered 51 times, elapsed tick 102
recursive wdog triggered 51 times, elapsed tick 102
recursive wdog triggered 51 times, elapsed tick 102
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
recursive wdog triggered 51 times, elapsed tick 102
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
wdtest_recursive 10000000ns
wdtest_recursive 10000000ns
wdtest_recursive 10000000ns
wdtest_recursive 10000000ns
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
wdog_test end...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         7       10
mxordblk  7b6f8f8  7b5b7b0
uordblks    1a590    1e728
fordblks  7b73a70  7b6f8d8

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=1
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=2
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=3
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=4
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=5
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks        10       10
mxordblk  7b5b7b0  7b5b7b0
uordblks    1e728    1e728
fordblks  7b6f8d8  7b6f8d8

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
         First get_primes_thread: 75
rr_test: Starting second get_primes_thread
         Second get_primes_thread: 76
rr_test: Waiting for threads to complete -- this should take awhile
         If RR scheduling is working, they should start and complete at
         about the same time
get_primes_thread id=1 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=1 finished, found 3246 primes, last one was 29989
get_primes_thread id=2 finished, found 3246 primes, last one was 29989
rr_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks        10        9
mxordblk  7b5b7b0  7b67878
uordblks    1e728    1e720
fordblks  7b6f8d8  7b6f8e0

user_main: sporadic scheduler test
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
sporadic_test: Initializing semaphore to 0
sporadic_test: Starting FIFO thread at priority 128
sporadic_test: Starting sporadic thread at priority 192 (hi) 64 (lo)
   0 SPORADIC: 0->192
   1 SPORADIC: 192->192
   1 FIFO:     128
   2 SPORADIC: 192->192
   2 FIFO:     128
   2 SPORADIC: 192->64
   3 SPORADIC: 64->64
   3 FIFO:     128
   4 FIFO:     128
   4 SPORADIC: 64->64
   5 SPORADIC: 64->64
   5 FIFO:     128
   5 SPORADIC: 64->192
   6 FIFO:     128
   6 SPORADIC: 192->192
   7 SPORADIC: 192->192
   7 FIFO:     128
   7 SPORADIC: 192->64
   8 FIFO:     128
   8 SPORADIC: 64->64
   9 SPORADIC: 64->64
   9 FIFO:     128
  10 SPORADIC: 64->64
  10 FIFO:     128
  10 SPORADIC: 64->192
  11 SPORADIC: 192->192
  11 FIFO:     128
  12 SPORADIC: 192->192
  12 FIFO:     128
  12 SPORADIC: 192->64
  13 SPORADIC: 64->64
  13 FIFO:     128
  14 FIFO:     128
  14 SPORADIC: 64->64
  15 FIFO:     128
  15 SPORADIC: 64->64
  15 SPORADIC: 64->192
  16 SPORADIC: 192->192
  17 SPORADIC: 192->192
  17 SPORADIC: 192->64
  18 SPORADIC: 64->64
  19 SPORADIC: 64->64
  20 SPORADIC: 64->64
  20 SPORADIC: 64->192
  21 SPORADIC: 192->192
  22 SPORADIC: 192->192
  22 SPORADIC: 192->64
  23 SPORADIC: 64->64
  24 SPORADIC: 64->64
  25 SPORADIC: 64->64
  25 SPORADIC: 64->192
  26 SPORADIC: 192->192
  27 SPORADIC: 192->192
  27 SPORADIC: 192->64
  28 SPORADIC: 64->64
  29 SPORADIC: 64->64
  30 SPORADIC: 64->64
  30 SPORADIC: 64->192
  31 SPORADIC: 192->192
  32 SPORADIC: 192->192
  32 SPORADIC: 192->64
  33 SPORADIC: 64->64
  34 SPORADIC: 64->64
  35 SPORADIC: 64->64
sporadic_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         9        6
mxordblk  7b67878  7b73900
uordblks    1e720    12278
fordblks  7b6f8e0  7b7bd88

user_main: Dual sporadic thread test
Sporadic 1: prio high 180, low 20, repl 100000000 ns
Sporadic 2: prio high 170, low 30, repl 100000000 ns

        THREAD    BUDGET  HI MS  LO MS
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
  1 Sporadic 1 000000000      0  50000
    Sporadic 2 030000000  14898  35102
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
  2 Sporadic 1 010000000   5885  44115
    Sporadic 2 030000000  14715  35285
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
  3 Sporadic 1 020000000   9856  40143
    Sporadic 2 030000000  14715  35285
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
  4 Sporadic 1 030000000  14715  35285
    Sporadic 2 030000000  15695  34305
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
  5 Sporadic 1 040000000  19803  30196
    Sporadic 2 030000000  14715  35285
sporadic_test: CONFIG_SCHED_SPORADIC_MAXREPL is small: 3
  -- There will some errors in the replenishment interval
  6 Sporadic 1 050000000  25500  24500
    Sporadic 2 030000000  14716  35284

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         6        4
mxordblk  7b73900  7b73900
uordblks    12278    12360
fordblks  7b7bd88  7b7bca0

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_func: Thread 0 started
barrier_test: Thread 1 created
barrier_func: Thread 1 started
barrier_test: Thread 2 created
barrier_func: Thread 2 started
barrier_test: Thread 3 created
barrier_func: Thread 3 started
barrier_test: Thread 4 created
barrier_func: Thread 4 started
barrier_test: Thread 5 created
barrier_func: Thread 5 started
barrier_test: Thread 6 created
barrier_func: Thread 6 started
barrier_test: Thread 7 created
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 0 done
barrier_func: Thread 7 done
barrier_test: Thread 0 completed with result=0
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_func: Thread 3 done
barrier_func: Thread 4 done
barrier_test: Thread 3 completed with result=0
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_test: Thread 4 completed with result=0
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         4        7
mxordblk  7b73900  7b5b7b0
uordblks    12360    1a678
fordblks  7b7bca0  7b73988

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         7        6
mxordblk  7b5b7b0  7b5b7b0
uordblks    1a678    1a678
fordblks  7b73988  7b73988

user_main: vfork() test
vfork_test: Child 122 ran successfully

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     7b8e000  7b8e000
ordblks         2        7
mxordblk  7b7be30  7b5b7b0
uordblks    12198    1a670
fordblks  7b7be68  7b73990
user_main: Exiting
ostest_main: Exiting with status 0
```


</details>