### PR TITLE
netutils/cjson: update download URL for cJSON tarball to include refs/tags

### DIFF
--- a/netutils/cjson/CMakeLists.txt
+++ b/netutils/cjson/CMakeLists.txt
@@ -23,20 +23,20 @@
 if(CONFIG_NETUTILS_CJSON)
 
   if(NOT CONFIG_NETUTILS_CJSON_URL)
-    set(CONFIG_NETUTILS_CJSON_URL "https://github.com/DaveGamble/cJSON/archive")
+    set(CONFIG_NETUTILS_CJSON_URL
+        "https://github.com/DaveGamble/cJSON/archive/refs/tags")
   endif()
 
   if(NOT CONFIG_NETUTILS_CJSON_VERSION)
     set(CONFIG_NETUTILS_CJSON_VERSION "1.7.10")
   endif()
 
-  # GitHub requires refs/tags/ in the archive URL for tag downloads
   if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/cJSON)
     FetchContent_Declare(
       cJSON
       DOWNLOAD_NAME "v${CONFIG_NETUTILS_CJSON_VERSION}.tar.gz"
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "${CONFIG_NETUTILS_CJSON_URL}/refs/tags/v${CONFIG_NETUTILS_CJSON_VERSION}.tar.gz"
+      URL "${CONFIG_NETUTILS_CJSON_URL}/v${CONFIG_NETUTILS_CJSON_VERSION}.tar.gz"
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/cJSON
           BINARY_DIR

--- a/netutils/cjson/Kconfig
+++ b/netutils/cjson/Kconfig
@@ -14,7 +14,7 @@ if NETUTILS_CJSON
 
 config NETUTILS_CJSON_URL
 	string "URL where cJSON library can be downloaded"
-	default "https://github.com/DaveGamble/cJSON/archive"
+	default "https://github.com/DaveGamble/cJSON/archive/refs/tags"
 
 config NETUTILS_CJSON_VERSION
 	string "Version number"

--- a/netutils/cjson/Makefile
+++ b/netutils/cjson/Makefile
@@ -28,7 +28,7 @@ include $(APPDIR)/Make.defs
 
 WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
-CONFIG_NETUTILS_CJSON_URL ?= "https://github.com/DaveGamble/cJSON/archive"
+CONFIG_NETUTILS_CJSON_URL ?= "https://github.com/DaveGamble/cJSON/archive/refs/tags"
 CONFIG_NETUTILS_CJSON_VERSION ?= "1.7.10"
 CJSON_VERSION = $(patsubst "%",%,$(strip $(CONFIG_NETUTILS_CJSON_VERSION)))
 
@@ -49,12 +49,10 @@ CSRCS = $(CJSON_SRCDIR)$(DELIM)cJSON.c
 CSRCS += $(CJSON_SRCDIR)$(DELIM)cJSON_Utils.c
 
 # Download and unpack tarball if no git repo found
-# GitHub requires refs/tags/ in the archive URL for tag downloads (see
-# https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives)
 ifeq ($(wildcard $(CJSON_UNPACKNAME)/.git),)
 $(CJSON_TARBALL):
 	@echo "Downloading: $(CJSON_TARBALL)"
-	$(Q) curl -O -L $(CONFIG_NETUTILS_CJSON_URL)/refs/tags/$(CJSON_TARBALL)
+	$(Q) curl -O -L $(CONFIG_NETUTILS_CJSON_URL)/$(CJSON_TARBALL)
 
 $(CJSON_UNPACKNAME): $(CJSON_TARBALL)
 	@echo "Unpacking: $(CJSON_TARBALL) -> $(CJSON_UNPACKNAME)"


### PR DESCRIPTION
## Summary

GitHub changed how source code archives for tags are served. The previous URL format for downloading a release tarball (e.g. `https://github.com/DaveGamble/cJSON/archive/v1.7.10.tar.gz`) no longer works; GitHub now requires `refs/tags/` in the path for tag-based archive downloads.

This change updates the cJSON download URL in both the Makefile and CMakeLists.txt build paths to use the correct format: `.../archive/refs/tags/v${VERSION}.tar.gz`. Without this, the cJSON tarball download fails during the apps build when the source is fetched from GitHub.

References:
- [GitHub: Downloading source code archives](https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives)

## Impact

- **Users**: Builds that fetch cJSON from GitHub (when the local cJSON tree is not present) will succeed instead of failing on the download step.
- **Build process**: No change to build options or defaults; only the URL used for downloading the cJSON tarball is updated. Both Makefile and CMake build systems are updated.
- **Compatibility**: Same cJSON version (e.g. 1.7.10) is downloaded; only the URL path is different. No API or behavioral change.

## Testing

- **Host**: [e.g. macOS / Linux, CPU, compiler]
- **Build**: Configured NuttX with `CONFIG_NETUTILS_CJSON=y`, cleaned the cJSON source directory and tarball, then ran the apps build to trigger download and build of cJSON.
- **Result**: cJSON tarball downloaded successfully from the updated URL and the netutils/cjson application built without errors.
- **Verification**: Build and runtime of a config that uses cJSON (e.g. a board that enables cJSON) to confirm no regressions.

