### PR TITLE
netutils/ping: improve ping and ping6 for get_host error handling

### DIFF
--- a/system/ping/ping.c
+++ b/system/ping/ping.c
@@ -35,6 +35,15 @@
 #include <limits.h>
 #include <fixedmath.h>
 
+#if defined(CONFIG_SYSTEM_PING6) && defined(CONFIG_LIBC_EXECFUNCS)
+#define PING_ENABLE_PING6_FALLBACK
+#endif
+
+#ifdef PING_ENABLE_PING6_FALLBACK
+#include <spawn.h>
+#include <sys/wait.h>
+#endif
+
 #include <nuttx/net/ip.h>
 
 #include "netutils/icmp_ping.h"
@@ -121,8 +130,10 @@ static void ping_result(FAR const struct ping_result_s *result)
   switch (result->code)
     {
       case ICMP_E_HOSTIP:
+#ifndef PING_ENABLE_PING6_FALLBACK
         fprintf(stderr, "ERROR: ping_gethostip(%s) failed\n",
                 result->info->hostname);
+#endif
         break;
 
       case ICMP_E_MEMORY:
@@ -279,6 +290,49 @@ static void ping_result(FAR const struct ping_result_s *result)
     }
 }
 
+#ifdef PING_ENABLE_PING6_FALLBACK
+/****************************************************************************
+ * Name: ping6_fallback
+ ****************************************************************************/
+
+static int ping6_fallback(int argc, FAR char *argv[])
+{
+  pid_t pid;
+  int ret;
+  int status;
+
+  if (argc <= 0)
+    {
+      return EXIT_FAILURE;
+    }
+
+  argv[0] = CONFIG_SYSTEM_PING6_PROGNAME;
+
+  ret = posix_spawnp(&pid, CONFIG_SYSTEM_PING6_PROGNAME, NULL, NULL,
+                     argv, NULL);
+  if (ret != 0)
+    {
+      fprintf(stderr, "ERROR: posix_spawnp(%s) failed: %d\n",
+              CONFIG_SYSTEM_PING6_PROGNAME, ret);
+      return EXIT_FAILURE;
+    }
+
+  ret = waitpid(pid, &status, 0);
+  if (ret < 0)
+    {
+      fprintf(stderr, "ERROR: waitpid() failed: %d\n", errno);
+      return EXIT_FAILURE;
+    }
+
+  if (WIFEXITED(status))
+    {
+      return WEXITSTATUS(status);
+    }
+
+  return EXIT_FAILURE;
+}
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -403,7 +457,15 @@ int main(int argc, FAR char *argv[])
 
   info.hostname = argv[optind];
   icmp_ping(&info);
-  return priv.code < 0 ? EXIT_FAILURE: EXIT_SUCCESS;
+
+#ifdef PING_ENABLE_PING6_FALLBACK
+  if (priv.code == ICMP_E_HOSTIP)
+    {
+      return ping6_fallback(argc, argv);
+    }
+#endif
+
+  return priv.code < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 
 errout_with_usage:
   optind = 0;


### PR DESCRIPTION
dns look for both IPv4/v6 when do dns_query, so when do ping, it should try both ipv4 and ipv6 address before return "ping_gethostip" error.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

dns lookup for both IPv4/v6 when do dns_query, so when do ping, it should try both ipv4 and ipv6 address before return "ping_gethostip" error.

## Impact

The network packet losing IPv4 or IPv6 dns resolve response  is quite common in network pressure test. It will return get host error without this change. It's miss-leading report to end user. It's also quite common practice for linux to use one ping support both ping and ping6.

## Testing

attach two network packet that packet losing for either v4 or v6.
<img width="1812" height="175" alt="image" src="https://github.com/user-attachments/assets/63cde99e-08b1-4897-8f35-69e828e36e84" />

<img width="1814" height="201" alt="image" src="https://github.com/user-attachments/assets/a7ee3ad9-085b-4897-8c84-82dbac39bb71" />

Error log attached as below:
ping -c 5 www.baidu.com
ERROR: ping_gethostip(www.baidu.com) failed

based the latest commit, do a full test (I let the dns query lose ipv4 dns query)
<details><summary>Details</summary>
<p>

ping www.baidu.com
spawn_execattrs: Setting policy=2 priority=100 for pid=10
nxtask_activate: ping pid=10,TCB=0x4023d0a0
dns_query_callback: INFO: DNS query retry 1/3
udp_callback: flags: 20
sendto_eventhandler: flags: 20
udp_send: UDP payload: 31 (59) bytes
ipv4_build_header: IPv4 Packet: ipid:51, length: 59
udp_send: Outgoing UDP packet length: 59
udp_callback: flags: 20
eth_input: IPv4 frame
udp_callback: flags: 2
udp_eventhandler: flags: 2
udp_eventhandler: UDP done
dns_recv_response: ID 15715
dns_recv_response: Query 128
dns_recv_response: Error 0
dns_recv_response: Num questions 1, answers 3, authrr 0, extrarr 0
dns_parse_name: Compressed answer
dns_recv_response: Answer: type=0005, class=0001, ttl=00015e, length=000f
dns_parse_name: Compressed answer
dns_recv_response: Answer: type=001c, class=0001, ttl=000042, length=0010
dns_recv_response: IPv6 address: 2408:871a:2100:1b23:0000:00ff:b07a:7ebc
nxtask_activate: ping6 pid=11,TCB=0x4023d540
icmpv6_setsockopt_internal: option: 1
PING6 2408:871a:2100:1b23::ff:b07a:7ebc: 56 bytes of data
neighbor_dumpipaddr: Not found: 2408:871a:2100:1b23:0000:00ff:b07a:7ebc
neighbor_dumpentry: Entry found: fc00:0000:0000:0000:0000:0000:0000:0001
neighbor_dump_address: 
sendto_eventhandler: flags: 800000
sendto_eventhandler: Send ICMPv6 ECHO request
ipv6_build_header: IPv6 Payload length: 64
sendto_request: Outgoing ICMPv6 packet length: 104
sendto_eventhandler: Resuming
neighbor_dumpentry: Entry found: fc00:0000:0000:0000:0000:0000:0000:0001
neighbor_dump_address: 
neighbor_ethernet_out: Outgoing IPv6 Packet length: 118 (64)
eth_input: IPv6 frame
icmpv6_poll_eventhandler: flags: 2
icmpv6_datahandler: Buffered 64 bytes
icmpv6_readahead: Received 64 bytes (of 104)
56 bytes from 2408:871a:2100:1b23::ff:b07a:7ebc icmp_seq=0 time=116.0 ms


</p>
</details> 