### PR TITLE
!apps: Simplify NuttX initialization

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -1,6 +1,8 @@
       mynewt-nimble/nimble/host/services/ans/src/ble_svc_ans.c
       mynewt-nimble/nimble/host/services/ans/include
+#include "services/ans/ble_svc_ans.h"
 #include "crypto/controlse/ccertificate.hxx"
+ * notifications for the ANS Unread Alert Status characteristic
               object = new Controlse::CCertificate(
           Controlse::CCertificate cert(se, settings->key_id);
       auto certificate = Controlse::CCertificate(

--- a/boot/miniboot/miniboot_main.c
+++ b/boot/miniboot/miniboot_main.c
@@ -39,7 +39,7 @@
  * Name: miniboot_main
  *
  * Description:
- *   Minimal bootlaoder entry point.
+ *   Minimal bootloader entry point.
  *
  ****************************************************************************/
 
@@ -48,10 +48,6 @@ int main(int argc, FAR char *argv[])
   struct boardioc_boot_info_s info;
 
   syslog(LOG_INFO, "*** miniboot ***\n");
-
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
 
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */

--- a/boot/nxboot/nxboot_main.c
+++ b/boot/nxboot/nxboot_main.c
@@ -264,16 +264,10 @@ int main(int argc, FAR char *argv[])
   FAR struct boardioc_reset_cause_s cause;
 #endif
 
-#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#endif
 #endif
 
   syslog(LOG_INFO, "*** nxboot ***\n");

--- a/examples/foc/foc_main.c
+++ b/examples/foc/foc_main.c
@@ -142,7 +142,7 @@ struct args_s g_args =
   }
 };
 
-/* Start allowed at defaule */
+/* Start allowed at default */
 
 static bool            g_start_allowed      = true;
 static pthread_mutex_t g_start_allowed_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -294,16 +294,10 @@ int main(int argc, char *argv[])
       goto errout_no_nxscope;
     }
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
-#  ifdef CONFIG_BOARDCTL_FINALINIT
+#ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#  endif
 #endif
 
   PRINTF("\nStart foc_main application!\n\n");

--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -38,23 +38,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Should we perform board-specific driver initialization? There are two
- * ways that board initialization can occur:  1) automatically via
- * board_late_initialize() during bootupif CONFIG_BOARD_LATE_INITIALIZE
- * or 2).
- * via a call to boardctl() if the interface is enabled
- * (CONFIG_BOARDCTL=y).
- * If this task is running as an NSH built-in application, then that
- * initialization has probably already been performed otherwise we do it
- * here.
- */
-
-#undef NEED_BOARDINIT
-
-#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
-#  define NEED_BOARDINIT 1
-#endif
-
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -121,13 +104,6 @@ int main(int argc, FAR char *argv[])
       LV_LOG_ERROR("LVGL already initialized! aborting.");
       return -1;
     }
-
-#ifdef NEED_BOARDINIT
-  /* Perform board-specific driver initialization */
-
-  boardctl(BOARDIOC_INIT, 0);
-
-#endif
 
   lv_init();
 

--- a/examples/lvglterm/lvglterm.c
+++ b/examples/lvglterm/lvglterm.c
@@ -63,23 +63,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Should we perform board-specific driver initialization?  There are two
- * ways that board initialization can occur:  1) automatically via
- * board_late_initialize() during bootupif CONFIG_BOARD_LATE_INITIALIZE
- * or 2).
- * via a call to boardctl() if the interface is enabled
- * (CONFIG_BOARDCTL=y).
- * If this task is running as an NSH built-in application, then that
- * initialization has probably already been performed otherwise we do it
- * here.
- */
-
-#undef NEED_BOARDINIT
-
-#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
-#  define NEED_BOARDINIT 1
-#endif
-
 /* How often to poll for output from NSH Shell (milliseconds) */
 
 #define TIMER_PERIOD_MS 100
@@ -550,16 +533,10 @@ int main(int argc, FAR char *argv[])
   uv_loop_t ui_loop;
 #endif
 
-#ifdef NEED_BOARDINIT
-  /* Perform board-specific driver initialization */
-
-  boardctl(BOARDIOC_INIT, 0);
-
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#endif
 #endif
 
   /* LVGL initialization */

--- a/examples/nimble/nimble_main.c
+++ b/examples/nimble/nimble_main.c
@@ -255,12 +255,6 @@ int main(int argc, FAR char *argv[])
       ble_hci_sock_set_device(atoi(argv[1]));
     }
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization */
-
-  boardctl(BOARDIOC_INIT, 0);
-#endif
-
 #ifndef CONFIG_NSH_NETINIT
   /* Bring up the network */
 

--- a/examples/nimble_blecent/nimble_blecent_main.c
+++ b/examples/nimble_blecent/nimble_blecent_main.c
@@ -412,7 +412,7 @@ static int blecent_gap_event(FAR struct ble_gap_event *event, FAR void *arg)
             return 0;
           }
 
-        /* An advertisment report was received during GAP discovery. */
+        /* An advertisement report was received during GAP discovery. */
 
         print_adv_fields(&fields);
 
@@ -631,12 +631,6 @@ int main(int argc, FAR char **argv)
     {
       ble_hci_sock_set_device(atoi(argv[1]));
     }
-
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization */
-
-  boardctl(BOARDIOC_INIT, 0);
-#endif
 
 #ifndef CONFIG_NSH_NETINIT
   /* Bring up the network */

--- a/examples/nimble_bleprph/nimble_bleprph_main.c
+++ b/examples/nimble_bleprph/nimble_bleprph_main.c
@@ -140,7 +140,7 @@ static void bleprph_advertise(void)
     BLE_HS_ADV_F_BREDR_UNSUP;
 
   /* Indicate that the TX power level field should be included; have the
-   * stack fill this value automatically.  This is done by assiging the
+   * stack fill this value automatically. This is done by assigning the
    * special value BLE_HS_ADV_TX_PWR_LVL_AUTO.
    */
 
@@ -371,12 +371,6 @@ int main(int argc, FAR char *argv[])
     {
       ble_hci_sock_set_device(atoi(argv[1]));
     }
-
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization */
-
-  boardctl(BOARDIOC_INIT, 0);
-#endif
 
 #ifndef CONFIG_NSH_NETINIT
   /* Bring up the network */

--- a/examples/nxscope/nxscope_main.c
+++ b/examples/nxscope/nxscope_main.c
@@ -527,16 +527,10 @@ int main(int argc, FAR char *argv[])
   printf("stream interval = %d\n", env.interval);
   printf("main interval = %d\n", interval);
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
-#  ifdef CONFIG_BOARDCTL_FINALINIT
+#ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#  endif
 #endif
 
 #ifdef CONFIG_EXAMPLES_NXSCOPE_CDCACM

--- a/examples/powerled/powerled_main.c
+++ b/examples/powerled/powerled_main.c
@@ -439,16 +439,10 @@ int main(int argc, char *argv[])
       goto errout;
     }
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#endif
 #endif
 
   /* Set LED current limit */

--- a/examples/smps/smps_main.c
+++ b/examples/smps/smps_main.c
@@ -476,16 +476,10 @@ int main(int argc, char *argv[])
       goto errout;
     }
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
 #ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#endif
 #endif
 
   /* Set SMPS mode */

--- a/graphics/nxwm/src/nxwm_main.cxx
+++ b/graphics/nxwm/src/nxwm_main.cxx
@@ -485,16 +485,6 @@ static bool createMediaPlayer(void)
 
 int main(int argc, char *argv[])
 {
-#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_BOARD_LATE_INITIALIZE)
-  // Should we perform board-specific initialization?  There are two ways
-  // that board initialization can occur:  1) automatically via
-  // board_late_initialize() during bootup if CONFIG_BOARD_LATE_INITIALIZE, or
-  // 2) here via a call to boardctl() if the interface is enabled
-  // (CONFIG_BOARDCTL=y).
-
-  boardctl(BOARDIOC_INIT, 0);
-#endif
-
 #ifdef CONFIG_NXWM_NXTERM
   // Initialize the NSH library
 

--- a/graphics/twm4nx/Kconfig
+++ b/graphics/twm4nx/Kconfig
@@ -42,17 +42,6 @@ config TWM4NX_REVMINOR
 	string "Twm4Nx minor version number"
 	default "0"
 
-config TWM4NX_ARCHINIT
-	bool "Have architecture-specific initialization"
-	default n
-	select BOARDCTL
-	depends on !NSH_ARCHINIT
-	---help---
-		Set if your board provides architecture specific initialization
-		via the board-interface function boardctl().  The boardctl()
-		function will be called early in Twm4Nx initialization to allow
-		board logic to do such things as configure MMC/SD slots.
-
 config TWM4NX_NETINIT
 	bool "Network initialization"
 	default y

--- a/graphics/twm4nx/src/twm4nx_main.cxx
+++ b/graphics/twm4nx/src/twm4nx_main.cxx
@@ -98,23 +98,6 @@ int main(int argc, FAR char *argv[])
 
   int ret;
 
-#if defined(CONFIG_TWM4NX_ARCHINIT) && defined(CONFIG_BOARDCTL) && \
-   !defined(CONFIG_BOARD_LATE_INITIALIZE)
-  // Should we perform board-specific initialization?  There are two ways
-  // that board initialization can occur:  1) automatically via
-  // board_late_initialize() during bootup if CONFIG_BOARD_LATE_INITIALIZE, or
-  // 2) here via a call to boardctl() if the interface is enabled
-  // (CONFIG_BOARDCTL=y).  board_early_initialize() is also possibility,
-  // although less likely.
-
-  ret = boardctl(BOARDIOC_INIT, 0);
-  if (ret < 0)
-    {
-      twmerr("ERROR: boardctl(BOARDIOC_INIT) failed: %d\n", errno);
-      return EXIT_FAILURE;
-    }
-#endif
-
 #ifdef CONFIG_TWM4NX_NETINIT
   /* Bring up the network */
 

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -9,7 +9,7 @@ config NSH_LIBRARY
 	bool "NSH Library"
 	default n
 	select NETUTILS_NETLIB if NET
-	select BOARDCTL if (!NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT) || NSH_ARCHINIT
+	select BOARDCTL if (!NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT)
 	select BOARDCTL_MKRD if !NSH_DISABLE_MKRD && !DISABLE_MOUNTPOINT
 	---help---
 		Build the NSH support library.  This is used, for example, by
@@ -1115,16 +1115,6 @@ config NSH_USBDEV_TRACEINTERRUPTS
 
 endif # NSH_USBDEV_TRACE
 endmenu # USB Device Trace Support
-
-config NSH_ARCHINIT
-	bool "Have architecture-specific initialization"
-	default n
-	select BOARDCTL
-	---help---
-		Set if your board provides architecture specific initialization
-		via the board-interface function boardctl().  The boardctl()
-		function will be called early in NSH initialization to allow
-		board logic to do such things as configure MMC/SD slots.
 
 menu "Networking Configuration"
 	depends on NET

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -807,13 +807,6 @@ int nsh_loginscript(FAR struct nsh_vtbl_s *vtbl);
  * available:
  */
 
-/* Architecture-specific initialization depends on boardctl(BOARDIOC_INIT) */
-
-#if defined(CONFIG_NSH_ARCHINIT) && !defined(CONFIG_BOARDCTL)
-#  warning CONFIG_NSH_ARCHINIT is set, but CONFIG_BOARDCTL is not
-#  undef CONFIG_NSH_ARCHINIT
-#endif
-
 /* The mkrd command depends on boardctl(BOARDIOC_MKRD) */
 
 #if !defined(CONFIG_BOARDCTL) || !defined(CONFIG_BOARDCTL_MKRD)

--- a/nshlib/nsh_init.c
+++ b/nshlib/nsh_init.c
@@ -143,12 +143,6 @@ void nsh_initialize(void)
   boardctl(BOARDIOC_APP_SYMTAB, (uintptr_t)&symdesc);
 #endif
 
-#ifdef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-#endif
-
 #if defined(CONFIG_ETC_ROMFS) && !defined(CONFIG_NSH_DISABLESCRIPT)
   pstate = nsh_newconsole(false);
 
@@ -161,12 +155,6 @@ void nsh_initialize(void)
   /* Bring up the network */
 
   netinit_bringup();
-#endif
-
-#if defined(CONFIG_NSH_ARCHINIT) && defined(CONFIG_BOARDCTL_FINALINIT)
-  /* Perform architecture-specific final-initialization (if configured) */
-
-  boardctl(BOARDIOC_FINALINIT, 0);
 #endif
 
 #if defined(CONFIG_ETC_ROMFS) && !defined(CONFIG_NSH_DISABLESCRIPT)

--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -200,19 +200,12 @@ config ADBD_SOCKET_SERVICE
 	---help---
 		Enable "adb forward|reverse" feature.
 
-config ADBD_BOARD_INIT
-	bool "Board initialization"
-	depends on BOARDCTL
-	default n
-	---help---
-		Setup board before running adb daemon.
-
 config ADBD_USB_BOARDCTL
 	bool "USB Board Control"
 	depends on BOARDCTL
 	depends on ADBD_USB_SERVER
 	select BOARDCTL_USBDEVCTRL
-	default ADBD_BOARD_INIT
+	default y
 	---help---
 		Connect usbdev before running adb daemon.
 

--- a/system/adb/adb_main.c
+++ b/system/adb/adb_main.c
@@ -32,8 +32,7 @@
 #include <syslog.h>
 #include <nuttx/streams.h>
 
-#if defined(CONFIG_ADBD_BOARD_INIT) || defined (CONFIG_BOARDCTL_RESET) || \
-    defined(CONFIG_ADBD_USB_BOARDCTL)
+#if defined (CONFIG_BOARDCTL_RESET) || defined(CONFIG_ADBD_USB_BOARDCTL)
 #  include <sys/boardctl.h>
 #endif
 
@@ -119,10 +118,6 @@ int main(int argc, FAR char **argv)
   FAR void *handle;
   int ret;
 #endif
-
-#ifdef CONFIG_ADBD_BOARD_INIT
-  boardctl(BOARDIOC_INIT, 0);
-#endif /* CONFIG_ADBD_BOARD_INIT */
 
 #ifdef CONFIG_ADBD_USB_BOARDCTL
 

--- a/system/adcscope/adcscope_main.c
+++ b/system/adcscope/adcscope_main.c
@@ -382,16 +382,10 @@ int main(int argc, FAR char *argv[])
   pthread_t                 thread;
   int                       ret;
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
-#  ifdef CONFIG_BOARDCTL_FINALINIT
+#ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#  endif
 #endif
 
 #ifdef CONFIG_SYSTEM_ADCSCOPE_CDCACM

--- a/system/ofloader/ofloader.c
+++ b/system/ofloader/ofloader.c
@@ -35,7 +35,7 @@
 #include "ofloader.h"
 
 /****************************************************************************
- * Private Typess
+ * Private Types
  ****************************************************************************/
 
 struct devinfo_s
@@ -320,16 +320,10 @@ int main(int argc, FAR char *argv[])
   size_t i;
   mqd_t mq;
 
-#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
-#  ifdef CONFIG_BOARDCTL_FINALINIT
+#ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#  endif
 #endif
 
   memset(&mqattr, 0, sizeof(struct mq_attr));

--- a/system/sensorscope/sensorscope_main.c
+++ b/system/sensorscope/sensorscope_main.c
@@ -412,16 +412,10 @@ int main(int argc, FAR char *argv[])
   pthread_t                   thread;
   int                         ret;
 
-#ifndef CONFIG_NSH_ARCHINIT
-  /* Perform architecture-specific initialization (if configured) */
-
-  boardctl(BOARDIOC_INIT, 0);
-
-#  ifdef CONFIG_BOARDCTL_FINALINIT
+#ifdef CONFIG_BOARDCTL_FINALINIT
   /* Perform architecture-specific final-initialization (if configured) */
 
   boardctl(BOARDIOC_FINALINIT, 0);
-#  endif
 #endif
 
 #ifdef CONFIG_SYSTEM_SENSORSCOPE_CDCACM


### PR DESCRIPTION
## Summary

**BREAKING:**

In an effort to simplify board initialization logic for NuttX, NSH will no longer support architecture initialization. This will happen during boot via the BOARD_LATE_INITIALIZE option. The boardctl command BOARDIOC_INIT is also no longer available from user-space.

Quick fix: Any application relying on BOARDIOC_INIT should now enable BOARD_LATE_INITIALIZE to have initialization performed by the kernel in advance of the application running. If control over initialization is still necessary, BOARDIOC_FINALINIT should be implemented and used. Boards relying on NSH for initialization should also enable BOARD_LATE_INITIALIZE instead.

Part of https://github.com/apache/nuttx/issues/11321.

To be merged with twin PR to NuttX kernel: https://github.com/apache/nuttx/pull/18408

## Impact

This reduces the complexity of NuttX initialization by keeping it within the
kernel logic for the normal case. Users can still control initialization from
their application using BOARDIOC_FINALINIT instead.

This impacts almost every NuttX supported board, as many configurations relied
on NSH for initialization. This also impacts each application in the diff which
relied on BOARDIOC_INIT.

## Testing

* NSH: tested by twin PR (see below)
* LVGL Demo: tested using `raspberrypi-4b:lvgl` (see image)

<img width="1055" height="1401" alt="image" src="https://github.com/user-attachments/assets/8e6fc305-8d0c-4af2-9640-77f414ffa7b3" />

Testing of modified NuttX kernel defconfigs can be found in the twin PR: https://github.com/apache/nuttx/pull/18408