### PR TITLE
examples: add ina260

### DIFF
--- a/examples/ina260/CMakeLists.txt
+++ b/examples/ina260/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/ina260/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_INA260)
+  nuttx_add_application(
+    NAME
+    ina260
+    SRCS
+    ina260_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_INA260_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_INA260_PRIORITY})
+endif()

--- a/examples/ina260/Kconfig
+++ b/examples/ina260/Kconfig
@@ -1,0 +1,36 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_INA260
+	tristate "INA260 example"
+	default n
+	depends on SENSORS_INA260
+	---help---
+		Enable the INA260 example
+
+if EXAMPLES_INA260
+
+config EXAMPLES_INA260_PROGNAME
+	string "Program name"
+	default "ina260"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config INA260_DEVICE_PATH
+	string "INA260 device name"
+	default "/dev/ina260"
+	---help---
+		This is the device path for the INA260 sensor.
+
+config EXAMPLES_INA260_PRIORITY
+	int "INA260 task priority"
+	default 100
+
+config EXAMPLES_INA260_STACKSIZE
+	int "INA260 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/ina260/Make.defs
+++ b/examples/ina260/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/ina260/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_INA260),)
+CONFIGURED_APPS += $(APPDIR)/examples/ina260
+endif

--- a/examples/ina260/Makefile
+++ b/examples/ina260/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/examples/ina260/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# INA260 built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_INA260_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_INA260_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_INA260_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_INA260)
+
+# INA260 Example
+
+MAINSRC = ina260_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/ina260/ina260_main.c
+++ b/examples/ina260/ina260_main.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * apps/examples/ina260/ina260_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <nuttx/config.h>
+#include <nuttx/sensors/ina260.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_INA260_DEVICE_PATH
+#  define CONFIG_INA260_DEVICE_PATH "/dev/ina260"
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * ina260_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct ina260_s sample;
+  int fd;
+  int ret;
+
+  fd = open(CONFIG_INA260_DEVICE_PATH, O_RDWR);
+  if (fd < 0)
+    {
+      int errcode = errno;
+      printf("ERROR: Failed to open %s: %d\n",
+             CONFIG_INA260_DEVICE_PATH, errcode);
+      return EXIT_FAILURE;
+    }
+
+  while (1)
+    {
+      ret = read(fd, &sample, sizeof(sample));
+      if (ret != sizeof(sample))
+        {
+          break;
+        }
+
+      printf("U=%6" PRIu32 "mV I=%6" PRIi32 "mA P=%6" PRIu32 "mW\n",
+             sample.voltage, sample.current, sample.power);
+
+      usleep(500000);
+    }
+
+  close(fd);
+  return 0;
+}


### PR DESCRIPTION
## Summary

Add example application for INA260 current/voltage/power sensor driver. Driver PR is currently being reviewed here: https://github.com/apache/nuttx/pull/18430

The program periodically outputs the voltage, current and power measurements from the chip.

## Impact

Add ina260 program.

## Testing

Tested on top of NuttX 12.12.0, compiled on macOS for STM32F407-DISC1. Output looks like this:

```
nsh> ina260
U= 23898mV I=   571mA P= 13680mW
U= 23870mV I=   728mA P= 17400mW
U= 23862mV I=   782mA P= 18680mW
U= 23858mV I=   796mA P= 19030mW
U= 23857mV I=   805mA P= 19200mW
U= 23857mV I=   805mA P= 19200mW
```

