### PR TITLE
Modifying sched_thread_local.c test to add corner cases.

### DIFF
--- a/testing/ostest/sched_thread_local.c
+++ b/testing/ostest/sched_thread_local.c
@@ -114,6 +114,23 @@ static void *thread_func(void *parameter)
       ASSERT(false);
     }
 
+  printf("thread_func[%d]: TLS addr=%p\n", id, &g_tls_int);
+
+  /* In a broken system, all threads might point to the same static address */
+
+  static void *g_first_thread_addr = NULL;
+  if (id == 0)
+    {
+      g_first_thread_addr = (void *)&g_tls_int;
+    }
+  else if (g_first_thread_addr == (void *)&g_tls_int)
+    {
+      printf("ERROR: Thread %d shares address with Thread 0\n", id);
+      ASSERT(false);
+
+      /* Checking 0 and other addresses */
+    }
+
   printf("thread_func[%d]: setting value_short (at 0x%p) to %d\n",
          id, &g_tls_short, value_short + id);
 
@@ -159,6 +176,9 @@ void sched_thread_local_test(void)
     {
       printf("sched_thread_local_test: pthread_barrier_init failed, "
              "status=%d\n", status);
+      ASSERT(false);
+
+      /* the threads will call pthread_barrier_wait on an invalid object */
     }
 
   for (i = 0; i < TEST_THREADS; i++)
@@ -227,6 +247,16 @@ void sched_thread_local_test(void)
       printf("sched_thread_local_test: pthread_barrier_destroy failed, "
              "status=%d\n", status);
     }
+
+  /* Confirm main thread still have initial values */
+
+  if (g_tls_int != INIT_VALUE)
+    {
+      printf("sched_thread_local_test: ERROR: Main thread TLS corrupted!\n");
+      ASSERT(false);
+    }
+
+  printf("sched_thread_local_test: Main thread isolation confirmed.\n");
 }
 
 #endif /* CONFIG_SCHED_THREAD_LOCAL */


### PR DESCRIPTION
a) Adding test to verify if all the created threads share the same static address (an issue.)
b) Checking if initial value is not corrupted.
c) assert(false)->incase status is not okay.
So faulty invalid object doesnt move forward.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

* The initial thread value starts at 6 ,After all worker threads modify their own TLS copies, the main thread’s TLS variable should remain unchanged. So a test case for that was added at the end of the test.
* A test to ensure all the different threads have their unique addresses and do not point to a static address.
* A assert(fail) to stop the flow on init of invalid gbarrier was added.
<img width="809" height="220" alt="image" src="https://github.com/user-attachments/assets/5b184890-c21d-49c4-8db6-6add2d993ee0" />


## Impact

Makes the testing cover more corner cases , more robust.

## Testing

For testing of these features I had used :  
* Configure nuttx with :  ./tools/configure.sh rv-virt:nsh64
* qemu-system-riscv64 -M virt -cpu rv64 -nographic -bios none -kernel nuttx
* To emulate the result and typed ostest in the nuttx shell.
* ensure that CONFIG_SCHED_THREAD_LOCAL is enabled.

Modified test section:
<img width="571" height="629" alt="image" src="https://github.com/user-attachments/assets/f8b936aa-3e90-469b-ae27-9633eca3e13b" />

```

NuttShell (NSH) NuttX-12.11.0
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=3

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         1        1
mxordblk  1fc56b0  1fc56b0
uordblks     5090     5090
fordblks  1fc56b0  1fc56b0

user_main: getopt() test
getopt():  Simple test
getopt():  Invalid argument
getopt():  Missing optional argument
getopt_long():  Simple test
getopt_long():  No short options
getopt_long():  Argument for --option=argument
getopt_long():  Invalid long option
getopt_long():  Mixed long and short options
getopt_long():  Invalid short option
getopt_long():  Missing optional arguments
getopt_long_only():  Mixed long and short options
getopt_long_only():  Single hyphen long options

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         1        1
mxordblk  1fc56b0  1fc56b0
uordblks     5090     5090
fordblks  1fc56b0  1fc56b0

user_main: libc tests

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         1        1
mxordblk  1fc56b0  1fc56b0
uordblks     5090     5090
fordblks  1fc56b0  1fc56b0
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         1        2
mxordblk  1fc56b0  1fc56b0
uordblks     5090     5070
fordblks  1fc56b0  1fc56d0
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     5070     4f98
fordblks  1fc56d0  1fc57a8

user_main: sched_thread_local test
sched_thread_local_test: g_tls_int value is: 6
sched_thread_local_test: Starting waiter thread 0
sched_thread_local_test: Starting waiter thread 1
sched_thread_local_test: Starting waiter thread 2
thread_func[2]: Thread Started
thread_func[2]: g_tls_short (at 0x0x8003bd84) initial value = 6
thread_func[2]: g_tls_int (at 0x0x8003bd80) initial value = 6
thread_func[2]: g_tls_lld (at 0x0x8003bd78) initial value = -6
thread_func[2]: TLS addr=0x8003bd80
thread_func[2]: setting value_short (at 0x0x8003bd84) to 8
thread_func[2]: setting value_int (at 0x0x8003bd80) to 8
thread_func[2]: setting value_lld (at 0x0x8003bd78) to -8
thread_func[2]: Thread done
thread_func[0]: Thread Started
thread_func[0]: g_tls_short (at 0x0x8003aad4) initial value = 6
thread_func[0]: g_tls_int (at 0x0x8003aad0) initial value = 6
thread_func[0]: g_tls_lld (at 0x0x8003aac8) initial value = -6
thread_func[0]: TLS addr=0x8003aad0
thread_func[0]: setting value_short (at 0x0x8003aad4) to 6
thread_func[0]: setting value_int (at 0x0x8003aad0) to 6
thread_func[0]: setting value_lld (at 0x0x8003aac8) to -6
thread_func[0]: Thread done
thread_func[1]: Thread Started
thread_func[1]: g_tls_short (at 0x0x8003b42c) initial value = 6
thread_func[1]: g_tls_int (at 0x0x8003b428) initial value = 6
thread_func[1]: g_tls_lld (at 0x0x8003b420) initial value = -6
thread_func[1]: TLS addr=0x8003b428
thread_func[1]: setting value_short (at 0x0x8003b42c) to 7
thread_func[1]: setting value_int (at 0x0x8003b428) to 7
thread_func[1]: setting value_lld (at 0x0x8003b420) to -7
thread_func[1]: Thread done
sched_thread_local_test: g_tls_variables[thread_0][g_tls_short] = 6
sched_thread_local_test: g_tls_variables[thread_0][g_tls_int] = 6
sched_thread_local_test: g_tls_variables[thread_0][g_tls_lld] = -6
sched_thread_local_test: g_tls_variables[thread_1][g_tls_short] = 7
sched_thread_local_test: g_tls_variables[thread_1][g_tls_int] = 7
sched_thread_local_test: g_tls_variables[thread_1][g_tls_lld] = -7
sched_thread_local_test: g_tls_variables[thread_2][g_tls_short] = 8
sched_thread_local_test: g_tls_variables[thread_2][g_tls_int] = 8
sched_thread_local_test: g_tls_variables[thread_2][g_tls_lld] = -8
sched_thread_local_test: Main thread isolation confirmed.

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4f98     4f98
fordblks  1fc57a8  1fc57a8

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4f98     4f98
fordblks  1fc57a8  1fc57a8

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4f98     4f98
fordblks  1fc57a8  1fc57a8

user_main: FPU test
Starting task FPU#1
fpu_test: Started task FPU#1 at PID=7
FPU#1: pass 1
Starting task FPU#2
fpu_test: Started task FPU#2 at PID=8
FPU#2: pass 1
FPU#1: pass 2
FPU#2: pass 2
FPU#1: pass 3
FPU#2: pass 3
FPU#1: pass 4
FPU#2: pass 4
FPU#1: pass 5
FPU#2: pass 5
FPU#1: pass 6
FPU#2: pass 6
FPU#1: pass 7
FPU#2: pass 7
FPU#1: pass 8
FPU#2: pass 8
FPU#1: pass 9
FPU#2: pass 9
FPU#1: pass 10
FPU#2: pass 10
FPU#1: pass 11
FPU#2: pass 11
FPU#1: pass 12
FPU#2: pass 12
FPU#1: pass 13
FPU#2: pass 13
FPU#1: pass 14
FPU#2: pass 14
FPU#1: pass 15
FPU#2: pass 15
FPU#1: pass 16
FPU#2: pass 16
FPU#1: Succeeded
FPU#2: Succeeded
fpu_test: Returning

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4f98     4f98
fordblks  1fc57a8  1fc57a8

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=9
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: I am still here
restart_main: I am still here
restart_main: Started restart_main at PID=9
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4f98     4ff0
fordblks  1fc57a8  1fc5750

user_main: waitpid test

Test waitpid()
waitpid_start_child: Started waitpid_main at PID=10
waitpid_start_child: Started waitpid_main at PID=11
waitpid_start_child: Started waitpid_main at PID=12
waitpid_test: Waiting for PID=10 with waitpid()
waitpid_main: PID 10 Started
waitpid_main: PID 11 Started
waitpid_main: PID 12 Started
waitpid_main: PID 10 exitting with result=14
waitpid_main: PID 11 exitting with result=14
waitpid_main: PID 12 exitting with result=14
waitpid_test: PID 10 waitpid succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=12 with waitpid()
waitpid_last: PASS: PID 12 waitpid failed with ECHILD.  That may be
              acceptable because child status is disabled on this thread.

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
                Thread1 Thread2
        Loops   32      32
        Errors  0       0

Testing moved mutex
Starting moved mutex thread 1
Starting moved mutex thread 2
                Thread1 Thread2
        Moved Loops     32      32
        Moved Errors    0       0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread:  Started
pthread:  Waiting for lock or timeout
mutex_test: Unlocking
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the timeout.  Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffffffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffffffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
waiter_func: Thread 1 Started
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
sem_test: Starting waiter thread 2
sem_test: Set thread 2 priority to 128
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
waiter_func: Thread 1 new semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
waiter_func: Thread 2 new semaphore value = 0
waiter_func: Thread 2 done
poster_func: Thread 3 new semaphore value = 0
poster_func: Thread 3 done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1638316884 sec, 913845700 nsec)
AFTER:  (1638316886 sec, 914507200 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1638316886 sec, 918859100 nsec)
AFTER:  (1638316887 sec, 921269300 nsec)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test:      Waiter  Signaler
cond_test: Loops        32      32
cond_test: Errors       0       0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     4ff0     4ff0
fordblks  1fc5750  1fc5750

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=36
pthread_exit_main 36: Starting pthread_exit_thread
pthread_exit_main 36: Sleeping for 5 seconds
pthread_exit_thread 37: Sleeping for 10 second
pthread_exit_main 36: Calling pthread_exit()
pthread_exit_thread 37: Still running...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        3
mxordblk  1fc56b0  1fc2c00
uordblks     4ff0     5948
fordblks  1fc5750  1fc4df8

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 37: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         3        2
mxordblk  1fc2c00  1fc56b0
uordblks     5948     5010
fordblks  1fc4df8  1fc5730

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     5010     5010
fordblks  1fc5730  1fc5730

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
timedwait_test: Joining
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        2
mxordblk  1fc56b0  1fc56b0
uordblks     5010     5010
fordblks  1fc5730  1fc5730

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        3
mxordblk  1fc56b0  1fc3500
uordblks     5010     50c0
fordblks  1fc5730  1fc5680

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         3        3
mxordblk  1fc3500  1fc3500
uordblks     50c0     50c0
fordblks  1fc5680  1fc5680

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
receiver_thread: Starting
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 64
mqueue_test: Waiting for sender to complete
sender_thread: Starting
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: mq_send succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         3        3
mxordblk  1fc3500  1fc3500
uordblks     50c0     50c0
fordblks  1fc5680  1fc5680

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=53
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=53 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         3        2
mxordblk  1fc3500  1fc3500
uordblks     50c0     50e8
fordblks  1fc5680  1fc5658

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
waiter_main: Waiter started
waiter_main: Setting signal mask
waiter_main: Registering signal handler
waiter_main: Waiting on semaphore
signest_test: Started waiter_main pid=54
signest_test: Starting interfering task at priority 102
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=55
signest_test: Simple case:
  Total signalled 1240  Odd=620 Even=620
  Total handled   1240  Odd=620 Even=620
  Total nested    0    Odd=0   Even=0  
signest_test: With task locking
  Total signalled 2480  Odd=1240 Even=1240
  Total handled   2480  Odd=1240 Even=1240
  Total nested    0    Odd=0   Even=0  
signest_test: With intefering thread
  Total signalled 3720  Odd=1860 Even=1860
  Total handled   3720  Odd=1860 Even=1860
  Total nested    0    Odd=0   Even=0  
signest_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         2        5
mxordblk  1fc3500  1fc06a0
uordblks     50e8     5198
fordblks  1fc5658  1fc55a8

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=1
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=2
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=3
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=4
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=5
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         5        5
mxordblk  1fc06a0  1fc06a0
uordblks     5198     5198
fordblks  1fc55a8  1fc55a8

user_main: spinlock test
Start Lock test:
Thread num: 1, Loop times: 10000000

Test type: spinlock
spinlock: Test Results:
spinlock: Final counter: 10000000
spinlock: Average throughput : 12020698 op/s
spinlock: Total execution time: 832203700 ns
 
Test type: rspinlock
rspinlock: Test Results:
rspinlock: Final counter: 10000000
rspinlock: Average throughput : 11896141 op/s
rspinlock: Total execution time: 840743300 ns
 
Test type: seqcount
seqcount: Test Results:
seqcount: Final counter: 10000000
seqcount: Average throughput : 11130113 op/s
seqcount: Total execution time: 898667500 ns
 

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         5        5
mxordblk  1fc06a0  1fc06a0
uordblks     5198     5198
fordblks  1fc55a8  1fc55a8

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wd_start with maximum delay, cancel OK, rest 1073741820
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741818
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741818
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741817
wdtest_recursive 1000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
wdog_test end...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         5        5
mxordblk  1fc06a0  1fc06a0
uordblks     5198     5198
fordblks  1fc55a8  1fc55a8

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
         First get_primes_thread: 63
rr_test: Starting second get_primes_thread
         Second get_primes_thread: 68
rr_test: Waiting for threads to complete -- this should take awhile
         If RR scheduling is working, they should start and complete at
         about the same time
get_primes_thread id=1 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=1 finished, found 3246 primes, last one was 29989
get_primes_thread id=2 finished, found 3246 primes, last one was 29989
rr_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         5        5
mxordblk  1fc06a0  1fc06a0
uordblks     5198     5198
fordblks  1fc55a8  1fc55a8

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 0 done
barrier_func: Thread 1 done
barrier_test: Thread 0 completed with result=0
barrier_test: Thread 1 completed with result=0
barrier_func: Thread 2 done
barrier_func: Thread 3 done
barrier_func: Thread 4 done
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_test: Thread 2 completed with result=0
barrier_test: Thread 3 completed with result=0
barrier_test: Thread 4 completed with result=0
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         5        5
mxordblk  1fc06a0  1fc06a0
uordblks     5198     5198
fordblks  1fc55a8  1fc55a8

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         5        5
mxordblk  1fc06a0  1fc06a0
uordblks     5198     5198
fordblks  1fc55a8  1fc55a8

user_main: vfork() test
vfork_test: Child 85 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fca740  1fca740
ordblks         1        5
mxordblk  1fc56b0  1fc06a0
uordblks     5090     5198
fordblks  1fc56b0  1fc55a8
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 
```


CI test:
<img width="1102" height="80" alt="image" src="https://github.com/user-attachments/assets/c0192751-638a-4602-8aa7-9593669ebeca" />

