### PR TITLE
examples/powerled: Fix board initialization compilation

### DIFF
--- a/examples/powerled/powerled_main.c
+++ b/examples/powerled/powerled_main.c
@@ -38,6 +38,10 @@
 #include <debug.h>
 #include <sys/ioctl.h>
 
+#ifndef CONFIG_NSH_ARCHINIT
+#include <sys/boardctl.h>
+#endif
+
 #include <nuttx/fs/fs.h>
 
 #include <nuttx/power/powerled.h>


### PR DESCRIPTION
## Summary

When NSH_ARCHINIT is not enabled, initialization is to be performed by boardctl(BOARDIOC_INIT). However, the boardctl header is not included so this causes compilation to fail. This commit corrects that issue.

Noticed in CI run: https://github.com/apache/nuttx/actions/runs/22338140146/job/64708159542

Until this is merged, the CI for the initialization simplification PR will never pass (https://github.com/apache/nuttx/pull/18408). This is a temporary solution before `boardctl(BOARDIOC_INIT)` is fully removed.

## Impact

Example can compile without `NSH_ARCHINIT` now.

## Testing

Before the change, with `raspberrypi-pico:usbnsh` configuration + `EXAMPLES_POWERLED` selected (even with `BOARDCTL=y`):

```console
$ make -j
powerled_main.c: In function 'powerled_main':
powerled_main.c:441:3: error: implicit declaration of function 'boardctl' [-Wimplicit-function-declaration]
  441 |   boardctl(BOARDIOC_INIT, 0);
      |   ^~~~~~~~
CC:  net/lib_inetntop.c powerled_main.c:441:12: error: 'BOARDIOC_INIT' undeclared (first use in this function)
  441 |   boardctl(BOARDIOC_INIT, 0);
      |            ^~~~~~~~~~~~~
powerled_main.c:441:12: note: each undeclared identifier is reported only once for each function it appears in
CC:  roundrobin.c make[2]: *** [/home/linguini/coding/nuttx-space/apps/Application.mk:330: powerled_main.c.home.linguini.coding.nuttx-space.apps.examples.powerled.o] Error 1
make[1]: *** [Makefile:54: /home/linguini/coding/nuttx-space/apps/examples/powerled_all] Error 2
make[1]: *** Waiting for unfinished jobs....
CC:  sched/task_startup.c make: *** [tools/LibTargets.mk:248: /home/linguini/coding/nuttx-space/apps/libapps.a] Error 2
make: *** Waiting for unfinished jobs....
[linguini@pastabox nuttx]$ 
```

After change:

```console
$ make -j
Create version.h
LN: platform/board to /home/linguini/coding/nuttx-space/apps/platform/dummy
Register: nsh
Register: hello
Register: sh
Register: getprime
Register: ostest
Register: dd
Register: powerled
CPP:  /home/linguini/coding/nuttx-space/nuttx/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld-> /home/linguini/coding/nuttx-space/nuttx/bLD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        164 KB         2 MB      8.01%
            sram:        8864 B       264 KB      3.28%
Generating: nuttx.uf2
Done.
```