### PR TITLE
Fix QOS arguments parsing for mqttc_pub

### DIFF
--- a/examples/mqttc/mqttc_pub.c
+++ b/examples/mqttc/mqttc_pub.c
@@ -528,7 +528,7 @@ int main(int argc, FAR char *argv[])
                       NULL);
   if (mqtterr != MQTT_OK)
     {
-      printf("ERRPR! mqtt_init() failed.\n");
+      printf("ERROR! mqtt_init() failed.\n");
       goto err_with_conn;
     }
 


### PR DESCRIPTION
## Summary

Modify the switch cases in parsearg function for QOS levels definition. The comparison was made between a long value and a char.

## Impact

All the 2 levels of QOS are now supported by the mqtt publisher example.

## Testing

Host used for build:
- OS: Linux 6.18.9-arch1-2
- CPU: AMD Ryzen 7 5800HS
- compiler: xtensa-esp32-elf-gcc

Target used for verification:
- board: ESP32C3
- config: esp32-devkitc:wifi

Connected the board to laptop's hotspot and dumped the packets in Wireshark. The broker used in testing is broker.hivemq.com.
For every QOS level the right handshakes are triggered.

1. Before:
    Before the changes, both QOS 1 and QOS 2 message publishing looked like this:

    <img width="776" height="137" alt="image" src="https://github.com/user-attachments/assets/84e2d6b9-add2-47a6-ad8d-9b11b2af3ee5" />

    They were sent with QOS 0, fire and forget, because the QOS level was not modified in the packet.

2. After: 

    QOS 1 handshake:
    <img width="887" height="160" alt="image" src="https://github.com/user-attachments/assets/665955b3-5bc6-4e5d-9ebd-e674d84eb7a6" />

    QOS 2 handshake:
    <img width="889" height="215" alt="image" src="https://github.com/user-attachments/assets/de6cd882-4c87-490d-a499-2c981d5e4b2a" />
