### PR TITLE
boot/nxboot: fix Clang warnings for format and va_start

### DIFF
--- a/boot/nxboot/include/nxboot.h
+++ b/boot/nxboot/include/nxboot.h
@@ -169,7 +169,7 @@ enum progress_msg_e
  ****************************************************************************/
 
 #ifdef CONFIG_NXBOOT_PROGRESS
-void nxboot_progress(enum progress_type_e type, ...);
+void nxboot_progress(int type, ...);
 #else
 #define nxboot_progress(type, ...) do {} while (0)
 #endif

--- a/boot/nxboot/loader/flash.c
+++ b/boot/nxboot/loader/flash.c
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <string.h>
 #include <stddef.h>
 #include <fcntl.h>
@@ -137,14 +138,15 @@ int flash_partition_write(int fd, const void *buf, size_t count, off_t off)
   pos = lseek(fd, off, SEEK_SET);
   if (pos != off)
     {
-      syslog(LOG_ERR, "Could not seek to %ld: %s\n", off, strerror(errno));
+      syslog(LOG_ERR, "Could not seek to %" PRIdOFF ": %s\n",
+              off, strerror(errno));
       return ERROR;
     }
 
   nbytes = write(fd, buf, count);
   if (nbytes != count)
     {
-      syslog(LOG_ERR, "Write to offset %ld failed %s\n",
+      syslog(LOG_ERR, "Write to offset %" PRIdOFF " failed %s\n",
               off, strerror(errno));
       return ERROR;
     }
@@ -195,15 +197,16 @@ int flash_partition_read(int fd, void *buf, size_t count, off_t off)
   pos = lseek(fd, off, SEEK_SET);
   if (pos != off)
     {
-      syslog(LOG_ERR, "Could not seek to %ld: %s\n", off, strerror(errno));
+      syslog(LOG_ERR, "Could not seek to %" PRIdOFF ": %s\n",
+              off, strerror(errno));
       return ERROR;
     }
 
   nbytes = read(fd, buf, count);
   if (nbytes != count)
     {
-      syslog(LOG_ERR, "Read from offset %ld failed %s\n", off,
-                      strerror(errno));
+      syslog(LOG_ERR, "Read from offset %" PRIdOFF " failed %s\n",
+              off, strerror(errno));
       return ERROR;
     }
 

--- a/boot/nxboot/nxboot_main.c
+++ b/boot/nxboot/nxboot_main.c
@@ -124,7 +124,7 @@ static const char *progress_msgs[] =
  ****************************************************************************/
 
 #ifdef CONFIG_NXBOOT_PROGRESS
-void nxboot_progress(enum progress_type_e type, ...)
+void nxboot_progress(int type, ...)
 {
 #ifdef CONFIG_NXBOOT_PRINTF_PROGRESS
   va_list arg;


### PR DESCRIPTION
## Summary

Fix two Clang `-Werror` failures when building nxboot with `CONFIG_ARM_TOOLCHAIN_CLANG`:

- `loader/flash.c`: use `PRIdOFF` instead of `%ld` for `off_t` arguments in syslog calls, fixing `-Wformat` when `off_t` is not `long`.
- `nxboot_main.c` / `nxboot.h`: change `nxboot_progress` parameter from `enum progress_type_e` to `int` to avoid undefined behavior from `va_start` on a parameter that undergoes default argument promotion (`-Wvarargs`).

## Impact

Fixes build failures for any board config that enables nxboot with Clang (e.g. nucleo-h743zi/nxboot-loader, nucleo-h743zi/nxboot-app in apache/nuttx#18509).

## Testing

Build: nucleo-h743zi/nxboot-loader and nucleo-h743zi/nxboot-app with `CONFIG_ARM_TOOLCHAIN_CLANG`.