### PR TITLE
examples/rmtchar: fix source file ordering for RMTCHAR

### DIFF
--- a/examples/rmtchar/CMakeLists.txt
+++ b/examples/rmtchar/CMakeLists.txt
@@ -29,8 +29,8 @@ if(CONFIG_EXAMPLES_RMTCHAR)
     MODULE
     ${CONFIG_EXAMPLES_RMTCHAR}
     SRCS
-    rmtchar_common.c
     rmtchar_main.c)
+  target_sources(apps PRIVATE rmtchar_common.c)
   if(CONFIG_EXAMPLES_RMTCHAR_TX)
     target_sources(apps PRIVATE rmtchar_transmitter.c)
   endif()


### PR DESCRIPTION
## Summary

<!--This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly-->

* examples/rmtchar: fix source file ordering for RMTCHAR

rmtchar_main.c is coming after rmtchar_common.c, which causes an undefined reference error. This change fixes the problem.

## Impact

Impact on user: Yes, allows building rmt example using CMake.

<!--Does it impact user's applications? How?-->

Impact on build: Yes, fixes build error.

<!--Does it impact on building NuttX? How? (please describe the required changes on the build system)-->

Impact on hardware: No.

<!--Does it impact a specific hardware supported by NuttX?-->

Impact on documentation: No.

<!--Does it impact the existing documentation? Please provide additional documentation to reflect that-->

Impact on security: No.

<!--Does it impact NuttX's security?-->

Impact on compatibility: No.

<!--Does it impact compatibility between previous and current versions? Is this a breaking change?-->

## Testing

Build the `rmt` defconfig for `esp32h2-devkit` (CMake support for ESP32 devices is a work in progress).

### Building

* `cmake -B build -DBOARD_CONFIG=esp32h2-devkit:rmt -GNinja`
* `cmake --build build`

### Results

Before the change:

```
$ cmake --build build
...
[1359/1362] Linking C executable nuttx
FAILED: nuttx
: && /home/fdcavalcanti/work/toolchains/riscv-none-elf-gcc/bin/riscv-none-elf-gcc  -Wl,-melf32lriscv -Wl,--gc-sections -nostdlib
-Wl,--entry=__start -Wl,--cref -Wl,-Map=nuttx.map -Wl,--no-warn-rwx-segments -u esp_system_include_startup_funcs
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.api.ld -T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.libc.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.libc-suboptimal_for_misaligned_mem.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.libgcc.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.newlib.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.version.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_hal_wdt/esp32h2/rom.wdt.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/esp_rom/esp32h2/ld/esp32h2.rom.heap.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/riscv/ld/rom.api.ld
-T/home/fdcavalcanti/nuttxspace3/nuttx/arch/risc-v/src/common/chip/esp-hal-3rdparty/components/soc/esp32h2/ld/esp32h2.peripherals.ld -Wl,--wrap=bootloader_print_banner @CMakeFiles/nuttx.rsp -o nuttx  && :
/home/fdcavalcanti/work/toolchains/riscv-none-elf-gcc/bin/../lib/gcc/riscv-none-elf/13.2.0/../../../../riscv-none-elf/bin/ld: apps/builtin/libapps_builtin.a(builtin_list.c.o):(.rodata.g_builtins+0x6c): undefined reference to `rmtchar_main'
collect2: error: ld returned 1 exit status
```

After the change:

```
$ cmake --build build
[1362/1362] Running utility command for nuttx_post_build
-- Generate NuttX image (esptool elf2image)
esptool v5.2.0
Creating ESP32-H2 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Note: Inserting 48772 bytes padding between .flash.text and .flash.rodata
Merged 1 ELF section.
Successfully created ESP32-H2 image.
-- Generated: nuttx.bin
```