### PR TITLE
system/fastboot: fix socket() parameter order for TCP transport

### DIFF
--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -1295,8 +1295,9 @@ static int fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx)
   netinit_bringup();
 #endif
 
-  ctx->tran_fd[0] = socket(AF_INET, SOCK_STREAM,
-                           SOCK_CLOEXEC | SOCK_NONBLOCK);
+  ctx->tran_fd[0] = socket(AF_INET,
+                           SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK,
+                           0);
   if (ctx->tran_fd[0] < 0)
     {
       fb_err("create socket failed %d", errno);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

In `fastboot_tcp_initialize()`, `SOCK_CLOEXEC` and `SOCK_NONBLOCK` were passed as the third argument (`protocol`) of `socket()` instead of being OR'd into the second argument (`type`).

The resulting protocol value (`SOCK_CLOEXEC | SOCK_NONBLOCK` = `0x80800`) is not a valid protocol number, causing `socket()` to fail on both Linux (`EINVAL`) and NuttX (`EPROTONOSUPPORT`). This means TCP transport has never worked.

Fix: move `SOCK_CLOEXEC | SOCK_NONBLOCK` into the `type` parameter and set `protocol` to 0.

```c
// Before (broken):
socket(AF_INET, SOCK_STREAM, SOCK_CLOEXEC | SOCK_NONBLOCK);

// After (correct):
socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
```

## Impact

Without this fix, `fastbootd` TCP transport fails on startup and cannot accept any connections. USB transport is not affected.

No API or configuration changes. Existing defconfigs with `CONFIG_SYSTEM_FASTBOOT_TCP=y` will now work correctly without any modification.

## Testing

- Host: Ubuntu 22.04 x86_64, GCC 14.2.0 (Xtensa esp32s3 cross-compiler)
- Target: xtensa, lckfb-szpi-esp32s3:fastboot_tcp (ESP32-S3)

Build:

```
$ make -j$(nproc)
```

Runtime verification (before fix):

```
nsh> fastbootd &
create socket failed 93
```

Runtime verification (after fix):

```
nsh> fastbootd &

$ fastboot -s tcp:192.168.137.81 getvar version
version: 12.12.0
```