### PR TITLE
CI: Revert GitHub Actions for Docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         run: tar zxf sources.tar.gz
 
       - name: Docker Login
-        uses: docker/login-action@v4
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -246,7 +246,7 @@ jobs:
         run: tar zxf sources.tar.gz
 
       - name: Docker Login
-        uses: docker/login-action@v4
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

All CI Builds have been failing since 18 hours ago:
- https://github.com/apache/nuttx/pull/18571#issuecomment-4104792750
- https://github.com/apache/nuttx/actions/runs/23389990049

> _The action docker/login-action@v4 is not allowed in apache/nuttx because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: 1Password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6, 1Password/load-secrets-action@8d0d610af187e78a2772c2d18d627f4c52d3fbfb, 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101, DavidAnson/markdownlint-cli2-action@30a0e04f1870d58f8d717450cc6134995f993c63, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23, JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f, Jimver/cuda-toolkit@6008063726ffe3309d1b22e413d9e88fed91a2f2, Jimver/cuda-toolkit@b6fc3a9f3f15256d9d94ffe1254f9c5a2565cde6, JustinBeckwith/linkinator-action@af984b9f30f63e796..._

That's because ASF Infrastructure Team has mandated that we use the Hash Versions of GitHub Actions for Docker, stated below:
- https://github.com/apache/infrastructure-actions/blob/main/actions.yml
- Which generates: https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml
- Due to: https://github.com/apache/infrastructure-actions/pull/547
- Because of the Trivy Security Incident: https://news.apache.org/foundation/entry/initial-report-on-trivy-security-incident

```yaml
docker/build-push-action:
  10e90e3645eae34f1e60eeb005ba3a3d33f178e8:
    tag: v6.19.2
docker/login-action:
  c94ce9fb468520275223c153574b00df6fe4bcc9:
    tag: v3.7.0
docker/metadata-action:
  c299e40c65443455700f0fdfc63efafe5b349051:
    tag: v5.10.0
docker/setup-buildx-action:
  8d2750c68a42422c14e847fe6c8ac0403b4cbd6f:
    tag: v3.12.0
```

This PR reverts our GitHub Actions for Docker to the hash versions stated above.

## Impact

All CI Builds will now be started correctly.

## Testing

We tested the updated GitHub Actions for Docker in our own NuttX Repo. The CI Build runs successfully:
- https://github.com/lupyuen14/nuttx/actions/runs/23392418389
