### PR TITLE
system/sensorscope: fix compilation

### DIFF
--- a/system/sensorscope/sensorscope_main.c
+++ b/system/sensorscope/sensorscope_main.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/list.h>
 #include <sys/boardctl.h>
 #include <sys/param.h>
 
@@ -58,7 +59,7 @@ struct nxsensor_info_s
   FAR const char *name;
   size_t          data_size;    /* Sensor read data size */
   size_t          data_offset;  /* Read data offset (no timestamp) */
-  size_t          dim;          /* Data vector dimenstion */
+  size_t          dim;          /* Data vector dimension */
   int             dtype;        /* Data vector type */
 };
 
@@ -313,7 +314,7 @@ static int nxscope_channels(FAR struct nxscope_thr_env_s *envp)
 
   list_initialize(&envp->objlist);
 
-  /* Open sensors direcotry */
+  /* Open sensors directory */
 
   dir = opendir(SENSOR_PATH);
   if (!dir)


### PR DESCRIPTION

## Summary
- system/sensorscope: fix compilation

fix compilation error:
```
sensorscope_main.c:314:3: error: implicit declaration of function 'list_initialize'; did you mean 'fs_initialize'? [-Wimplicit-function-declaration]
```
## Impact
fix compilation error

## Testing
sensorscope on thingy53 (not upstream yet)

