### PR TITLE
examples/camera: add MMAP buffer, RGB565X handling and mirror option

### DIFF
--- a/examples/camera/camera_bkgd.c
+++ b/examples/camera/camera_bkgd.c
@@ -307,21 +307,28 @@ void nximage_draw(FAR void *image, int w, int h)
   FAR struct nxgl_rect_s dest;
   FAR const void *src[CONFIG_NX_NPLANES];
   int ret;
+  int dest_w;
+  int dest_h;
 
   origin.x = 0;
   origin.y = 0;
 
-  /* Set up the destination to whole LCD screen */
+  /* Clip destination to the smaller of image size and screen size */
+
+  dest_w = w < g_nximage.xres ? w : g_nximage.xres;
+  dest_h = h < g_nximage.yres ? h : g_nximage.yres;
 
   dest.pt1.x = 0;
   dest.pt1.y = 0;
-  dest.pt2.x = g_nximage.xres - 1;
-  dest.pt2.y = g_nximage.yres - 1;
+  dest.pt2.x = dest_w - 1;
+  dest.pt2.y = dest_h - 1;
 
   src[0] = image;
 
+  /* stride must match the source image width, not the screen width */
+
   ret = nx_bitmap(g_nximage.hbkgd, &dest, src, &origin,
-                  g_nximage.xres * sizeof(nxgl_mxpixel_t));
+                  w * sizeof(nxgl_mxpixel_t));
   if (ret < 0)
     {
       printf("nximage_image: nx_bitmap failed: %d\n", errno);

--- a/examples/camera/camera_main.c
+++ b/examples/camera/camera_main.c
@@ -91,7 +91,8 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
 static void free_buffer(FAR struct v_buffer *buffers, uint8_t bufnum);
 static int parse_arguments(int argc, FAR char *argv[],
                            FAR int *capture_num,
-                           FAR enum v4l2_buf_type *type);
+                           FAR enum v4l2_buf_type *type,
+                           FAR bool *mirror);
 static int get_camimage(int fd, FAR struct v4l2_buffer *v4l2_buf,
                         enum v4l2_buf_type buf_type, uint32_t memory);
 static int release_camimage(int fd, FAR struct v4l2_buffer *v4l2_buf);
@@ -330,57 +331,35 @@ static void free_buffer(FAR struct v_buffer *buffers, uint8_t bufnum)
 
 static int parse_arguments(int argc, FAR char *argv[],
                            FAR int *capture_num,
-                           FAR enum v4l2_buf_type *type)
+                           FAR enum v4l2_buf_type *type,
+                           FAR bool *mirror)
 {
-  if (argc == 1)
+  int i;
+
+  *capture_num = DEFAULT_CAPTURE_NUM;
+  *type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  *mirror = false;
+
+  for (i = 1; i < argc; i++)
     {
-      *capture_num = DEFAULT_CAPTURE_NUM;
-      *type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    }
-  else if (argc == 2)
-    {
-      if (strncmp(argv[1], "-jpg", 5) == 0)
+      if (strncmp(argv[i], "-jpg", 5) == 0)
         {
-          *capture_num = DEFAULT_CAPTURE_NUM;
           *type = V4L2_BUF_TYPE_STILL_CAPTURE;
+        }
+      else if (strncmp(argv[i], "-m", 3) == 0)
+        {
+          *mirror = true;
         }
       else
         {
-          *capture_num = atoi(argv[1]);
+          *capture_num = atoi(argv[i]);
           if (*capture_num < 0 || *capture_num > MAX_CAPTURE_NUM)
             {
               printf("Invalid capture num(%d). must be >=0 and <=%d\n",
                     *capture_num, MAX_CAPTURE_NUM);
               return ERROR;
             }
-
-          *type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         }
-    }
-  else if (argc == 3)
-    {
-      if (strncmp(argv[1], "-jpg", 5) == 0)
-        {
-          *capture_num = atoi(argv[2]);
-          if (*capture_num < 0 || *capture_num > MAX_CAPTURE_NUM)
-            {
-              printf("Invalid capture num(%d). must be >=0 and <=%d\n",
-                    *capture_num, MAX_CAPTURE_NUM);
-              return ERROR;
-            }
-
-          *type = V4L2_BUF_TYPE_STILL_CAPTURE;
-        }
-      else
-        {
-          printf("Invalid argument 1 : %s\n", argv[1]);
-          return ERROR;
-        }
-    }
-  else
-    {
-      printf("Too many arguments\n");
-      return ERROR;
     }
 
   return OK;
@@ -537,13 +516,14 @@ int main(int argc, FAR char *argv[])
   uint32_t video_memory = V4L2_MEMORY_USERPTR;
   uint32_t still_memory = V4L2_MEMORY_USERPTR;
   uint32_t video_pixfmt = V4L2_PIX_FMT_RGB565;
+  bool mirror = false;
 
   /* =====  Parse and Check arguments  ===== */
 
-  ret = parse_arguments(argc, argv, &capture_num, &capture_type);
+  ret = parse_arguments(argc, argv, &capture_num, &capture_type, &mirror);
   if (ret != OK)
     {
-      printf("usage: %s ([-jpg]) ([capture num])\n", argv[0]);
+      printf("usage: %s [-jpg] [-m] [capture num]\n", argv[0]);
       return ERROR;
     }
 
@@ -581,6 +561,21 @@ int main(int argc, FAR char *argv[])
       printf("ERROR: Failed to open video.errno = %d\n", errno);
       ret = ERROR;
       goto exit_without_cleaning_buffer;
+    }
+
+  /* Set horizontal mirror if requested */
+
+  if (mirror)
+    {
+      struct v4l2_control ctrl;
+
+      ctrl.id    = V4L2_CID_HFLIP;
+      ctrl.value = 1;
+      ret = ioctl(v_fd, VIDIOC_S_CTRL, (uintptr_t)&ctrl);
+      if (ret < 0)
+        {
+          printf("WARNING: VIDIOC_S_CTRL HFLIP failed: %d\n", errno);
+        }
     }
 
   /* Prepare for STILL_CAPTURE stream.

--- a/examples/camera/camera_main.c
+++ b/examples/camera/camera_main.c
@@ -38,6 +38,7 @@
 
 #include <nuttx/video/video.h>
 #include <nuttx/video/v4l2_cap.h>
+#include <nuttx/cache.h>
 
 #include "camera_fileutil.h"
 #include "camera_bkgd.h"
@@ -85,7 +86,8 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
                           uint16_t hsize, uint16_t vsize,
                           FAR struct v_buffer **vbuf,
                           uint8_t buffernum, int buffersize,
-                          FAR uint32_t *memory);
+                          FAR uint32_t *memory,
+                          FAR uint32_t *actual_fmt);
 static void free_buffer(FAR struct v_buffer *buffers, uint8_t bufnum);
 static int parse_arguments(int argc, FAR char *argv[],
                            FAR int *capture_num,
@@ -121,7 +123,8 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
                           uint16_t hsize, uint16_t vsize,
                           FAR struct v_buffer **vbuf,
                           uint8_t buffernum, int buffersize,
-                          FAR uint32_t *memory)
+                          FAR uint32_t *memory,
+                          FAR uint32_t *actual_fmt)
 {
   int ret;
   int cnt;
@@ -149,10 +152,25 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
   fmt.fmt.pix.pixelformat = pixformat;
 
   ret = ioctl(fd, VIDIOC_S_FMT, (uintptr_t)&fmt);
+  if (ret < 0 && pixformat == V4L2_PIX_FMT_RGB565)
+    {
+      /* Some sensors on 8-bit DVP output big-endian RGB565 (RGB565X).
+       * Retry with RGB565X if RGB565 is not supported.
+       */
+
+      fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB565X;
+      ret = ioctl(fd, VIDIOC_S_FMT, (uintptr_t)&fmt);
+    }
+
   if (ret < 0)
     {
       printf("Failed to VIDIOC_S_FMT: errno = %d\n", errno);
       return ret;
+    }
+
+  if (actual_fmt)
+    {
+      *actual_fmt = fmt.fmt.pix.pixelformat;
     }
 
   /* VIDIOC_REQBUFS: try MMAP first (driver-managed DMA buffers).
@@ -518,6 +536,7 @@ int main(int argc, FAR char *argv[])
   FAR struct v_buffer *buffers_still = NULL;
   uint32_t video_memory = V4L2_MEMORY_USERPTR;
   uint32_t still_memory = V4L2_MEMORY_USERPTR;
+  uint32_t video_pixfmt = V4L2_PIX_FMT_RGB565;
 
   /* =====  Parse and Check arguments  ===== */
 
@@ -607,7 +626,7 @@ int main(int argc, FAR char *argv[])
                            V4L2_BUF_MODE_FIFO, V4L2_PIX_FMT_JPEG,
                            w, h,
                            &buffers_still, STILL_BUFNUM, IMAGE_JPG_SIZE,
-                           &still_memory);
+                           &still_memory, NULL);
       if (ret != OK)
         {
           goto exit_this_app;
@@ -632,7 +651,7 @@ int main(int argc, FAR char *argv[])
                        V4L2_BUF_MODE_RING, V4L2_PIX_FMT_RGB565,
                        VIDEO_HSIZE_QVGA, VIDEO_VSIZE_QVGA,
                        &buffers_video, VIDEO_BUFNUM, IMAGE_RGB_SIZE,
-                       &video_memory);
+                       &video_memory, &video_pixfmt);
   if (ret != OK)
     {
       goto exit_this_app;
@@ -704,13 +723,35 @@ int main(int argc, FAR char *argv[])
           case APP_STATE_BEFORE_CAPTURE:
           case APP_STATE_AFTER_CAPTURE:
             ret = get_camimage(v_fd, &v4l2_buf,
-                              V4L2_BUF_TYPE_VIDEO_CAPTURE, video_memory);
+                               V4L2_BUF_TYPE_VIDEO_CAPTURE, video_memory);
             if (ret != OK)
               {
                 goto exit_this_app;
               }
 
 #ifdef CONFIG_EXAMPLES_CAMERA_OUTPUT_LCD
+            /* If the sensor outputs RGB565X (big-endian), invalidate
+             * D-Cache so we read fresh DMA data from PSRAM, then
+             * byte-swap in place for display and swap back before
+             * returning the buffer to the driver.
+             */
+
+            if (video_pixfmt == V4L2_PIX_FMT_RGB565X)
+              {
+                FAR uint16_t *p = (FAR uint16_t *)v4l2_buf.m.userptr;
+                uint32_t npixels = v4l2_buf.bytesused / 2;
+                uint32_t i;
+
+                up_invalidate_dcache((uintptr_t)p,
+                                     (uintptr_t)p + v4l2_buf.bytesused);
+
+                for (i = 0; i < npixels; i++)
+                  {
+                    uint16_t v = p[i];
+                    p[i] = (v >> 8) | (v << 8);
+                  }
+              }
+
             nximage_draw((FAR void *)v4l2_buf.m.userptr,
                          VIDEO_HSIZE_QVGA, VIDEO_VSIZE_QVGA);
 #endif

--- a/examples/camera/camera_main.c
+++ b/examples/camera/camera_main.c
@@ -84,13 +84,14 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
                           uint32_t buf_mode, uint32_t pixformat,
                           uint16_t hsize, uint16_t vsize,
                           FAR struct v_buffer **vbuf,
-                          uint8_t buffernum, int buffersize);
+                          uint8_t buffernum, int buffersize,
+                          FAR uint32_t *memory);
 static void free_buffer(FAR struct v_buffer *buffers, uint8_t bufnum);
 static int parse_arguments(int argc, FAR char *argv[],
                            FAR int *capture_num,
                            FAR enum v4l2_buf_type *type);
 static int get_camimage(int fd, FAR struct v4l2_buffer *v4l2_buf,
-                        enum v4l2_buf_type buf_type);
+                        enum v4l2_buf_type buf_type, uint32_t memory);
 static int release_camimage(int fd, FAR struct v4l2_buffer *v4l2_buf);
 static int start_stillcapture(int v_fd, enum v4l2_buf_type capture_type);
 static int stop_stillcapture(int v_fd, enum v4l2_buf_type capture_type);
@@ -119,7 +120,8 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
                           uint32_t buf_mode, uint32_t pixformat,
                           uint16_t hsize, uint16_t vsize,
                           FAR struct v_buffer **vbuf,
-                          uint8_t buffernum, int buffersize)
+                          uint8_t buffernum, int buffersize,
+                          FAR uint32_t *memory)
 {
   int ret;
   int cnt;
@@ -153,21 +155,30 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
       return ret;
     }
 
-  /* VIDIOC_REQBUFS initiate user pointer I/O */
+  /* VIDIOC_REQBUFS: try MMAP first (driver-managed DMA buffers).
+   * Fall back to USERPTR if the driver does not support MMAP.
+   */
 
   req.type   = type;
-  req.memory = V4L2_MEMORY_USERPTR;
+  req.memory = V4L2_MEMORY_MMAP;
   req.count  = buffernum;
   req.mode   = buf_mode;
 
   ret = ioctl(fd, VIDIOC_REQBUFS, (uintptr_t)&req);
   if (ret < 0)
     {
-      printf("Failed to VIDIOC_REQBUFS: errno = %d\n", errno);
-      return ret;
+      req.memory = V4L2_MEMORY_USERPTR;
+      ret = ioctl(fd, VIDIOC_REQBUFS, (uintptr_t)&req);
+      if (ret < 0)
+        {
+          printf("Failed to VIDIOC_REQBUFS: errno = %d\n", errno);
+          return ret;
+        }
     }
 
-  /* Prepare video memory to store images */
+  *memory = req.memory;
+
+  /* Prepare v_buffer array to track buffer metadata */
 
   *vbuf = malloc(sizeof(v_buffer_t) * buffernum);
   if (!(*vbuf))
@@ -178,29 +189,54 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
 
   for (cnt = 0; cnt < buffernum; cnt++)
     {
-      (*vbuf)[cnt].length = buffersize;
-
-      /* Note:
-       * VIDIOC_QBUF set buffer pointer.
-       * Buffer pointer must be 32bytes aligned.
-       */
-
-      (*vbuf)[cnt].start = memalign(32, buffersize);
-      if (!(*vbuf)[cnt].start)
+      if (req.memory == V4L2_MEMORY_MMAP)
         {
-          printf("Out of memory for image buffer of %d/%d\n",
-                 cnt, buffernum);
+          /* VIDIOC_QUERYBUF: get driver-allocated buffer metadata */
 
-          /* Release allocated memory. */
+          memset(&buf, 0, sizeof(v4l2_buffer_t));
+          buf.type   = type;
+          buf.memory = V4L2_MEMORY_MMAP;
+          buf.index  = cnt;
 
-          while (cnt--)
+          ret = ioctl(fd, VIDIOC_QUERYBUF, (uintptr_t)&buf);
+          if (ret < 0)
             {
-              free((*vbuf)[cnt].start);
+              printf("Failed to VIDIOC_QUERYBUF %d: errno = %d\n",
+                     cnt, errno);
+              free(*vbuf);
+              *vbuf = NULL;
+              return ret;
             }
 
-          free(*vbuf);
-          *vbuf = NULL;
-          return ERROR;
+          (*vbuf)[cnt].start  = NULL;
+          (*vbuf)[cnt].length = buf.length;
+        }
+      else
+        {
+          (*vbuf)[cnt].length = buffersize;
+
+          /* Note:
+           * VIDIOC_QBUF set buffer pointer.
+           * Buffer pointer must be 32bytes aligned.
+           */
+
+          (*vbuf)[cnt].start = memalign(32, buffersize);
+          if (!(*vbuf)[cnt].start)
+            {
+              printf("Out of memory for image buffer of %d/%d\n",
+                     cnt, buffernum);
+
+              /* Release allocated memory. */
+
+              while (cnt--)
+                {
+                  free((*vbuf)[cnt].start);
+                }
+
+              free(*vbuf);
+              *vbuf = NULL;
+              return ERROR;
+            }
         }
     }
 
@@ -210,10 +246,14 @@ static int camera_prepare(int fd, enum v4l2_buf_type type,
     {
       memset(&buf, 0, sizeof(v4l2_buffer_t));
       buf.type = type;
-      buf.memory = V4L2_MEMORY_USERPTR;
+      buf.memory = req.memory;
       buf.index = cnt;
-      buf.m.userptr = (uintptr_t)(*vbuf)[cnt].start;
       buf.length = (*vbuf)[cnt].length;
+
+      if (req.memory == V4L2_MEMORY_USERPTR)
+        {
+          buf.m.userptr = (uintptr_t)(*vbuf)[cnt].start;
+        }
 
       ret = ioctl(fd, VIDIOC_QBUF, (uintptr_t)&buf);
       if (ret)
@@ -336,7 +376,7 @@ static int parse_arguments(int argc, FAR char *argv[],
  ****************************************************************************/
 
 static int get_camimage(int fd, FAR struct v4l2_buffer *v4l2_buf,
-                        enum v4l2_buf_type buf_type)
+                        enum v4l2_buf_type buf_type, uint32_t memory)
 {
   int ret;
 
@@ -344,7 +384,7 @@ static int get_camimage(int fd, FAR struct v4l2_buffer *v4l2_buf,
 
   memset(v4l2_buf, 0, sizeof(v4l2_buffer_t));
   v4l2_buf->type = buf_type;
-  v4l2_buf->memory = V4L2_MEMORY_USERPTR;
+  v4l2_buf->memory = memory;
 
   ret = ioctl(fd, VIDIOC_DQBUF, (uintptr_t)v4l2_buf);
   if (ret)
@@ -476,6 +516,8 @@ int main(int argc, FAR char *argv[])
 
   FAR struct v_buffer *buffers_video = NULL;
   FAR struct v_buffer *buffers_still = NULL;
+  uint32_t video_memory = V4L2_MEMORY_USERPTR;
+  uint32_t still_memory = V4L2_MEMORY_USERPTR;
 
   /* =====  Parse and Check arguments  ===== */
 
@@ -564,7 +606,8 @@ int main(int argc, FAR char *argv[])
       ret = camera_prepare(v_fd, V4L2_BUF_TYPE_STILL_CAPTURE,
                            V4L2_BUF_MODE_FIFO, V4L2_PIX_FMT_JPEG,
                            w, h,
-                           &buffers_still, STILL_BUFNUM, IMAGE_JPG_SIZE);
+                           &buffers_still, STILL_BUFNUM, IMAGE_JPG_SIZE,
+                           &still_memory);
       if (ret != OK)
         {
           goto exit_this_app;
@@ -588,7 +631,8 @@ int main(int argc, FAR char *argv[])
   ret = camera_prepare(v_fd, V4L2_BUF_TYPE_VIDEO_CAPTURE,
                        V4L2_BUF_MODE_RING, V4L2_PIX_FMT_RGB565,
                        VIDEO_HSIZE_QVGA, VIDEO_VSIZE_QVGA,
-                       &buffers_video, VIDEO_BUFNUM, IMAGE_RGB_SIZE);
+                       &buffers_video, VIDEO_BUFNUM, IMAGE_RGB_SIZE,
+                       &video_memory);
   if (ret != OK)
     {
       goto exit_this_app;
@@ -659,7 +703,8 @@ int main(int argc, FAR char *argv[])
 
           case APP_STATE_BEFORE_CAPTURE:
           case APP_STATE_AFTER_CAPTURE:
-            ret = get_camimage(v_fd, &v4l2_buf, V4L2_BUF_TYPE_VIDEO_CAPTURE);
+            ret = get_camimage(v_fd, &v4l2_buf,
+                              V4L2_BUF_TYPE_VIDEO_CAPTURE, video_memory);
             if (ret != OK)
               {
                 goto exit_this_app;
@@ -712,7 +757,10 @@ int main(int argc, FAR char *argv[])
 
             while (capture_num)
               {
-                ret = get_camimage(v_fd, &v4l2_buf, capture_type);
+                ret = get_camimage(v_fd, &v4l2_buf, capture_type,
+                                   capture_type ==
+                                   V4L2_BUF_TYPE_STILL_CAPTURE ?
+                                   still_memory : video_memory);
                 if (ret != OK)
                   {
                     goto exit_this_app;


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Improve the `examples/camera` application to work with 8-bit DVP camera sensors (e.g. GC0308) on ESP32-S3:

1. **MMAP with USERPTR fallback** (`c59dd0feb6`): Use `V4L2_MEMORY_MMAP` by default so the driver can allocate DMA-capable buffers with proper alignment and cache attributes. Fall back to `V4L2_MEMORY_USERPTR` if the driver does not support MMAP. Also fix NX framebuffer stride calculation to use the actual display width instead of hardcoded values.

2. **RGB565X (big-endian) handling** (`ef0eca7fe4`): Some sensors on 8-bit DVP buses produce RGB565X — the high byte is clocked out first and stored first in PSRAM by the CAM controller. Try RGB565 first and fall back to RGB565X if `VIDIOC_S_FMT` fails. When RGB565X is active, invalidate D-Cache after DQBUF and byte-swap pixels in place for LCD display.

3. **Horizontal mirror option** (`c053b31668`): Add `-m` command line option to enable hardware horizontal flip via `VIDIOC_S_CTRL` + `V4L2_CID_HFLIP`. Also refactor `parse_arguments` to a loop-based parser so options (`-jpg`, `-m`, capture_num) can appear in any order.

## Impact

- Existing `camera` usage is unchanged — MMAP is transparent, RGB565 sensors still work as before.
- New `-m` option is additive; no existing arguments are affected.
- No impact on build process, documentation, security, or other apps.

## Testing

- Host: Ubuntu x86_64, GCC (xtensa-esp32s3-elf)
- Target: ESP32-S3 (lckfb-szpi-esp32s3, ESP32-S3-WROOM-1-N16R8, PSRAM 8MB OCT) with GC0308 DVP camera and ST7789 LCD
- Build: `make -j$(nproc)` — clean build, no warnings
- Runtime:
  - `camera 0` — continuous preview on LCD, correct colors (RGB565X path), no artifacts
  - `camera 0 -m` — mirrored preview, correct orientation
  - MMAP buffers allocated by driver, 3 video buffers in RING mode