### PR TITLE
nshlib/nsh_timcmds.c: fix incorrect time set during summer time

### DIFF
--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -265,6 +265,10 @@ static inline int date_settime(FAR struct nsh_vtbl_s *vtbl,
 
   tm.tm_year = (int)result - 1900;
 
+  /* Information about daylight saving not available -> let TZ handle it */
+
+  tm.tm_isdst = -1;
+
   /* Convert this to the right form, then set the timer */
 
   ts.tv_sec  = utc ? timegm(&tm): mktime(&tm);


### PR DESCRIPTION
## Summary
Value zero in `tm_isdst` means daylight saving time (or summer time) is not in effect. This is obviously not true for half of the year in most timezones and keeping it at zero leads to incorrect time being set. This commit sets `tm_isdst` to -1, which means the information is not available and it should be handled according to timezone rules.

## Impact

Fixes time set with `date` command.

## Testing

On custom device with Europe/Prague (UTC+2 now in summer time, otherwise UTC+1) timezone set.

Before the fix -> both local and UTC time not correctly set:

```
vtk25> date -s "Sep 15 11:30:00 2023"
vtk25> date
Fri, Sep 15 12:30:01 2023
vtk25> date -u
Fri, Sep 15 10:30:02 2023
```

After the fix (tested both with and without daylight saving):

```
vtk25> date -s "Sep 15 11:30:00 2023"
vtk25> date
Fri, Sep 15 11:30:01 2023
vtk25> date -u
Fri, Sep 15 09:30:05 2023
```

```
vtk25> date -s "Jan 15 11:30:00 2023"
vtk25> date
Sun, Jan 15 11:30:01 2023
vtk25> date -u
Sun, Jan 15 10:30:03 2023
vtk25> 
```

Tests if no timezone is uploaded

```
vtk25> date -s "Sep 15 11:30:00 2023"
vtk25> date
Fri, Sep 15 11:30:02 2023
vtk25> date -u
Fri, Sep 15 11:30:04 2023
vtk25> 
```

```
vtk25> date -s "Jan 15 11:30:00 2023"
vtk25> date
Sun, Jan 15 11:30:01 2023
vtk25> date -u
Sun, Jan 15 11:30:02 2023
vtk25> 
```
