### PR TITLE
graphics/lvgl: bump version to 9.2.2

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -27,12 +27,21 @@ if(CONFIG_GRAPHICS_LVGL)
   # ############################################################################
   set(LVGL_DIR ${CMAKE_CURRENT_LIST_DIR}/lvgl)
 
+  set(LVGL_VERSION
+      "${CONFIG_LVGL_VERSION_MAJOR}.${CONFIG_LVGL_VERSION_MINOR}.${CONFIG_LVGL_VERSION_PATCH}"
+  )
+
   if(NOT EXISTS ${LVGL_DIR})
+    set(LVGL_URL
+        "https://github.com/lvgl/lvgl/archive/refs/tags/v${LVGL_VERSION}.zip")
     FetchContent_Declare(
       lvgl_fetch
-      DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://github.com/lvgl/lvgl/archive/refs/tags/v9.2.1.zip" SOURCE_DIR
-          ${CMAKE_CURRENT_LIST_DIR}/lvgl BINARY_DIR
+      URL ${LVGL_URL}
+          DOWNLOAD_DIR
+          ${CMAKE_CURRENT_LIST_DIR}
+          SOURCE_DIR
+          ${CMAKE_CURRENT_LIST_DIR}/lvgl
+          BINARY_DIR
           ${CMAKE_BINARY_DIR}/apps/graphics/lvgl/lvgl
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 120)

--- a/graphics/lvgl/Kconfig
+++ b/graphics/lvgl/Kconfig
@@ -11,7 +11,7 @@ menuconfig GRAPHICS_LVGL
 
 if GRAPHICS_LVGL
 
-# Kconfig file for LVGL v9.2.1
+# Kconfig file for LVGL v9.2.2
 
 menu "LVGL configuration"
 
@@ -1495,7 +1495,7 @@ menu "LVGL configuration"
 			default 2 # LVGL_VERSION_MINOR
 		config LVGL_VERSION_PATCH
 			int
-			default 1 # LVGL_VERSION_PATCH
+			default 2 # LVGL_VERSION_PATCH
 	endmenu
 
 	menu "Devices"

--- a/graphics/lvgl/Makefile
+++ b/graphics/lvgl/Makefile
@@ -58,8 +58,11 @@ WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
 CONFIG_GRAPH_LVGL_URL ?= "https://github.com/lvgl/lvgl/archive/refs/tags"
 
-LVGL_VERSION = 9.2.1
-LVGL_TARBALL = v$(LVGL_VERSION).zip
+_MAJ         := $(CONFIG_LVGL_VERSION_MAJOR)
+_MIN         := $(CONFIG_LVGL_VERSION_MINOR)
+_PAT         := $(CONFIG_LVGL_VERSION_PATCH)
+LVGL_VERSION := $(_MAJ).$(_MIN).$(_PAT)
+LVGL_TARBALL := v$(LVGL_VERSION).zip
 
 LVGL_UNPACKNAME = lvgl
 UNPACK ?= unzip -o $(if $(V),,-q)


### PR DESCRIPTION
## Summary

- Update lvlg version from 9.2.1 to 9.2.2 that includes fix for nuttx lcd release assert.
- Get version from config in Makefile
- Get version from config in cmake file

## Impact

There should be no impact,

## Testing

Tested by @shtirlic on pico2 on risc-v cores, and by @cederom on FreeBSD with ESP32S3-WS-LCD128 board under development :-)

```
% uname -a
FreeBSD hexagon 14.4-RELEASE-p2 FreeBSD 14.4-RELEASE-p2 GENERIC amd64

% gmake clean distclean -j ; ./tools/configure.sh -B -S esp32s3-ws-lcd128:touch-lvgl && /usr/bin/time -h gmake flash -j && cu -l /dev/cuaU0 -s 115200
(..)
#
# configuration written to .config
#
Create version.h
LN: platform/board to /XXX/nuttx/nuttx-apps.git/platform/dummy
Downloading: v9.2.2.zipCloning Espressif HAL for 3rd Party Platforms
Espressif HAL for 3rd Party Platforms: cleaning current repository...
(..)
Espressif HAL for 3rd Party Platforms: b7e51db97a3f9dc82d3b3524d2bad298ba1e2647
Espressif HAL for 3rd Party Platforms: initializing submodules...
Applying patches...
Register: dd
Register: sh
Register: nsh
Register: lvgldemo
(..)
Memory region         Used Size  Region Size  %age Used
             ROM:      613188 B    4194272 B     14.62%
     iram0_0_seg:       36096 B       304 KB     11.60%
     irom0_0_seg:      387423 B    4194272 B      9.24%
     dram0_0_seg:       43896 B       288 KB     14.88%
     drom0_0_seg:      678688 B    4194272 B     16.18%
    rtc_iram_seg:           0 B       8168 B      0.00%
    rtc_data_seg:           0 B       8168 B      0.00%
rtc_reserved_seg:          24 B         24 B    100.00%
    rtc_slow_seg:          36 B         8 KB      0.44%
CP: nuttx.hex
MKIMAGE: ESP32-S3 binary
esptool.py -c esp32s3 elf2image --ram-only-header -fs 4MB -fm dio -ff "40m" -o nuttx.bin nuttx
esptool.py v4.10.0
Creating esp32s3 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Merged 1 ELF section
Successfully created esp32s3 image.
Generated: nuttx.bin
esptool.py -c esp32s3 -p /dev/cuaU0 -b 115200  write_flash -fs detect -fm dio -ff "40m" 0x0000 nuttx.bin
esptool.py v4.10.0
Serial port /dev/cuaU0
Connecting....
Chip is ESP32-S3 (QFN56) (revision v0.2)
Features: WiFi, BLE, Embedded PSRAM 2MB (AP_3v3)
Crystal is 40MHz
MAC: XXX
Uploading stub...
Running stub...
Stub running...
Configuring flash size...
Auto-detected Flash size: 16MB
Flash will be erased from 0x00000000 to 0x00095fff...
Flash params set to 0x0240
Compressed 613184 bytes to 340547...
Wrote 613184 bytes (340547 compressed) at 0x00000000 in 30.0 seconds (effective 163.4 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
	1m30,68s real		1m29,31s user		1m50,82s sys
Connected
Initializing LCD SPI 2 port.

                            Initializing GC9A01 LCD.

                                                    SPI port 2 bound to LCD 0.
esp32s3_bringup(): end.
[LVGL] [User]	(0.610, +610)	 check_stack_size: tid: 3, Stack size : 16312 lv_nuttx_entry.c:297
[LVGL] [User]	(0.610, +0)	 lv_nuttx_lcd_create: lcd /dev/lcd0 opening lv_nuttx_lcd.c:77
[LVGL] [User]	(0.620, +10)	 lv_nuttx_lcd_create: lcd /dev/lcd0 open success lv_nuttx_lcd.c:84
[LVGL] [Warn]	(0.630, +10)	 lv_demo_widgets: LV_FONT_MONTSERRAT_18 is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead. lv_demo_widgets.c:156
[LVGL] [Warn]	(0.640, +10)	 lv_demo_widgets: LV_FONT_MONTSERRAT_12 is not enabled for the widgets demo. Using LV_FONT_DEFAULT instead. lv_demo_widgets.c:161
```