### PR TITLE
netutils/ntpclient: fix a warning if CONFIG_NETUTILS_DHCPC not defined

### DIFF
--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -227,6 +227,7 @@ unsigned int g_last_nsamples = 0;
  ****************************************************************************/
 
 static int ntpc_daemon(int argc, FAR char **argv);
+#ifdef CONFIG_NETUTILS_DHCPC
 static int ntpc_set_servers_from_dhcp(FAR const char *ntp_server_list);
 
 static FAR char *ntpc_dup_server_list(FAR const char *ntp_server_list)
@@ -238,6 +239,7 @@ static FAR char *ntpc_dup_server_list(FAR const char *ntp_server_list)
 
   return strdup(ntp_server_list);
 }
+#endif
 
 static FAR const char *ntpc_select_server_list(FAR uint8_t *source)
 {
@@ -1687,6 +1689,7 @@ int ntpc_start(void)
   return ret;
 }
 
+#ifdef CONFIG_NETUTILS_DHCPC
 static int ntpc_set_servers_from_dhcp(FAR const char *ntp_server_list)
 {
   FAR char *new_servers;
@@ -1749,6 +1752,7 @@ static int ntpc_set_servers_from_dhcp(FAR const char *ntp_server_list)
 
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: ntpc_stop


### PR DESCRIPTION
  ## Summary

  This change fixes a warning in `netutils/ntpclient/ntpclient.c` when
  `CONFIG_NETUTILS_DHCPC` is not enabled.

  `ntpc_set_servers_from_dhcp()` is only used from the DHCP notification
  path, but it and its local helper `ntpc_dup_server_list()` were compiled
  unconditionally. In non-DHCP builds this can leave unused static helpers
  and trigger compiler warnings.

  This patch wraps the DHCP-only declaration and helper definitions with
  `#ifdef CONFIG_NETUTILS_DHCPC` and keeps the shared startup logic
  unchanged. `ntpc_select_server_list()` remains unconditional because it
  is still used by the normal `ntpc_start()` path.

  ## Impact

  This change is limited to `netutils/ntpclient`.

  It does not change runtime behavior when `CONFIG_NETUTILS_DHCPC` is
  enabled. For builds without `CONFIG_NETUTILS_DHCPC`, it removes
  unnecessary DHCP-only code from compilation and avoids warning noise.

  There is no API change and no documentation update is needed for this
  internal warning fix.

  ## Testing

  Build-tested change only.

  Host:
  - Ubuntu Linux
  - Compiler: GCC

  Target / config:
  - a configuration with `CONFIG_NETUTILS_DHCPC=y`
  - a configuration with `CONFIG_NETUTILS_DHCPC` not set

  Verification:
  - confirmed the DHCP-enabled build still compiles with the DHCP callback path
  - confirmed the non-DHCP build no longer compiles the DHCP-only helpers

  Runtime testing on hardware was not performed for this warning fix.

