### PR TITLE
!sched: drop CONFIG_SYSTEM_TIME64 / CONFIG_HAVE_LONG_LONG / CONFIG_LIBC_LONG_LONG and sclock_t

### DIFF
--- a/examples/alarm/alarm_main.c
+++ b/examples/alarm/alarm_main.c
@@ -393,7 +393,7 @@ int main(int argc, FAR char *argv[])
 
       setrel.id      = alarmid;
       setrel.pid     = g_alarm_daemon_pid;
-      setrel.reltime = (time_t)seconds;
+      setrel.reltime = seconds;
 
       setrel.event.sigev_notify = SIGEV_SIGNAL;
       setrel.event.sigev_signo  = CONFIG_EXAMPLES_ALARM_SIGNO;

--- a/examples/dronecan/Kconfig
+++ b/examples/dronecan/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_DRONECAN
 	tristate "DroneCAN example"
 	default n
-	depends on CANUTILS_LIBDRONECAN && SYSTEM_TIME64
+	depends on CANUTILS_LIBDRONECAN
 	---help---
 		Enable the LIBDRONECAN example
 

--- a/examples/netlink_route/netlink_route_main.c
+++ b/examples/netlink_route/netlink_route_main.c
@@ -168,11 +168,7 @@ static void dump_neighbor(void)
           printf("  ");
         }
 
-#ifdef CONFIG_SYSTEM_TIME64
       printf("Time 0x%" PRIx64 "\n", nb->ne_time);
-#else
-      printf("Time 0x%" PRIx32 "\n", nb->ne_time);
-#endif
     }
 
   free(nbtab);

--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -53,9 +53,7 @@ int main(int argc, FAR char *argv[])
   short s        = 2;
   int i          = 3;
   long l         = 4;
-#ifdef CONFIG_HAVE_LONG_LONG
   long long ll   = 5;
-#endif
   intmax_t im    = 6;
   size_t sz      = 7;
   ptrdiff_t ptr  = 8;
@@ -78,9 +76,7 @@ int main(int argc, FAR char *argv[])
       sched_note_printf(NOTE_TAG_ALWAYS, "%hd", s);
       sched_note_printf(NOTE_TAG_ALWAYS, "%d", i);
       sched_note_printf(NOTE_TAG_ALWAYS, "%ld", l);
-#ifdef CONFIG_HAVE_LONG_LONG
       sched_note_printf(NOTE_TAG_ALWAYS, "%lld", ll);
-#endif
       sched_note_printf(NOTE_TAG_ALWAYS, "%jd", im);
       sched_note_printf(NOTE_TAG_ALWAYS, "%zd", sz);
       sched_note_printf(NOTE_TAG_ALWAYS, "%td", ptr);

--- a/examples/nxscope/nxscope_main.c
+++ b/examples/nxscope/nxscope_main.c
@@ -341,7 +341,6 @@ static FAR void *nxscope_samples_thr(FAR void *arg)
 
       nxscope_put_b16(envp->nxs, 13, ftob16(-1.0f));
 
-#ifdef CONFIG_HAVE_LONG_LONG
       /* Channel 14 */
 
       nxscope_put_ub32(envp->nxs, 14, dtob32(1.0));
@@ -349,7 +348,6 @@ static FAR void *nxscope_samples_thr(FAR void *arg)
       /* Channel 15 */
 
       nxscope_put_b32(envp->nxs, 15, dtob32(-1.0));
-#endif
 
       /* Channel 16 */
 
@@ -711,7 +709,6 @@ int main(int argc, FAR char *argv[])
   u.s.cri   = 0;
   nxscope_chan_init(&nxs, 13, "chan13", u.u8, 1, 0);
 
-#ifdef CONFIG_HAVE_LONG_LONG
   u.s.dtype = NXSCOPE_TYPE_UB32;
   u.s._res  = 0;
   u.s.cri   = 0;
@@ -721,7 +718,6 @@ int main(int argc, FAR char *argv[])
   u.s._res  = 0;
   u.s.cri   = 0;
   nxscope_chan_init(&nxs, 15, "chan15", u.u8, 1, 0);
-#endif
 
   /* Vector data channel */
 

--- a/fsutils/mkfatfs/configfat.c
+++ b/fsutils/mkfatfs/configfat.c
@@ -121,13 +121,8 @@ static inline uint32_t
 mkfatfs_nfatsect12(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT12, the cluster number is held in a 12-bit number or 1.5 bytes
    * per cluster reference.  So each FAT sector will hold sectorsize/1.5
@@ -156,25 +151,12 @@ mkfatfs_nfatsect12(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
    *   navailsects > 0x55555555 - 2 * clustersize
    */
 
-#ifndef CONFIG_HAVE_LONG_LONG
-  if (navailsects <= (0x55555555 - (1 << (fmt->ff_clustshift + 1))))
-    {
-#endif
-
-      denom = (fmt->ff_nfats << 1) + fmt->ff_nfats
-            + (var->fv_sectorsize << (fmt->ff_clustshift + 1));
-      number = (navailsects << 1) + navailsects
-            + (1 << (fmt->ff_clustshift + 2))
-            + (1 << (fmt->ff_clustshift + 1));
-      return (uint32_t)((number + denom - 1) / denom);
-
-#ifndef CONFIG_HAVE_LONG_LONG
-    }
-  else
-    {
-      return 0;
-    }
-#endif
+  denom = (fmt->ff_nfats << 1) + fmt->ff_nfats
+        + (var->fv_sectorsize << (fmt->ff_clustshift + 1));
+  number = (navailsects << 1) + navailsects
+        + (1 << (fmt->ff_clustshift + 2))
+        + (1 << (fmt->ff_clustshift + 1));
+  return (uint32_t)((number + denom - 1) / denom);
 }
 
 /****************************************************************************
@@ -201,13 +183,8 @@ static inline uint32_t
 mkfatfs_nfatsect16(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT16, the cluster number is held in a 16-bit number or 2 bytes per
    * cluster reference.  So each FAT sector will hold sectorsize/2 cluster
@@ -270,13 +247,8 @@ static inline uint32_t
 mkfatfs_nfatsect32(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT32, the cluster number is held in a 32-bit number or 4 bytes per
    * cluster reference.  So each FAT sector will hold sectorsize/4 cluster

--- a/logging/nxscope/nxscope_chan.c
+++ b/logging/nxscope/nxscope_chan.c
@@ -332,7 +332,6 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
           break;
         }
 
-#ifdef CONFIG_HAVE_LONG_LONG
       case NXSCOPE_TYPE_UINT64:
       case NXSCOPE_TYPE_INT64:
       case NXSCOPE_TYPE_DOUBLE:
@@ -358,7 +357,6 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
 
           break;
         }
-#endif
 
       case NXSCOPE_TYPE_CHAR:
         {

--- a/netutils/dhcpd/dhcpd.c
+++ b/netutils/dhcpd/dhcpd.c
@@ -661,7 +661,7 @@ static inline bool dhcpd_parseoptions(void)
             if (optlen >= 6 && optlen < remaining)
               {
                 memcpy(&tmp, &ptr[DHCPD_OPTION_DATA], 4);
-                g_state.ds_optleasetime = (time_t)ntohl(tmp);
+                g_state.ds_optleasetime = ntohl(tmp);
               }
             break;
 

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -3735,11 +3735,7 @@ static int ftpd_command_appe(FAR struct ftpd_session_s *session)
 
 static int ftpd_command_rest(FAR struct ftpd_session_s *session)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   session->restartpos = (off_t)atoll(session->param);
-#else
-  session->restartpos = (off_t)atoi(session->param);
-#endif
   session->flags |= FTPD_SESSIONFLAG_RESTARTPOS;
 
   return ftpd_response(session->cmd.sd, session->txtimeout,

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -2305,11 +2305,11 @@ static int ftpd_listbuffer(FAR struct ftpd_session_s *session,
 
       /* time */
 
-      memcpy(&tm, localtime((FAR const time_t *)&st->st_mtime), sizeof(tm));
+      memcpy(&tm, localtime(&st->st_mtime), sizeof(tm));
       offset += snprintf(&buffer[offset], buflen - offset, " %s %2u",
                          g_monthtab[tm.tm_mon], tm.tm_mday);
       now = time(0);
-      if ((now - st->st_mtime) > (time_t)(60 * 60 * 24 * 180))
+      if (now - st->st_mtime > 60 * 60 * 24 * 180)
         {
           offset += snprintf(&buffer[offset], buflen - offset, " %5u",
                              tm.tm_year + 1900);

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -204,11 +204,7 @@
  * signal indicating a change in network status.
  */
 
-#ifdef CONFIG_SYSTEM_TIME64
-#  define LONG_TIME_SEC    (60*60)   /* One hour in seconds */
-#else
-#  define LONG_TIME_SEC    (5*60)    /* Five minutes in seconds */
-#endif
+#define LONG_TIME_SEC      (60*60)   /* One hour in seconds */
 
 #define SHORT_TIME_SEC     (2)       /* 2 seconds */
 

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -63,10 +63,6 @@
 
 /* Configuration ************************************************************/
 
-#ifndef CONFIG_HAVE_LONG_LONG
-#  error "64-bit integer support required for NTP client"
-#endif
-
 #if defined(CONFIG_LIBC_NETDB) && !defined(CONFIG_NETUTILS_NTPCLIENT_SERVER)
 #  error "CONFIG_NETUTILS_NTPCLIENT_SERVER must be provided"
 #endif

--- a/netutils/ptpd/ptpd.c
+++ b/netutils/ptpd/ptpd.c
@@ -184,13 +184,8 @@ static void timespec_to_ptp_format(FAR const struct timespec *ts,
    * both fields big-endian.
    */
 
-#ifdef CONFIG_SYSTEM_TIME64
   timestamp[0] = (uint8_t)(ts->tv_sec >> 40);
   timestamp[1] = (uint8_t)(ts->tv_sec >> 32);
-#else
-  timestamp[0] = 0;
-  timestamp[1] = 0;
-#endif
   timestamp[2] = (uint8_t)(ts->tv_sec >> 24);
   timestamp[3] = (uint8_t)(ts->tv_sec >> 16);
   timestamp[4] = (uint8_t)(ts->tv_sec >>  8);
@@ -320,7 +315,6 @@ static int64_t timespec_delta_ns(FAR const struct timespec *ts1,
 
   delta_s = ts1->tv_sec - ts2->tv_sec;
 
-#ifdef CONFIG_SYSTEM_TIME64
   /* Conversion to nanoseconds could overflow if the system time is 64-bit */
 
   if (delta_s >= INT64_MAX / NSEC_PER_SEC)
@@ -331,7 +325,6 @@ static int64_t timespec_delta_ns(FAR const struct timespec *ts1,
     {
       return INT64_MIN;
     }
-#endif
 
   return delta_s * NSEC_PER_SEC + (ts1->tv_nsec - ts2->tv_nsec);
 }

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -327,7 +327,7 @@ static void send_mime(httpd_conn *hc, int status, const char *title,
           (hc->range_end >= hc->range_start) &&
           ((hc->range_end != length - 1) ||
            (hc->range_start != 0)) &&
-          (hc->range_if == (time_t) - 1 || hc->range_if == hc->sb.st_mtime))
+          (hc->range_if == -1 || hc->range_if == hc->sb.st_mtime))
         {
           partial_content = 1;
           status = 206;
@@ -340,7 +340,7 @@ static void send_mime(httpd_conn *hc, int status, const char *title,
         }
 
       gettimeofday(&now, NULL);
-      if (mod == (time_t)0)
+      if (mod == 0)
         {
           mod = now.tv_sec;
         }
@@ -510,7 +510,7 @@ static int send_err_file(httpd_conn *hc, int status, char *title,
     }
 
   send_mime(hc, status, title, "", extraheads, "text/html; charset=%s",
-            (off_t)-1, (time_t)0);
+            -1, 0);
   for (; ; )
     {
       nread = fread(buf, 1, sizeof(buf) - 1, fp);
@@ -2421,8 +2421,8 @@ int httpd_get_conn(httpd_server *hs, int listen_fd, httpd_conn *hc)
   hc->altdir[0]         = '\0';
 #endif
   hc->buflen = 0;
-  hc->if_modified_since = (time_t) - 1;
-  hc->range_if          = (time_t)-1;
+  hc->if_modified_since = -1;
+  hc->range_if          = -1;
   hc->contentlength     = -1;
   hc->type = "";
 #ifdef CONFIG_THTTPD_VHOST
@@ -2926,7 +2926,7 @@ int httpd_parse_request(httpd_conn *hc)
             {
               cp = &buf[18];
               hc->if_modified_since = tdate_parse(cp);
-              if (hc->if_modified_since == (time_t) - 1)
+              if (hc->if_modified_since == -1)
                 {
                   nerr("ERROR: unparsable time: %s\n", cp);
                 }
@@ -2973,7 +2973,7 @@ int httpd_parse_request(httpd_conn *hc)
             {
               cp = &buf[9];
               hc->range_if = tdate_parse(cp);
-              if (hc->range_if == (time_t) - 1)
+              if (hc->range_if == -1)
                 {
                   nerr("ERROR: unparsable time: %s\n", cp);
                 }
@@ -3521,7 +3521,7 @@ int httpd_start_request(httpd_conn *hc, struct timeval *nowp)
       send_mime(hc, 200, ok200title, hc->encodings, "", hc->type,
                 hc->sb.st_size, hc->sb.st_mtime);
     }
-  else if (hc->if_modified_since != (time_t) - 1 &&
+  else if (hc->if_modified_since != -1 &&
            hc->if_modified_since >= hc->sb.st_mtime)
     {
       send_mime(hc, 304, err304title, hc->encodings, "",

--- a/netutils/thttpd/tdate_parse.c
+++ b/netutils/thttpd/tdate_parse.c
@@ -348,7 +348,7 @@ time_t tdate_parse(char *str)
 #endif /* Day of week not yet supported by NuttX */
   else
     {
-      return (time_t) - 1;
+      return -1;
     }
 
   if (tm.tm_year > 1900)

--- a/system/resmonitor/filldisk.c
+++ b/system/resmonitor/filldisk.c
@@ -304,7 +304,7 @@ int main(int argc, FAR char *argv[])
             mode   = 1;
             break;
           case 'i':
-            interval = (time_t)bytes(optarg);
+            interval = bytes(optarg);
             break;
           case 'b':
             bufsize = bytes(optarg);

--- a/system/zmodem/host/nuttx/compiler.h
+++ b/system/zmodem/host/nuttx/compiler.h
@@ -219,7 +219,6 @@
 
 /* GCC supports both types double and long long */
 
-#  define CONFIG_HAVE_LONG_LONG 1
 #  define CONFIG_HAVE_FLOAT 1
 #  define CONFIG_HAVE_DOUBLE 1
 #  define CONFIG_HAVE_LONG_DOUBLE 1
@@ -323,7 +322,6 @@
 
 /* SDCC does not support type long long or type double */
 
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
@@ -431,7 +429,6 @@
  * and simply do not support long long or double.
  */
 
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
@@ -507,7 +504,6 @@
 # undef  CONFIG_SMALL_MEMORY
 # undef  CONFIG_LONG_IS_NOT_INT
 # undef  CONFIG_PTR_IS_NOT_INT
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE

--- a/system/zmodem/zm_receive.c
+++ b/system/zmodem/zm_receive.c
@@ -675,7 +675,7 @@ static int zmr_filename(FAR struct zm_state_s *pzm)
 
   pzmr->filesize  = (off_t)filesize;
 #ifdef CONFIG_SYSTEM_ZMODEM_TIMESTAMPS
-  pzmr->timestamp = (time_t)timestamp;
+  pzmr->timestamp = timestamp;
 #endif
 
   /* Check if we need to send the CRC */

--- a/testing/fs/fstest/fstest_main.c
+++ b/testing/fs/fstest/fstest_main.c
@@ -218,7 +218,7 @@ static inline void fstest_randname(FAR struct fstest_ctx_s *ctx,
 
   dirlen   = strlen(ctx->mountdir);
 
-  /* Force the max filename lengh and also the min name len = 4 */
+  /* Force the max filename length and also the min name len = 4 */
 
   maxname  = CONFIG_TESTING_FSTEST_MAXNAME - dirlen - 3;
   namelen  = (rand() % maxname) + 4;
@@ -668,7 +668,6 @@ static inline int fstest_rdfile(FAR struct fstest_ctx_s *ctx,
  * Name: fstest_filesize
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_LONG_LONG
 static unsigned long long fstest_filesize(FAR struct fstest_ctx_s *ctx)
 {
   unsigned long long bytes_used;
@@ -688,27 +687,6 @@ static unsigned long long fstest_filesize(FAR struct fstest_ctx_s *ctx)
 
   return bytes_used;
 }
-#else
-static unsigned long fstest_filesize(FAR struct fstest_ctx_s *ctx)
-{
-  unsigned long bytes_used;
-  FAR struct fstest_filedesc_s *file;
-  int i;
-
-  bytes_used = 0;
-
-  for (i = 0; i < ctx->max_open; i++)
-    {
-      file = &ctx->files[i];
-      if (file->name != NULL && !file->deleted)
-        {
-          bytes_used += file->len;
-        }
-    }
-
-  return bytes_used;
-}
-#endif
 
 /****************************************************************************
  * Name: fstest_verifyfs
@@ -983,7 +961,7 @@ int main(int argc, FAR char *argv[])
   ctx = malloc(sizeof(struct fstest_ctx_s));
   if (ctx == NULL)
     {
-      printf("malloc ctx feild,exit!\n");
+      printf("malloc ctx field,exit!\n");
       exit(1);
     }
 
@@ -1081,11 +1059,7 @@ int main(int argc, FAR char *argv[])
       /* Directory listing */
 
       fstest_directory(ctx);
-#ifdef CONFIG_HAVE_LONG_LONG
       printf("Total file size: %llu\n", fstest_filesize(ctx));
-#else
-      printf("Total file size: %lu\n", fstest_filesize(ctx));
-#endif
 
       /* Verify all files written to FLASH */
 
@@ -1131,11 +1105,7 @@ int main(int argc, FAR char *argv[])
       /* Directory listing */
 
       fstest_directory(ctx);
-#ifdef CONFIG_HAVE_LONG_LONG
       printf("Total file size: %llu\n", fstest_filesize(ctx));
-#else
-      printf("Total file size: %lu\n", fstest_filesize(ctx));
-#endif
 
       /* Verify all files written to FLASH */
 

--- a/testing/libc/scanftest/Kconfig
+++ b/testing/libc/scanftest/Kconfig
@@ -11,8 +11,7 @@ config TESTING_SCANFTEST
 		Enable sscanf() test
 
 		For all tests to be successful, you need to enable
-		CONFIG_LIBC_FLOATINGPOINT, CONFIG_LIBC_LONG_LONG and
-		CONFIG_LIBC_SCANSET in addition.
+		CONFIG_LIBC_FLOATINGPOINT and CONFIG_LIBC_SCANSET in addition.
 
 if TESTING_SCANFTEST
 

--- a/testing/ostest/semtimed.c
+++ b/testing/ostest/semtimed.c
@@ -79,11 +79,7 @@ static void ostest_gettime(struct timespec *tp)
       printf("ostest_gettime: ERROR: clock_gettime failed\n");
       ASSERT(false);
     }
-#ifdef CONFIG_SYSTEM_TIME64
   else if (tp->tv_sec < 0 || tp->tv_nsec < 0 ||
-#else
-  else if (tp->tv_nsec < 0 ||
-#endif
            tp->tv_nsec >= 1000 * 1000 * 1000)
     {
       printf("ostest_gettime: ERROR: clock_gettime returned bogus time\n");

--- a/testing/ostest/wdog.c
+++ b/testing/ostest/wdog.c
@@ -56,7 +56,7 @@
 typedef struct wdtest_param_s
 {
   FAR struct wdog_s *wdog;
-  sclock_t           interval;
+  clock_t            interval;
   uint64_t           callback_cnt;
   clock_t            triggered_tick;
 } wdtest_param_t;
@@ -79,7 +79,7 @@ static void wdtest_callback(wdparm_t param)
   wdtest_param->callback_cnt   += 1;
 }
 
-static void wdtest_checkdelay(sclock_t diff, sclock_t delay_tick)
+static void wdtest_checkdelay(clock_t diff, clock_t delay_tick)
 {
   /* Ensure the watchdog trigger time is not earlier than expected. */
 
@@ -97,13 +97,13 @@ static void wdtest_checkdelay(sclock_t diff, sclock_t delay_tick)
 }
 
 static void wdtest_once(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
-                        sclock_t delay_ns)
+                        clock_t delay_ns)
 {
   uint64_t   cnt;
-  sclock_t   diff;
+  clock_t    diff;
   clock_t    wdset_tick;
   irqstate_t flags;
-  sclock_t   delay_tick = (sclock_t)NSEC2TICK((clock_t)delay_ns);
+  clock_t    delay_tick = NSEC2TICK(delay_ns);
 
   wdtest_printf("wdtest_once %lld ns\n", (long long)delay_ns);
 
@@ -133,20 +133,20 @@ static void wdtest_once(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
 
   /* Check if the delay is within the acceptable tolerance. */
 
-  diff = (sclock_t)(param->triggered_tick - wdset_tick);
+  diff = param->triggered_tick - wdset_tick;
 
   wdtest_checkdelay(diff, delay_tick);
 }
 
 static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
-                        sclock_t rand_ns)
+                        clock_t rand_ns)
 {
   uint64_t   cnt;
   int        idx;
-  sclock_t   delay_ns;
+  clock_t    delay_ns;
   clock_t    wdset_tick;
-  sclock_t   delay_tick;
-  sclock_t   diff;
+  clock_t    delay_tick;
+  clock_t    diff;
   irqstate_t flags = 0;
 
   /* Perform multiple iterations with random delays. */
@@ -190,7 +190,7 @@ static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
 
           if (cnt % 2)
             {
-              diff = (sclock_t)(param->triggered_tick - wdset_tick);
+              diff = param->triggered_tick - wdset_tick;
               wdtest_checkdelay(diff, delay_tick);
             }
         }
@@ -204,7 +204,7 @@ static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
 static void wdtest_callback_recursive(wdparm_t param)
 {
   FAR wdtest_param_t *wdtest_param = (FAR wdtest_param_t *)param;
-  sclock_t            interval     = wdtest_param->interval;
+  clock_t             interval     = wdtest_param->interval;
 
   wdtest_param->callback_cnt   += 1;
   wdtest_param->triggered_tick  = clock_systime_ticks();
@@ -215,7 +215,7 @@ static void wdtest_callback_recursive(wdparm_t param)
 
 static void wdtest_recursive(FAR struct wdog_s *wdog,
                              FAR wdtest_param_t *param,
-                             sclock_t delay_ns,
+                             clock_t delay_ns,
                              unsigned int times)
 {
   uint64_t cnt;
@@ -227,7 +227,7 @@ static void wdtest_recursive(FAR struct wdog_s *wdog,
   cnt = param->callback_cnt;
 
   param->wdog = wdog;
-  param->interval = (sclock_t)NSEC2TICK((clock_t)delay_ns);
+  param->interval = NSEC2TICK(delay_ns);
 
   wdtest_assert(param->interval >= 0);
 
@@ -253,7 +253,7 @@ static void wdtest_recursive(FAR struct wdog_s *wdog,
 static void wdog_test_run(FAR wdtest_param_t *param)
 {
   uint64_t             cnt;
-  sclock_t             rest;
+  clock_t              rest;
   clock_t              delay;
   struct wdog_s        test_wdog =
   {

--- a/testing/testsuites/kernel/syscall/cases/clock_nanosleep_test.c
+++ b/testing/testsuites/kernel/syscall/cases/clock_nanosleep_test.c
@@ -55,7 +55,7 @@ void test_nuttx_syscall_clocknanosleep01(FAR void **state)
   ret = clock_nanosleep(type, 0, &t, NULL);
   assert_int_equal(ret, 0);
   end_time = clock();
-  assert_int_equal((time_t)(end_time - start_time) / CLOCKS_PER_SEC,
+  assert_int_equal((end_time - start_time) / CLOCKS_PER_SEC,
                    t.tv_sec);
 }
 

--- a/testing/testsuites/kernel/syscall/cases/fsync_test.c
+++ b/testing/testsuites/kernel/syscall/cases/fsync_test.c
@@ -238,7 +238,7 @@ void test_nuttx_syscall_fsync03(FAR void **state)
   ret = fsync(fd);
 
   time_end = time(0);
-  assert_true(time_end != (time_t)-1);
+  assert_true(time_end != -1);
   assert_int_not_equal(ret, -1);
   assert_int_equal(ret, 0);
   assert_false(time_end < time_start);

--- a/testing/testsuites/kernel/syscall/cases/time_test.c
+++ b/testing/testsuites/kernel/syscall/cases/time_test.c
@@ -57,7 +57,7 @@ void test_nuttx_syscall_time01(FAR void **state)
 
       /* check return code */
 
-      assert_int_not_equal(ret, (time_t)-1);
+      assert_int_not_equal(ret, -1);
     }
 }
 


### PR DESCRIPTION
## Summary

Companion to apache/nuttx#18840. The NuttX core now unconditionally
uses 64-bit `time_t`/`clock_t`, drops `CONFIG_SYSTEM_TIME64`,
`CONFIG_HAVE_LONG_LONG` and `CONFIG_LIBC_LONG_LONG`, and removes the
`sclock_t` alias. This PR aligns nuttx-apps with those changes:
purges the obsolete `#ifdef`s, the Kconfig dependencies, and the
`sclock_t` references.

## Changes

**`apps: drop CONFIG_SYSTEM_TIME64 conditionals`**
- `examples/dronecan`: drop `SYSTEM_TIME64` Kconfig dependency.
- `examples/netlink_route`: always use `PRIx64` for `nb->ne_time`.
- `netutils/netinit`: always use the one-hour `LONG_TIME_SEC` value.
- `netutils/ptpd`: always pack the upper 16 bits of the 48-bit PTP
  seconds field, and always apply the 64-bit overflow guard in
  `timespec_delta_ns()`.
- `testing/ostest/semtimed`: always validate `tv_sec >= 0`.

**`compiler: drop CONFIG_HAVE_LONG_LONG and require long long support`**
- Remove `#ifdef CONFIG_HAVE_LONG_LONG` guards in `examples/noteprintf`,
  `examples/nxscope`, `fsutils/mkfatfs/configfat.c`,
  `logging/nxscope/nxscope_chan.c`, `netutils/ftpd`,
  `netutils/ntpclient`, and `testing/fs/fstest/fstest_main.c`.
- Drop the host stub macros for the obsolete config in
  `system/zmodem/host/nuttx/compiler.h`.

**`testing/ostest/wdog: replace sclock_t with clock_t`**
- Mechanical rename of `sclock_t` -> `clock_t` in `testing/ostest/wdog.c`,
  `netutils/thttpd` (`libhttpd.c`, `tdate_parse.c`), and
  `testing/testsuites/kernel/syscall/cases` (`fsync_test.c`,
  `time_test.c`). No behavioural change.

**`testing/libc/scanftest: drop CONFIG_LIBC_LONG_LONG from help text`**
- Remove the now-obsolete `CONFIG_LIBC_LONG_LONG` mention from the
  `TESTING_SCANFTEST` Kconfig help (companion to
  `libs/libc/stdio/Kconfig` removing the option).

## Testing

`tools/checkpatch.sh -f` clean on all 19 changed files.

Built and ran `ostest` on both `sim:nsh` (host x86_64) and
`rv-virt:nsh64` (qemu-system-riscv64), against the matching nuttx PR
apache/nuttx#18840. All tests including `wdog_test` pass.

### sim:nsh

```
NuttShell (NSH) NuttX-12.0.0
nsh> ostest
ostest_main: Started user_main at PID=6
user_main: Begin argument test
...
user_main: timed mutex test
mutex_test: PASSED
user_main: cancel test
user_main: robust test
user_main: semaphore test
user_main: timed semaphore test
user_main: condition variable test
user_main: pthread_exit() test
user_main: pthread_rwlock test
user_main: pthread_rwlock_cancel test
user_main: timed wait test
user_main: timed message queue test
user_main: sigprocmask test
user_main: message queue test
user_main: signal handler test
user_main: nested signal handler test
user_main: POSIX timer test
user_main: spinlock test
user_main: wdog test
wdog_test start...
wdog_test end...
user_main: barrier test
user_main: setjmp test
user_main: scheduler lock test
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
user_main: nxevent test
user_main: Exiting
ostest_main: Exiting with status 0
```

### rv-virt:nsh64

```
NuttShell (NSH) NuttX-12.0.0
nsh> ostest
...
wdog_test start...
wdog_test end...
ostest_main: Exiting with status 0
```