### PR TITLE
compiler: drop CONFIG_HAVE_LONG_LONG and require long long support

### DIFF
--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -53,9 +53,7 @@ int main(int argc, FAR char *argv[])
   short s        = 2;
   int i          = 3;
   long l         = 4;
-#ifdef CONFIG_HAVE_LONG_LONG
   long long ll   = 5;
-#endif
   intmax_t im    = 6;
   size_t sz      = 7;
   ptrdiff_t ptr  = 8;
@@ -78,9 +76,7 @@ int main(int argc, FAR char *argv[])
       sched_note_printf(NOTE_TAG_ALWAYS, "%hd", s);
       sched_note_printf(NOTE_TAG_ALWAYS, "%d", i);
       sched_note_printf(NOTE_TAG_ALWAYS, "%ld", l);
-#ifdef CONFIG_HAVE_LONG_LONG
       sched_note_printf(NOTE_TAG_ALWAYS, "%lld", ll);
-#endif
       sched_note_printf(NOTE_TAG_ALWAYS, "%jd", im);
       sched_note_printf(NOTE_TAG_ALWAYS, "%zd", sz);
       sched_note_printf(NOTE_TAG_ALWAYS, "%td", ptr);

--- a/examples/nxscope/nxscope_main.c
+++ b/examples/nxscope/nxscope_main.c
@@ -341,7 +341,6 @@ static FAR void *nxscope_samples_thr(FAR void *arg)
 
       nxscope_put_b16(envp->nxs, 13, ftob16(-1.0f));
 
-#ifdef CONFIG_HAVE_LONG_LONG
       /* Channel 14 */
 
       nxscope_put_ub32(envp->nxs, 14, dtob32(1.0));
@@ -349,7 +348,6 @@ static FAR void *nxscope_samples_thr(FAR void *arg)
       /* Channel 15 */
 
       nxscope_put_b32(envp->nxs, 15, dtob32(-1.0));
-#endif
 
       /* Channel 16 */
 
@@ -711,7 +709,6 @@ int main(int argc, FAR char *argv[])
   u.s.cri   = 0;
   nxscope_chan_init(&nxs, 13, "chan13", u.u8, 1, 0);
 
-#ifdef CONFIG_HAVE_LONG_LONG
   u.s.dtype = NXSCOPE_TYPE_UB32;
   u.s._res  = 0;
   u.s.cri   = 0;
@@ -721,7 +718,6 @@ int main(int argc, FAR char *argv[])
   u.s._res  = 0;
   u.s.cri   = 0;
   nxscope_chan_init(&nxs, 15, "chan15", u.u8, 1, 0);
-#endif
 
   /* Vector data channel */
 

--- a/fsutils/mkfatfs/configfat.c
+++ b/fsutils/mkfatfs/configfat.c
@@ -121,13 +121,8 @@ static inline uint32_t
 mkfatfs_nfatsect12(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT12, the cluster number is held in a 12-bit number or 1.5 bytes
    * per cluster reference.  So each FAT sector will hold sectorsize/1.5
@@ -156,25 +151,12 @@ mkfatfs_nfatsect12(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
    *   navailsects > 0x55555555 - 2 * clustersize
    */
 
-#ifndef CONFIG_HAVE_LONG_LONG
-  if (navailsects <= (0x55555555 - (1 << (fmt->ff_clustshift + 1))))
-    {
-#endif
-
       denom = (fmt->ff_nfats << 1) + fmt->ff_nfats
             + (var->fv_sectorsize << (fmt->ff_clustshift + 1));
       number = (navailsects << 1) + navailsects
             + (1 << (fmt->ff_clustshift + 2))
             + (1 << (fmt->ff_clustshift + 1));
       return (uint32_t)((number + denom - 1) / denom);
-
-#ifndef CONFIG_HAVE_LONG_LONG
-    }
-  else
-    {
-      return 0;
-    }
-#endif
 }
 
 /****************************************************************************
@@ -201,13 +183,8 @@ static inline uint32_t
 mkfatfs_nfatsect16(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT16, the cluster number is held in a 16-bit number or 2 bytes per
    * cluster reference.  So each FAT sector will hold sectorsize/2 cluster
@@ -270,13 +247,8 @@ static inline uint32_t
 mkfatfs_nfatsect32(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT32, the cluster number is held in a 32-bit number or 4 bytes per
    * cluster reference.  So each FAT sector will hold sectorsize/4 cluster

--- a/logging/nxscope/nxscope_chan.c
+++ b/logging/nxscope/nxscope_chan.c
@@ -332,7 +332,6 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
           break;
         }
 
-#ifdef CONFIG_HAVE_LONG_LONG
       case NXSCOPE_TYPE_UINT64:
       case NXSCOPE_TYPE_INT64:
       case NXSCOPE_TYPE_DOUBLE:
@@ -358,7 +357,6 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
 
           break;
         }
-#endif
 
       case NXSCOPE_TYPE_CHAR:
         {

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -3735,11 +3735,7 @@ static int ftpd_command_appe(FAR struct ftpd_session_s *session)
 
 static int ftpd_command_rest(FAR struct ftpd_session_s *session)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   session->restartpos = (off_t)atoll(session->param);
-#else
-  session->restartpos = (off_t)atoi(session->param);
-#endif
   session->flags |= FTPD_SESSIONFLAG_RESTARTPOS;
 
   return ftpd_response(session->cmd.sd, session->txtimeout,

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -63,10 +63,6 @@
 
 /* Configuration ************************************************************/
 
-#ifndef CONFIG_HAVE_LONG_LONG
-#  error "64-bit integer support required for NTP client"
-#endif
-
 #if defined(CONFIG_LIBC_NETDB) && !defined(CONFIG_NETUTILS_NTPCLIENT_SERVER)
 #  error "CONFIG_NETUTILS_NTPCLIENT_SERVER must be provided"
 #endif

--- a/system/zmodem/host/nuttx/compiler.h
+++ b/system/zmodem/host/nuttx/compiler.h
@@ -219,7 +219,6 @@
 
 /* GCC supports both types double and long long */
 
-#  define CONFIG_HAVE_LONG_LONG 1
 #  define CONFIG_HAVE_FLOAT 1
 #  define CONFIG_HAVE_DOUBLE 1
 #  define CONFIG_HAVE_LONG_DOUBLE 1
@@ -323,7 +322,6 @@
 
 /* SDCC does not support type long long or type double */
 
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
@@ -431,7 +429,6 @@
  * and simply do not support long long or double.
  */
 
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
@@ -507,7 +504,6 @@
 # undef  CONFIG_SMALL_MEMORY
 # undef  CONFIG_LONG_IS_NOT_INT
 # undef  CONFIG_PTR_IS_NOT_INT
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE

--- a/testing/fs/fstest/fstest_main.c
+++ b/testing/fs/fstest/fstest_main.c
@@ -668,7 +668,6 @@ static inline int fstest_rdfile(FAR struct fstest_ctx_s *ctx,
  * Name: fstest_filesize
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_LONG_LONG
 static unsigned long long fstest_filesize(FAR struct fstest_ctx_s *ctx)
 {
   unsigned long long bytes_used;
@@ -688,27 +687,6 @@ static unsigned long long fstest_filesize(FAR struct fstest_ctx_s *ctx)
 
   return bytes_used;
 }
-#else
-static unsigned long fstest_filesize(FAR struct fstest_ctx_s *ctx)
-{
-  unsigned long bytes_used;
-  FAR struct fstest_filedesc_s *file;
-  int i;
-
-  bytes_used = 0;
-
-  for (i = 0; i < ctx->max_open; i++)
-    {
-      file = &ctx->files[i];
-      if (file->name != NULL && !file->deleted)
-        {
-          bytes_used += file->len;
-        }
-    }
-
-  return bytes_used;
-}
-#endif
 
 /****************************************************************************
  * Name: fstest_verifyfs
@@ -1081,11 +1059,7 @@ int main(int argc, FAR char *argv[])
       /* Directory listing */
 
       fstest_directory(ctx);
-#ifdef CONFIG_HAVE_LONG_LONG
       printf("Total file size: %llu\n", fstest_filesize(ctx));
-#else
-      printf("Total file size: %lu\n", fstest_filesize(ctx));
-#endif
 
       /* Verify all files written to FLASH */
 
@@ -1131,11 +1105,7 @@ int main(int argc, FAR char *argv[])
       /* Directory listing */
 
       fstest_directory(ctx);
-#ifdef CONFIG_HAVE_LONG_LONG
       printf("Total file size: %llu\n", fstest_filesize(ctx));
-#else
-      printf("Total file size: %lu\n", fstest_filesize(ctx));
-#endif
 
       /* Verify all files written to FLASH */
 


### PR DESCRIPTION
## Summary

Companion to apache/nuttx PR removing `CONFIG_HAVE_LONG_LONG`.  All
toolchains supported by NuttX provide `long long`, so the conditional
guards are unnecessary noise.  Drop the `#ifdef`/`#ifndef` ladders in
the apps that still referenced the macro and remove the host stub
defines under `system/zmodem/host/nuttx/compiler.h`.

## Testing

- `tools/checkpatch.sh -f` clean on all changed files.

## Companion PR

Requires the matching apache/nuttx PR to land first/together.
