### PR TITLE
testing/ostest/wdog: replace sclock_t with clock_t

### DIFF
--- a/examples/dronecan/Kconfig
+++ b/examples/dronecan/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_DRONECAN
 	tristate "DroneCAN example"
 	default n
-	depends on CANUTILS_LIBDRONECAN && SYSTEM_TIME64
+	depends on CANUTILS_LIBDRONECAN
 	---help---
 		Enable the LIBDRONECAN example
 

--- a/examples/netlink_route/netlink_route_main.c
+++ b/examples/netlink_route/netlink_route_main.c
@@ -168,11 +168,7 @@ static void dump_neighbor(void)
           printf("  ");
         }
 
-#ifdef CONFIG_SYSTEM_TIME64
       printf("Time 0x%" PRIx64 "\n", nb->ne_time);
-#else
-      printf("Time 0x%" PRIx32 "\n", nb->ne_time);
-#endif
     }
 
   free(nbtab);

--- a/examples/noteprintf/noteprintf_main.c
+++ b/examples/noteprintf/noteprintf_main.c
@@ -53,9 +53,7 @@ int main(int argc, FAR char *argv[])
   short s        = 2;
   int i          = 3;
   long l         = 4;
-#ifdef CONFIG_HAVE_LONG_LONG
   long long ll   = 5;
-#endif
   intmax_t im    = 6;
   size_t sz      = 7;
   ptrdiff_t ptr  = 8;
@@ -78,9 +76,7 @@ int main(int argc, FAR char *argv[])
       sched_note_printf(NOTE_TAG_ALWAYS, "%hd", s);
       sched_note_printf(NOTE_TAG_ALWAYS, "%d", i);
       sched_note_printf(NOTE_TAG_ALWAYS, "%ld", l);
-#ifdef CONFIG_HAVE_LONG_LONG
       sched_note_printf(NOTE_TAG_ALWAYS, "%lld", ll);
-#endif
       sched_note_printf(NOTE_TAG_ALWAYS, "%jd", im);
       sched_note_printf(NOTE_TAG_ALWAYS, "%zd", sz);
       sched_note_printf(NOTE_TAG_ALWAYS, "%td", ptr);

--- a/examples/nxscope/nxscope_main.c
+++ b/examples/nxscope/nxscope_main.c
@@ -341,7 +341,6 @@ static FAR void *nxscope_samples_thr(FAR void *arg)
 
       nxscope_put_b16(envp->nxs, 13, ftob16(-1.0f));
 
-#ifdef CONFIG_HAVE_LONG_LONG
       /* Channel 14 */
 
       nxscope_put_ub32(envp->nxs, 14, dtob32(1.0));
@@ -349,7 +348,6 @@ static FAR void *nxscope_samples_thr(FAR void *arg)
       /* Channel 15 */
 
       nxscope_put_b32(envp->nxs, 15, dtob32(-1.0));
-#endif
 
       /* Channel 16 */
 
@@ -711,7 +709,6 @@ int main(int argc, FAR char *argv[])
   u.s.cri   = 0;
   nxscope_chan_init(&nxs, 13, "chan13", u.u8, 1, 0);
 
-#ifdef CONFIG_HAVE_LONG_LONG
   u.s.dtype = NXSCOPE_TYPE_UB32;
   u.s._res  = 0;
   u.s.cri   = 0;
@@ -721,7 +718,6 @@ int main(int argc, FAR char *argv[])
   u.s._res  = 0;
   u.s.cri   = 0;
   nxscope_chan_init(&nxs, 15, "chan15", u.u8, 1, 0);
-#endif
 
   /* Vector data channel */
 

--- a/fsutils/mkfatfs/configfat.c
+++ b/fsutils/mkfatfs/configfat.c
@@ -121,13 +121,8 @@ static inline uint32_t
 mkfatfs_nfatsect12(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT12, the cluster number is held in a 12-bit number or 1.5 bytes
    * per cluster reference.  So each FAT sector will hold sectorsize/1.5
@@ -156,25 +151,12 @@ mkfatfs_nfatsect12(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
    *   navailsects > 0x55555555 - 2 * clustersize
    */
 
-#ifndef CONFIG_HAVE_LONG_LONG
-  if (navailsects <= (0x55555555 - (1 << (fmt->ff_clustshift + 1))))
-    {
-#endif
-
       denom = (fmt->ff_nfats << 1) + fmt->ff_nfats
             + (var->fv_sectorsize << (fmt->ff_clustshift + 1));
       number = (navailsects << 1) + navailsects
             + (1 << (fmt->ff_clustshift + 2))
             + (1 << (fmt->ff_clustshift + 1));
       return (uint32_t)((number + denom - 1) / denom);
-
-#ifndef CONFIG_HAVE_LONG_LONG
-    }
-  else
-    {
-      return 0;
-    }
-#endif
 }
 
 /****************************************************************************
@@ -201,13 +183,8 @@ static inline uint32_t
 mkfatfs_nfatsect16(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT16, the cluster number is held in a 16-bit number or 2 bytes per
    * cluster reference.  So each FAT sector will hold sectorsize/2 cluster
@@ -270,13 +247,8 @@ static inline uint32_t
 mkfatfs_nfatsect32(FAR struct fat_format_s *fmt, FAR struct fat_var_s *var,
                    uint32_t navailsects)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   uint64_t denom;
   uint64_t number;
-#else
-  uint32_t denom;
-  uint32_t number;
-#endif
 
   /* For FAT32, the cluster number is held in a 32-bit number or 4 bytes per
    * cluster reference.  So each FAT sector will hold sectorsize/4 cluster

--- a/logging/nxscope/nxscope_chan.c
+++ b/logging/nxscope/nxscope_chan.c
@@ -332,7 +332,6 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
           break;
         }
 
-#ifdef CONFIG_HAVE_LONG_LONG
       case NXSCOPE_TYPE_UINT64:
       case NXSCOPE_TYPE_INT64:
       case NXSCOPE_TYPE_DOUBLE:
@@ -358,7 +357,6 @@ static int nxscope_put_vector(FAR uint8_t *buff, uint8_t type, FAR void *val,
 
           break;
         }
-#endif
 
       case NXSCOPE_TYPE_CHAR:
         {

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -3735,11 +3735,7 @@ static int ftpd_command_appe(FAR struct ftpd_session_s *session)
 
 static int ftpd_command_rest(FAR struct ftpd_session_s *session)
 {
-#ifdef CONFIG_HAVE_LONG_LONG
   session->restartpos = (off_t)atoll(session->param);
-#else
-  session->restartpos = (off_t)atoi(session->param);
-#endif
   session->flags |= FTPD_SESSIONFLAG_RESTARTPOS;
 
   return ftpd_response(session->cmd.sd, session->txtimeout,

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -204,11 +204,7 @@
  * signal indicating a change in network status.
  */
 
-#ifdef CONFIG_SYSTEM_TIME64
-#  define LONG_TIME_SEC    (60*60)   /* One hour in seconds */
-#else
-#  define LONG_TIME_SEC    (5*60)    /* Five minutes in seconds */
-#endif
+#define LONG_TIME_SEC      (60*60)   /* One hour in seconds */
 
 #define SHORT_TIME_SEC     (2)       /* 2 seconds */
 

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -63,10 +63,6 @@
 
 /* Configuration ************************************************************/
 
-#ifndef CONFIG_HAVE_LONG_LONG
-#  error "64-bit integer support required for NTP client"
-#endif
-
 #if defined(CONFIG_LIBC_NETDB) && !defined(CONFIG_NETUTILS_NTPCLIENT_SERVER)
 #  error "CONFIG_NETUTILS_NTPCLIENT_SERVER must be provided"
 #endif

--- a/netutils/ptpd/ptpd.c
+++ b/netutils/ptpd/ptpd.c
@@ -184,13 +184,8 @@ static void timespec_to_ptp_format(FAR const struct timespec *ts,
    * both fields big-endian.
    */
 
-#ifdef CONFIG_SYSTEM_TIME64
   timestamp[0] = (uint8_t)(ts->tv_sec >> 40);
   timestamp[1] = (uint8_t)(ts->tv_sec >> 32);
-#else
-  timestamp[0] = 0;
-  timestamp[1] = 0;
-#endif
   timestamp[2] = (uint8_t)(ts->tv_sec >> 24);
   timestamp[3] = (uint8_t)(ts->tv_sec >> 16);
   timestamp[4] = (uint8_t)(ts->tv_sec >>  8);
@@ -320,7 +315,6 @@ static int64_t timespec_delta_ns(FAR const struct timespec *ts1,
 
   delta_s = ts1->tv_sec - ts2->tv_sec;
 
-#ifdef CONFIG_SYSTEM_TIME64
   /* Conversion to nanoseconds could overflow if the system time is 64-bit */
 
   if (delta_s >= INT64_MAX / NSEC_PER_SEC)
@@ -331,7 +325,6 @@ static int64_t timespec_delta_ns(FAR const struct timespec *ts1,
     {
       return INT64_MIN;
     }
-#endif
 
   return delta_s * NSEC_PER_SEC + (ts1->tv_nsec - ts2->tv_nsec);
 }

--- a/system/zmodem/host/nuttx/compiler.h
+++ b/system/zmodem/host/nuttx/compiler.h
@@ -219,7 +219,6 @@
 
 /* GCC supports both types double and long long */
 
-#  define CONFIG_HAVE_LONG_LONG 1
 #  define CONFIG_HAVE_FLOAT 1
 #  define CONFIG_HAVE_DOUBLE 1
 #  define CONFIG_HAVE_LONG_DOUBLE 1
@@ -323,7 +322,6 @@
 
 /* SDCC does not support type long long or type double */
 
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
@@ -431,7 +429,6 @@
  * and simply do not support long long or double.
  */
 
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE
@@ -507,7 +504,6 @@
 # undef  CONFIG_SMALL_MEMORY
 # undef  CONFIG_LONG_IS_NOT_INT
 # undef  CONFIG_PTR_IS_NOT_INT
-# undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 # undef  CONFIG_HAVE_DOUBLE
 # undef  CONFIG_HAVE_LONG_DOUBLE

--- a/testing/fs/fstest/fstest_main.c
+++ b/testing/fs/fstest/fstest_main.c
@@ -218,7 +218,7 @@ static inline void fstest_randname(FAR struct fstest_ctx_s *ctx,
 
   dirlen   = strlen(ctx->mountdir);
 
-  /* Force the max filename lengh and also the min name len = 4 */
+  /* Force the max filename length and also the min name len = 4 */
 
   maxname  = CONFIG_TESTING_FSTEST_MAXNAME - dirlen - 3;
   namelen  = (rand() % maxname) + 4;
@@ -668,7 +668,6 @@ static inline int fstest_rdfile(FAR struct fstest_ctx_s *ctx,
  * Name: fstest_filesize
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_LONG_LONG
 static unsigned long long fstest_filesize(FAR struct fstest_ctx_s *ctx)
 {
   unsigned long long bytes_used;
@@ -688,27 +687,6 @@ static unsigned long long fstest_filesize(FAR struct fstest_ctx_s *ctx)
 
   return bytes_used;
 }
-#else
-static unsigned long fstest_filesize(FAR struct fstest_ctx_s *ctx)
-{
-  unsigned long bytes_used;
-  FAR struct fstest_filedesc_s *file;
-  int i;
-
-  bytes_used = 0;
-
-  for (i = 0; i < ctx->max_open; i++)
-    {
-      file = &ctx->files[i];
-      if (file->name != NULL && !file->deleted)
-        {
-          bytes_used += file->len;
-        }
-    }
-
-  return bytes_used;
-}
-#endif
 
 /****************************************************************************
  * Name: fstest_verifyfs
@@ -983,7 +961,7 @@ int main(int argc, FAR char *argv[])
   ctx = malloc(sizeof(struct fstest_ctx_s));
   if (ctx == NULL)
     {
-      printf("malloc ctx feild,exit!\n");
+      printf("malloc ctx field,exit!\n");
       exit(1);
     }
 
@@ -1081,11 +1059,7 @@ int main(int argc, FAR char *argv[])
       /* Directory listing */
 
       fstest_directory(ctx);
-#ifdef CONFIG_HAVE_LONG_LONG
       printf("Total file size: %llu\n", fstest_filesize(ctx));
-#else
-      printf("Total file size: %lu\n", fstest_filesize(ctx));
-#endif
 
       /* Verify all files written to FLASH */
 
@@ -1131,11 +1105,7 @@ int main(int argc, FAR char *argv[])
       /* Directory listing */
 
       fstest_directory(ctx);
-#ifdef CONFIG_HAVE_LONG_LONG
       printf("Total file size: %llu\n", fstest_filesize(ctx));
-#else
-      printf("Total file size: %lu\n", fstest_filesize(ctx));
-#endif
 
       /* Verify all files written to FLASH */
 

--- a/testing/ostest/semtimed.c
+++ b/testing/ostest/semtimed.c
@@ -79,11 +79,7 @@ static void ostest_gettime(struct timespec *tp)
       printf("ostest_gettime: ERROR: clock_gettime failed\n");
       ASSERT(false);
     }
-#ifdef CONFIG_SYSTEM_TIME64
   else if (tp->tv_sec < 0 || tp->tv_nsec < 0 ||
-#else
-  else if (tp->tv_nsec < 0 ||
-#endif
            tp->tv_nsec >= 1000 * 1000 * 1000)
     {
       printf("ostest_gettime: ERROR: clock_gettime returned bogus time\n");

--- a/testing/ostest/wdog.c
+++ b/testing/ostest/wdog.c
@@ -56,9 +56,9 @@
 typedef struct wdtest_param_s
 {
   FAR struct wdog_s *wdog;
-  sclock_t           interval;
-  uint64_t           callback_cnt;
-  clock_t            triggered_tick;
+  clock_t           interval;
+  uint64_t          callback_cnt;
+  clock_t           triggered_tick;
 } wdtest_param_t;
 
 /****************************************************************************
@@ -79,7 +79,7 @@ static void wdtest_callback(wdparm_t param)
   wdtest_param->callback_cnt   += 1;
 }
 
-static void wdtest_checkdelay(sclock_t diff, sclock_t delay_tick)
+static void wdtest_checkdelay(clock_t diff, clock_t delay_tick)
 {
   /* Ensure the watchdog trigger time is not earlier than expected. */
 
@@ -97,13 +97,13 @@ static void wdtest_checkdelay(sclock_t diff, sclock_t delay_tick)
 }
 
 static void wdtest_once(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
-                        sclock_t delay_ns)
+                        clock_t delay_ns)
 {
   uint64_t   cnt;
-  sclock_t   diff;
+  clock_t   diff;
   clock_t    wdset_tick;
   irqstate_t flags;
-  sclock_t   delay_tick = (sclock_t)NSEC2TICK((clock_t)delay_ns);
+  clock_t   delay_tick = NSEC2TICK(delay_ns);
 
   wdtest_printf("wdtest_once %lld ns\n", (long long)delay_ns);
 
@@ -133,20 +133,20 @@ static void wdtest_once(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
 
   /* Check if the delay is within the acceptable tolerance. */
 
-  diff = (sclock_t)(param->triggered_tick - wdset_tick);
+  diff = param->triggered_tick - wdset_tick;
 
   wdtest_checkdelay(diff, delay_tick);
 }
 
 static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
-                        sclock_t rand_ns)
+                        clock_t rand_ns)
 {
   uint64_t   cnt;
   int        idx;
-  sclock_t   delay_ns;
+  clock_t    delay_ns;
   clock_t    wdset_tick;
-  sclock_t   delay_tick;
-  sclock_t   diff;
+  clock_t    delay_tick;
+  clock_t    diff;
   irqstate_t flags = 0;
 
   /* Perform multiple iterations with random delays. */
@@ -190,7 +190,7 @@ static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
 
           if (cnt % 2)
             {
-              diff = (sclock_t)(param->triggered_tick - wdset_tick);
+              diff = param->triggered_tick - wdset_tick;
               wdtest_checkdelay(diff, delay_tick);
             }
         }
@@ -204,7 +204,7 @@ static void wdtest_rand(FAR struct wdog_s *wdog, FAR wdtest_param_t *param,
 static void wdtest_callback_recursive(wdparm_t param)
 {
   FAR wdtest_param_t *wdtest_param = (FAR wdtest_param_t *)param;
-  sclock_t            interval     = wdtest_param->interval;
+  clock_t             interval     = wdtest_param->interval;
 
   wdtest_param->callback_cnt   += 1;
   wdtest_param->triggered_tick  = clock_systime_ticks();
@@ -215,7 +215,7 @@ static void wdtest_callback_recursive(wdparm_t param)
 
 static void wdtest_recursive(FAR struct wdog_s *wdog,
                              FAR wdtest_param_t *param,
-                             sclock_t delay_ns,
+                             clock_t delay_ns,
                              unsigned int times)
 {
   uint64_t cnt;
@@ -227,7 +227,7 @@ static void wdtest_recursive(FAR struct wdog_s *wdog,
   cnt = param->callback_cnt;
 
   param->wdog = wdog;
-  param->interval = (sclock_t)NSEC2TICK((clock_t)delay_ns);
+  param->interval = NSEC2TICK(delay_ns);
 
   wdtest_assert(param->interval >= 0);
 
@@ -253,7 +253,7 @@ static void wdtest_recursive(FAR struct wdog_s *wdog,
 static void wdog_test_run(FAR wdtest_param_t *param)
 {
   uint64_t             cnt;
-  sclock_t             rest;
+  clock_t              rest;
   clock_t              delay;
   struct wdog_s        test_wdog =
   {


### PR DESCRIPTION
Companion to apache/nuttx#18842.

The upstream nuttx change drops the `sclock_t` alias now that
`clock_t` is itself a signed 64-bit type (`int64_t`).  This patch is
the pure-mechanical rename of the only in-tree apps consumer
(`testing/ostest/wdog.c`).