### PR TITLE
nimble: remove -Wno-pointer-to-int-cast from CFLAGS

### DIFF
--- a/wireless/bluetooth/nimble/CMakeLists.txt
+++ b/wireless/bluetooth/nimble/CMakeLists.txt
@@ -193,7 +193,8 @@ if(CONFIG_NIMBLE)
 
   target_include_directories(nimble PUBLIC include ${INCLUDES})
 
-  target_compile_options(nimble PUBLIC -Wno-pointer-to-int-cast -Wno-undef
-                                       -Wno-format -Wno-unused-but-set-variable)
+  target_compile_options(nimble PUBLIC -Wno-undef -Wno-format
+                                       -Wno-unused-but-set-variable)
+
   target_sources(nimble PRIVATE ${SRCS})
 endif()

--- a/wireless/bluetooth/nimble/Makefile.nimble
+++ b/wireless/bluetooth/nimble/Makefile.nimble
@@ -64,7 +64,7 @@ CXXFLAGS += $(addprefix ${INCDIR_PREFIX}, $(NIMBLE_ALL_INC))
 
 # NimBLE assumes this flag since it expects undefined macros to be zero value
 
-CFLAGS += -Wno-pointer-to-int-cast -Wno-undef
+CFLAGS += -Wno-undef
 
 # disable printf format checks
 


### PR DESCRIPTION
## Summary

nimble: remove -Wno-pointer-to-int-cast from CFLAGS
it's not needed and cause warnings for C++ builds:

`cc1plus: warning: command-line option '-Wno-pointer-to-int-cast' is valid for C/ObjC but not for C++`


## Impact
remove warnings from c++ builds

## Testing

out of tree c++ project with nimble builds without warnings. `nrf52840-dk/sdc_nimble` with make builds.