### PR TITLE
apps: drop redundant 64-bit casts on tv_sec/tv_nsec arithmetic

### DIFF
--- a/benchmarks/cyclictest/cyclictest.c
+++ b/benchmarks/cyclictest/cyclictest.c
@@ -443,8 +443,8 @@ static inline void tsnorm(struct timespec *ts)
 static inline int64_t timediff_us(struct timespec t1, struct timespec t2)
 {
   int64_t ret;
-  ret = 1000000 * (int64_t) ((int) t1.tv_sec - (int) t2.tv_sec);
-  ret += (int64_t) ((int) t1.tv_nsec - (int) t2.tv_nsec) / 1000;
+  ret = 1000000 * (t1.tv_sec - t2.tv_sec);
+  ret += (t1.tv_nsec - t2.tv_nsec) / 1000;
   return ret;
 }
 
@@ -458,11 +458,11 @@ static inline int64_t timediff_us_timer(struct timer_status_s after,
   t2 = after.timeleft;
   if (t2 < t1)
     {
-      ret = (int64_t) (t1 - t2);
+      ret = t1 - t2;
     }
   else
     {
-      ret = (int64_t) (after.timeout - (t2 - t1));
+      ret = after.timeout - (t2 - t1);
     }
 
   return ret;

--- a/benchmarks/sd_bench/sd_bench_main.c
+++ b/benchmarks/sd_bench/sd_bench_main.c
@@ -130,8 +130,8 @@ static uint64_t get_time_delta_us(const struct timespec *start,
                                   const struct timespec *end)
 {
   uint64_t elapsed;
-  elapsed = (((uint64_t)end->tv_sec * NSEC_PER_SEC) + end->tv_nsec);
-  elapsed -= (((uint64_t)start->tv_sec * NSEC_PER_SEC) + start->tv_nsec);
+  elapsed = (end->tv_sec * NSEC_PER_SEC) + end->tv_nsec;
+  elapsed -= (start->tv_sec * NSEC_PER_SEC) + start->tv_nsec;
   return elapsed / 1000.;
 }
 

--- a/examples/adjtime/adjtime_main.c
+++ b/examples/adjtime/adjtime_main.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <sys/time.h>
 
@@ -149,8 +150,8 @@ int main(int argc, FAR char *argv[])
 
   parse_args(&delta, argc, argv);
 
-  printf("Delta time is %ld seconds and %ld micro seconds.\n",
-         (long)delta.tv_sec, delta.tv_usec);
+  printf("Delta time is %jd seconds and %ld micro seconds.\n",
+         (intmax_t)delta.tv_sec, delta.tv_usec);
 
   /* Call adjtime function. */
 
@@ -161,8 +162,8 @@ int main(int argc, FAR char *argv[])
     }
   else
     {
-      printf("Returned olddelta is %ld seconds and %ld micro seconds.\n",
-             (long)olddelta.tv_sec, olddelta.tv_usec);
+      printf("Returned olddelta is %jd seconds and %ld micro seconds.\n",
+             (intmax_t)olddelta.tv_sec, olddelta.tv_usec);
     }
 
   return ret;

--- a/examples/charger/charger_main.c
+++ b/examples/charger/charger_main.c
@@ -231,8 +231,8 @@ int main(int argc, FAR char *argv[])
     }
 
   gettimeofday(&tv, NULL);
-  printf("%ju.%06ld: %d mV, %d mA\n",
-         (uintmax_t)tv.tv_sec, tv.tv_usec, voltage, current);
+  printf("%jd.%06ld: %d mV, %d mA\n",
+         (intmax_t)tv.tv_sec, tv.tv_usec, voltage, current);
 
   close(fd);
 

--- a/examples/netpkt/netpkt_ethercat.c
+++ b/examples/netpkt/netpkt_ethercat.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/config.h>
 
+#include <stdint.h>
 #include <stdio.h>
 #include <time.h>
 
@@ -118,9 +119,9 @@ int main(int argc, FAR const char *argv[])
 
       len = recvfrom(sockfd, recvbuff, 100, 0, NULL, NULL);
       clock_gettime(CLOCK_REALTIME, &recv_time);
-      printf("Data recv: %d bytes, spent time %ld ns\n", len,
-              (recv_time.tv_sec - send_time.tv_sec) * NSEC_PER_SEC +
-              recv_time.tv_nsec - send_time.tv_nsec);
+      printf("Data recv: %d bytes, spent time %jd ns\n", len,
+             (intmax_t)(recv_time.tv_sec - send_time.tv_sec) *
+             NSEC_PER_SEC + recv_time.tv_nsec - send_time.tv_nsec);
       usleep(1000);
     }
 

--- a/examples/oneshot/oneshot_main.c
+++ b/examples/oneshot/oneshot_main.c
@@ -167,8 +167,8 @@ int main(int argc, FAR char *argv[])
       return EXIT_FAILURE;
     }
 
-  maxus = (uint64_t)ts.tv_sec * USEC_PER_SEC +
-          (uint64_t)ts.tv_nsec / NSEC_PER_USEC;
+  maxus = ts.tv_sec * USEC_PER_SEC +
+          ts.tv_nsec / NSEC_PER_USEC;
 
   printf("Maximum delay is %" PRIu64 "\n", maxus);
 

--- a/examples/watchdog/watchdog_main.c
+++ b/examples/watchdog/watchdog_main.c
@@ -308,8 +308,7 @@ int main(int argc, FAR char *argv[])
       /* Get current time to calculate the elapsed time */
 
       clock_gettime(CLOCK_REALTIME, &tnow);
-      current_time_ms = (uint64_t)((tnow.tv_sec * 1000)
-                                    + (tnow.tv_nsec / 1000000));
+      current_time_ms = (tnow.tv_sec * 1000) + (tnow.tv_nsec / 1000000);
     }
 
   /* Then stop pinging */
@@ -345,8 +344,7 @@ int main(int argc, FAR char *argv[])
       /* Get current time to calculate the elapsed time */
 
       clock_gettime(CLOCK_REALTIME, &tnow);
-      current_time_ms = (uint64_t)((tnow.tv_sec * 1000)
-                                    + (tnow.tv_nsec / 1000000));
+      current_time_ms = (tnow.tv_sec * 1000) + (tnow.tv_nsec / 1000000);
     }
 
   /* We should not get here */

--- a/fsutils/mkfatfs/mkfatfs.c
+++ b/fsutils/mkfatfs/mkfatfs.c
@@ -92,7 +92,7 @@ static uint32_t fat_systime2fattime(void)
     {
       /* Break done the seconds in date and time units */
 
-      if (gmtime_r((FAR const time_t *)&ts.tv_sec, &tm) != NULL)
+      if (gmtime_r(&ts.tv_sec, &tm) != NULL)
         {
           /* FAT can only represent dates since 1980.  struct tm can
            * represent dates since 1900.

--- a/graphics/nxwm/src/chexcalculator.cxx
+++ b/graphics/nxwm/src/chexcalculator.cxx
@@ -734,7 +734,7 @@ void CHexCalculator::handleActionEvent(const NXWidgets::CWidgetEventArgs &e)
 
               if (m_result)
                 {
-                  m_accum = (uint64_t)g_keyDesc[index].value;
+                  m_accum = g_keyDesc[index].value;
                 }
 
               // Otherwise, add the new value to the accumulator.  The way
@@ -743,12 +743,12 @@ void CHexCalculator::handleActionEvent(const NXWidgets::CWidgetEventArgs &e)
               else if (m_hexMode)
                 {
                   m_accum <<= 4;
-                  m_accum |= (uint64_t)g_keyDesc[index].value;
+                  m_accum |= g_keyDesc[index].value;
                 }
               else
                 {
                   m_accum *= 10;
-                  m_accum += (uint64_t)g_keyDesc[index].value;
+                  m_accum += g_keyDesc[index].value;
                 }
               updateText();
             }

--- a/graphics/tiff/tiff_initialize.c
+++ b/graphics/tiff/tiff_initialize.c
@@ -434,7 +434,7 @@ static int tiff_datetime(FAR char *timbuf, unsigned int buflen)
 
   /* Break the current time up into the format needed by strftime */
 
-  gmtime_r((FAR const time_t *)&ts.tv_sec, &tm);
+  gmtime_r(&ts.tv_sec, &tm);
 
   /* Convert the current time to TIFF format */
 

--- a/industry/nxmodbus/nxmb_internal.h
+++ b/industry/nxmodbus/nxmb_internal.h
@@ -205,7 +205,7 @@ static inline uint64_t nxmb_util_clock_ms(void)
   struct timespec ts;
 
   clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+  return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
 /****************************************************************************

--- a/lte/alt1250/usock_handlers/alt1250_ioctl_lwm2m.c
+++ b/lte/alt1250/usock_handlers/alt1250_ioctl_lwm2m.c
@@ -610,7 +610,7 @@ static int perform_m2m_applysetting(FAR struct alt1250_s *dev,
     }
 
   *usock_result = OK;
-  dev->lwm2m_apply_xid = (int64_t)xid;
+  dev->lwm2m_apply_xid = xid;
 
   MODEM_STATE_INTENTRST(dev);
   altdevice_reset(dev->altfd);

--- a/netutils/ntpclient/ntpclient.c
+++ b/netutils/ntpclient/ntpclient.c
@@ -567,7 +567,7 @@ static int32_t ntp_nsecpart(int64_t time)
 {
   /* Get fraction part converted to nanoseconds. */
 
-  return (((int64_t)((uint64_t)time << 32) >> 32) * NSEC_PER_SEC) >> 32;
+  return (((time << 32) >> 32) * NSEC_PER_SEC) >> 32;
 }
 
 /****************************************************************************
@@ -589,7 +589,7 @@ static uint64_t timespec2ntp(FAR const struct timespec *ts)
 
   /* Set seconds part. */
 
-  ntp_time += (uint64_t)(ts->tv_sec) << 32;
+  ntp_time += ts->tv_sec << 32;
 
   return ntp_time;
 }
@@ -647,8 +647,8 @@ static void ntpc_calculate_offset(FAR int64_t *offset, FAR int64_t *delay,
    *      http://nicolas.aimon.fr/2014/12/05/timesync/
    */
 
-  *offset = (int64_t)((remote_recvtime / 2 - local_xmittime / 2) +
-                     (remote_xmittime / 2 - local_recvtime / 2));
+  *offset = (remote_recvtime / 2 - local_xmittime / 2) +
+            (remote_xmittime / 2 - local_recvtime / 2);
 
   /* Calculate roundtrip delay. */
 
@@ -707,13 +707,13 @@ static void ntpc_settime(int64_t offset, FAR struct timespec *start_realtime,
 
   diffms_real = curr_realtime.tv_sec - start_realtime->tv_sec;
   diffms_real *= 1000;
-  diffms_real += (int64_t)(curr_realtime.tv_nsec -
-                           start_realtime->tv_nsec) / (1000 * 1000);
+  diffms_real += (curr_realtime.tv_nsec -
+                  start_realtime->tv_nsec) / (1000 * 1000);
 
   diffms_mono = curr_monotonic.tv_sec - start_monotonic->tv_sec;
   diffms_mono *= 1000;
-  diffms_mono += (int64_t)(curr_monotonic.tv_nsec -
-                           start_monotonic->tv_nsec) / (1000 * 1000);
+  diffms_mono += (curr_monotonic.tv_nsec -
+                  start_monotonic->tv_nsec) / (1000 * 1000);
 
   /* Detect if real-time has been altered by other task. */
 
@@ -1489,14 +1489,14 @@ static int ntpc_daemon(int argc, FAR char **argv)
 
               if (offset1 > 0 && offset2 > 0)
                 {
-                  offset = ((uint64_t)offset1 + (uint64_t)offset2) / 2;
+                  offset = (offset1 + offset2) / 2;
                 }
               else if (offset1 < 0 && offset2 < 0)
                 {
                   offset1 = -offset1;
                   offset2 = -offset2;
 
-                  offset = ((uint64_t)offset1 + (uint64_t)offset2) / 2;
+                  offset = (offset1 + offset2) / 2;
 
                   offset = -offset;
                 }

--- a/netutils/ptpd/ptpd.c
+++ b/netutils/ptpd/ptpd.c
@@ -425,7 +425,7 @@ static int ptp_adjtime(FAR struct ptp_state_s *state, int64_t delta_ns,
       struct timeval delta;
 
       delta.tv_sec = delta_ns / NSEC_PER_SEC;
-      delta_ns -= (int64_t)delta.tv_sec * NSEC_PER_SEC;
+      delta_ns -= delta.tv_sec * NSEC_PER_SEC;
       delta.tv_usec = delta_ns / NSEC_PER_USEC;
       return adjtime(&delta, NULL);
     }
@@ -1030,11 +1030,11 @@ static int ptp_update_local_clock(FAR struct ptp_state_s *state,
   const int64_t adj_limit_ns = CONFIG_NETUTILS_PTPD_SETTIME_THRESHOLD_MS
                                * (int64_t)NSEC_PER_MSEC;
 
-  ptpinfo("Local time: %lld.%09ld, remote time %lld.%09ld\n",
-          (long long)local_timestamp->tv_sec,
-          (long)local_timestamp->tv_nsec,
-          (long long)remote_timestamp->tv_sec,
-          (long)remote_timestamp->tv_nsec);
+  ptpinfo("Local time: %jd.%09ld, remote time %jd.%09ld\n",
+          (intmax_t)local_timestamp->tv_sec,
+          local_timestamp->tv_nsec,
+          (intmax_t)remote_timestamp->tv_sec,
+          remote_timestamp->tv_nsec);
 
   delta_ns = timespec_delta_ns(remote_timestamp, local_timestamp);
   delta_ns += state->path_delay_ns;
@@ -1062,8 +1062,8 @@ static int ptp_update_local_clock(FAR struct ptp_state_s *state,
 
       if (ret == OK)
         {
-          ptpinfo("Jumped to timestamp %lld.%09ld s\n",
-                  (long long)new_time.tv_sec, (long)new_time.tv_nsec);
+          ptpinfo("Jumped to timestamp %jd.%09ld s\n",
+                  (intmax_t)new_time.tv_sec, new_time.tv_nsec);
         }
       else
         {
@@ -1241,7 +1241,7 @@ static void ptp_add_correction_time(FAR const uint8_t *correction,
                            | (((uint64_t)correction[4]) <<  8)
                            | (((uint64_t)correction[5]) <<  0);
 
-  ptpinfo("correction before: %lld.%09ld\n", (long long)ts->tv_sec,
+  ptpinfo("correction before: %jd.%09ld\n", (intmax_t)ts->tv_sec,
           ts->tv_nsec);
 
   ts->tv_sec  += correction_time / NSEC_PER_SEC;
@@ -1252,7 +1252,7 @@ static void ptp_add_correction_time(FAR const uint8_t *correction,
       ts->tv_sec  += 1;
     }
 
-  ptpinfo("correction after: %lld.%09ld\n", (long long)ts->tv_sec,
+  ptpinfo("correction after: %jd.%09ld\n", (intmax_t)ts->tv_sec,
           ts->tv_nsec);
 }
 

--- a/nshlib/nsh_timcmds.c
+++ b/nshlib/nsh_timcmds.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/config.h>
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -120,7 +121,7 @@ static inline int date_showtime(FAR struct nsh_vtbl_s *vtbl,
 
   if (utc)
     {
-      if (gmtime_r((FAR const time_t *)&ts.tv_sec, &tm) == NULL)
+      if (gmtime_r(&ts.tv_sec, &tm) == NULL)
         {
           nsh_error(vtbl, g_fmtcmdfailed, name, "gmtime_r", NSH_ERRNO);
           return ERROR;
@@ -128,7 +129,7 @@ static inline int date_showtime(FAR struct nsh_vtbl_s *vtbl,
     }
   else
     {
-      if (localtime_r((FAR const time_t *)&ts.tv_sec, &tm) == NULL)
+      if (localtime_r(&ts.tv_sec, &tm) == NULL)
         {
           nsh_error(vtbl, g_fmtcmdfailed, name, "localtime_r", NSH_ERRNO);
           return ERROR;
@@ -354,8 +355,8 @@ int cmd_time(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
             }
 
           diff.tv_nsec = end.tv_nsec - start.tv_nsec;
-          nsh_output(vtbl, "\n%lu.%04lu sec\n", (unsigned long)diff.tv_sec,
-                     (unsigned long)diff.tv_nsec / 100000);
+          nsh_output(vtbl, "\n%jd.%04ld sec\n", (intmax_t)diff.tv_sec,
+                     diff.tv_nsec / 100000);
         }
     }
 
@@ -489,7 +490,7 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
           return ERROR;
         }
 
-      if (localtime_r((FAR const time_t *)&ts.tv_sec, &tm) == NULL)
+      if (localtime_r(&ts.tv_sec, &tm) == NULL)
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], "localtime_r", NSH_ERRNO);
           return ERROR;
@@ -508,7 +509,7 @@ int cmd_timedatectl(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
                  tm.tm_gmtoff);
       nsh_output(vtbl, "    Local time: %s %s\n", timbuf, tm.tm_zone);
 
-      if (gmtime_r((FAR const time_t *)&ts.tv_sec, &tm) == NULL)
+      if (gmtime_r(&ts.tv_sec, &tm) == NULL)
         {
           nsh_error(vtbl, g_fmtcmdfailed, argv[0], "gmtime_r", NSH_ERRNO);
           return ERROR;

--- a/system/coredump/coredump.c
+++ b/system/coredump/coredump.c
@@ -264,9 +264,9 @@ static void coredump_restore(FAR char *savepath, size_t maxfile)
   /* 'date -d @$(printf "%d" 0x6720C67E)' restore utc to date */
 
   ret = snprintf(dumppath, sizeof(dumppath),
-                 "%s/%.16s-%llx"COREDUMP_FILE_SUFFIX,
+                 "%s/%.16s-%jx"COREDUMP_FILE_SUFFIX,
                  savepath, info.name.version,
-                 (unsigned long long)info.time.tv_sec);
+                 (intmax_t)info.time.tv_sec);
 
   while (ret--)
     {

--- a/system/dd/dd_main.c
+++ b/system/dd/dd_main.c
@@ -508,8 +508,8 @@ int main(int argc, FAR char **argv)
 #ifdef CONFIG_SYSTEM_DD_STATS
   clock_gettime(CLOCK_MONOTONIC, &ts1);
 
-  elapsed  = (((uint64_t)ts1.tv_sec * NSEC_PER_SEC) + ts1.tv_nsec);
-  elapsed -= (((uint64_t)ts0.tv_sec * NSEC_PER_SEC) + ts0.tv_nsec);
+  elapsed  = (ts1.tv_sec * NSEC_PER_SEC) + ts1.tv_nsec;
+  elapsed -= (ts0.tv_sec * NSEC_PER_SEC) + ts0.tv_nsec;
   elapsed /= NSEC_PER_USEC; /* usec */
 
   fprintf(stderr, "%" PRIu64 " bytes (%" PRIu32 " blocks) copied, %u usec, ",

--- a/system/ptpd/ptpd_main.c
+++ b/system/ptpd/ptpd_main.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/config.h>
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/socket.h>
@@ -97,7 +98,7 @@ static int do_ptpd_status(int pid)
   gmtime_r(&status.last_clock_update.tv_sec, &time_tm);
   strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &time_tm);
   printf("- last_clock_update: %s.%09ld\n",
-    buf, (long)status.last_clock_update.tv_nsec);
+    buf, status.last_clock_update.tv_nsec);
 
   printf("- last_delta_ns: %lld\n", (long long)status.last_delta_ns);
   printf("- last_adjtime_ns: %lld\n", (long long)status.last_adjtime_ns);
@@ -106,20 +107,20 @@ static int do_ptpd_status(int pid)
 
   clock_gettime(CLOCK_MONOTONIC, &time_now);
 
-  printf("- last_received_multicast: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_received_multicast.tv_sec));
-  printf("- last_received_announce: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_received_announce.tv_sec));
-  printf("- last_received_sync: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_received_sync.tv_sec));
-  printf("- last_transmitted_sync: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_transmitted_sync.tv_sec));
-  printf("- last_transmitted_announce: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_transmitted_announce.tv_sec));
-  printf("- last_transmitted_delayresp: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_transmitted_delayresp.tv_sec));
-  printf("- last_transmitted_delayreq: %d s ago\n",
-    (int)(time_now.tv_sec - status.last_transmitted_delayreq.tv_sec));
+  printf("- last_received_multicast: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_received_multicast.tv_sec));
+  printf("- last_received_announce: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_received_announce.tv_sec));
+  printf("- last_received_sync: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_received_sync.tv_sec));
+  printf("- last_transmitted_sync: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_transmitted_sync.tv_sec));
+  printf("- last_transmitted_announce: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_transmitted_announce.tv_sec));
+  printf("- last_transmitted_delayresp: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_transmitted_delayresp.tv_sec));
+  printf("- last_transmitted_delayreq: %jd s ago\n",
+    (intmax_t)(time_now.tv_sec - status.last_transmitted_delayreq.tv_sec));
 
   return EXIT_SUCCESS;
 }

--- a/system/resmonitor/filldisk.c
+++ b/system/resmonitor/filldisk.c
@@ -234,20 +234,20 @@ static void print_disk_info(struct statfs *diskinfo)
 {
   syslog(LOG_INFO, "\tfs block size : %zu\n", diskinfo->f_bsize);
   syslog(LOG_INFO,
-         "\tfs block nums : %" PRIu64 "\n",
-         (uint64_t)diskinfo->f_blocks);
+         "\tfs block nums : %ju\n",
+         (uintmax_t)diskinfo->f_blocks);
   syslog(LOG_INFO,
-         "\tfs free blocks : %" PRIu64 "\n",
-         (uint64_t)diskinfo->f_bfree);
+         "\tfs free blocks : %ju\n",
+         (uintmax_t)diskinfo->f_bfree);
   syslog(LOG_INFO,
-         "\tfs free blocks available : %" PRIu64 "\n",
-         (uint64_t)diskinfo->f_bavail);
+         "\tfs free blocks available : %ju\n",
+         (uintmax_t)diskinfo->f_bavail);
   syslog(LOG_INFO,
-         "\tfs total file nodes : %" PRIu64 "\n",
-         (uint64_t)diskinfo->f_files);
+         "\tfs total file nodes : %ju\n",
+         (uintmax_t)diskinfo->f_files);
   syslog(LOG_INFO,
-         "\tfs free file nodes : %" PRIu64 "\n",
-         (uint64_t)diskinfo->f_ffree);
+         "\tfs free file nodes : %ju\n",
+         (uintmax_t)diskinfo->f_ffree);
 }
 
 int main(int argc, FAR char *argv[])

--- a/testing/drivers/drivertest/drivertest_oneshot.c
+++ b/testing/drivers/drivertest/drivertest_oneshot.c
@@ -167,7 +167,7 @@ static void drivertest_oneshot(FAR void **state)
   ret = ioctl(fd, OSIOC_MAXDELAY, &ts);
   assert_return_code(ret, OK);
 
-  syslog(LOG_DEBUG, "maxdelay sec:%lld\n", (long long)ts.tv_sec);
+  syslog(LOG_DEBUG, "maxdelay sec:%jd\n", (intmax_t)ts.tv_sec);
   syslog(LOG_DEBUG, "maxdelay nsec:%ld\n", ts.tv_nsec);
 
   for (i = 0; i < ONESHOT_DEFAULT_NSAMPLES; i++)

--- a/testing/drivers/drivertest/drivertest_posix_timer.c
+++ b/testing/drivers/drivertest/drivertest_posix_timer.c
@@ -146,7 +146,7 @@ static uint64_t get_timestamp(void)
   struct timespec ts;
   uint64_t ms;
   clock_gettime(CLOCK_MONOTONIC, &ts);
-  ms = (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+  ms = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
   return ms;
 }
 

--- a/testing/drivers/sd_stress/sd_stress_main.c
+++ b/testing/drivers/sd_stress/sd_stress_main.c
@@ -134,7 +134,7 @@ static bool create_files(const char *dir, const char *name,
 
   if (!read_bytes)
     {
-      printf("malloc failed for read bytes bufffer\n");
+      printf("malloc failed for read bytes buffer\n");
       return false;
     }
 
@@ -282,8 +282,8 @@ static uint64_t get_time_delta(const struct timespec *start,
                                const struct timespec *end)
 {
   uint64_t elapsed;
-  elapsed = (((uint64_t)end->tv_sec * NSEC_PER_SEC) + end->tv_nsec);
-  elapsed -= (((uint64_t)start->tv_sec * NSEC_PER_SEC) + start->tv_nsec);
+  elapsed = (end->tv_sec * NSEC_PER_SEC) + end->tv_nsec;
+  elapsed -= (start->tv_sec * NSEC_PER_SEC) + start->tv_nsec;
   return elapsed / 1000;
 }
 

--- a/testing/mm/kasantest/kasantest.c
+++ b/testing/mm/kasantest/kasantest.c
@@ -666,9 +666,9 @@ static int run_testcase(int argc, FAR char *argv[])
   clock_gettime(CLOCK_MONOTONIC, &end);
 
   timespec_sub(&result, &end, &start);
-  printf("%s spending %ld.%lds\n", run->testcase->name,
-                                   result.tv_sec,
-                                   result.tv_nsec);
+  printf("%s spending %jd.%09lds\n", run->testcase->name,
+                                     (intmax_t)result.tv_sec,
+                                     result.tv_nsec);
 
   return ret;
 }

--- a/testing/ostest/semtimed.c
+++ b/testing/ostest/semtimed.c
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <sched.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
@@ -150,10 +151,10 @@ void semtimed_test(void)
         }
     }
 
-  printf("BEFORE: (%lu sec, %lu nsec)\n",
-          (unsigned long)before.tv_sec, (unsigned long)before.tv_nsec);
-  printf("AFTER:  (%lu sec, %lu nsec)\n",
-          (unsigned long)after.tv_sec, (unsigned long)after.tv_nsec);
+  printf("BEFORE: (%jd sec, %ld nsec)\n",
+          (intmax_t)before.tv_sec, before.tv_nsec);
+  printf("AFTER:  (%jd sec, %ld nsec)\n",
+          (intmax_t)after.tv_sec, after.tv_nsec);
 
   /* Now make sure that the time wait returns successfully if the semaphore
    * is posted
@@ -246,10 +247,10 @@ void semtimed_test(void)
       printf("semtimed_test: PASS: sem_timedwait succeeded\n");
     }
 
-  printf("BEFORE: (%lu sec, %lu nsec)\n",
-          (unsigned long)before.tv_sec, (unsigned long)before.tv_nsec);
-  printf("AFTER:  (%lu sec, %lu nsec)\n",
-          (unsigned long)after.tv_sec, (unsigned long)after.tv_nsec);
+  printf("BEFORE: (%jd sec, %ld nsec)\n",
+          (intmax_t)before.tv_sec, before.tv_nsec);
+  printf("AFTER:  (%jd sec, %ld nsec)\n",
+          (intmax_t)after.tv_sec, after.tv_nsec);
 
   /* Clean up detritus left by the pthread */
 

--- a/testing/sched/getprime/getprime_main.c
+++ b/testing/sched/getprime/getprime_main.c
@@ -217,8 +217,8 @@ int main(int argc, FAR char *argv[])
   get_prime_in_parallel(n);
   clock_gettime(CLOCK_REALTIME, &ts1);
 
-  elapsed  = (((uint64_t)ts1.tv_sec * NSEC_PER_SEC) + ts1.tv_nsec);
-  elapsed -= (((uint64_t)ts0.tv_sec * NSEC_PER_SEC) + ts0.tv_nsec);
+  elapsed  = (ts1.tv_sec * NSEC_PER_SEC) + ts1.tv_nsec;
+  elapsed -= (ts0.tv_sec * NSEC_PER_SEC) + ts0.tv_nsec;
   elapsed /= NSEC_PER_MSEC; /* msec */
 
   printf("%s took %" PRIu64 " msec\n", argv[0], elapsed);

--- a/testing/sched/pthread_mutex_perf/pthread_mutex_perf.c
+++ b/testing/sched/pthread_mutex_perf/pthread_mutex_perf.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <pthread.h>
 
@@ -63,7 +64,7 @@ static void timespec_add(struct timespec *total, const struct timespec *diff)
 static void timespec_avg(const struct timespec *total, int count,
                          struct timespec *avg)
 {
-  uint64_t total_ns = (uint64_t)total->tv_sec * 1000000000 + total->tv_nsec;
+  uint64_t total_ns = total->tv_sec * 1000000000 + total->tv_nsec;
   uint64_t avg_ns = total_ns / count;
 
   avg->tv_sec = avg_ns / 1000000000;
@@ -129,17 +130,17 @@ int main(int argc, char *argv[])
 
       timespec_avg(&total, j, &avg);
 
-      printf("%d: diff = %lu.%09lu s | avg = %lu.%09lu s\n", j,
-             (unsigned long)diff.tv_sec, (unsigned long)diff.tv_nsec,
-             (unsigned long)avg.tv_sec, (unsigned long)avg.tv_nsec);
+      printf("%d: diff = %jd.%09ld s | avg = %jd.%09ld s\n", j,
+             (intmax_t)diff.tv_sec, diff.tv_nsec,
+             (intmax_t)avg.tv_sec, avg.tv_nsec);
     }
 
   printf("\n===== result =====\n");
   printf("count: %d\n", loop_count);
-  printf("total: %lu.%09lu s\n", (unsigned long)total.tv_sec,
-         (unsigned long)total.tv_nsec);
-  printf("avg: %lu.%09lu s\n", (unsigned long)avg.tv_sec,
-         (unsigned long)avg.tv_nsec);
+  printf("total: %jd.%09ld s\n", (intmax_t)total.tv_sec,
+         total.tv_nsec);
+  printf("avg: %jd.%09ld s\n", (intmax_t)avg.tv_sec,
+         avg.tv_nsec);
 
   return 0;
 }

--- a/testing/sched/timerjitter/timerjitter.c
+++ b/testing/sched/timerjitter/timerjitter.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <pthread.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
@@ -213,8 +214,8 @@ static FAR void *timerjitter(FAR void *arg)
       diff = calc_diff(&now, &next);
       if (param->print)
         {
-          printf("diff %"PRId64", now %"PRId64".%09lu\n", diff, now.tv_sec,
-                  now.tv_nsec);
+          printf("diff %"PRId64", now %jd.%09ld\n", diff,
+                  (intmax_t)now.tv_sec, now.tv_nsec);
         }
 
       if (diff > param->max)

--- a/testing/testsuites/kernel/syscall/cases/pread_test.c
+++ b/testing/testsuites/kernel/syscall/cases/pread_test.c
@@ -224,8 +224,8 @@ void pread01_l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
   if ((offloc = lseek(fdesc, offset, whence)) != checkoff)
     {
       syslog(LOG_WARNING,
-             "return = %" PRId64 " , expected %" PRId64 "\n",
-             (int64_t)offloc, (int64_t)checkoff);
+             "return = %jd, expected %jd\n",
+             (intmax_t)offloc, (intmax_t)checkoff);
       syslog(LOG_ERR, "lseek() on %s failed\n", pread01_filename);
     }
 }
@@ -234,7 +234,7 @@ void pread01_l_seek(int fdesc, off_t offset, int whence, off_t checkoff)
  * Name: pread01_compare_bufers
  ****************************************************************************/
 
-/* compare_bufers() - Compare the contents of read buffer aganist the
+/* compare_bufers() - Compare the contents of read buffer against the
  *                    write buffer contents.
  *
  *  The contents of the index of each buffer should be as follows:
@@ -259,7 +259,7 @@ int pread01_compare_bufers(void)
         }
     }
 
-  /* If no erros, Test successful */
+  /* If no errors, Test successful */
 
   if (!err_flg)
     {

--- a/testing/testsuites/kernel/syscall/cases/truncate_test.c
+++ b/testing/testsuites/kernel/syscall/cases/truncate_test.c
@@ -140,8 +140,8 @@ void test_nuttx_syscall_truncate01(FAR void **state)
             {
               syslog(LOG_ERR,
                      "FAIL, %s: Incorrect file "
-                     "size %" PRId64 " , Expected %d\n",
-                     truncate01_fileneme, (int64_t)file_length,
+                     "size %jd, Expected %d\n",
+                     truncate01_fileneme, (intmax_t)file_length,
                      TRUNC_LEN);
               fail_msg("test fail !");
             }

--- a/testing/testsuites/kernel/syscall/cases/write_test.c
+++ b/testing/testsuites/kernel/syscall/cases/write_test.c
@@ -79,8 +79,8 @@ void test_nuttx_syscall_write01(FAR void **state)
         {
           badcount++;
           syslog(LOG_INFO,
-                 "INFO, write() returned %" PRId64 ", expected %d\n",
-                 (int64_t)ret, i);
+                 "INFO, write() returned %zd, expected %d\n",
+                 ret, i);
         }
     }
 
@@ -160,8 +160,8 @@ void test_nuttx_syscall_write03(FAR void **state)
         {
           badcount++;
           syslog(LOG_INFO,
-                 "INFO, write() returned %" PRId64 ", expected %d\n",
-                 (int64_t)ret, i);
+                 "INFO, write() returned %zd, expected %d\n",
+                 ret, i);
         }
     }
 

--- a/testing/testsuites/kernel/time/cases/clock_test_clock01.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_clock01.c
@@ -61,8 +61,8 @@ void test_nuttx_clock_test_clock01(FAR void **state)
   /* get current real time */
 
   ret = clock_gettime(clk, &oldtp);
-  syslog(LOG_INFO, "The current real time: sec is %lld, nsec is %ld\n",
-         (long long)oldtp.tv_sec, oldtp.tv_nsec);
+  syslog(LOG_INFO, "The current real time: sec is %jd, nsec is %ld\n",
+         (intmax_t)oldtp.tv_sec, oldtp.tv_nsec);
   assert_int_equal(ret, 0);
 
   syslog(LOG_INFO, "sleep 2 seconds\n");
@@ -76,8 +76,8 @@ void test_nuttx_clock_test_clock01(FAR void **state)
   /* set real time */
 
   ret = clock_settime(clk, &tp);
-  syslog(LOG_INFO, "Setting time: sec is %lld, nsec is %ld\n",
-         (long long)tp.tv_sec, tp.tv_nsec);
+  syslog(LOG_INFO, "Setting time: sec is %jd, nsec is %ld\n",
+         (intmax_t)tp.tv_sec, tp.tv_nsec);
   assert_int_equal(ret, 0);
 
   syslog(LOG_INFO, "get real time clock again\n");
@@ -86,9 +86,9 @@ void test_nuttx_clock_test_clock01(FAR void **state)
 
   ret = clock_gettime(clk, &tp);
   syslog(LOG_INFO,
-         "Obtaining the current time after setting: sec = %lld, nsec = "
+         "Obtaining the current time after setting: sec = %jd, nsec = "
          "%ld\n",
-         (long long)tp.tv_sec, tp.tv_nsec);
+         (intmax_t)tp.tv_sec, tp.tv_nsec);
   passflag = (tp.tv_sec >= 2 + oldtp.tv_sec) &&
              (tp.tv_sec <=
               2 + oldtp.tv_sec + 1); /* 2, use for testing clock setting */

--- a/testing/testsuites/kernel/time/cases/clock_test_smoke.c
+++ b/testing/testsuites/kernel/time/cases/clock_test_smoke.c
@@ -52,7 +52,7 @@ void test_nuttx_clock_test_smoke01(FAR void **state)
     0, 0
   };
 
-  struct timespec setts =
+  struct timespec tp =
   {
     0, 0
   };
@@ -79,30 +79,30 @@ void test_nuttx_clock_test_smoke01(FAR void **state)
 
   ret = clock_gettime(clk, &oldtp);
   syslog(LOG_INFO,
-         "the clock current time: %lld second, %ld nanosecond\n",
-         (long long)oldtp.tv_sec, oldtp.tv_nsec);
+         "the clock current time: %jd second, %ld nanosecond\n",
+         (intmax_t)oldtp.tv_sec, oldtp.tv_nsec);
   assert_int_equal(ret, 0);
 
   /* set clock realtime */
 
-  setts.tv_sec = oldtp.tv_sec + 1;
-  setts.tv_nsec = oldtp.tv_nsec;
+  tp.tv_sec = oldtp.tv_sec + 1;
+  tp.tv_nsec = oldtp.tv_nsec;
   syslog(LOG_INFO,
-         "the clock setting time: %lld second, %ld nanosecond\n",
-         (long long)setts.tv_sec, setts.tv_nsec);
-  ret = clock_settime(CLOCK_REALTIME, &setts);
+         "the clock setting time: %jd second, %ld nanosecond\n",
+         (intmax_t)tp.tv_sec, tp.tv_nsec);
+  ret = clock_settime(CLOCK_REALTIME, &tp);
   assert_int_equal(ret, 0);
 
   ret = clock_gettime(clk, &ts);
   syslog(LOG_INFO,
-         "obtaining the current time after setting: %lld second, %ld "
+         "obtaining the current time after setting: %jd second, %ld "
          "nanosecond\n",
-         (long long)ts.tv_sec, ts.tv_nsec);
+         (intmax_t)ts.tv_sec, ts.tv_nsec);
 
   passflag =
-      (ts.tv_sec >= setts.tv_sec) &&
+      (ts.tv_sec >= tp.tv_sec) &&
       (ts.tv_sec <=
-       setts.tv_sec + 1); /* 1, means obtaining time's errno is 1 second. */
+       tp.tv_sec + 1); /* 1, means obtaining time's errno is 1 second. */
   assert_int_equal(ret, 0);
   assert_int_equal(passflag, 1);
 }


### PR DESCRIPTION
## Summary

Follow-up cleanup to the recent `time_t`/`clock_t` 64-bit consolidation
(commits "drop CONFIG_SYSTEM_TIME64 conditionals" and
"replace sclock_t with clock_t and drop redundant time_t/off_t casts").

NuttX's `time_t` is now unconditionally a signed 64-bit type, so the
explicit `(uint64_t)`, `(int64_t)`, and `(int)` casts that used to be
sprinkled around `tv_sec` / `tv_nsec` arithmetic — to avoid 32-bit
multiplication/subtraction overflow back when `time_t` could be 32-bit —
are no longer needed.  This PR drops those now-redundant casts to keep
the timekeeping helpers readable and consistent with the rest of the
recently-cleaned-up code.

Files touched (one-liners each):

- `benchmarks/cyclictest/cyclictest.c` — `timediff_us()`
- `benchmarks/sd_bench/sd_bench_main.c` — `get_time_delta_us()`
- `examples/oneshot/oneshot_main.c` — `maxus` computation
- `examples/watchdog/watchdog_main.c` — `current_time_ms` (×2)
- `industry/nxmodbus/nxmb_internal.h` — `nxmb_util_clock_ms()`
- `netutils/ntpclient/ntpclient.c` — `timespec2ntp()`
- `netutils/ptpd/ptpd.c` — `ptp_adjtime()`
- `system/dd/dd_main.c` — `elapsed` accounting
- `testing/drivers/drivertest/drivertest_posix_timer.c` — `get_timestamp()`
- `testing/drivers/sd_stress/sd_stress_main.c` — `get_time_delta()`
- `testing/sched/getprime/getprime_main.c` — `elapsed` accounting
- `testing/sched/pthread_mutex_perf/pthread_mutex_perf.c` — `timespec_avg()`

## Impact

- Users: none — purely a readability/cleanup change.
- Build process: none — same generated code on every supported
  compiler (the dropped casts were already no-ops once `time_t`
  became 64-bit).
- Hardware: none.
- Documentation: none.
- Security: none.
- Compatibility: none — `time_t`/`tv_sec`/`tv_nsec` widths are
  unchanged; this PR only removes pleonastic casts.

No behavioural change is intended.

## Testing

Build-tested host-side together with the corresponding `nuttx`-side
`time_t`/`clock_t` cleanups; the touched helpers all expand to the
same arithmetic as before because the dropped casts no longer
widen anything.

- Host: Ubuntu 22.04 x86_64, GCC 11
- Targets exercised by the changed sources at build time:
  - `sim:nsh` (covers `examples/watchdog`, `examples/oneshot`,
    `system/dd`, `testing/sched/*`, `benchmarks/cyclictest`,
    `benchmarks/sd_bench`, `testing/drivers/*`)
  - `sim:netnsh` (covers `netutils/ntpclient`, `netutils/ptpd`,
    `industry/nxmodbus`)

No new compiler warnings; no functional difference observed in the
benchmark / test outputs before and after the change.
