### PR TITLE
apps/cmake: Make hello_rust_cargo buildable with cmake

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -47,6 +47,8 @@ include(nuttx_parse_function_args)
 # ~~~
 
 function(nuttx_rust_target_triple ARCHTYPE ABITYPE CPUTYPE OUTPUT)
+  get_filename_component(APPDIR "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/.."
+                         ABSOLUTE)
   if(ARCHTYPE STREQUAL "x86_64")
     set(TARGET_TRIPLE "${APPDIR}/tools/x86_64-unknown-nuttx.json")
   elseif(ARCHTYPE STREQUAL "x86")
@@ -127,9 +129,11 @@ function(nuttx_add_rust)
 
   # Determine build profile based on CONFIG_DEBUG_FULLOPT
   if(CONFIG_DEBUG_FULLOPT)
+    set(RUST_PROFILE_FLAG "--release")
     set(RUST_PROFILE "release")
     set(RUST_PANIC_FLAGS "-Zunstable-options -Cpanic=immediate-abort")
   else()
+    set(RUST_PROFILE_FLAG "")
     set(RUST_PROFILE "debug")
     set(RUST_PANIC_FLAGS "")
   endif()
@@ -145,9 +149,9 @@ function(nuttx_add_rust)
     set(TARGET_BASE ${RUST_TARGET})
   endif()
 
-  set(RUST_BUILD_DIR
-      ${CMAKE_CURRENT_BINARY_DIR}/${CRATE_NAME}/target/${TARGET_BASE})
-  set(RUST_LIB_PATH ${RUST_BUILD_DIR}/${RUST_PROFILE}/lib${CRATE_NAME}.a)
+  set(RUST_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CRATE_NAME}/target)
+  set(RUST_LIB_PATH
+      ${RUST_BUILD_DIR}/${TARGET_BASE}/${RUST_PROFILE}/lib${CRATE_NAME}.a)
 
   # Create build directory
   file(MAKE_DIRECTORY ${RUST_BUILD_DIR})
@@ -158,9 +162,10 @@ function(nuttx_add_rust)
     COMMAND
       ${CMAKE_COMMAND} -E env
       NUTTX_INCLUDE_DIR=${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include:${CMAKE_BINARY_DIR}/include/arch
-      RUSTFLAGS=${RUST_PANIC_FLAGS} cargo build --${RUST_PROFILE}
-      -Zbuild-std=std,panic_abort --manifest-path ${CRATE_PATH}/Cargo.toml
-      --target ${RUST_TARGET} --target-dir ${RUST_BUILD_DIR}
+      RUSTFLAGS=${RUST_PANIC_FLAGS} cargo build ${RUST_PROFILE_FLAG}
+      -Zbuild-std=std,panic_abort -Zjson-target-spec --manifest-path
+      ${CRATE_PATH}/Cargo.toml --target ${RUST_TARGET} --target-dir
+      ${RUST_BUILD_DIR}
     COMMENT "Building Rust crate ${CRATE_NAME}"
     VERBATIM)
 


### PR DESCRIPTION
## Summary

* Fixes errors related to cargo options and library paths when building hello_rust_cargo with CMake.
* Related NuttX Apps [Issue #3472](https://github.com/apache/nuttx-apps/issues/3472) , [Issue #3473](https://github.com/apache/nuttx-apps/issues/3473)

## Impact

* Impact on build: enables building with cargo and cmake.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (Linux), CPU(Intel), compiler(cc 15.2.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration:

```
~/nuttxspace/nuttx$ make distclean
NuttX has not been configured!
To configure the project:
  tools/configure.sh <config>
For a list of available configurations:
  tools/configure.sh -L
~/nuttxspace/nuttx$ cmake -S . -B build-debug -DBOARD_CONFIG=sim:nsh -GNinja
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
Loaded configuration '/home/toku/nuttxspace/nuttx/build-debug/.config.compressed'
Minimal configuration saved to '/home/toku/nuttxspace/nuttx/build-debug/defconfig.tmp'
  Select HOST_LINUX=y
  Select HOST_X86_64=y
--   CMake:  4.2.3
--   Ninja:  1.13.2
--   Board:  sim
--   Config: nsh
--   Appdir: /home/toku/nuttxspace/apps
-- The C compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Linux
-- CMake host system processor: x86_64
   TOOLS_DIR path is "/home/toku/nuttxspace/nuttx"
   HOST = Linux
-- Configuring done (1.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug/bin_host
-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is GNU 15.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (7.8s)
-- Generating done (0.5s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug
~/nuttxspace/nuttx$ printf "CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
" >> build-debug/.config
~/nuttxspace/nuttx$ cmake --build build-debug -t olddefconfig
[0/1] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Linux
-- CMake host system processor: x86_64
   TOOLS_DIR path is "/home/toku/nuttxspace/nuttx"
   HOST = Linux
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (0.4s)
-- Generating done (0.3s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug
[1/2] cd /home/toku/nuttxspace/nuttx && /usr/bin/cmake -E ...n/cmake -E touch /home/toku/nuttxspace/nuttx/CMakeLists.tx
/home/toku/nuttxspace/nuttx/build-debug/.config:1814: warning: SYSTEM_TIME64 (defined at sched/Kconfig:170) set more than once. Old value "n", new value "y".
/home/toku/nuttxspace/nuttx/build-debug/.config:1815: warning: FS_LARGEFILE (defined at fs/Kconfig:20) set more than once. Old value "n", new value "y".
/home/toku/nuttxspace/nuttx/build-debug/.config:1816: warning: TLS_NELEM (defined at libs/libc/tls/Kconfig:45) set more than once. Old value "0", new value "16".
/home/toku/nuttxspace/nuttx/build-debug/.config:1817: warning: DEV_URANDOM (defined at drivers/crypto/Kconfig:16) set more than once. Old value "n", new value "y".
/home/toku/nuttxspace/nuttx/build-debug/.config:1818: warning: EXAMPLES_HELLO_RUST_CARGO (defined at /home/toku/nuttxspace/apps/examples/rust/hello/Kconfig:6) set more than once. Old value "n", new value "y".
Loaded configuration '/home/toku/nuttxspace/nuttx/build-debug/.config'
Configuration saved to '/home/toku/nuttxspace/nuttx/build-debug/.config'
```

Testing logs before change:

```
~/nuttxspace/nuttx$ cmake --build build-debug -j 6
[0/1] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Linux
-- CMake host system processor: x86_64
   TOOLS_DIR path is "/home/toku/nuttxspace/nuttx"
   HOST = Linux
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (1.2s)
-- Generating done (1.0s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug
[1214/1230] Building Rust crate hello
FAILED: [code=1] apps/examples/rust/hello/hello/target/x86_64-unknown-nuttx/debug/libhello.a /home/toku/nuttxspace/nuttx/build-debug/apps/examples/rust/hello/hello/target/x86_64-unknown-nuttx/debug/libhello.a
cd /home/toku/nuttxspace/nuttx/build-debug/apps/examples/rust/hello && /usr/bin/cmake -E env NUTTX_INCLUDE_DIR=/home/toku/nuttxspace/nuttx/include:/home/toku/nuttxspace/nuttx/build-debug/include:/home/toku/nuttxspace/nuttx/build-debug/include/arch RUSTFLAGS= cargo build --debug -Zbuild-std=std,panic_abort --manifest-path /home/toku/nuttxspace/apps/examples/rust/hello/Cargo.toml --target /tools/x86_64-unknown-nuttx.json --target-dir /home/toku/nuttxspace/nuttx/build-debug/apps/examples/rust/hello/hello/target/x86_64-unknown-nuttx
error: unexpected argument '--debug' found

  tip: `--debug` is the default for `cargo build`; instead `--release` is supported

Usage: cargo build [OPTIONS]

For more information, try '--help'.
[1215/1230] Linking C static library libs/libc/libc.a
ninja: build stopped: subcommand failed.
```

Testing logs after change:

```
~/nuttxspace/nuttx$ cmake --build build-debug -j 6
[0/1] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Linux
-- CMake host system processor: x86_64
   TOOLS_DIR path is "/home/toku/nuttxspace/nuttx"
   HOST = Linux
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (0.3s)
-- Generating done (0.3s)
-- Build files have been written to: /home/toku/nuttxspace/nuttx/build-debug
[1216/1230] Building Rust crate hello
   Compiling compiler_builtins v0.1.160 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/compiler-builtins/compiler-builtins)
   Compiling core v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling libc v0.2.185
   Compiling object v0.37.3
   Compiling std v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
   Compiling proc-macro2 v1.0.106
   Compiling unicode-ident v1.0.24
   Compiling quote v1.0.45
   Compiling serde_core v1.0.228
   Compiling zmij v1.0.21
   Compiling serde v1.0.228
   Compiling serde_json v1.0.149
   Compiling syn v2.0.117
   Compiling serde_derive v1.0.228
   Compiling rustc-std-workspace-core v1.99.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc)
   Compiling memchr v2.7.6
   Compiling adler2 v2.0.1
   Compiling panic_abort v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_abort)
   Compiling cfg-if v1.0.4
   Compiling rustc-demangle v0.1.27
   Compiling rustc-literal-escaper v0.0.7
   Compiling unwind v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/unwind)
   Compiling rustc-std-workspace-alloc v1.99.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/rustc-std-workspace-alloc)
   Compiling panic_unwind v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/panic_unwind)
   Compiling gimli v0.32.3
   Compiling std_detect v0.1.5 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std_detect)
   Compiling miniz_oxide v0.8.9
   Compiling hashbrown v0.17.0
   Compiling addr2line v0.25.1
   Compiling proc_macro v0.0.0 (/home/toku/.rustup/toolchains/nightly-2026-04-29-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/proc_macro)
   Compiling pin-project-lite v0.2.17
   Compiling memchr v2.8.0
   Compiling itoa v1.0.18
   Compiling tokio v1.52.3
   Compiling hello v0.1.0 (/home/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.90s
[1229/1230] Pac SIM with dynamic libs in nuttx.tgz
'/usr/lib/x86_64-linux-gnu/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/usr/lib/x86_64-linux-gnu/libgcc_s.so.1' -> 'sim-pac/libs/libgcc_s.so.1'
'/usr/lib/x86_64-linux-gnu/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
~/nuttxspace/nuttx$ ./build-debug/nuttx

NuttShell (NSH) NuttX-12.13.0
nsh> help
help usage:  help [-v] [<cmd>]

    .           cmp         fdinfo      mkrd        rm          true
    [           dirname     free        mount       rmdir       truncate
    ?           df          help        mv          set         uname
    alias       dmesg       hexdump     pidof       kill        umount
    unalias     echo        losetup     poweroff    pkill       unset
    basename    env         ln          quit        sleep       uptime
    break       exec        ls          printf      usleep      watch
    cat         exit        mkdir       ps          source      xd
    cd          expr        mkfatfs     pwd         test        wait
    cp          false       mkfifo      readlink    time

Builtin Apps:
    dd                  nsh                 gpio
    dumpstack           sh                  hello
    gcov                ostest              hello_rust_cargo
nsh> uname -a
NuttX 12.13.0 d9f6216f30-dirty May 13 2026 13:06:16 sim sim
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}
Hello world from tokio!

# An infinite loop here.
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
