### PR TITLE
testing/ltp: silence -Wshift-count-overflow on -Werror builds

### DIFF
--- a/testing/ltp/Makefile
+++ b/testing/ltp/Makefile
@@ -238,6 +238,7 @@ CFLAGS += -Wno-int-conversion -Wno-shadow
 
 # Should be removed if possible in the future
 CFLAGS += -Wno-incompatible-pointer-types -Wno-overflow -Wno-int-to-pointer-cast
+CFLAGS += -Wno-shift-count-overflow
 
 # Specific compilation errors ignored in MacOS platform
 ifneq ($(CONFIG_HOST_MACOS),)


### PR DESCRIPTION
## Summary

The LTP `open_posix_testsuite` header `testcases/open_posix_testsuite/include/timespec.h` has, since 2019 ([linux-test-project/ltp@568ae4e](https://github.com/linux-test-project/ltp/commit/568ae4e3cfd1d2864b4116e383e9933110b48fd8)):

```c
#define TIME_T_MAX (time_t)((1UL << ((sizeof(time_t) << 3) - 1)) - 1)
```

When `time_t` is 64 bits, the shift reaches the sign bit of the underlying integer type and toolchains emit `-Wshift-count-overflow`. The LTP build promotes warnings to errors via `-Werror`, so `rv-virt/citest` and `rv-virt/citest64` fail on CI. This is independent of NuttX changes — the defect is upstream — but it surfaces in NuttX CI now that `time_t` is unconditionally 64-bit.

## Impact

This was reproduced on CI runs such as: https://github.com/apache/nuttx/actions/runs/25755497045/job/75643127334

## Solution

Silence the warning alongside the other 'should be removed in the future' relaxations already present in `apps/testing/ltp/Makefile`. The diagnostic is benign here (the value of `TIME_T_MAX` is correct on two's-complement targets), and the fix can be dropped once upstream LTP addresses it.

## Testing

`./tools/configure.sh rv-virt:citest && make` and `rv-virt:citest64` no longer fail with `-Werror=shift-count-overflow`.