### PR TITLE
apps:cmake: Add APPLE to a build target for sim's configuration using CMake

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -35,6 +35,7 @@ include(nuttx_parse_function_args)
 #   - riscv64: riscv64imac/imafdc-unknown-nuttx-elf
 #   - x86: i686-unknown-nuttx
 #   - x86_64: x86_64-unknown-nuttx
+#   - aarch64: aarch64-apple-darwin
 #
 # Inputs:
 #   ARCHTYPE - Architecture type (e.g. thumbv7m, riscv32)
@@ -53,6 +54,12 @@ function(nuttx_rust_target_triple ARCHTYPE ABITYPE CPUTYPE OUTPUT)
     set(TARGET_TRIPLE "${APPDIR}/tools/x86_64-unknown-nuttx.json")
   elseif(ARCHTYPE STREQUAL "x86")
     set(TARGET_TRIPLE "${APPDIR}/tools/i486-unknown-nuttx.json")
+  elseif(ARCHTYPE STREQUAL "aarch64")
+    if(APPLE)
+      set(TARGET_TRIPLE "aarch64-apple-darwin")
+    elseif(UNIX)
+      set(TARGET_TRIPLE "aarch64-unknown-linux-gnu")
+    endif()
   elseif(ARCHTYPE MATCHES "thumb")
     if(ARCHTYPE MATCHES "thumbv8m")
       # Extract just the base architecture type (thumbv8m.main or thumbv8m.base)
@@ -91,6 +98,13 @@ function(nuttx_rust_target_triple ARCHTYPE ABITYPE CPUTYPE OUTPUT)
     else()
       set(TARGET_TRIPLE "riscv64imac-unknown-nuttx-elf")
     endif()
+  endif()
+
+  if(NOT TARGET_TRIPLE)
+    message(
+      FATAL_ERROR
+        "Unsupported Rust target: LLVM_ARCHTYPE=${ARCHTYPE}, LLVM_ABITYPE=${ABITYPE}, LLVM_CPUTYPE=${CPUTYPE}"
+    )
   endif()
   set(${OUTPUT}
       ${TARGET_TRIPLE}
@@ -138,6 +152,11 @@ function(nuttx_add_rust)
     set(RUST_PANIC_FLAGS "")
   endif()
 
+  string(APPEND RUST_PANIC_FLAGS " --check-cfg=cfg(nuttx_arch_sim)")
+  if(CONFIG_ARCH_SIM)
+    string(APPEND RUST_PANIC_FLAGS " --cfg nuttx_arch_sim")
+  endif()
+
   # Get the Rust target triple
   nuttx_rust_target_triple(${LLVM_ARCHTYPE} ${LLVM_ABITYPE} ${LLVM_CPUTYPE}
                            RUST_TARGET)
@@ -153,6 +172,8 @@ function(nuttx_add_rust)
   set(RUST_LIB_PATH
       ${RUST_BUILD_DIR}/${TARGET_BASE}/${RUST_PROFILE}/lib${CRATE_NAME}.a)
 
+  file(GLOB_RECURSE RUST_SOURCES CONFIGURE_DEPENDS ${CRATE_PATH}/src/*.rs)
+
   # Create build directory
   file(MAKE_DIRECTORY ${RUST_BUILD_DIR})
 
@@ -166,6 +187,7 @@ function(nuttx_add_rust)
       -Zbuild-std=std,panic_abort -Zjson-target-spec --manifest-path
       ${CRATE_PATH}/Cargo.toml --target ${RUST_TARGET} --target-dir
       ${RUST_BUILD_DIR}
+    DEPENDS ${CRATE_PATH}/Cargo.toml ${RUST_SOURCES}
     COMMENT "Building Rust crate ${CRATE_NAME}"
     VERBATIM)
 


### PR DESCRIPTION
## Summary

* Add macOS support to the `hello_rust_cargo` CMake build configuration.
* Depends on nuttx PR: sim/posix: Add APPLE to a build target for sim's configuration using CMake.

## Impact

* Impact on build: Enables building on macOS.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration:

```
❯ make distclean
NuttX has not been configured!
To configure the project:
  tools/configure.sh <config>
For a list of available configurations:
  tools/configure.sh -L

❯ cmake -S . -B build-debug -DBOARD_CONFIG=sim:nsh -GNinja
-- NuttX Host Tools
-- CMake C compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
   TOOLS_DIR path is "/Users/toku/nuttxspace/nuttx"
   HOST = Darwin
-- Configuring done (0.1s)
-- Generating done (0.4s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (2.9s)
-- Generating done (1.0s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug

❯ printf "CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
" >> build-debug/.config

❯ cmake --build build-debug -t olddefconfig
[0/2] Re-checking globbed directories...
[1/2] cd /Users/toku/nuttxspace/nuttx && /opt/homebrew...ke -E touch /Users/toku/nuttxspace/nuttx/CMakeLists.tx
/Users/toku/nuttxspace/nuttx/build-debug/.config:1819: warning: SYSTEM_TIME64 (defined at sched/Kconfig:170) set more than once. Old value "y", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:1820: warning: FS_LARGEFILE (defined at fs/Kconfig:20) set more than once. Old value "y", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:1821: warning: TLS_NELEM (defined at libs/libc/tls/Kconfig:45) set more than once. Old value "16", new value "16".
/Users/toku/nuttxspace/nuttx/build-debug/.config:1822: warning: DEV_URANDOM (defined at drivers/crypto/Kconfig:16) set more than once. Old value "y", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:1823: warning: EXAMPLES_HELLO_RUST_CARGO (defined at /Users/toku/nuttxspace/apps/examples/rust/hello/Kconfig:6) set more than once. Old value "y", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:1824: warning: EXAMPLES_HELLO_RUST_CARGO_STACKSIZE (defined at /Users/toku/nuttxspace/apps/examples/rust/hello/Kconfig:25) set more than once. Old value "8192", new value "8192".
Loaded configuration '/Users/toku/nuttxspace/nuttx/build-debug/.config'
Configuration saved to '/Users/toku/nuttxspace/nuttx/build-debug/.config'
```

Testing logs before change:

```
❯ cmake --build build-debug
[0/1] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
   TOOLS_DIR path is "/Users/toku/nuttxspace/nuttx"
   HOST = Darwin
-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (3.0s)
-- Generating done (0.8s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug
[1202/1211] Building Rust crate hello
FAILED: [code=101] apps/examples/rust/hello/hello/target/debug/libhello.a /Users/toku/nuttxspace/nuttx/build-debug/apps/examples/rust/hello/hello/target/debug/libhello.a
cd /Users/toku/nuttxspace/nuttx/build-debug/apps/examples/rust/hello && /opt/homebrew/bin/cmake -E env NUTTX_INCLUDE_DIR=/Users/toku/nuttxspace/nuttx/include:/Users/toku/nuttxspace/nuttx/build-debug/include:/Users/toku/nuttxspace/nuttx/build-debug/include/arch RUSTFLAGS= cargo build -Zbuild-std=std,panic_abort -Zjson-target-spec --manifest-path /Users/toku/nuttxspace/apps/examples/rust/hello/Cargo.toml --target --target-dir /Users/toku/nuttxspace/nuttx/build-debug/apps/examples/rust/hello/hello/target
error: "--target" takes a target architecture as an argument.

Run `rustup target list` to see possible targets.
[1205/1211] Linking C static library libs/libc/libc.a
ninja: build stopped: subcommand failed.
```

Testing logs after change:

```
❯ cmake --build build-debug
[0/2] Re-checking globbed directories...
[1/2] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
   TOOLS_DIR path is "/Users/toku/nuttxspace/nuttx"
   HOST = Darwin
-- Configuring done (0.1s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (2.0s)
-- Generating done (1.2s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug
[0/4] Re-checking globbed directories...
[1202/1211] Building Rust crate hello
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.26s
[1207/1211] Linking C executable nuttx
ld: warning: -ld_classic is deprecated and will be removed in a future release
[1208/1211] Generating System.map

                                                                                took 30s
❯ ./build-debug/nuttx

                                                                                           NuttShell (NSH) NuttX-12.13.0                                                                                   nsh> help
                                                                                                       help usage:  help [-v] [<cmd>]

    .           cmp         fdinfo      mkrd        rm          true
    [           dirname     free        mount       rmdir       truncate
    ?           df          help        mv          set         uname
    alias       dmesg       hexdump     pidof       kill        umount
    unalias     echo        losetup     poweroff    pkill       unset
    basename    env         ln          quit        sleep       uptime
    break       exec        ls          printf      usleep      watch
    cat         exit        mkdir       ps          source      xd
    cd          expr        mkfatfs     pwd         test        wait
    cp          false       mkfifo      readlink    time

Builtin Apps:
    dd                  nsh                 gpio
    dumpstack           sh                  hello
    gcov                ostest              hello_rust_cargo
nsh> uname -a
NuttX 12.13.0 1076cb933d-dirty May 15 2026 14:48:07 sim sim
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}
Hello world from tokio!

# An infinite loop here.
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
