### PR TITLE
apps/cmake: Add DEPENDS for Rust-related files.

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -156,6 +156,18 @@ function(nuttx_add_rust)
   # Create build directory
   file(MAKE_DIRECTORY ${RUST_BUILD_DIR})
 
+  # Collect Rust source files and manifests as dependencies so that changes in
+  # the crate trigger a rebuild via CMake/Ninja.
+  file(
+    GLOB_RECURSE
+    RUST_CRATE_SOURCES
+    CONFIGURE_DEPENDS
+    "${CRATE_PATH}/Cargo.toml"
+    "${CRATE_PATH}/Cargo.lock"
+    "${CRATE_PATH}/build.rs"
+    "${CRATE_PATH}/src/*.rs"
+    "${CRATE_PATH}/src/**/*.rs")
+
   # Add a custom command to build the Rust crate
   add_custom_command(
     OUTPUT ${RUST_LIB_PATH}
@@ -166,6 +178,7 @@ function(nuttx_add_rust)
       -Zbuild-std=std,panic_abort -Zjson-target-spec --manifest-path
       ${CRATE_PATH}/Cargo.toml --target ${RUST_TARGET} --target-dir
       ${RUST_BUILD_DIR}
+    DEPENDS ${RUST_CRATE_SOURCES}
     COMMENT "Building Rust crate ${CRATE_NAME}"
     VERBATIM)
 


### PR DESCRIPTION
## Summary

Add `DEPENDS` to ensure staticlib rebuilds when Rust-related files change.

## Impact

* Impact on build: Rebuilding with CMake for rust-related changes

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(thumbv8m)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration:

```
❯ make distclean
NuttX has not been configured!
To configure the project:
  tools/configure.sh <config>
For a list of available configurations:
  tools/configure.sh -L

❯ cmake -S . -B build-debug -DBOARD_CONFIG=nucleo-h563zi:nsh -GNinja
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
Loaded configuration '/Users/toku/nuttxspace/nuttx/build-debug/.config.compressed'
Minimal configuration saved to '/Users/toku/nuttxspace/nuttx/build-debug/defconfig.tmp'
  Select HOST_MACOS=y
--   CMake:  4.3.2
--   Ninja:  1.13.2
--   Board:  nucleo-h563zi
--   Config: nsh
--   Appdir: /Users/toku/nuttxspace/apps
-- The C compiler identification is AppleClang 21.0.0.21000101
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
   TOOLS_DIR path is "/Users/toku/nuttxspace/nuttx"
   HOST = Darwin
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug/bin_host
-- The C compiler identification is GNU 14.3.1
-- The CXX compiler identification is GNU 14.3.1
-- The ASM compiler identification is GNU
-- Found assembler: /Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/arm-none-eabi-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/arm-none-eabi-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/arm-none-eabi-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (4.2s)
-- Generating done (0.5s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug

❯ printf "CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
" >> build-debug/.config

❯ cmake --build build-debug -t olddefconfig
[0/1] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
   TOOLS_DIR path is "/Users/toku/nuttxspace/nuttx"
   HOST = Darwin
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (0.5s)
-- Generating done (0.4s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug
[0/3] Re-checking globbed directories...
[1/3] cd /Users/toku/nuttxspace/nuttx && /opt/homebrew/...ke -E touch /Users/toku/nuttxspace/nuttx/CMakeLists.tx
/Users/toku/nuttxspace/nuttx/build-debug/.config:2014: warning: SYSTEM_TIME64 (defined at sched/Kconfig:170) set more than once. Old value "n", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:2015: warning: FS_LARGEFILE (defined at fs/Kconfig:20) set more than once. Old value "n", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:2016: warning: TLS_NELEM (defined at libs/libc/tls/Kconfig:45) set more than once. Old value "0", new value "16".
/Users/toku/nuttxspace/nuttx/build-debug/.config:2017: warning: DEV_URANDOM (defined at drivers/crypto/Kconfig:16) set more than once. Old value "n", new value "y".
/Users/toku/nuttxspace/nuttx/build-debug/.config:2018: warning: EXAMPLES_HELLO_RUST_CARGO (defined at /Users/toku/nuttxspace/apps/examples/rust/hello/Kconfig:6) set more than once. Old value "n", new value "y".
Loaded configuration '/Users/toku/nuttxspace/nuttx/build-debug/.config'
Configuration saved to '/Users/toku/nuttxspace/nuttx/build-debug/.config'
```

Build:

```

❯ cmake --build build-debug
[0/2] Re-checking globbed directories...
[1/2] Re-running CMake...
-- NuttX Host Tools
-- CMake C compiler: AppleClang
-- CMake system name: Darwin
-- CMake host system processor: arm64
   TOOLS_DIR path is "/Users/toku/nuttxspace/nuttx"
   HOST = Darwin
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug/bin_host
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (0.5s)
-- Generating done (0.4s)
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug
[0/4] Re-checking globbed directories...
[1156/1162] Building Rust crate hello
   Compiling compiler_builtins v0.1.160 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/compiler-builtins/compiler-builtins)
   Compiling core v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/core)
   Compiling libc v0.2.185
   Compiling object v0.37.3
   Compiling std v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/std)
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.45
   Compiling unicode-ident v1.0.24
   Compiling serde_core v1.0.228
   Compiling zmij v1.0.21
   Compiling serde_json v1.0.149
   Compiling serde v1.0.228
   Compiling syn v2.0.117
   Compiling serde_derive v1.0.228
   Compiling rustc-std-workspace-core v1.99.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc)
   Compiling memchr v2.7.6
   Compiling adler2 v2.0.1
   Compiling rustc-demangle v0.1.27
   Compiling cfg-if v1.0.4
   Compiling panic_abort v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/panic_abort)
   Compiling rustc-literal-escaper v0.0.7
   Compiling unwind v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/unwind)
   Compiling rustc-std-workspace-alloc v1.99.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/rustc-std-workspace-alloc)
   Compiling panic_unwind v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/panic_unwind)
   Compiling gimli v0.32.3
   Compiling hashbrown v0.17.0
   Compiling miniz_oxide v0.8.9
   Compiling std_detect v0.1.5 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/std_detect)
   Compiling addr2line v0.25.1
   Compiling proc_macro v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/proc_macro)
   Compiling pin-project-lite v0.2.17
   Compiling itoa v1.0.18
   Compiling memchr v2.8.0
   Compiling tokio v1.52.3
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.59s
[1157/1162] Linking CXX executable nuttx
/Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/../lib/gcc/arm-none-eabi/14.3.1/../../../../arm-none-eabi/bin/ld: warning: umm_mallinfo.c.o: missing .note.GNU-stack section implies executable stack
/Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/../lib/gcc/arm-none-eabi/14.3.1/../../../../arm-none-eabi/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
Memory region         Used Size  Region Size  %age Used
           flash:     1267368 B         2 MB     60.43%
            sram:       11576 B       256 KB      4.42%
[1159/1162] Generating System.map
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
