### PR TITLE
boot/mcuboot: Update commit version

### DIFF
--- a/boot/mcuboot/Kconfig
+++ b/boot/mcuboot/Kconfig
@@ -22,7 +22,7 @@ config MCUBOOT_REPOSITORY
 
 config MCUBOOT_VERSION
 	string "MCUboot version"
-	default "457be0cf3fb03e9e09938728dece8f03309db973"
+	default "e36d3c8d6ca5e0ed1f510f2a7d110f405a7c396b"
 	---help---
 		Defines MCUboot version to be downloaded. Either release tag
 		or commit hash should be specified. Using newer MCUboot version


### PR DESCRIPTION
## Summary

This updates the version of mcuboot used by NuttX now that BOARDIOC_INIT is removed.

## Impact

MCU boot only.

## Testing

I have no way to test whether this MCU boot version breaks other things, but it
will cause CI to pass (fix compilation error) in https://github.com/apache/nuttx/pull/18832. It has passed MCU boot CI.