### PR TITLE
examples: separate pulse count from PWM

### DIFF
--- a/examples/pulsecount/CMakeLists.txt
+++ b/examples/pulsecount/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/pulsecount/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_PULSECOUNT)
+  nuttx_add_application(
+    NAME
+    pulsecount
+    STACKSIZE
+    ${CONFIG_DEFAULT_TASK_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_PULSECOUNT}
+    SRCS
+    pulsecount_main.c)
+endif()

--- a/examples/pulsecount/Kconfig
+++ b/examples/pulsecount/Kconfig
@@ -1,0 +1,42 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_PULSECOUNT
+	tristate "pulsecount example"
+	default n
+	depends on PULSECOUNT
+	---help---
+		Enable the finite pulsecount example
+
+if EXAMPLES_PULSECOUNT
+
+config EXAMPLES_PULSECOUNT_DEVPATH
+	string "pulsecount device path"
+	default "/dev/pulsecount0"
+	---help---
+		The path to the pulsecount device.  Default: /dev/pulsecount0
+
+config EXAMPLES_PULSECOUNT_HIGH_NS
+	int "Default pulsecount high time"
+	default 5000000
+	---help---
+		The default pulsecount high time in nanoseconds.
+		Default: 5000000 ns
+
+config EXAMPLES_PULSECOUNT_LOW_NS
+	int "Default pulsecount low time"
+	default 5000000
+	---help---
+		The default pulsecount low time in nanoseconds.
+		Default: 5000000 ns
+
+config EXAMPLES_PULSECOUNT_COUNT
+	int "Default pulsecount count"
+	default 100
+	range 1 2147483647
+	---help---
+		The default number of pulses to generate.
+
+endif

--- a/examples/pulsecount/Make.defs
+++ b/examples/pulsecount/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/pulsecount/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_PULSECOUNT),)
+CONFIGURED_APPS += $(APPDIR)/examples/pulsecount
+endif

--- a/examples/pulsecount/Makefile
+++ b/examples/pulsecount/Makefile
@@ -1,0 +1,32 @@
+############################################################################
+# apps/examples/pulsecount/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+MAINSRC = pulsecount_main.c
+
+PROGNAME = pulsecount
+PRIORITY = SCHED_PRIORITY_DEFAULT
+STACKSIZE = $(CONFIG_DEFAULT_TASK_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_PULSECOUNT)
+
+include $(APPDIR)/Application.mk

--- a/examples/pulsecount/pulsecount_main.c
+++ b/examples/pulsecount/pulsecount_main.c
@@ -1,0 +1,247 @@
+/****************************************************************************
+ * apps/examples/pulsecount/pulsecount_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/ioctl.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <nuttx/timers/pulsecount.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct pulsecount_state_s
+{
+  FAR char *devpath;
+  uint32_t high_ns;
+  uint32_t low_ns;
+  uint32_t count;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void pulsecount_devpath(FAR struct pulsecount_state_s *state,
+                               FAR const char *devpath)
+{
+  if (state->devpath != NULL)
+    {
+      free(state->devpath);
+    }
+
+  state->devpath = strdup(devpath);
+}
+
+static int arg_string(FAR char **arg, FAR char **value)
+{
+  FAR char *ptr = *arg;
+
+  if (ptr[2] == '\0')
+    {
+      *value = arg[1];
+      return 2;
+    }
+
+  *value = &ptr[2];
+  return 1;
+}
+
+static int arg_decimal(FAR char **arg, FAR long *value)
+{
+  FAR char *string;
+  int ret;
+
+  ret = arg_string(arg, &string);
+  *value = strtol(string, NULL, 10);
+  return ret;
+}
+
+static void pulsecount_help(FAR struct pulsecount_state_s *state)
+{
+  printf("Usage: pulsecount [OPTIONS]\n");
+  printf("  [-p devpath] Default: %s Current: %s\n",
+         CONFIG_EXAMPLES_PULSECOUNT_DEVPATH,
+         state->devpath != NULL ? state->devpath : "NONE");
+  printf("  [-H high-ns] Default: %d ns Current: %" PRIu32 " ns\n",
+         CONFIG_EXAMPLES_PULSECOUNT_HIGH_NS, state->high_ns);
+  printf("  [-L low-ns] Default: %d ns Current: %" PRIu32 " ns\n",
+         CONFIG_EXAMPLES_PULSECOUNT_LOW_NS, state->low_ns);
+  printf("  [-n count] Default: %d Current: %" PRIu32 "\n",
+         CONFIG_EXAMPLES_PULSECOUNT_COUNT, state->count);
+  printf("  [-h] shows this message and exits\n");
+}
+
+static void parse_args(FAR struct pulsecount_state_s *state, int argc,
+                       FAR char **argv)
+{
+  FAR char *str;
+  long value;
+  int index;
+  int nargs;
+
+  for (index = 1; index < argc; )
+    {
+      if (argv[index][0] != '-')
+        {
+          printf("Invalid options format: %s\n", argv[index]);
+          exit(1);
+        }
+
+      switch (argv[index][1])
+        {
+          case 'p':
+            nargs = arg_string(&argv[index], &str);
+            pulsecount_devpath(state, str);
+            index += nargs;
+            break;
+
+          case 'H':
+            nargs = arg_decimal(&argv[index], &value);
+            if (value < 1)
+              {
+                printf("High time out of range: %ld\n", value);
+                exit(1);
+              }
+
+            state->high_ns = (uint32_t)value;
+            index += nargs;
+            break;
+
+          case 'L':
+            nargs = arg_decimal(&argv[index], &value);
+            if (value < 1)
+              {
+                printf("Low time out of range: %ld\n", value);
+                exit(1);
+              }
+
+            state->low_ns = (uint32_t)value;
+            index += nargs;
+            break;
+
+          case 'n':
+            nargs = arg_decimal(&argv[index], &value);
+            if (value < 1)
+              {
+                printf("Count out of range: %ld\n", value);
+                exit(1);
+              }
+
+            state->count = (uint32_t)value;
+            index += nargs;
+            break;
+
+          case 'h':
+            pulsecount_help(state);
+            exit(0);
+
+          default:
+            printf("Unsupported option: %s\n", argv[index]);
+            pulsecount_help(state);
+            exit(1);
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  struct pulsecount_state_s state;
+  struct pulsecount_info_s info;
+  int fd;
+  int ret;
+
+  /* Defaults */
+
+  memset(&state, 0, sizeof(state));
+  state.high_ns = CONFIG_EXAMPLES_PULSECOUNT_HIGH_NS;
+  state.low_ns = CONFIG_EXAMPLES_PULSECOUNT_LOW_NS;
+  state.count = CONFIG_EXAMPLES_PULSECOUNT_COUNT;
+
+  /* Parse args */
+
+  parse_args(&state, argc, argv);
+
+  if (state.devpath == NULL)
+    {
+      pulsecount_devpath(&state, CONFIG_EXAMPLES_PULSECOUNT_DEVPATH);
+    }
+
+  fd = open(state.devpath, O_RDONLY);
+  if (fd < 0)
+    {
+      printf("pulsecount: open %s failed: %d\n", state.devpath, errno);
+      goto errout;
+    }
+
+  memset(&info, 0, sizeof(info));
+  info.high_ns = state.high_ns;
+  info.low_ns = state.low_ns;
+  info.count = state.count;
+
+  printf("pulsecount: high: %" PRIu32 " ns low: %" PRIu32
+         " ns count: %" PRIu32 "\n",
+         info.high_ns, info.low_ns, info.count);
+
+  ret = ioctl(fd, PULSECOUNTIOC_SETCHARACTERISTICS,
+              (unsigned long)((uintptr_t)&info));
+  if (ret < 0)
+    {
+      printf("pulsecount: ioctl(PULSECOUNTIOC_SETCHARACTERISTICS) "
+             "failed: %d\n", errno);
+      goto errout_with_dev;
+    }
+
+  ret = ioctl(fd, PULSECOUNTIOC_START, 0);
+  if (ret < 0)
+    {
+      printf("pulsecount: ioctl(PULSECOUNTIOC_START) failed: %d\n", errno);
+      goto errout_with_dev;
+    }
+
+  close(fd);
+  fflush(stdout);
+  return OK;
+
+errout_with_dev:
+  close(fd);
+errout:
+  fflush(stdout);
+  return ERROR;
+}

--- a/examples/pwm/Kconfig
+++ b/examples/pwm/Kconfig
@@ -28,8 +28,7 @@ config EXAMPLES_PWM_DURATION
 	int "Default PWM duration"
 	default 5
 	---help---
-		The default PWM pulse train duration in seconds.  Used only if the current
-		pulse count is zero.  Default: 5 seconds
+		The default PWM pulse train duration in seconds.  Default: 5 seconds
 
 config EXAMPLES_PWM_DUTYPCT1
 	int "First PWM duty percentage"
@@ -134,14 +133,5 @@ config EXAMPLES_PWM_CHANNEL6
 		The sixth PWM channel number.  Default: 6
 
 endif
-
-config EXAMPLES_PWM_PULSECOUNT
-	int "Default pulse count"
-	default 0
-	depends on PWM_PULSECOUNT
-	---help---
-		The initial PWM pulse count.  This option is only available if
-		PWM_PULSECOUNT is defined.  Default: 0 (i.e., use the duration, not
-		the count).
 
 endif

--- a/examples/pwm/pwm.h
+++ b/examples/pwm/pwm.h
@@ -45,12 +45,8 @@
  * CONFIG_EXAMPLES_PWM_CHANNELn - The PWM channel number for channel n.
  *   Default: n
  * CONFIG_EXAMPLES_PWM_DURATION - The initial PWM pulse train duration
- *   in seconds. Used only if the current pulse count is zero
- *   (pulse count is only supported if CONFIG_PWM_PULSECOUNT is defined).
+ *   in seconds.
  *   Default: 5 seconds
- * CONFIG_EXAMPLES_PWM_PULSECOUNT - The initial PWM pulse count.
- *   This option is only available if CONFIG_PWM_PULSECOUNT is defined.
- *   Default: 0 (i.e., use the duration, not the count).
  */
 
 #ifndef CONFIG_PWM
@@ -67,10 +63,6 @@
 
 #ifndef CONFIG_EXAMPLES_PWM_DURATION
 #  define CONFIG_EXAMPLES_PWM_DURATION 5
-#endif
-
-#ifndef CONFIG_EXAMPLES_PWM_PULSECOUNT
-#  define CONFIG_EXAMPLES_PWM_PULSECOUNT 0
 #endif
 
 /****************************************************************************

--- a/examples/pwm/pwm_main.c
+++ b/examples/pwm/pwm_main.c
@@ -98,9 +98,6 @@ struct pwm_state_s
   int8_t    channels[CONFIG_PWM_NCHANNELS];
   uint8_t   duties[CONFIG_PWM_NCHANNELS];
   uint32_t  freq;
-#ifdef CONFIG_PWM_PULSECOUNT
-  uint32_t  count;
-#endif
   int       duration;
 };
 
@@ -230,11 +227,6 @@ static void pwm_help(FAR struct pwm_state_s *pwm)
     }
 
   printf("\n");
-#ifdef CONFIG_PWM_PULSECOUNT
-  printf("  [-n count] selects the pulse count.  "
-         "Default: %d Current: %" PRIx32 "\n",
-         CONFIG_EXAMPLES_PWM_PULSECOUNT, pwm->count);
-#endif
   printf("  [-t duration] is the duration of the pulse train in seconds.  "
          "Default: %d Current: %d\n",
          CONFIG_EXAMPLES_PWM_DURATION, pwm->duration);
@@ -361,20 +353,6 @@ static void parse_args(FAR struct pwm_state_s *pwm, int argc,
             index += nargs;
             break;
 
-#ifdef CONFIG_PWM_PULSECOUNT
-          case 'n':
-            nargs = arg_decimal(&argv[index], &value);
-            if (value < 0)
-              {
-                printf("Count must be non-negative: %ld\n", value);
-                exit(1);
-              }
-
-            pwm->count = (uint32_t)value;
-            index += nargs;
-            break;
-#endif
-
           case 'p':
             nargs = arg_string(&argv[index], &str);
             pwm_devpath(pwm, str);
@@ -449,9 +427,6 @@ int main(int argc, FAR char *argv[])
 #endif
       g_pwmstate.freq        = CONFIG_EXAMPLES_PWM_FREQUENCY;
       g_pwmstate.duration    = CONFIG_EXAMPLES_PWM_DURATION;
-#ifdef CONFIG_PWM_PULSECOUNT
-      g_pwmstate.count       = CONFIG_EXAMPLES_PWM_PULSECOUNT;
-#endif
       g_pwmstate.initialized = true;
     }
 
@@ -511,10 +486,6 @@ int main(int argc, FAR char *argv[])
         info.channels[i].channel, info.channels[i].duty);
     }
 
-#ifdef CONFIG_PWM_PULSECOUNT
-  info.channels[0].count = g_pwmstate.count;
-  printf(" count: %" PRIx32, info.channels[0].count);
-#endif
   printf("\n");
 
   ret = ioctl(fd, PWMIOC_SETCHARACTERISTICS,
@@ -526,9 +497,7 @@ int main(int argc, FAR char *argv[])
       goto errout_with_dev;
     }
 
-  /* Then start the pulse train.  Since the driver was opened in blocking
-   * mode, this call will block if the count value is greater than zero.
-   */
+  /* Then start the pulse train. */
 
   ret = ioctl(fd, PWMIOC_START, 0);
   if (ret < 0)
@@ -537,28 +506,19 @@ int main(int argc, FAR char *argv[])
       goto errout_with_dev;
     }
 
-  /* It a non-zero count was not specified, then wait for the selected
-   * duration, then stop the PWM output.
-   */
+  /* Wait for the specified duration, then stop the PWM output. */
 
-#ifdef CONFIG_PWM_PULSECOUNT
-  if (info.channels[0].count == 0)
-#endif
+  sleep(g_pwmstate.duration);
+
+  /* Then stop the pulse train */
+
+  printf("pwm_main: stopping output\n");
+
+  ret = ioctl(fd, PWMIOC_STOP, 0);
+  if (ret < 0)
     {
-      /* Wait for the specified duration */
-
-      sleep(g_pwmstate.duration);
-
-      /* Then stop the pulse train */
-
-      printf("pwm_main: stopping output\n");
-
-      ret = ioctl(fd, PWMIOC_STOP, 0);
-      if (ret < 0)
-        {
-          printf("pwm_main: ioctl(PWMIOC_STOP) failed: %d\n", errno);
-          goto errout_with_dev;
-        }
+      printf("pwm_main: ioctl(PWMIOC_STOP) failed: %d\n", errno);
+      goto errout_with_dev;
     }
 
   close(fd);


### PR DESCRIPTION
## Summary

Remove pulse count feature from PWM example and create new example dedicated to pulse count.

Depends-on: https://github.com/apache/nuttx/pull/18916.

## Impact
details in https://github.com/apache/nuttx/pull/18916

## Testing
details in https://github.com/apache/nuttx/pull/18916

