### PR TITLE
apps/system/microros: add empty library skeleton

### DIFF
--- a/system/microros/.gitignore
+++ b/system/microros/.gitignore
@@ -1,0 +1,13 @@
+# Build artifacts
+/build/
+/install/
+/micro_ros_dev/
+/micro_ros_src/
+
+# Generated files
+/libmicroros.a
+/toolchain.cmake
+/colcon.meta
+
+# Archives
+*.tar.gz

--- a/system/microros/CMakeLists.txt
+++ b/system/microros/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/system/microros/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_MICROROS)
+  nuttx_add_library(microros)
+endif()

--- a/system/microros/Kconfig
+++ b/system/microros/Kconfig
@@ -1,0 +1,102 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig SYSTEM_MICROROS
+	bool "micro-ROS Integration"
+	default n
+	depends on NET_UDP || SERIAL_TERMIOS
+	---help---
+		Enable micro-ROS integration for NuttX RTOS. Provides a ROS 2
+		client library for embedded and real-time systems.
+
+if SYSTEM_MICROROS
+
+config MICROROS_DISTRO
+	string "ROS 2 Distribution"
+	default "jazzy"
+	---help---
+		Specifies the ROS 2 distribution branch (e.g., humble, jazzy, kilted).
+		This determines which versions of micro-ROS packages are fetched.
+
+choice
+	prompt "Transport Method"
+	default MICROROS_TRANSPORT_UDP
+
+config MICROROS_TRANSPORT_UDP
+	bool "UDP Transport"
+	---help---
+		Use UDP socket for communication with micro-ROS agent.
+
+config MICROROS_TRANSPORT_SERIAL
+	bool "Serial Transport"
+	depends on SERIAL_TERMIOS
+	---help---
+		Use serial (UART/USB-CDC) for communication with micro-ROS agent.
+
+endchoice
+
+if MICROROS_TRANSPORT_UDP
+
+config MICROROS_AGENT_IP
+	string "Agent IP Address"
+	default "10.42.0.214"
+	---help---
+		IP address of the micro-ROS agent.
+
+config MICROROS_AGENT_PORT
+	int "Agent Port"
+	default 8888
+	---help---
+		UDP port of the micro-ROS agent.
+
+endif
+
+if MICROROS_TRANSPORT_SERIAL
+
+config MICROROS_SERIAL_DEVICE
+	string "Serial Device Path"
+	default "/dev/ttyS0"
+	---help---
+		Serial device to use for transport (e.g., /dev/ttyS0, /dev/ttyACM0).
+
+config MICROROS_SERIAL_BAUD
+	int "Serial Baud Rate"
+	default 115200
+	---help---
+		Baud rate for serial communication.
+
+endif
+
+config MICROROS_MAX_NODES
+	int "Maximum Nodes"
+	default 1
+	---help---
+		Maximum number of ROS nodes that can be created.
+
+config MICROROS_MAX_PUBLISHERS
+	int "Maximum Publishers"
+	default 5
+	---help---
+		Maximum number of publishers per node.
+
+config MICROROS_MAX_SUBSCRIPTIONS
+	int "Maximum Subscriptions"
+	default 5
+	---help---
+		Maximum number of subscriptions per node.
+
+config MICROROS_MAX_SERVICES
+	int "Maximum Services"
+	default 1
+	---help---
+		Maximum number of services per node.
+
+config MICROROS_MAX_CLIENTS
+	int "Maximum Clients"
+	default 1
+	---help---
+		Maximum number of service clients per node.
+
+endif

--- a/system/microros/Make.defs
+++ b/system/microros/Make.defs
@@ -1,0 +1,21 @@
+############################################################################
+# apps/system/microros/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################

--- a/system/microros/Makefile
+++ b/system/microros/Makefile
@@ -1,0 +1,25 @@
+############################################################################
+# apps/system/microros/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+MENUDESC = "micro-ROS Library"
+
+include $(APPDIR)/Directory.mk


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Establish the directory structure and build system integration for micro-ROS 
library in NuttX apps. This PR adds the foundational skeleton for Phase 2 of 
the micro-ROS integration project—Kconfig with full configuration options for 
ROS 2 distribution selection, transport layer choice (UDP/serial), agent 
addressing, and resource limits. Makefile follows standard NuttX pattern using 
MENUDESC and Directory.mk.


## Impact

**Build System:**
- Adds `apps/system/microros/` as new system module
- Integrates via existing parent `Make.defs` wildcard include
- Auto-discovered by `mkkconfig.sh` Kconfig generation

**Configuration:**
- Introduces CONFIG_SYSTEM_MICROROS menuconfig option (bool, default n)
- Adds 13 subordinate configuration options:
  - MICROROS_DISTRO: ROS 2 distribution (humble, jazzy, kilted)
  - MICROROS_TRANSPORT_UDP / MICROROS_TRANSPORT_SERIAL: transport selection
  - MICROROS_AGENT_IP, MICROROS_AGENT_PORT: UDP agent addressing
  - MICROROS_SERIAL_DEVICE, MICROROS_SERIAL_BAUD: serial transport config
  - MICROROS_MAX_NODES, MICROROS_MAX_PUBLISHERS, MICROROS_MAX_SUBSCRIPTIONS, 
    MICROROS_MAX_SERVICES, MICROROS_MAX_CLIENTS: resource limits
- Proper dependencies declared (NET_UDP || SERIAL_TERMIOS for main config)
- Sensible defaults (distro=jazzy, transport=UDP, conservative resource limits)


## Testing

**Host Environment:**
- OS: macOS 13.x + Ubuntu 26.04 (EC2)
- Build tools: gcc, make, colcon (installed)
- NuttX source: apache/nuttx master branch
- NuttX apps: apache/nuttx-apps master branch

**Target Verification:**
- Configuration: sim:nsh (simulator, no hardware needed)
- Board: sim (Kconfig structure only, not full cross-compilation)

**Test Procedure:**

```bash
# 1. Configure NuttX with sim:nsh and apps directory
cd nuttx
./tools/configure.sh sim:nsh -a ../apps

# 2. Enable micro-ROS library configuration
kconfig-tweak --enable CONFIG_SYSTEM_MICROROS

# 3. Attempt build to verify no errors
make -j$(nproc)

# Expected output: Configuration succeeds, make completes without errors
```
