### PR TITLE
apps/cmake: Remove stale in-source builtin headers

### DIFF
--- a/builtin/CMakeLists.txt
+++ b/builtin/CMakeLists.txt
@@ -21,6 +21,12 @@
 # ##############################################################################
 
 if(CONFIG_BUILTIN)
+  # Out-of-tree builds generate these headers in the binary directory. Remove
+  # stale in-source copies to avoid accidental inclusion.
+  if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
+    file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/builtin_list.h
+         ${CMAKE_CURRENT_SOURCE_DIR}/builtin_proto.h)
+  endif()
 
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
apps/cmake: Remove stale in-source builtin headers

## Summary

Remove stale in-source generated builtin headers during out-of-tree CMake builds.

## Impact

* Impact on build: Prevents out-of-tree CMake builds from accidentally including stale `apps/builtin/builtin_list.h` and `apps/builtin/builtin_proto.h` generated by previous in-source or Make builds.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(ARM GCC 14.3.rel1)
* Target(s): arch(thumbv8m)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration:

* First, set `hello_rust_cargo` to a valid state, then build it using `make`.

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.72s
LN: platform/board to /Users/toku/nuttxspace/apps/platform/dummy
Register: hello_rust_cargo
Register: dd
Register: nsh
Register: sh
CPP:  /Users/toku/nuttxspace/nuttx/boards/arm/stm32h5/nucleo-h563zi/scripts/flash.ld-> /Users/toku/nuttxspace/nuLD: nuttx
arm-none-eabi-ld: warning: group_join.o: missing .note.GNU-stack section implies executable stack
arm-none-eabi-ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
Memory region         Used Size  Region Size  %age Used
           flash:     1266212 B         2 MB     60.38%
            sram:       11560 B       256 KB      4.41%
CP: nuttx.bin
```

* Assume the scenario where `make distclean` fails, leaving `~/apps/builtin/builtin_list.h` and `builtin_proto.h` intact.
* Set the default configuration using cmake.

```
rm -rf build-default
cmake -S . -B build-default -DBOARD_CONFIG=nucleo-h563zi:nsh -GNinja
cmake --build build-default -t olddefconfig
```

Testing logs before change:

```
> cmake --build build-debug
...
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug
[1149/1152] Linking CXX executable nuttx
FAILED: [code=1] nuttx
: && /Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/arm-none-eabi-g++  --specs=nosys.specs -Wl,--print-memory-usage -Wl,--entry=__start -nostdlib -Wl,--gc-sections -Wl,--cref -Wl,-Map=nuttx.map @CMakeFiles/nuttx.rsp -o nuttx && :
/Applications/ArmGNUToolchain/14.3.rel1/arm-none-eabi/bin/../lib/gcc/arm-none-eabi/14.3.1/../../../../arm-none-eabi/bin/ld: apps/builtin/libapps_builtin.a(builtin_list.c.o):(.rodata.g_builtins+0x1c): undefined reference to `hello_rust_cargo_main'
Memory region         Used Size  Region Size  %age Used
           flash:      218876 B         2 MB     10.44%
            sram:        9808 B       256 KB      3.74%
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

Testing logs after change:

At `cmake -S . -B build-default -DBOARD_CONFIG=nucleo-h563zi:nsh -GNinja` stage, `apps/builtin/builtin_list.h` and `apps/builtin/builtin_proto.h` are removed.

```
-- Build files have been written to: /Users/toku/nuttxspace/nuttx/build-debug
[1149/1152] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      218848 B         2 MB     10.44%
            sram:        9808 B       256 KB      3.74%
[1151/1152] Generating System.map
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
