### PR TITLE
nshlib: fix infinite loop on broken stdout in nsh_catfile

### DIFF
--- a/nshlib/nsh_console.c
+++ b/nshlib/nsh_console.c
@@ -131,18 +131,19 @@ static ssize_t nsh_consolewrite(FAR struct nsh_vtbl_s *vtbl,
                                 FAR const void *buffer, size_t nbytes)
 {
   FAR struct console_stdio_s *pstate = (FAR struct console_stdio_s *)vtbl;
-  ssize_t ret;
 
-  /* Write the data to the output stream */
+  /* Write the data to the output stream.
+   *
+   * Errors are reported to the caller via the negative return value and
+   * errno; do NOT _err() here.  OUTFD may itself be wired to the syslog
+   * backend (e.g. nsh_catfile dumping /dev/log on dmesg), in which case
+   * logging on write failure would produce new bytes, get picked up by
+   * the next read(), and lock the shell into an infinite loop at the
+   * highest priority — independent of which errno (EPIPE/EIO/ENOSPC/...)
+   * the underlying device returns.
+   */
 
-  ret = write(OUTFD(pstate), buffer, nbytes);
-  if (ret < 0)
-    {
-      _err("ERROR: [%d] Failed to send buffer: %d\n",
-          OUTFD(pstate), errno);
-    }
-
-  return ret;
+  return write(OUTFD(pstate), buffer, nbytes);
 }
 
 /****************************************************************************

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -228,8 +228,14 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                                  NSH_ERRNO_OF(errcode));
                     }
 
+                  /* Jump straight to cleanup.  On a broken stdout (e.g.
+                   * closed PTY master) we must not keep reading: the
+                   * outer loop would otherwise drain /dev/log forever
+                   * when cat is dumping it on dmesg.
+                   */
+
                   ret = ERROR;
-                  break;
+                  goto errout;
                 }
               else
                 {
@@ -255,6 +261,7 @@ int nsh_catfile(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
   /* Close the input file and return the result */
 
+errout:
   close(fd);
   free(buffer);
   return ret;


### PR DESCRIPTION
## Summary

Fixes an infinite loop in `nsh_catfile` (used by `cat` / `dmesg`) when stdout is broken — for example when a PTY master is closed while the shell is dumping `/dev/log`.

Failure mode:

1. `nsh_catfile` reads a chunk from the input file (e.g. `/dev/log`).
2. `nsh_consolewrite` calls `write(OUTFD, ...)`, which fails (EPIPE/EIO/ENOSPC/…).
3. The old code logged the failure via `_err()`, which the syslog backend turned into more bytes on `/dev/log`.
4. `nsh_catfile` ignored the write error and looped back to `read()`, picking up the bytes that step 3 just produced.
5. Goto 2 — the shell spins forever at the highest priority.

Two independent fixes, either of which would break the loop, both applied for defense in depth:

- **`nshlib/nsh_console.c`**: drop the `_err()` in `nsh_consolewrite` entirely. The hazard is errno-agnostic: any logging at this layer can be re-injected when `OUTFD` is bound to the syslog backend. Callers already get the failure via the negative return value and `errno`, so on-failure logging here is redundant.
- **`nshlib/nsh_fsutils.c`**: on inner-loop write failure in `nsh_catfile`, jump straight to a single `errout:` cleanup label instead of using a two-level `break` and falling through to another `read()`. A failed write can no longer be followed by another read of the same fd.

## Impact

- **User-visible behavior**: `cat /dev/log`, `dmesg`, and similar commands now exit cleanly with `ERROR` when stdout is broken, instead of hanging the shell. No change on the success path or for non-syslog outputs.
- **Logging**: write failures inside `nsh_consolewrite` are no longer logged at this layer. The information is still available to callers through the return value and `errno`, and other layers (e.g. command implementations) remain free to report errors as appropriate.
- **API / build / config**: none. No public API, Kconfig, or build changes.
- **Security**: removes a denial-of-service style hang triggered by closing the controlling PTY while NSH is streaming the syslog device.
- **Compatibility**: backward compatible. Behavior only changes on the previously broken error path.
- **Documentation**: no doc changes required.

## Testing
Regression checks on the happy path:

- `cat <regular file>` — unchanged output, exit status 0.
- `dmesg` to a healthy console — unchanged output.
- `cat` of a non-existent / unreadable file — still reports the original error via the existing `nsh_error()` paths in callers; no behavioral change beyond the dropped `_err()` line in `nsh_consolewrite`.