### PR TITLE
apps: Check string allocation failures

### DIFF
--- a/.codespell-ignore-lines
+++ b/.codespell-ignore-lines
@@ -6,3 +6,5 @@
               object = new Controlse::CCertificate(
           Controlse::CCertificate cert(se, settings->key_id);
       auto certificate = Controlse::CCertificate(
+ *  |---------- [-rw-r--r--        15]  afile.txt
+  g_afile.name                 = "afile.txt";

--- a/examples/mount/mount_main.c
+++ b/examples/mount/mount_main.c
@@ -217,6 +217,13 @@ static void show_directories(const char *path, int indent)
           snprintf(g_namebuffer, sizeof(g_namebuffer),
                    "%s/%s", path, direntry->d_name);
           subdir = strdup(g_namebuffer);
+          if (subdir == NULL)
+            {
+              printf("show_directories: ERROR out of memory\n");
+              g_nerrors++;
+              continue;
+            }
+
           show_directories(subdir, indent + 1);
           free(subdir);
         }

--- a/examples/romfs/romfs_main.c
+++ b/examples/romfs/romfs_main.c
@@ -394,6 +394,12 @@ static void readdirectories(const char *path, struct node_s *entry)
       snprintf(g_scratchbuffer, sizeof(g_scratchbuffer),
                "%s/%s", path, direntry->d_name);
       fullpath = strdup(g_scratchbuffer);
+      if (fullpath == NULL)
+        {
+          printf("  ERROR: Out of memory\n");
+          g_nerrors++;
+          continue;
+        }
 
       if (DIRENT_ISDIRECTORY(direntry->d_type))
         {

--- a/netutils/chat/chat.c
+++ b/netutils/chat/chat.c
@@ -108,6 +108,8 @@ static int chat_tokenise(FAR struct chat *priv,
 
   int tok_on_delimiter(void)
   {
+    FAR struct chat_token *newtok;
+
     if (!tok_pos && !quoted && !no_termin)
       {
           /* a) the first character in the script is a delimiter or
@@ -122,9 +124,29 @@ static int chat_tokenise(FAR struct chat *priv,
     /* Terminate the temporary */
 
     tok_str[tok_pos] = '\0';
+    newtok = malloc(sizeof(struct chat_token));
+    if (newtok == NULL)
+      {
+        /* out of memory */
+
+        return -ENOMEM;
+      }
+
+    /* Copy the temporary */
+
+    newtok->string = strdup(tok_str);
+    if (newtok->string == NULL)
+      {
+        free(newtok);
+        return -ENOMEM;
+      }
+
+    newtok->no_termin = no_termin;
+    newtok->next = NULL;
+
     if (tok)
       {
-        tok->next = malloc(sizeof(struct chat_token));
+        tok->next = newtok;
 
         /* The terminated token becomes previous */
 
@@ -134,25 +156,9 @@ static int chat_tokenise(FAR struct chat *priv,
       {
         /* There was no previous token */
 
-        *first_tok = malloc(sizeof(struct chat_token));
+        *first_tok = newtok;
         tok = *first_tok;
       }
-
-    if (!tok)
-      {
-        /* out of memory */
-
-        return -ENOMEM;
-      }
-
-    /* Copy the temporary */
-
-    tok->string = strdup(tok_str);
-    tok->no_termin = no_termin;
-
-    /* Initialize the next token */
-
-    tok->next = NULL;
 
     /* Reset the buffer position */
 

--- a/netutils/ftpc/ftpc_connect.c
+++ b/netutils/ftpc/ftpc_connect.c
@@ -108,6 +108,11 @@ SESSION ftpc_connect(FAR union ftpc_sockaddr_u *server)
    */
 
   session->homeldir = strdup(ftpc_lpwd());
+  if (session->homeldir == NULL)
+    {
+      nerr("ERROR: Failed to allocate local home directory\n");
+      goto errout_with_alloc;
+    }
 
   /* And (Re-)connect to the server */
 

--- a/netutils/ftpc/ftpc_listdir.c
+++ b/netutils/ftpc/ftpc_listdir.c
@@ -257,6 +257,7 @@ FAR struct ftpc_dirlist_s *ftpc_listdir(SESSION handle,
   FAR char *tmpfname;
   bool iscurrdir;
   unsigned int nnames;
+  unsigned int i;
   int allocsize;
   int ret;
 
@@ -365,6 +366,17 @@ FAR struct ftpc_dirlist_s *ftpc_listdir(SESSION handle,
 
       ftpc_nlstparse(filestream, ftpc_addname, dirlist);
       DEBUGASSERT(nnames == dirlist->nnames);
+
+      for (i = 0; i < dirlist->nnames; i++)
+        {
+          if (dirlist->name[i] == NULL)
+            {
+              nerr("ERROR: Failed to allocate directory name\n");
+              ftpc_dirfree(dirlist);
+              dirlist = NULL;
+              break;
+            }
+        }
     }
 
 errout:

--- a/netutils/ftpc/ftpc_login.c
+++ b/netutils/ftpc/ftpc_login.c
@@ -172,6 +172,10 @@ int ftpc_relogin(FAR struct ftpc_session_s *session)
   if (session->homerdir != NULL)
     {
       session->currdir = strdup(session->homerdir);
+      if (session->currdir == NULL)
+        {
+          return -ENOMEM;
+        }
     }
 
   /* If the user has requested a special start up directory, then change to

--- a/netutils/ftpd/ftpd.c
+++ b/netutils/ftpd/ftpd.c
@@ -627,6 +627,11 @@ static bool ftpd_account_login(FAR struct ftpd_session_s *session,
       if (account->home != NULL)
         {
           home = strdup(account->home);
+          if (home == NULL)
+            {
+              ftpd_account_free(account);
+              return false;
+            }
         }
 
       flags = account->flags;
@@ -645,6 +650,11 @@ static bool ftpd_account_login(FAR struct ftpd_session_s *session,
         {
           home = strdup(home);
         }
+
+      if (home == NULL)
+        {
+          return false;
+        }
     }
 
   if ((flags & FTPD_ACCOUNTFLAG_ADMIN) != 0)
@@ -652,6 +662,12 @@ static bool ftpd_account_login(FAR struct ftpd_session_s *session,
       /* admin user */
 
       session->home = strdup("/");
+      if (session->home == NULL)
+        {
+          free(home);
+          return false;
+        }
+
       session->work = home;
     }
   else
@@ -660,6 +676,12 @@ static bool ftpd_account_login(FAR struct ftpd_session_s *session,
 
       session->home = home;
       session->work = strdup("/");
+      if (session->work == NULL)
+        {
+          free(home);
+          session->home = NULL;
+          return false;
+        }
     }
 
   return true;
@@ -2517,6 +2539,17 @@ static int ftpd_command_user(FAR struct ftpd_session_s *session)
       session->loggedin = false;
       session->home     = strdup(home == NULL ? "/" : home);
       session->work     = strdup("/");
+      if (session->home == NULL || session->work == NULL)
+        {
+          free(session->home);
+          free(session->work);
+          session->home = NULL;
+          session->work = NULL;
+
+          return ftpd_response(session->cmd.sd, session->txtimeout,
+                               g_respfmt1, 451, ' ',
+                               "Memory exhausted !");
+        }
 
       return ftpd_response(session->cmd.sd, session->txtimeout,
                            g_respfmt1, 230, ' ', "Login successful.");

--- a/netutils/thttpd/libhttpd.c
+++ b/netutils/thttpd/libhttpd.c
@@ -2163,13 +2163,14 @@ FAR httpd_server *httpd_initialize(FAR httpd_sockaddr *sa)
 #else
   hs->hostname = httpd_strdup(httpd_ntoa(sa));
 #endif
-  ninfo("hostname: %s\n", hs->hostname);
-
   if (!hs->hostname)
     {
       nerr("ERROR: out of memory copying hostname\n");
+      free_httpd_server(hs);
       return NULL;
     }
+
+  ninfo("hostname: %s\n", hs->hostname);
 
   hs->cgi_count = 0;
 

--- a/netutils/webserver/httpd_dirlist.c
+++ b/netutils/webserver/httpd_dirlist.c
@@ -196,7 +196,11 @@ ssize_t httpd_dirlist(int outfd, FAR struct httpd_fs_file *file)
         }
 
       ret = asprintf(&path, "%s/%s", file->path, dent->d_name);
-      ASSERT(ret > 0 && path);
+      if (ret < 0 || path == NULL)
+        {
+          nerr("ERROR: asprintf failed\n");
+          break;
+        }
 
       /* call stat() to obtain modified time and size */
 

--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -257,17 +257,38 @@ int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   else if (strcmp(path, "-") == 0)
     {
       alloc = strdup(nsh_getwd(g_oldpwd));
+      if (alloc == NULL)
+        {
+          nsh_error(vtbl, g_fmtcmdoutofmemory, argv[0]);
+          ret = ERROR;
+          goto errout;
+        }
+
       path  = alloc;
     }
 #endif
   else if (strcmp(path, "..") == 0)
     {
       alloc = strdup(nsh_getcwd(vtbl));
+      if (alloc == NULL)
+        {
+          nsh_error(vtbl, g_fmtcmdoutofmemory, argv[0]);
+          ret = ERROR;
+          goto errout;
+        }
+
       path  = dirname(alloc);
     }
   else
     {
       fullpath = nsh_getfullpath(vtbl, path);
+      if (fullpath == NULL)
+        {
+          nsh_error(vtbl, g_fmtcmdoutofmemory, argv[0]);
+          ret = ERROR;
+          goto errout;
+        }
+
       path     = fullpath;
     }
 
@@ -288,6 +309,7 @@ int cmd_cd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 
   /* Free any memory that was allocated */
 
+errout:
   if (alloc)
     {
       free(alloc);

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -1555,6 +1555,12 @@ int cmd_wget(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (localfile == NULL)
     {
       allocfile = strdup(url);
+      if (allocfile == NULL)
+        {
+          fmt = g_fmtcmdoutofmemory;
+          goto errout;
+        }
+
       localfile = basename(allocfile);
     }
 

--- a/system/telnet/telnet_chatd.c
+++ b/system/telnet/telnet_chatd.c
@@ -40,7 +40,7 @@
 /* Leveraged from libtelnet, https://github.com/seanmiddleditch/libtelnet.
  * Modified and re-released under the BSD license.
  *
- * The original authors of libtelnet are listed below.  Per their licesne,
+ * The original authors of libtelnet are listed below.  Per their license,
  * "The author or authors of this code dedicate any and all copyright
  * interest in this code to the public domain. We make this dedication for
  * the benefit of the public at large and to the detriment of our heirs and
@@ -52,6 +52,7 @@
  *   (Also listed in the AUTHORS file are Jack Kelly <endgame.dos@gmail.com>
  *   and Katherine Flavel <kate@elide.org>)
  */
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
@@ -254,6 +255,12 @@ static void _online(const char *line, int overflow, void *ud)
       /* Keep name */
 
       user->name = strdup(line);
+      if (user->name == NULL)
+        {
+          telnet_printf(user->telnet, "Out of memory.\nEnter name: ");
+          return;
+        }
+
       telnet_printf(user->telnet, "Welcome, %s!\n", line);
       return;
     }


### PR DESCRIPTION
﻿## Summary

Refs #1727.

This PR adds missing allocation-failure handling for selected `strdup()` and `asprintf()` call sites.

Commit structure:
- Commit 1 (`apps: Fix unchecked strdup()/asprintf() as requested in #1727`) fixes the direct `strdup()` / `asprintf()` cases requested in #1727 where the allocated result is used locally before a failure check.
- Commit 2 (`netutils/thttpd: Apply the same check to related allocation sites`) applies the same check to `httpd_strdup()`, the thttpd-local wrapper around `strdup()`.

The second commit is logically separable, happy to drop if out of scope.

Scope notes:
- The direct fixes cover app-owned call sites where failure would otherwise flow into immediate use, such as path splitting, directory list construction, login path setup, and web directory listing formatting.
- The related extension is limited to `httpd_strdup()` because it has the same NULL-on-allocation-failure contract as `strdup()` and the caller used the result before checking it.
- I did not expand this PR to `malloc()`, `calloc()`, `realloc()`, or other raw allocation APIs because #1727 specifically asks about `strdup()` / `asprintf()`, and covering all allocation APIs would broaden the review substantially.

## Impact

No user-facing behavior change is intended except that low-memory paths now fail cleanly instead of using NULL allocation results.

- New feature: NO
- User adaptation required: NO
- Build process change: NO
- Hardware/architecture/board change: NO
- Documentation update required: NO
- Security impact: NO intended security impact; this improves low-memory failure handling.
- Compatibility impact: NO intended compatibility impact.

## Testing

Host:
- Windows with WSL Ubuntu 24.04
- CPU: x86_64
- Compiler: GCC 13.3.0

Target:
- `sim:nsh`

Checks run:
- `git diff --check upstream/master..HEAD`
- `checkpatch.sh -c -u -m -g HEAD~2..HEAD` from a WSL temp clone with `codespell` / `cvt2utf` in a temporary venv
- `./tools/configure.sh -a ../nuttx-apps-check-1727 sim:nsh`
- `make -j$(nproc)`

Results:
- `git diff --check`: pass
- `checkpatch.sh`: pass
- `sim:nsh` build: pass; build completed and generated `nuttx.tgz`

Note: the WSL temp build printed clock-skew warnings on `.config`; compilation and link completed successfully.