### PR TITLE
apps/system/microros: add libmicroros.a colcon cross-build orchestration

### DIFF
--- a/system/microros/CMakeLists.txt
+++ b/system/microros/CMakeLists.txt
@@ -21,5 +21,27 @@
 # ##############################################################################
 
 if(CONFIG_SYSTEM_MICROROS)
-  nuttx_add_library(microros)
+  set(MICROROS_DIR ${CMAKE_CURRENT_LIST_DIR})
+  set(MICROROS_LIB_DIR ${MICROROS_DIR}/micro_ros_lib)
+  set(MICROROS_DISTRO ${CONFIG_MICROROS_DISTRO})
+
+  include(ExternalProject)
+
+  ExternalProject_Add(
+    microros_build
+    SOURCE_DIR ${MICROROS_LIB_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND
+      ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+      AR=${CMAKE_AR} CFLAGS=${CMAKE_C_FLAGS} CXXFLAGS=${CMAKE_CXX_FLAGS} make -C
+      ${MICROROS_DIR} libmicroros.a
+    INSTALL_COMMAND ""
+    BUILD_IN_SOURCE TRUE
+    BUILD_BYPRODUCTS ${MICROROS_DIR}/libmicroros.a)
+
+  nuttx_add_library(microros STATIC IMPORTED GLOBAL)
+  set_target_properties(
+    microros PROPERTIES IMPORTED_LOCATION ${MICROROS_DIR}/libmicroros.a
+                        INTERFACE_INCLUDE_DIRECTORIES ${MICROROS_DIR}/include)
+  add_dependencies(microros microros_build)
 endif()

--- a/system/microros/Make.defs
+++ b/system/microros/Make.defs
@@ -19,3 +19,12 @@
 # under the License.
 #
 ############################################################################
+
+ifneq ($(CONFIG_SYSTEM_MICROROS),)
+CONFIGURED_APPS += $(APPDIR)/system/microros
+
+CFLAGS   += ${INCDIR_PREFIX}$(APPDIR)/system/microros/include
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/system/microros/include
+
+LDLIBS   += $(APPDIR)/system/microros/libmicroros.a
+endif

--- a/system/microros/Makefile
+++ b/system/microros/Makefile
@@ -20,6 +20,227 @@
 #
 ############################################################################
 
+include $(APPDIR)/Make.defs
+
+MICROROS_DIR     := $(APPDIR)/system/microros
+MICROROS_LIB_DIR := $(MICROROS_DIR)/micro_ros_lib
+MICROROS_DISTRO  := $(patsubst "%",%,$(CONFIG_MICROROS_DISTRO))
+MICROROS_AR      := $(CROSSDEV)ar
+
+MAX_NODES   := $(CONFIG_MICROROS_MAX_NODES)
+MAX_PUB     := $(CONFIG_MICROROS_MAX_PUBLISHERS)
+MAX_SUB     := $(CONFIG_MICROROS_MAX_SUBSCRIPTIONS)
+MAX_SVC     := $(CONFIG_MICROROS_MAX_SERVICES)
+MAX_CLIENTS := $(CONFIG_MICROROS_MAX_CLIENTS)
+
+# Escape for sed: forward slashes and strip quotes
+ESCAPED_CC     := $(subst /,\/,$(CC))
+ESCAPED_CXX    := $(subst /,\/,$(CXX))
+ESCAPED_TOPDIR := $(subst /,\/,$(TOPDIR))
+ESCAPED_APPDIR := $(subst /,\/,$(APPDIR))
+ESCAPED_LIBDIR := $(subst /,\/,$(MICROROS_LIB_DIR))
+ESCAPED_CFLAGS   := $(subst /,\/,$(subst ",,$(CFLAGS)))
+ESCAPED_CXXFLAGS := $(subst /,\/,$(subst ",,$(CXXFLAGS)))
+
 MENUDESC = "micro-ROS Library"
 
-include $(APPDIR)/Directory.mk
+# Architecture for CMake toolchain
+ifeq ($(CONFIG_ARCH_ARM),y)
+MICROROS_ARCH := arm
+else ifeq ($(CONFIG_ARCH_ARM64),y)
+MICROROS_ARCH := arm64
+else ifeq ($(CONFIG_ARCH_RISCV),y)
+MICROROS_ARCH := riscv
+else ifeq ($(CONFIG_ARCH_XTENSA),y)
+MICROROS_ARCH := xtensa
+else
+MICROROS_ARCH := generic
+endif
+
+# Wire libmicroros.a into the build when the context target fires
+context:: $(MICROROS_DIR)/libmicroros.a
+
+# ---------------------------------------------------------------------------
+# Step 1 – Build the ament/colcon dev tools (host-side)
+# ---------------------------------------------------------------------------
+
+$(MICROROS_LIB_DIR)/micro_ros_dev/install:
+	rm -rf $(MICROROS_LIB_DIR)/micro_ros_dev
+	mkdir -p $(MICROROS_LIB_DIR)/micro_ros_dev/src
+	cd $(MICROROS_LIB_DIR)/micro_ros_dev && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ament/ament_cmake src/ament_cmake && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ament/ament_lint src/ament_lint && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ament/ament_package src/ament_package && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ament/googletest src/googletest && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/ament_cmake_ros src/ament_cmake_ros && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ament/ament_index src/ament_index && \
+	  touch src/ament_cmake_ros/rmw_test_fixture_implementation/COLCON_IGNORE 2>/dev/null || true && \
+	  touch src/ament_cmake_ros/rmw_test_fixture/COLCON_IGNORE 2>/dev/null || true && \
+	  colcon build --cmake-args -DBUILD_TESTING=OFF
+
+# ---------------------------------------------------------------------------
+# Step 2 – Clone all micro-ROS source packages
+# ---------------------------------------------------------------------------
+
+$(MICROROS_LIB_DIR)/micro_ros_src/src: $(MICROROS_LIB_DIR)/micro_ros_dev/install
+	rm -rf $(MICROROS_LIB_DIR)/micro_ros_src
+	mkdir -p $(MICROROS_LIB_DIR)/micro_ros_src/src
+	cd $(MICROROS_LIB_DIR)/micro_ros_src && \
+	  git clone -b ros2 --depth 1 \
+	    https://github.com/eProsima/micro-CDR src/micro-CDR && \
+	  git clone -b ros2 --depth 1 \
+	    https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/rmw-microxrcedds src/rmw_microxrcedds && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/rcl src/rcl && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rclc src/rclc && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/rcutils src/rcutils && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rosidl src/rosidl && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rosidl_defaults src/rosidl_defaults && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rosidl_dynamic_typesupport src/rosidl_dynamic_typesupport && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rosidl_core src/rosidl_core && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rmw src/rmw && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rmw_implementation src/rmw_implementation && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rcl_interfaces src/rcl_interfaces && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/common_interfaces src/common_interfaces && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/rcl_logging src/rcl_logging && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/micro_ros_msgs src/micro_ros_msgs && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/rosidl_typesupport src/rosidl_typesupport && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/micro-ROS/micro_ros_utilities src/micro_ros_utilities && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/unique_identifier_msgs src/unique_identifier_msgs && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/test_interface_files src/test_interface_files && \
+	  git clone -b $(MICROROS_DISTRO) --depth 1 \
+	    https://github.com/ros2/ros2_tracing src/ros2_tracing && \
+	  touch src/ros2_tracing/test_tracetools/COLCON_IGNORE && \
+	  touch src/ros2_tracing/lttngpy/COLCON_IGNORE && \
+	  touch src/rmw/rmw_security_common/COLCON_IGNORE && \
+	  touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE && \
+	  touch src/rclc/rclc_examples/COLCON_IGNORE && \
+	  touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE && \
+	  touch src/rosidl/rosidl_typesupport_introspection_cpp/COLCON_IGNORE && \
+	  touch src/rcl_interfaces/test_msgs/COLCON_IGNORE && \
+	  touch src/common_interfaces/actionlib_msgs/COLCON_IGNORE && \
+	  touch src/common_interfaces/std_srvs/COLCON_IGNORE && \
+	  patch -p1 --forward --ignore-whitespace \
+	    -d src < $(MICROROS_LIB_DIR)/patches/0001-dir-typedef-nuttx-guard.patch || true && \
+	  patch -p1 --forward --ignore-whitespace \
+	    -d src < $(MICROROS_LIB_DIR)/patches/0002-rcutils-process-nuttx-compat.patch || true && \
+	  patch -p1 --forward --ignore-whitespace \
+	    -d src < $(MICROROS_LIB_DIR)/patches/0003-rcutils-strcasecmp-include-strings-h.patch || true
+
+# ---------------------------------------------------------------------------
+# Step 3 – Generate toolchain.cmake from template
+# ---------------------------------------------------------------------------
+
+$(MICROROS_LIB_DIR)/toolchain.cmake: $(MICROROS_LIB_DIR)/toolchain.cmake.in
+	sed \
+	  -e 's/@CMAKE_C_COMPILER@/$(ESCAPED_CC)/g' \
+	  -e 's/@CMAKE_CXX_COMPILER@/$(ESCAPED_CXX)/g' \
+	  -e 's/@ARCH_C_FLAGS@/$(ESCAPED_CFLAGS)/g' \
+	  -e 's/@ARCH_CPP_FLAGS@/$(ESCAPED_CXXFLAGS)/g' \
+	  -e 's/@NUTTX_TOPDIR@/$(ESCAPED_TOPDIR)/g' \
+	  -e 's/@NUTTX_APPDIR@/$(ESCAPED_APPDIR)/g' \
+	  -e 's/@INCLUDE_OVR_DIR@/$(ESCAPED_LIBDIR)/g' \
+	  -e 's/@CMAKE_SYSTEM_PROCESSOR@/$(MICROROS_ARCH)/g' \
+	  $< > $@
+
+# ---------------------------------------------------------------------------
+# Step 4 – Generate colcon.meta from template
+# ---------------------------------------------------------------------------
+
+$(MICROROS_LIB_DIR)/colcon.meta: $(MICROROS_LIB_DIR)/colcon.meta.in
+	sed \
+	  -e 's/@MAX_NODES@/$(MAX_NODES)/g' \
+	  -e 's/@MAX_PUBLISHERS@/$(MAX_PUB)/g' \
+	  -e 's/@MAX_SUBSCRIPTIONS@/$(MAX_SUB)/g' \
+	  -e 's/@MAX_SERVICES@/$(MAX_SVC)/g' \
+	  -e 's/@MAX_CLIENTS@/$(MAX_CLIENTS)/g' \
+	  $< > $@
+
+# ---------------------------------------------------------------------------
+# Step 5 – Cross-build micro-ROS packages with colcon
+# ---------------------------------------------------------------------------
+
+$(MICROROS_LIB_DIR)/micro_ros_src/install: \
+    $(MICROROS_LIB_DIR)/toolchain.cmake \
+    $(MICROROS_LIB_DIR)/colcon.meta \
+    $(MICROROS_LIB_DIR)/micro_ros_src/src
+	cd $(MICROROS_LIB_DIR)/micro_ros_src && \
+	  unset AMENT_PREFIX_PATH && \
+	  . ../micro_ros_dev/install/local_setup.sh && \
+	  colcon build \
+	    --merge-install \
+	    "--packages-ignore-regex=(.*_cpp$$|.*_py$$|test_rmw_implementation|rclc_examples)" \
+	    --metas $(MICROROS_LIB_DIR)/colcon.meta \
+	    --cmake-args \
+	      --no-warn-unused-cli \
+	      -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
+	      -DTHIRDPARTY=ON \
+	      -DBUILD_SHARED_LIBS=OFF \
+	      -DBUILD_TESTING=OFF \
+	      -DCMAKE_BUILD_TYPE=Release \
+	      "-DCMAKE_TOOLCHAIN_FILE=$(MICROROS_LIB_DIR)/toolchain.cmake" \
+	      -DCMAKE_VERBOSE_MAKEFILE=OFF
+
+# ---------------------------------------------------------------------------
+# Step 6 – Merge all .a files into a single libmicroros.a
+# ---------------------------------------------------------------------------
+
+$(MICROROS_DIR)/libmicroros.a: $(MICROROS_LIB_DIR)/micro_ros_src/install
+	mkdir -p $(MICROROS_LIB_DIR)/libmicroros_obj
+	cd $(MICROROS_LIB_DIR)/libmicroros_obj && \
+	  for file in $$(find $(MICROROS_LIB_DIR)/micro_ros_src/install/lib/ -name '*.a'); do \
+	    folder=$$(basename $$file .a); \
+	    mkdir -p $$folder && cd $$folder; \
+	    $(MICROROS_AR) x $$file; \
+	    for f in *; do \
+	      [ -f "$$f" ] && mv "$$f" "../$${folder}-$${f}" 2>/dev/null || true; \
+	    done; \
+	    cd ..; \
+	    rm -rf $$folder; \
+	  done && \
+	  $(MICROROS_AR) rc libmicroros.a $$(find . -maxdepth 1 -type f ! -name 'libmicroros.a') && \
+	  cp libmicroros.a $(MICROROS_DIR)/
+	cd $(MICROROS_LIB_DIR) && rm -rf libmicroros_obj
+	cp -R $(MICROROS_LIB_DIR)/micro_ros_src/install/include $(MICROROS_DIR)/include
+
+# ---------------------------------------------------------------------------
+# Cleanup targets
+# ---------------------------------------------------------------------------
+
+clean::
+	$(call DELFILE,$(MICROROS_DIR)/libmicroros.a)
+	$(call DELDIR,$(MICROROS_DIR)/include)
+	$(call DELFILE,$(MICROROS_LIB_DIR)/toolchain.cmake)
+	$(call DELFILE,$(MICROROS_LIB_DIR)/colcon.meta)
+
+distclean:: clean
+	$(call DELDIR,$(MICROROS_LIB_DIR)/micro_ros_src)
+	$(call DELDIR,$(MICROROS_LIB_DIR)/micro_ros_dev)
+
+include $(APPDIR)/Application.mk

--- a/system/microros/micro_ros_lib/colcon.meta.in
+++ b/system/microros/micro_ros_lib/colcon.meta.in
@@ -1,0 +1,52 @@
+{
+  "names": {
+    "microxrcedds_client": {
+      "cmake-args": [
+        "-DUCLIENT_PIC=OFF",
+        "-DUCLIENT_PROFILE_DISCOVERY=OFF",
+        "-DUCLIENT_PROFILE_UDP=OFF",
+        "-DUCLIENT_PROFILE_TCP=OFF",
+        "-DUCLIENT_PROFILE_SERIAL=OFF",
+        "-DUCLIENT_PROFILE_CUSTOM_TRANSPORT=ON",
+        "-DUCLIENT_PROFILE_STREAM_FRAMING=ON",
+        "-DUCLIENT_EXTERNAL_SERIAL=ON"
+      ]
+    },
+    "rmw_microxrcedds": {
+      "cmake-args": [
+        "-DRMW_UXRCE_TRANSPORT=custom",
+        "-DRMW_UXRCE_MAX_NODES=@MAX_NODES@",
+        "-DRMW_UXRCE_MAX_PUBLISHERS=@MAX_PUBLISHERS@",
+        "-DRMW_UXRCE_MAX_SUBSCRIPTIONS=@MAX_SUBSCRIPTIONS@",
+        "-DRMW_UXRCE_MAX_SERVICES=@MAX_SERVICES@",
+        "-DRMW_UXRCE_MAX_CLIENTS=@MAX_CLIENTS@",
+        "-DRMW_UXRCE_MAX_HISTORY=4"
+      ]
+    },
+    "rcl": {
+      "cmake-args": [
+        "-DRCL_MICROROS=ON"
+      ]
+    },
+    "rcutils": {
+      "cmake-args": [
+        "-DRCUTILS_NO_FILESYSTEM=OFF",
+        "-DRCUTILS_NO_THREAD_SUPPORT=ON",
+        "-DRCUTILS_NO_64_ATOMIC=ON",
+        "-DRCUTILS_AVOID_DYNAMIC_ALLOCATION=ON",
+        "-DENABLE_TESTING=OFF"
+      ]
+    },
+    "rosidl_typesupport": {
+      "cmake-args": [
+        "-DROSIDL_TYPESUPPORT_SINGLE_TYPESUPPORT=ON"
+      ]
+    },
+    "tracetools": {
+      "cmake-args": [
+        "-DTRACETOOLS_DISABLED=ON",
+        "-DTRACETOOLS_STATUS_CHECKING_TOOL=OFF"
+      ]
+    }
+  }
+}

--- a/system/microros/micro_ros_lib/include_override/assert.h
+++ b/system/microros/micro_ros_lib/include_override/assert.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * apps/system/microros/micro_ros_lib/include_override/assert.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __MICROROS_INCLUDE_OVERRIDE_ASSERT_H
+#define __MICROROS_INCLUDE_OVERRIDE_ASSERT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/* Pull the system assert.h, then redefine assert to a no-op when NDEBUG is
+ * set.  Avoids an assert redefinition conflict in rosidl typesupport.
+ */
+
+#include_next <assert.h>
+
+#ifdef NDEBUG
+#  undef assert
+#  define assert(x) ((void)(0))
+#endif
+
+#endif /* __MICROROS_INCLUDE_OVERRIDE_ASSERT_H */

--- a/system/microros/micro_ros_lib/toolchain.cmake.in
+++ b/system/microros/micro_ros_lib/toolchain.cmake.in
@@ -9,8 +9,8 @@ set(PLATFORM_NAME "nuttx")
 set(CMAKE_C_COMPILER @CMAKE_C_COMPILER@)
 set(CMAKE_CXX_COMPILER @CMAKE_CXX_COMPILER@)
 
-set(CMAKE_C_FLAGS_INIT "-std=c11 @ARCH_C_FLAGS@ -D'__attribute__(x)='" CACHE STRING "" FORCE)
-set(CMAKE_CXX_FLAGS_INIT "-std=c++14 @ARCH_CPP_FLAGS@ -fno-rtti -D'__attribute__(x)='" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_INIT "-std=c11 @ARCH_C_FLAGS@ -D__NuttX__ -D'__attribute__(x)='" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS_INIT "-std=c++14 @ARCH_CPP_FLAGS@ -fno-rtti -D__NuttX__ -D'__attribute__(x)='" CACHE STRING "" FORCE)
 
 set(NUTTX_TOPDIR @NUTTX_TOPDIR@)
 set(NUTTX_APPDIR @NUTTX_APPDIR@)

--- a/system/microros/micro_ros_lib/toolchain.cmake.in
+++ b/system/microros/micro_ros_lib/toolchain.cmake.in
@@ -1,0 +1,29 @@
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR @CMAKE_SYSTEM_PROCESSOR@)
+set(CMAKE_CROSSCOMPILING 1)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+set(PLATFORM_NAME "nuttx")
+
+set(CMAKE_C_COMPILER @CMAKE_C_COMPILER@)
+set(CMAKE_CXX_COMPILER @CMAKE_CXX_COMPILER@)
+
+set(CMAKE_C_FLAGS_INIT "-std=c11 @ARCH_C_FLAGS@ -D'__attribute__(x)='" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS_INIT "-std=c++14 @ARCH_CPP_FLAGS@ -fno-rtti -D'__attribute__(x)='" CACHE STRING "" FORCE)
+
+set(NUTTX_TOPDIR @NUTTX_TOPDIR@)
+set(NUTTX_APPDIR @NUTTX_APPDIR@)
+set(INCLUDE_OVR_DIR @INCLUDE_OVR_DIR@)
+
+include_directories(SYSTEM
+	${NUTTX_TOPDIR}/include
+	${NUTTX_TOPDIR}/include/cxx
+	${NUTTX_APPDIR}/include
+)
+
+include_directories(AFTER SYSTEM
+	${INCLUDE_OVR_DIR}/include_override
+)
+
+set(__BIG_ENDIAN__ 0)

--- a/system/microros/patches/0001-dir-typedef-nuttx-guard.patch
+++ b/system/microros/patches/0001-dir-typedef-nuttx-guard.patch
@@ -1,0 +1,31 @@
+From: micro-ROS NuttX Port <noreply@nuttx.apache.org>
+Subject: [PATCH] rcutils: guard bare DIR typedef to avoid conflict with NuttX dirent.h
+
+NuttX defines DIR as a struct type in dirent.h.  The bare
+  typedef int DIR;
+in rcutils/src/filesystem.c causes a redefinition error when the
+NuttX system headers are on the include path.  Guard it so it is
+only emitted when DIR has not already been defined.
+
+--- a/rcutils/src/filesystem.c
++++ b/rcutils/src/filesystem.c
+@@ -1,6 +1,8 @@
+ // Copyright 2017 Open Source Robotics Foundation, Inc.
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+ // You may obtain a copy of the License at
+ //
+ //     http://www.apache.org/licenses/LICENSE-2.0
+ //
+ // Unless required by applicable law or agreed to in writing, software
+ // distributed under the License is distributed on an "AS IS" BASIS,
+ // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+
+ #if !defined _WIN32 && !defined __QNXTO__
++#ifndef DIR
+ typedef int DIR;
++#endif
+ #endif

--- a/system/microros/patches/0002-rcutils-process-nuttx-compat.patch
+++ b/system/microros/patches/0002-rcutils-process-nuttx-compat.patch
@@ -1,0 +1,20 @@
+From: micro-ROS NuttX Port <noreply@nuttx.apache.org>
+Subject: [PATCH] rcutils: skip program_invocation_name on NuttX
+
+When cross-compiling for NuttX on a Linux host the compiler still
+defines __linux__, causing rcutils_get_executable_name() to reference
+program_invocation_name which is a glibc extension absent from the
+NuttX C library.  Guard the Linux branch with !defined(__NuttX__) so
+the "embedded OS" fallback (empty string) is taken instead.
+
+--- a/rcutils/src/process.c
++++ b/rcutils/src/process.c
+@@ -61,7 +61,7 @@ int rcutils_get_pid()
+ #if defined __APPLE__ || defined __FreeBSD__ || (defined __ANDROID__ && __ANDROID_API__ >= 21)
+   const char * appname = getprogname();
+ #elif defined __GNUC__ && !defined(__QNXNTO__) && !defined(__OHOS__)
+-  #if defined __linux__ || defined __linux || defined __gnu_linux__ || defined linux
++  #if (defined __linux__ || defined __linux || defined __gnu_linux__ || defined linux) && !defined(__NuttX__)
+     const char * appname = program_invocation_name;
+   #else
+     // Some embedded OS compile with __GNUC__ but are not quite conformant with GNU-specific extensions.

--- a/system/microros/patches/0003-rcutils-strcasecmp-include-strings-h.patch
+++ b/system/microros/patches/0003-rcutils-strcasecmp-include-strings-h.patch
@@ -1,0 +1,19 @@
+From: micro-ROS NuttX Port <noreply@nuttx.apache.org>
+Subject: [PATCH] rcutils: include <strings.h> for strcasecmp on NuttX
+
+POSIX specifies strcasecmp/strncasecmp in <strings.h>, not <string.h>.
+NuttX follows the standard strictly so omitting this header causes an
+"implicit declaration" error.  Guard the include with __NuttX__ so it
+only applies where needed and does not affect Linux or other platforms
+that already expose strcasecmp through <string.h>.
+
+--- a/rcutils/src/strcasecmp.c
++++ b/rcutils/src/strcasecmp.c
+@@ -17,6 +17,9 @@ extern "C"
+ #include <errno.h>
+ #include <string.h>
++#ifdef __NuttX__
++#include <strings.h>
++#endif
+
+ #include "rcutils/strcasecmp.h"


### PR DESCRIPTION
## Summary

This PR implements an automated build pipeline that fetches all upstream micro-ROS jazzy packages, cross-compiles them with colcon and a NuttX CMake toolchain, and merges the resulting static libraries into a single `libmicroros.a` ready for linking into a NuttX image.

## Impact

- **Users:** Applications that enable `CONFIG_SYSTEM_MICROROS` automatically
  get `libmicroros.a` linked in and all micro-ROS headers available under
  `system/microros/include/`.  No manual build steps are required.
- **Build:** `make context` in the apps tree triggers the colcon build the first
  time; subsequent builds are incremental.  Full build time on a 2-core machine
  is approximately 4–5 minutes.  `make distclean` fully removes all downloaded
  sources.
- **Disk:** The colcon build requires approximately 1.5 GB of temporary build
  space; only `libmicroros.a` (~13–80 MB depending on included message types)
  and the headers are retained after the build.
- **Dependencies:** Host requires `colcon-common-extensions`, `cmake ≥ 3.16`,
  Python 3, and a C/C++ cross-compiler matching `$(CROSSDEV)`.
- **Compatibility:** No existing app or config is modified.  The feature is
  entirely gated behind `CONFIG_SYSTEM_MICROROS`.

## Testing

**Host:** Ubuntu 22.04 (EC2 `t3.medium`), `gcc 13`, `cmake 3.28`, `colcon 0.3`

**Target:** `stm32f4discovery:nsh` (ARM Cortex-M4, `arm-none-eabi-gcc 14.2`)
— library produced but not yet run on hardware due to availability issues.

**Verified with `make context` end-to-end:**

```
$ cd ~/nuttx-apps/system/microros && rm -f micro_ros_lib/toolchain.cmake \
    micro_ros_lib/colcon.meta libmicroros.a && rm -rf include && \
  make context APPDIR=~/nuttx-apps TOPDIR=~/nuttx CC=gcc CXX=g++ \
    CONFIG_MICROROS_DISTRO='"jazzy"' CONFIG_MICROROS_MAX_NODES=8 \
    CONFIG_MICROROS_MAX_PUBLISHERS=16 CONFIG_MICROROS_MAX_SUBSCRIPTIONS=16 \
    CONFIG_MICROROS_MAX_SERVICES=4 CONFIG_MICROROS_MAX_CLIENTS=4 \
    CONFIG_ARCH_ARM=y 2>&1 | tail -3
Summary: 72 packages finished [4min 27s]

$ ls -lh ~/nuttx-apps/system/microros/libmicroros.a
-rw-rw-r-- 1 ubuntu ubuntu 13M May 23 16:47 libmicroros.a

$ ar t ~/nuttx-apps/system/microros/libmicroros.a | wc -l
1492

$ ls ~/nuttx-apps/system/microros/include/ | wc -l
44
```
[phase3.log](https://github.com/user-attachments/files/28183341/phase3.log)


**`make clean` verified** removes `libmicroros.a`, `include/`, `toolchain.cmake`,
and `colcon.meta`.

