### PR TITLE
testing/sd_stress: Handle stale temporary directories

### DIFF
--- a/testing/drivers/sd_stress/sd_stress_main.c
+++ b/testing/drivers/sd_stress/sd_stress_main.c
@@ -233,6 +233,7 @@ static bool create_files(const char *dir, const char *name,
   if (path_len + 5 >= MAX_PATH_LEN)
     {
       printf("path name too long\n");
+      free(read_bytes);
       return false;
     }
 
@@ -267,7 +268,7 @@ static bool create_files(const char *dir, const char *name,
           printf("write %s failed, ret: %d, errno %d -> %s\n",
                  path, ret, errno, strerror(errno));
           passed = false;
-          break;
+          goto close_file;
         }
 
       ret = lseek(fd, 0, SEEK_SET);
@@ -277,7 +278,7 @@ static bool create_files(const char *dir, const char *name,
           printf("lseek %s failed, ret: %d, errno %d -> %s\n",
                  path, ret, errno, strerror(errno));
           passed = false;
-          break;
+          goto close_file;
         }
 
       ret = read(fd, read_bytes, num_bytes);
@@ -287,16 +288,17 @@ static bool create_files(const char *dir, const char *name,
           printf("read %s failed, ret: %d, errno %d -> %s\n",
                  path, ret, errno, strerror(errno));
           passed = false;
-          break;
+          goto close_file;
         }
 
       if (memcmp(read_bytes, bytes, num_bytes) != 0)
         {
           printf("read and write buffers are not the same\n");
           passed = false;
-          break;
+          goto close_file;
         }
 
+close_file:
       ret = close(fd);
 
       if (ret < 0)
@@ -304,6 +306,11 @@ static bool create_files(const char *dir, const char *name,
           printf("close %s failed, ret: %d, errno %d -> %s\n",
                  path, ret, errno, strerror(errno));
           passed = false;
+          break;
+        }
+
+      if (!passed)
+        {
           break;
         }
     }

--- a/testing/drivers/sd_stress/sd_stress_main.c
+++ b/testing/drivers/sd_stress/sd_stress_main.c
@@ -47,12 +47,14 @@
  * Included Files
  ****************************************************************************/
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
 
@@ -94,7 +96,7 @@ static void usage(void)
 
 static bool create_dir(const char *path)
 {
-  int ret = mkdir(TEMPDIR, S_IRWXU | S_IRWXG | S_IRWXO);
+  int ret = mkdir(path, S_IRWXU | S_IRWXG | S_IRWXO);
 
   if (ret < 0)
     {
@@ -108,7 +110,7 @@ static bool create_dir(const char *path)
 
 static bool remove_dir(const char *path)
 {
-  int ret = rmdir(TEMPDIR2);
+  int ret = rmdir(path);
 
   if (ret < 0)
     {
@@ -118,6 +120,94 @@ static bool remove_dir(const char *path)
     }
 
   return true;
+}
+
+static bool is_temp_file(const char *name, const char *prefix)
+{
+  size_t prefix_len = strlen(prefix);
+  int i;
+
+  if (strncmp(name, prefix, prefix_len) != 0)
+    {
+      return false;
+    }
+
+  for (i = 0; i < 3; i++)
+    {
+      char ch = name[prefix_len + i];
+
+      if (ch < '0' || ch > '9')
+        {
+          return false;
+        }
+    }
+
+  return name[prefix_len + i] == '\0';
+}
+
+static bool cleanup_dir(const char *path, const char *name)
+{
+  FAR DIR *dir;
+  FAR struct dirent *entry;
+  char filepath[MAX_PATH_LEN];
+  int ret;
+
+  dir = opendir(path);
+  if (dir == NULL)
+    {
+      if (errno == ENOENT)
+        {
+          return true;
+        }
+
+      printf("opendir %s failed, errno: %d -> %s\n",
+             path, errno, strerror(errno));
+      return false;
+    }
+
+  while ((entry = readdir(dir)) != NULL)
+    {
+      if (strcmp(entry->d_name, ".") == 0 ||
+          strcmp(entry->d_name, "..") == 0)
+        {
+          continue;
+        }
+
+      if (!is_temp_file(entry->d_name, name))
+        {
+          printf("%s contains unexpected entry %s\n", path, entry->d_name);
+          closedir(dir);
+          return false;
+        }
+
+      ret = snprintf(filepath, sizeof(filepath), "%s/%s",
+                     path, entry->d_name);
+      if (ret < 0 || (size_t)ret >= sizeof(filepath))
+        {
+          printf("path name too long\n");
+          closedir(dir);
+          return false;
+        }
+
+      ret = unlink(filepath);
+      if (ret < 0)
+        {
+          printf("unlink %s failed, ret: %d, errno %d -> %s\n",
+                 filepath, ret, errno, strerror(errno));
+          closedir(dir);
+          return false;
+        }
+    }
+
+  ret = closedir(dir);
+  if (ret < 0)
+    {
+      printf("closedir %s failed, ret: %d, errno %d -> %s\n",
+             path, ret, errno, strerror(errno));
+      return false;
+    }
+
+  return remove_dir(path);
 }
 
 static bool create_files(const char *dir, const char *name,
@@ -371,6 +461,12 @@ int main(int argc, char *argv[])
     }
 
   total_time = 0;
+
+  if (!cleanup_dir(TEMPDIR, TEMPFILE) || !cleanup_dir(TEMPDIR2, TEMPFILE))
+    {
+      free(bytes);
+      return -1;
+    }
 
   for (size_t i = 0; i < num_runs; ++i)
     {


### PR DESCRIPTION
﻿## Summary

Fixes #3205.

This PR makes `sdstress` recover from temporary directories left behind by an interrupted or failed previous run.

Commit structure:

- Commit 1 (`testing/sd_stress: Handle stale temporary directories`) is the strict #3205 fix. It cleans stale `/sd/stress` and `/sd/moved` work directories before starting a new test, but only removes files matching the app-generated `tmpNNN` pattern. Unexpected entries make the cleanup fail instead of deleting user data. It also fixes `create_dir()` / `remove_dir()` to use their `path` argument.
- Commit 2 (`testing/sd_stress: Harden file creation cleanup`) is a logically separable extension. It closes the temp file descriptor on `create_files()` failures after `open()`, and releases the read buffer on the path-length failure branch.

The second commit is logically separable and I am happy to drop it if maintainers consider it out of scope for #3205.

Out of scope:

- This does not change BCM2711 SDIO / EMMC driver behavior.
- This does not address the separate `-b 1024` / SD/MMC timeout behavior discussed in apache/nuttx#17245.
- This does not recursively delete arbitrary directory contents; cleanup is limited to `sdstress`-generated `tmpNNN` files.

## Impact

Users no longer need to manually remove stale `sdstress` temporary directories before running the test again after an interrupted or failed run.

- New feature: NO
- User adaptation required: NO
- Build process change: NO
- Hardware/architecture/board change: NO
- Documentation update required: NO
- Security impact: NO intended security impact
- Compatibility impact: NO intended compatibility impact

## Testing

Host:

- Windows with WSL Ubuntu 24.04
- CPU: x86_64
- Compiler: GCC 13.3.0

Checks:

- `git diff --check upstream/master..HEAD`: pass
- `checkpatch.sh -c -u -m -g HEAD~2..HEAD`: pass
- `sim:nsh` build with `CONFIG_ALLOW_BSD_COMPONENTS=y` and `CONFIG_TESTING_SD_STRESS=y`: pass
  - confirmed `Register: sdstress`
  - confirmed `CC: sd_stress_main.c`
  - result: `SIM elf with dynamic libs archive in nuttx.tgz`

Note: `.config` printed an expected override warning because the temporary test build appended `CONFIG_ALLOW_BSD_COMPONENTS=y` / `CONFIG_TESTING_SD_STRESS=y` after configuring `sim:nsh`.