### PR TITLE
system/settings: Fix non-cached save deadlock

### DIFF
--- a/system/settings/settings.c
+++ b/system/settings/settings.c
@@ -772,9 +772,9 @@ void settings_init(void)
   pthread_mutexattr_t attr;
 
   pthread_mutexattr_init(&attr);
-  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
   pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
   pthread_mutex_init(&g_settings.mtx, &attr);
+  pthread_mutexattr_destroy(&attr);
 
   memset(map, 0, sizeof(map));
   memset(g_settings.store, 0, sizeof(g_settings.store));

--- a/system/settings/settings.c
+++ b/system/settings/settings.c
@@ -82,7 +82,10 @@ static int      set_ip(FAR setting_t *setting, FAR struct in_addr *ip);
 static int      load(void);
 static void     save(void);
 static void     signotify(void);
+static void     dump_cache_locked(FAR bool *wrpend);
+#ifdef CONFIG_SYSTEM_SETTINGS_CACHED_SAVES
 static void     dump_cache(union sigval ptr);
+#endif
 
 /****************************************************************************
  * Private Data
@@ -623,12 +626,7 @@ static void save(void)
 #ifdef CONFIG_SYSTEM_SETTINGS_CACHED_SAVES
   timer_settime(g_settings.timerid, 0, &g_settings.trigger, NULL);
 #else
-  union sigval value =
-  {
-    .sival_ptr = &g_settings.wrpend,
-  };
-
-  dump_cache(value);
+  dump_cache_locked(&g_settings.wrpend);
 #endif
 }
 
@@ -662,6 +660,38 @@ static void signotify(void)
 }
 
 /****************************************************************************
+ * Name: dump_cache_locked
+ *
+ * Description:
+ *    Writes out the cached data to the appropriate storage.  The caller
+ *    must hold g_settings.mtx.
+ *
+ * Input Parameters:
+ *    wrpend           - pending write flag to clear after dumping
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void dump_cache_locked(FAR bool *wrpend)
+{
+  int i;
+
+  for (i = 0; i < CONFIG_SYSTEM_SETTINGS_MAX_STORAGES; i++)
+    {
+      if ((g_settings.store[i].file[0] != '\0') &&
+           g_settings.store[i].save_fn)
+        {
+          (void)g_settings.store[i].save_fn(g_settings.store[i].file);
+        }
+    }
+
+  *wrpend = false;
+}
+
+#ifdef CONFIG_SYSTEM_SETTINGS_CACHED_SAVES
+/****************************************************************************
  * Name: dump_cache
  *
  * Description:
@@ -677,36 +707,16 @@ static void signotify(void)
 
 static void dump_cache(union sigval ptr)
 {
-  int ret = OK;
-  FAR bool *wrpend = (bool *)ptr.sival_ptr;
-
-  int i;
+  FAR bool *wrpend = (FAR bool *)ptr.sival_ptr;
+  int ret;
 
   ret = pthread_mutex_lock(&g_settings.mtx);
   assert(ret >= 0);
 
-  for (i = 0; i < CONFIG_SYSTEM_SETTINGS_MAX_STORAGES; i++)
-    {
-      if ((g_settings.store[i].file[0] != '\0') &&
-           g_settings.store[i].save_fn)
-        {
-          ret = g_settings.store[i].save_fn(g_settings.store[i].file);
-#if 0
-          if (ret < 0)
-            {
-              /* What to do? We can't return anything from a void function.
-               *
-               * MIGHT BE A FUTURE REVISIT NEEDED
-               */
-            }
-#endif
-        }
-    }
-
-  *wrpend = false;
-
+  dump_cache_locked(wrpend);
   pthread_mutex_unlock(&g_settings.mtx);
 }
+#endif
 
 /****************************************************************************
  * Name: sanity_check


### PR DESCRIPTION
﻿## Summary

Fixes #3105.

This PR fixes the settings deadlock that can happen when `CONFIG_SYSTEM_SETTINGS_CACHED_SAVES` is disabled.

Commit structure:

- Commit 1 (`system/settings: Avoid recursive save locking`) is the strict #3105 fix. The immediate save path now writes pending settings through a helper that assumes `g_settings.mtx` is already held, instead of calling the timer callback that locks the same mutex again. The cached-save timer callback still takes the mutex before using the same helper.
- Commit 2 (`system/settings: Drop unused recursive mutex type`) is a small related cleanup. Since the settings save path no longer re-enters `g_settings.mtx`, the mutex no longer needs `PTHREAD_MUTEX_RECURSIVE`; this also keeps the fix independent of `CONFIG_PTHREAD_MUTEX_TYPES`. It also destroys the temporary mutex attribute object after initialization.

The second commit is logically separable and I am happy to drop it if maintainers consider it out of scope for #3105.

Out of scope:

- This does not change the public settings API.
- This does not change the storage file formats.
- This does not include the separate safer string handling work requested in #3109.

## Impact

With cached saves disabled, settings operations that save immediately no longer try to lock `g_settings.mtx` recursively via `dump_cache()`.

- New feature: NO
- User adaptation required: NO
- Build process change: NO
- Hardware/architecture/board change: NO
- Documentation update required: NO
- Security impact: NO intended security impact
- Compatibility impact: NO intended compatibility impact

## Testing

Host:

- Windows with WSL Ubuntu 24.04
- CPU: x86_64
- Compiler: GCC 13.3.0

Checks:

- `git diff --check upstream/master..HEAD`: pass
- `checkpatch.sh -c -u -m -g HEAD~2..HEAD`: pass
- `sim:nsh` build: pass
  - `CONFIG_SYSTEM_SETTINGS=y`
  - `# CONFIG_SYSTEM_SETTINGS_CACHED_SAVES is not set`
  - `# CONFIG_PTHREAD_MUTEX_TYPES is not set`
  - confirmed `CC: settings.c`
  - result: `SIM elf with dynamic libs archive in nuttx.tgz`

Note: the temporary test build appended config overrides after configuring `sim:nsh`, so `.config` printed expected override warnings for the settings and pthread mutex options.