### PR TITLE
apps/tools: Make hello_rust_cargo buildable with make

### DIFF
--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -52,6 +52,9 @@ $(or \
   $(and $(filter x86,$(LLVM_ARCHTYPE)), \
     $(APPDIR)/tools/i486-unknown-nuttx.json \
   ), \
+  $(and $(filter aarch64,$(LLVM_ARCHTYPE)), \
+    $(if $(filter y,$(CONFIG_HOST_MACOS)),aarch64-apple-darwin) \
+  ), \
   $(and $(filter thumb%,$(LLVM_ARCHTYPE)), \
     $(if $(filter thumbv8m%,$(LLVM_ARCHTYPE)), \
       $(if $(filter cortex-m23,$(LLVM_CPUTYPE)),thumbv8m.base,thumbv8m.main)-nuttx-$(LLVM_ABITYPE), \
@@ -91,7 +94,7 @@ ifeq ($(CONFIG_DEBUG_FULLOPT),y)
 define RUST_CARGO_BUILD
 	NUTTX_INCLUDE_DIR=$(TOPDIR)/include:$(TOPDIR)/include/arch \
     RUSTFLAGS="-Zunstable-options -Cpanic=immediate-abort" \
-    cargo build --release -Zbuild-std=std,panic_abort \
+    cargo build --release -Zbuild-std=std,panic_abort -Zjson-target-spec \
 		--manifest-path $(2)/$(1)/Cargo.toml \
 		--target $(call RUST_TARGET_TRIPLE)
 endef
@@ -99,7 +102,7 @@ else
 define RUST_CARGO_BUILD
 	@echo "Building Rust code with cargo..."
 	NUTTX_INCLUDE_DIR=$(TOPDIR)/include:$(TOPDIR)/include/arch \
-    cargo build -Zbuild-std=std,panic_abort \
+    cargo build -Zbuild-std=std,panic_abort -Zjson-target-spec \
 		--manifest-path $(2)/$(1)/Cargo.toml \
 		--target $(call RUST_TARGET_TRIPLE)
 endef


### PR DESCRIPTION
## Summary

Fix the Make-based build for Rust-enabled `sim:nsh` configurations.

This change addresses two Make/Cargo issues:

### Add the missing Apple Silicon macOS Rust target mapping

When building `sim:nsh` with Make on an ARM64 macOS host, `LLVM_ARCHTYPE` is set to `aarch64`. However, `apps/tools/Rust.mk` did not handle `aarch64` in `RUST_TARGET_TRIPLE`, so Cargo was invoked with an empty `--target` argument:

```
error: "--target" takes a target architecture as an argument.
```

The Make build now maps this case to the same target used by the CMake Rust helper: `aarch64-apple-darwin`

### Pass `-Zjson-target-spec` to Cargo

The Rust build uses JSON target specifications for NuttX targets such as the simulator targets under `apps/tools/`. Cargo requires `-Zjson-target-spec` when building with these JSON target files.

## Impact

* Impact on build: Enables building with Make/Cargo configurations.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration:

```
make distclean
./tools/configure.sh sim:nsh
make menuconfig

printf "CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
# CONFIG_COVERAGE_TOOLCHAIN is not set
CONFIG_COVERAGE_NONE=y
" >> .config

make olddefconfig
```

Testing logs before change:

```
❯ make
Create version.h
Building Rust code with cargo...
error: "--target" takes a target architecture as an argument.

Run `rustup target list` to see possible targets.
make[3]: *** [Makefile:31: context] Error 101
make[2]: *** [Makefile:57: /Users/toku/nuttxspace/apps/examples/rust/hello_context] Error 2
make[1]: *** [Makefile:187: context] Error 2
make: *** [tools/Unix.mk:471: /Users/toku/nuttxspace/apps/.context] Error 2
```

Testing logs after change:

```
> make
...
  Compiling tokio v1.52.3
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.92s
LN: platform/board to /Users/toku/nuttxspace/apps/platform/dummy
Register: gpio
Register: hello
Register: hello_rust_cargo
Register: dd
Register: dumpstack
Register: nsh
Register: sh
Register: ostest
CP:  /Users/toku/nuttxspace/nuttx/include/nuttx/config.h
CP:  /Users/toku/nuttxspace/nuttx/include/nuttx/fs/hostfs.h
LD:  nuttx
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
