### PR TITLE
system/settings: Bound settings string handling

### DIFF
--- a/system/settings/settings.c
+++ b/system/settings/settings.c
@@ -152,6 +152,13 @@ static int get_setting(FAR char *key, FAR setting_t **setting)
 
   assert(*setting == NULL);
 
+  if (strnlen(key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE) >=
+      CONFIG_SYSTEM_SETTINGS_KEY_SIZE)
+    {
+      ret = -EINVAL;
+      goto exit;
+    }
+
   for (i = 0; i < CONFIG_SYSTEM_SETTINGS_MAP_SIZE; i++)
     {
       if (map[i].type == SETTING_EMPTY)
@@ -160,7 +167,7 @@ static int get_setting(FAR char *key, FAR setting_t **setting)
           goto exit;
         }
 
-      if (strcmp(map[i].key, key) == 0)
+      if (strncmp(map[i].key, key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE) == 0)
         {
           *setting = &map[i];
           goto exit;
@@ -201,16 +208,16 @@ static size_t get_string(FAR setting_t *setting, FAR char *buffer,
   if (setting->type == SETTING_STRING)
     {
       FAR const char *s = setting->val.s;
-      size_t len = strlen(s);
+      size_t len = strnlen(s, CONFIG_SYSTEM_SETTINGS_VALUE_SIZE);
 
+      assert(len < CONFIG_SYSTEM_SETTINGS_VALUE_SIZE);
       assert(len < size);
-      if (len >= size)
+      if (len >= CONFIG_SYSTEM_SETTINGS_VALUE_SIZE || len >= size)
         {
           return 0;
         }
 
-      strncpy(buffer, s, size);
-      buffer[size - 1] = '\0';
+      strlcpy(buffer, s, size);
 
       return len;
     }
@@ -221,7 +228,7 @@ static size_t get_string(FAR setting_t *setting, FAR char *buffer,
       inet_ntop(AF_INET, &setting->val.ip, buffer, size);
       buffer[size - 1] = '\0';
 
-      return strlen(buffer);
+      return strnlen(buffer, size);
     }
 
   return 0;
@@ -244,6 +251,8 @@ static size_t get_string(FAR setting_t *setting, FAR char *buffer,
 
 static int set_string(FAR setting_t *setting, FAR char *str)
 {
+  size_t len;
+
   assert(setting);
 
   if ((setting->type != SETTING_STRING) &&
@@ -252,19 +261,19 @@ static int set_string(FAR setting_t *setting, FAR char *str)
       return -EACCES;
     }
 
-  if (strlen(str) >= CONFIG_SYSTEM_SETTINGS_VALUE_SIZE)
+  len = strnlen(str, CONFIG_SYSTEM_SETTINGS_VALUE_SIZE);
+  if (len >= CONFIG_SYSTEM_SETTINGS_VALUE_SIZE)
     {
       return -EINVAL;
     }
 
-  if (strlen(str) && (sanity_check(str) < 0))
+  if (len > 0 && (sanity_check(str) < 0))
     {
       return -EINVAL;
     }
 
   setting->type = SETTING_STRING;
-  strncpy(setting->val.s, str, CONFIG_SYSTEM_SETTINGS_VALUE_SIZE);
-  setting->val.s[CONFIG_SYSTEM_SETTINGS_VALUE_SIZE - 1] = '\0';
+  strlcpy(setting->val.s, str, CONFIG_SYSTEM_SETTINGS_VALUE_SIZE);
 
   return OK;
 }
@@ -825,6 +834,7 @@ int settings_setstorage(FAR char *file, enum storage_type_e type)
   int ret = OK;
   int idx = 0;
   uint32_t h;
+  size_t filelen;
 
   assert(g_settings.initialized);
 
@@ -847,16 +857,16 @@ int settings_setstorage(FAR char *file, enum storage_type_e type)
       goto errout;
     }
 
-  assert(strlen(file) < CONFIG_SYSTEM_SETTINGS_MAX_FILENAME);
-  if (strlen(file) >= CONFIG_SYSTEM_SETTINGS_MAX_FILENAME)
+  filelen = strnlen(file, CONFIG_SYSTEM_SETTINGS_MAX_FILENAME);
+  assert(filelen < CONFIG_SYSTEM_SETTINGS_MAX_FILENAME);
+  if (filelen >= CONFIG_SYSTEM_SETTINGS_MAX_FILENAME)
     {
       ret = -EINVAL;
       goto errout;
     }
 
   storage = &g_settings.store[idx];
-  strncpy(storage->file, file, sizeof(storage->file));
-  storage->file[sizeof(storage->file) - 1] = '\0';
+  strlcpy(storage->file, file, sizeof(storage->file));
 
   switch (type)
   {
@@ -1114,6 +1124,7 @@ int settings_create(FAR char *key, enum settings_type_e type, ...)
 {
   int ret = OK;
   FAR setting_t *setting = NULL;
+  size_t keylen;
   int j;
 
   assert(g_settings.initialized);
@@ -1123,7 +1134,8 @@ int settings_create(FAR char *key, enum settings_type_e type, ...)
       return -EINVAL;
     }
 
-  if (strlen(key) == 0 || strlen(key) >= CONFIG_SYSTEM_SETTINGS_KEY_SIZE)
+  keylen = strnlen(key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
+  if (keylen == 0 || keylen >= CONFIG_SYSTEM_SETTINGS_KEY_SIZE)
     {
       return -EINVAL;
     }
@@ -1141,7 +1153,7 @@ int settings_create(FAR char *key, enum settings_type_e type, ...)
 
   for (j = 0; j < CONFIG_SYSTEM_SETTINGS_MAP_SIZE; j++)
     {
-      if (strcmp(key, map[j].key) == 0)
+      if (strncmp(key, map[j].key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE) == 0)
         {
           setting = &map[j];
 
@@ -1153,8 +1165,7 @@ int settings_create(FAR char *key, enum settings_type_e type, ...)
       if (map[j].type == SETTING_EMPTY)
         {
           setting = &map[j];
-          strncpy(setting->key, key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
-          setting->key[CONFIG_SYSTEM_SETTINGS_KEY_SIZE - 1] = '\0';
+          strlcpy(setting->key, key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
 
           /* This setting is empty/unused - we can use it */
 

--- a/system/settings/storage_bin.c
+++ b/system/settings/storage_bin.c
@@ -96,12 +96,19 @@ extern setting_t map[CONFIG_SYSTEM_SETTINGS_MAP_SIZE];
 FAR setting_t *getsetting(FAR char *key)
 {
   int i;
+  size_t keylen;
+
+  keylen = strnlen(key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
+  if (keylen >= CONFIG_SYSTEM_SETTINGS_KEY_SIZE)
+    {
+      return NULL;
+    }
 
   for (i = 0; i < CONFIG_SYSTEM_SETTINGS_MAP_SIZE; i++)
     {
       FAR setting_t *setting = &map[i];
 
-      if (strcmp(key, setting->key) == 0)
+      if (strncmp(key, setting->key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE) == 0)
         {
           return setting;
         }
@@ -186,6 +193,13 @@ int load_bin(FAR char *file)
 
       slot = getsetting(setting.key);
       if (slot == NULL)
+        {
+          continue;
+        }
+
+      if (setting.type == SETTING_STRING &&
+          strnlen(setting.val.s, CONFIG_SYSTEM_SETTINGS_VALUE_SIZE) >=
+          CONFIG_SYSTEM_SETTINGS_VALUE_SIZE)
         {
           continue;
         }

--- a/system/settings/storage_text.c
+++ b/system/settings/storage_text.c
@@ -97,9 +97,11 @@ extern setting_t map[CONFIG_SYSTEM_SETTINGS_MAP_SIZE];
 FAR setting_t *getsetting(char *key)
 {
   int i;
+  size_t keylen;
   FAR setting_t *setting;
 
-  if (strlen(key) >= CONFIG_SYSTEM_SETTINGS_KEY_SIZE)
+  keylen = strnlen(key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
+  if (keylen >= CONFIG_SYSTEM_SETTINGS_KEY_SIZE)
     {
       return NULL;
     }
@@ -108,15 +110,14 @@ FAR setting_t *getsetting(char *key)
     {
       setting = &map[i];
 
-      if (strcmp(key, setting->key) == 0)
+      if (strncmp(key, setting->key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE) == 0)
         {
           return setting;
         }
 
       if (setting->type == SETTING_EMPTY)
         {
-          strncpy(setting->key, key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
-          setting->key[CONFIG_SYSTEM_SETTINGS_KEY_SIZE - 1] = '\0';
+          strlcpy(setting->key, key, CONFIG_SYSTEM_SETTINGS_KEY_SIZE);
           return setting;
         }
     }
@@ -152,21 +153,27 @@ int load_text(FAR char *file)
   FAR char      *backup_file;
   FAR char      *buffer;
   FAR setting_t *setting;
+  size_t        filelen;
 
   /* Check that the file exists */
+
+  filelen = strnlen(file, CONFIG_SYSTEM_SETTINGS_MAX_FILENAME);
+  if (filelen >= CONFIG_SYSTEM_SETTINGS_MAX_FILENAME)
+    {
+      return -EINVAL;
+    }
 
   if (access(file, F_OK) != 0)
     {
       /* If not, try the backup file */
 
-      backup_file = malloc(strlen(file) + 2);
+      backup_file = malloc(filelen + 2);
       if (backup_file == NULL)
         {
           return -ENODEV;
         }
 
-      strcpy(backup_file, file);
-      strcat(backup_file, "~");
+      snprintf(backup_file, filelen + 2, "%s~", file);
 
       if (access(backup_file, F_OK) == 0)
         {
@@ -196,10 +203,12 @@ int load_text(FAR char *file)
   while (fgets(buffer, BUFFER_SIZE, f))
     {
       int  i;
+      size_t linelen;
 
       /* Remove any line terminators */
 
-      for (i = ((int)strlen(buffer) - 1); i > 0; i--)
+      linelen = strnlen(buffer, BUFFER_SIZE);
+      for (i = ((int)linelen - 1); i > 0; i--)
         {
           if (buffer[i] == ';' || buffer[i] == '\n' || buffer[i] == '\r')
             {
@@ -260,15 +269,15 @@ int load_text(FAR char *file)
             {
               /* It's a string */
 
-              if (strlen(val) >= CONFIG_SYSTEM_SETTINGS_VALUE_SIZE)
+              if (strnlen(val, CONFIG_SYSTEM_SETTINGS_VALUE_SIZE) >=
+                  CONFIG_SYSTEM_SETTINGS_VALUE_SIZE)
                 {
                   continue;
                 }
 
               setting->type = SETTING_STRING;
-              strncpy(setting->val.s, val,
+              strlcpy(setting->val.s, val,
                       CONFIG_SYSTEM_SETTINGS_VALUE_SIZE);
-              setting->val.s[CONFIG_SYSTEM_SETTINGS_VALUE_SIZE - 1] = '\0';
             }
         }
       else
@@ -343,17 +352,24 @@ abort:
 int save_text(FAR char *file)
 {
   int      ret = OK;
-  FAR char *backup_file = malloc(strlen(file) + 2);
+  FAR char *backup_file;
   FAR FILE *f;
+  size_t   filelen;
   int      i;
 
+  filelen = strnlen(file, CONFIG_SYSTEM_SETTINGS_MAX_FILENAME);
+  if (filelen >= CONFIG_SYSTEM_SETTINGS_MAX_FILENAME)
+    {
+      return -EINVAL;
+    }
+
+  backup_file = malloc(filelen + 2);
   if (backup_file == NULL)
     {
       return -ENODEV;
     }
 
-  strcpy(backup_file, file);
-  strcat(backup_file, "~");
+  snprintf(backup_file, filelen + 2, "%s~", file);
 
   f = fopen(backup_file, "w");
   if (f == NULL)


### PR DESCRIPTION
﻿## Summary

Fixes #3109.

This PR bounds string handling in `system/settings` where the maximum field sizes are already defined by Kconfig.

Commit structure:
- Commit 1 (`system/settings: Bound public string handling`) updates the public settings paths to validate key/value/file strings with `strnlen()` before scanning, compare fixed-size keys with `strncmp()`, and copy into fixed-size fields with `strlcpy()`.
- Commit 2 (`system/settings: Bound storage string handling`) applies the same bounds to text and binary storage loading/saving. Text storage backup filenames are built with a sized buffer and `snprintf()`, and storage-loaded keys/string values are rejected if they are not terminated within their configured field sizes.

The second commit is logically separable. I am happy to drop it if maintainers prefer to limit this PR to the public settings API paths only.

Scope:
- Uses existing `CONFIG_SYSTEM_SETTINGS_KEY_SIZE`, `CONFIG_SYSTEM_SETTINGS_VALUE_SIZE`, and `CONFIG_SYSTEM_SETTINGS_MAX_FILENAME` limits.
- Does not change the settings API.
- Does not change the text or binary storage formats.
- Does not mechanically replace every string helper; changes are limited to settings fields with known configured bounds.

## Impact

Settings input and storage-loaded string fields are no longer scanned or compared beyond their configured maximum sizes.

- New feature: NO
- User adaptation required: NO intended user adaptation
- Build process change: NO
- Hardware/architecture/board change: NO
- Documentation update required: NO
- Security impact: YES, hardens bounded string handling in `system/settings`
- Compatibility impact: NO intended compatibility impact

## Testing

Host:
- Windows with WSL Ubuntu 24.04
- CPU: x86_64
- Compiler: GCC 13.3.0

Checks:
- `git diff --check upstream/master..HEAD`: pass
- `checkpatch.sh -c -u -m -g HEAD~2..HEAD`: pass
- `rg -n "strlen\(|strcmp\(|strncpy\(|strcpy\(|strcat\(" system/settings`: no matches
- `sim:nsh` build with `CONFIG_SYSTEM_SETTINGS=y` and `CONFIG_SYSTEM_SETTINGS_CACHED_SAVES` disabled: pass
  - confirmed `CC: settings.c`
  - confirmed `CC: storage_bin.c`
  - confirmed `CC: storage_text.c`
  - result: `SIM elf with dynamic libs archive in nuttx.tgz`

Note: the temporary test build disables `CONFIG_SYSTEM_SETTINGS_CACHED_SAVES` because the base `sim:nsh` settings configuration otherwise needs `SIGEV_THREAD` support, which is outside the scope of this string-handling PR.