### PR TITLE
apps/nxinit: Make init.rc file path configurable

### DIFF
--- a/system/nxinit/Kconfig
+++ b/system/nxinit/Kconfig
@@ -77,7 +77,7 @@ config SYSTEM_NXINIT_ACTION_MANAGER_EVENT_MAX
 config SYSTEM_NXINIT_FINALINIT
 	bool "Enable NXInit final event"
 	default n
-	--help--
+	---help---
 		Enable support to run the "final" event. Currently only "boot",
 		and "init" event are enabled by default, where "netinit" and
 		"final" are optional.

--- a/system/nxinit/Kconfig
+++ b/system/nxinit/Kconfig
@@ -31,6 +31,12 @@ config SYSTEM_NXINIT_PROGNAME
 
 comment "NXInit Run Control(RC)"
 
+config SYSTEM_NXINIT_RC_FILE_PATH
+	string "Path to RC file"
+	default "/etc/init.d/init.rc"
+	---help---
+		Path to the init.rc file to use for NXInit's boot logic.
+
 config SYSTEM_NXINIT_RC_LINE_MAX
 	int "Max line length of RC file"
 	default 128

--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -80,13 +80,7 @@ static void reap_process(FAR struct service_manager_s *sm,
 
   for (; ; )
     {
-      pid = waitpid(-1,
-#ifdef CONFIG_SYSTEM_NXINIT_DEBUG
-                    &wstatus,
-#else
-                    NULL,
-#endif
-                    WNOHANG);
+      pid = waitpid(-1, &wstatus, WNOHANG);
       if (pid <= 0)
         {
           break;

--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -180,7 +180,7 @@ int main(int argc, FAR char *argv[])
         }
     }
 
-  r = init_parse_config_file(parser, "/etc/init.d/init.rc");
+  r = init_parse_config_file(parser, CONFIG_SYSTEM_NXINIT_RC_FILE_PATH);
   if (r < 0)
     {
       goto out;

--- a/system/nxinit/service.c
+++ b/system/nxinit/service.c
@@ -206,8 +206,11 @@ static int option_class(FAR struct service_manager_s *sm,
 {
   FAR struct service_s *s = list_last_entry(&sm->services, struct service_s,
                                             node);
-  size_t len = strlen(argv[1]) + 1;
+  size_t len;
   FAR struct service_class_s *c;
+
+  len = strlen(argv[1]) + 1;
+  len = (len >= NXINIT_SERVICE_NAME_MAX) ? NXINIT_SERVICE_NAME_MAX : len;
 
   list_for_every_entry(&s->classes, c, struct service_class_s, node)
     {
@@ -217,15 +220,15 @@ static int option_class(FAR struct service_manager_s *sm,
         }
     }
 
-  c = malloc(sizeof(*c) + len);
+  c = malloc(sizeof(*c));
   if (c == NULL)
     {
       init_err("Alloc class");
       return -errno;
     }
 
-  len = (len >= MAX_NXINIT_SERVICE_NAME) ? MAX_NXINIT_SERVICE_NAME : len;
   memcpy(c->name, argv[1], len);
+  c->name[len] = '\0'; /* Always ensure null termination */
   list_add_tail(&s->classes, &c->node);
   return 0;
 }


### PR DESCRIPTION
## Summary

The init.rc file path is now configurable to allow users to choose where to put the startup script. This is useful for devices that mount external media to a special directory like `/sd`.

Also fixed some compilation errors not caught earlier.

Documentation update here: https://github.com/apache/nuttx/pull/18981

## Impact

Better user experience with NXInit.

## Testing

N/A.