### PR TITLE
nxinit/Kconfig: Change `--help--` to `---help---`

### DIFF
--- a/system/nxinit/Kconfig
+++ b/system/nxinit/Kconfig
@@ -77,7 +77,7 @@ config SYSTEM_NXINIT_ACTION_MANAGER_EVENT_MAX
 config SYSTEM_NXINIT_FINALINIT
 	bool "Enable NXInit final event"
 	default n
-	--help--
+	---help---
 		Enable support to run the "final" event. Currently only "boot",
 		and "init" event are enabled by default, where "netinit" and
 		"final" are optional.


### PR DESCRIPTION
## Summary

PR https://github.com/apache/nuttx-apps/pull/3504 introduced a typo in nxinit/Kconfig: `--help--`. This PR changes it to `---help---` to fix this build error: 
```
$ tools/configure.sh rv-virt:nsh
apps/system/nxinit/Kconfig:81: syntax error
apps/system/nxinit/Kconfig:80: unknown option "--help--"
```
https://github.com/lupyuen/nuttx-riscv64/actions/runs/26546602390/job/78199683651#step:5:162

## Impact

`configure.sh` now works correctly, see below.

## Testing

```bash
## Tested on Ubuntu 24.04.2 LTS x86_64
## gcc version 13.2.0 (xPack GNU RISC-V Embedded GCC x86_64) 
$ tools/configure.sh rv-virt:nsh
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
  configuration written to .config
$ make -j 8
CPP:  /tmp/fix-nxinit/nuttx/boards/risc-v/qemu-rv/rv-virt/scripts/ld.script-> /tmp/fix-LD: nuttx
```
