### PR TITLE
interpreters/quickjs,testing/nettest: fix typos in Kconfig and source.

### DIFF
--- a/interpreters/quickjs/Kconfig
+++ b/interpreters/quickjs/Kconfig
@@ -14,7 +14,7 @@ choice
 	default INTERPRETERS_QUICKJS_NONE
 
 config INTERPRETERS_QUICKJS_NONE
-	bool "distable quickjs interpreter"
+	bool "Disable quickjs interpreter"
 
 config INTERPRETERS_QUICKJS_MINI
 	bool "Minimal quickjs interpreter"
@@ -40,11 +40,11 @@ config INTERPRETERS_QUICKJS_STACKSIZE
 	default 8192
 
 config INTERPRETERS_QUICKJS_EXT_HOOK
-	bool "External init/destory hook"
+	bool "External init/destroy hook"
 	default n
 	depends on INTERPRETERS_QUICKJS_MINI
 	---help---
 		Since minimal interpreter only support 'console.log',
-		you can export custom module by implement init/destory hook.
+		you can export custom module by implement init/destroy hook.
 
 endif # INTERPRETERS_QUICKJS

--- a/testing/nettest/utils/nettest_tcpserver.c
+++ b/testing/nettest/utils/nettest_tcpserver.c
@@ -409,13 +409,13 @@ int nettest_destroy_tcp_lo_server(pthread_t server_tid)
       ret = connect(sockfd, (FAR struct sockaddr *)&myaddr, addrlen);
       if (ret < 0)
         {
-          goto err_destory;
+          goto err_destroy;
         }
 
       ret = send(sockfd, EXIT_MSG, strlen(EXIT_MSG), 0);
       if (ret < 0)
         {
-          goto err_destory;
+          goto err_destroy;
         }
 
       pthread_join(server_tid, NULL);
@@ -424,7 +424,7 @@ int nettest_destroy_tcp_lo_server(pthread_t server_tid)
 
   return 0;
 
-err_destory:
+err_destroy:
   close(sockfd);
   return -errno;
 }


### PR DESCRIPTION
## Summary

  * Fix spelling errors in QuickJS Kconfig and nettest source that affect user-visible configuration text and internal code labels.
  * Changes:
    - `interpreters/quickjs/Kconfig:17`: "distable" -> "Disable" in INTERPRETERS_QUICKJS_NONE choice description
    - `interpreters/quickjs/Kconfig:43`: "destory" -> "destroy" in INTERPRETERS_QUICKJS_EXT_HOOK bool text
    - `interpreters/quickjs/Kconfig:48`: "destory" -> "destroy" in help text for the same option
    - `testing/nettest/utils/nettest_tcpserver.c:412,418,427`: `err_destory` -> `err_destroy` label name (2 goto targets + 1 label definition)
  * No functional change — cosmetic fixes only.

## Impact

  * Is new feature added? Is existing feature changed? NO
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? NO
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO

## Testing

  * Build Host(s): Linux (WSL Ubuntu), x86_64
  * Verification: `checkpatch.sh -f` on both modified files — all checks pass.
  * The changes are to Kconfig user-visible text and an internal C label name; no runtime behavior is affected.