### PR TITLE
system/lzf: Fix missing space in Kconfig help text.

### DIFF
--- a/system/lzf/Kconfig
+++ b/system/lzf/Kconfig
@@ -8,7 +8,7 @@ config SYSTEM_LZF
 	default n
 	depends on LIBC_LZF
 	---help---
-		Enable theLZF compression tool
+		Enable the LZF compression tool
 
 if SYSTEM_LZF
 


### PR DESCRIPTION
## Summary

Fix a missing space in the Kconfig help text for `SYSTEM_LZF`:

```diff
- Enable theLZF compression tool
+ Enable the LZF compression tool
```

## Impact

- [x] Impact on build: NO
- [x] Impact on hardware: NO
- [x] Impact on documentation: NO (this is a Kconfig help text fix, not Sphinx docs)
- [x] Impact on security: NO
- [x] Impact on compatibility: NO

## Testing

- `checkpatch.sh -f system/lzf/Kconfig`: All checks pass.
- Verified the fix in the Kconfig file.

## Self-Check

- [x] PR title follows NuttX convention: `<subsystem>: <description>.`
- [x] Commit body explains what changed, how, and why
- [x] Signed-off-by present
- [x] checkpatch passes
- [x] Single file, minimal diff (+1/-1)