### PR TITLE
system/popen: Avoid copying FILE

### DIFF
--- a/system/popen/popen.c
+++ b/system/popen/popen.c
@@ -37,16 +37,64 @@
  * Private Types
  ****************************************************************************/
 
-/* struct popen_file_s is a cast compatible version of FILE that contains
- * the additional PID of the shell processes needed by pclose().
- */
-
 struct popen_file_s
 {
-  FILE copy;
-  FILE *original;
+  int fd;
   pid_t shell;
 };
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: popen_file_read
+ ****************************************************************************/
+
+static ssize_t popen_file_read(FAR void *cookie, FAR char *buf,
+                               size_t size)
+{
+  FAR struct popen_file_s *filep = (FAR struct popen_file_s *)cookie;
+
+  return read(filep->fd, buf, size);
+}
+
+/****************************************************************************
+ * Name: popen_file_write
+ ****************************************************************************/
+
+static ssize_t popen_file_write(FAR void *cookie, FAR const char *buf,
+                                size_t size)
+{
+  FAR struct popen_file_s *filep = (FAR struct popen_file_s *)cookie;
+
+  return write(filep->fd, buf, size);
+}
+
+/****************************************************************************
+ * Name: popen_file_seek
+ ****************************************************************************/
+
+static off_t popen_file_seek(FAR void *cookie, FAR off_t *offset,
+                             int whence)
+{
+  set_errno(ESPIPE);
+  return ERROR;
+}
+
+/****************************************************************************
+ * Name: popen_file_close
+ ****************************************************************************/
+
+static int popen_file_close(FAR void *cookie)
+{
+  FAR struct popen_file_s *filep = (FAR struct popen_file_s *)cookie;
+  int ret;
+
+  ret = dpclose(filep->fd, filep->shell);
+  free(filep);
+  return ret < 0 ? ERROR : OK;
+}
 
 /****************************************************************************
  * Public Functions
@@ -93,6 +141,15 @@ struct popen_file_s
 FILE *popen(FAR const char *command, FAR const char *mode)
 {
   FAR struct popen_file_s *container;
+  FAR FILE *stream;
+  cookie_io_functions_t popen_io =
+    {
+      .read  = popen_file_read,
+      .write = popen_file_write,
+      .seek  = popen_file_seek,
+      .close = popen_file_close
+    };
+
   int oflag;
   int fd;
 
@@ -142,8 +199,9 @@ FILE *popen(FAR const char *command, FAR const char *mode)
 
   /* Wrap the raw fd in a FILE stream */
 
-  container->original = fdopen(fd, mode);
-  if (container->original == NULL)
+  container->fd = fd;
+  stream = fopencookie(container, mode, popen_io);
+  if (stream == NULL)
     {
       int errcode = errno;
       dpclose(fd, container->shell);
@@ -152,8 +210,7 @@ FILE *popen(FAR const char *command, FAR const char *mode)
       return NULL;
     }
 
-  memcpy(&container->copy, container->original, sizeof(FILE));
-  return &container->copy;
+  return stream;
 }
 
 /****************************************************************************
@@ -193,33 +250,12 @@ FILE *popen(FAR const char *command, FAR const char *mode)
  *   stream - The stream reference returned by a previous call to popen()
  *
  * Returned Value:
- *   The child termination status on success, or -1 (ERROR) on failure
- *   with errno set.
+ *   Zero (OK) is returned on success; otherwise -1 (ERROR) is returned and
+ *   errno is set appropriately.
  *
  ****************************************************************************/
 
 int pclose(FILE *stream)
 {
-  FAR struct popen_file_s *container = (FAR struct popen_file_s *)stream;
-  FILE *original;
-  pid_t shell;
-
-  original = container->original;
-
-  /* Set the state of the original file descriptor to the state of the
-   * working copy
-   */
-
-  memcpy(original, &container->copy, sizeof(FILE));
-
-  /* Then close the original and free the container (saving the PID of the
-   * shell process).  Pass -1 to dpclose since fclose already closed the fd.
-   */
-
-  fclose(original);
-
-  shell = container->shell;
-  free(container);
-
-  return dpclose(-1, shell);
+  return fclose(stream);
 }


### PR DESCRIPTION
﻿## Summary

Fixes #2937.

`system/popen` was embedding a copied `FILE` object in its private tracking container and copying it back in `pclose()`. That depends on libc `FILE` layout details.

This PR makes `popen()` return the actual stream from `fdopen()` and keeps a small private `FILE * -> pid` tracking list so `pclose()` can find the spawned shell process without copying `FILE`.

Scope:
- Does not change supported `popen()` modes.
- Does not change the spawn/file-action setup.
- Keeps `pclose()` responsible for closing the stream and waiting for the shell pid.
- Returns `EINVAL` if `pclose()` cannot find the stream in the private popen list.

## Impact

`popen()`/`pclose()` no longer rely on libc `FILE` internals.

- New feature: NO
- User adaptation required: NO
- Build process change: NO
- Hardware/architecture/board change: NO
- Documentation update required: NO
- Security impact: NO
- Compatibility impact: NO intended compatibility impact

## Testing

Host:
- Windows with WSL Ubuntu 24.04
- Target: `sim:nsh`

Checks:
- `git diff --check`: pass
- `checkpatch.sh -g HEAD~1..HEAD`: pass
- `sim:nsh` build with `CONFIG_SYSTEM_POPEN=y` and `CONFIG_EXAMPLES_POPEN=y`: pass
  - confirmed `CC: popen.c`
  - result: `SIM elf with dynamic libs archive in nuttx.tgz`
- `printf 'popen\npoweroff\n' | timeout 30s ./nuttx`: pass
  - confirmed `popen("help")` output is read
  - confirmed execution reaches `pclose()`