### PR TITLE
testing/drivers/crypto: Fix typo on hash test

### DIFF
--- a/testing/drivers/crypto/hash.c
+++ b/testing/drivers/crypto/hash.c
@@ -260,7 +260,7 @@ static const unsigned char sha1_huge_block_result[20] =
 };
 #  endif
 
-#  ifndef CONFIG_TESTING_CRYPTO_HASH_DISABLE_SHA256
+#  ifndef CONFIG_TESTING_CRYPTO_HASH_DISABLE_SHA224
 static const unsigned char sha224_huge_block_result[28] =
 {
   0xff, 0x42, 0x9e, 0x92, 0x94, 0xce, 0x0a, 0x31,


### PR DESCRIPTION
## Summary

* testing/drivers/crypto: Fix typo on hash test

Fix typo issue on hash test

## Impact

Impact on user: Yes, potencial build warnings when using hash test fixed

Impact on build: No

Impact on hardware: No

Impact on documentation: No

Impact on security: No

Impact on compatibility: No


## Testing

`esp32-devkitc:crypto` used to test.

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command to build:

```
make -j distclean && ./tools/configure.sh esp32-devkitc:crypto && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

`hash` command used to test:

### Results
<!-- Provide tests' results and runtime logs -->

Output:

```
nsh> hash
hash sha1 success
hash sha1 success
hash sha1 success
hash sha256 success
hash sha256 success
hash sha256 success
hash sha512 success
hash sha512 success
hash sha512 success
sha1 huge block test success(16 passes over 38400 bytes to hash 614400 bytes)
sha256 huge block test success(16 passes over 38400 bytes to hash 614400 bytes)
sha512 huge block test success(16 passes over 38400 bytes to hash 614400 bytes)
nsh> 
```
