### PR TITLE
system/popen: select PIPES automatically when popen is enabled

### DIFF
--- a/system/popen/Kconfig
+++ b/system/popen/Kconfig
@@ -7,7 +7,7 @@ config SYSTEM_POPEN
 	bool "popen()/pclose()/dpopen()/dpclose() Functions"
 	default n
 	select SCHED_WAITPID
-	depends on PIPES
+	select PIPES
 	---help---
 		Enable support for the popen(), pclose(), dpopen(), and
 		dpclose() interfaces.


### PR DESCRIPTION
## Summary

Fixes #11435

`SYSTEM_POPEN` currently uses `depends on PIPES`, requiring users to manually enable the pipe driver before popen becomes visible. Since `popen()` fundamentally requires pipes to function, it should `select PIPES` automatically — matching the pattern already used by `gs2200m`, `alt1250`, `usrsocktest`, and `lely-canopen`.

## Change

```diff
 config SYSTEM_POPEN
 	bool "popen()/pclose() Functions"
 	default n
 	select SCHED_WAITPID
-	depends on NSH_LIBRARY && PIPES
+	depends on NSH_LIBRARY
+	select PIPES
```

## Testing

Verified on `sim:nsh` with CMake build:

1. **Default config** (`PIPES=y`, `SYSTEM_POPEN` unset) — compiles normally ✅
2. **Manual disable PIPES + enable SYSTEM_POPEN** — `olddefconfig` automatically re-enables `CONFIG_PIPES=y` ✅
3. **Build with popen enabled** — compiles successfully ✅
4. **Runtime** — ran `popen` example, `popen("help")` executed and returned shell output correctly ✅