### PR TITLE
examples/microros_sub: Add minimal Int32 subscriber example.

### DIFF
--- a/examples/microros_sub/CMakeLists.txt
+++ b/examples/microros_sub/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/microros_sub/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_MICROROS_SUB)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_MICROROS_SUB_PROGNAME}
+    SRCS
+    microros_sub_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_MICROROS_SUB_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_MICROROS_SUB_PRIORITY}
+    DEPENDS
+    microros_transport)
+endif()

--- a/examples/microros_sub/Kconfig
+++ b/examples/microros_sub/Kconfig
@@ -1,0 +1,31 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_MICROROS_SUB
+	tristate "micro-ROS int32 subscriber example"
+	default n
+	depends on SYSTEM_MICROROS
+	---help---
+		Minimal micro-ROS subscriber that creates a node, subscribes to
+		the topic /nuttx_sub with std_msgs/Int32, and prints each
+		received value.  Drives an rclc_executor spin loop and is used
+		together with microros_pub (or any external publisher) to
+		validate the NuttX-native transport in the receive direction.
+
+if EXAMPLES_MICROROS_SUB
+
+config EXAMPLES_MICROROS_SUB_PROGNAME
+	string "Program name"
+	default "microros_sub"
+
+config EXAMPLES_MICROROS_SUB_PRIORITY
+	int "micro-ROS sub task priority"
+	default 100
+
+config EXAMPLES_MICROROS_SUB_STACKSIZE
+	int "micro-ROS sub stack size"
+	default 8192
+
+endif

--- a/examples/microros_sub/Make.defs
+++ b/examples/microros_sub/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/microros_sub/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_MICROROS_SUB),)
+CONFIGURED_APPS += $(APPDIR)/examples/microros_sub
+endif

--- a/examples/microros_sub/Makefile
+++ b/examples/microros_sub/Makefile
@@ -1,0 +1,32 @@
+############################################################################
+# apps/examples/microros_sub/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_MICROROS_SUB_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_MICROROS_SUB_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_MICROROS_SUB_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_MICROROS_SUB)
+
+MAINSRC = microros_sub_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/microros_sub/microros_sub_main.c
+++ b/examples/microros_sub/microros_sub_main.c
@@ -1,0 +1,131 @@
+/****************************************************************************
+ * apps/examples/microros_sub/microros_sub_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include <rcl/rcl.h>
+#include <rcl/error_handling.h>
+#include <rclc/rclc.h>
+#include <rclc/executor.h>
+#include <std_msgs/msg/int32.h>
+
+#include <system/microros_transport.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static std_msgs__msg__Int32 g_rx_msg;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void sub_callback(const void *msgin)
+{
+  const std_msgs__msg__Int32 *msg = (const std_msgs__msg__Int32 *)msgin;
+
+  printf("microros_sub: got %d\n", (int)msg->data);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  rcl_subscription_t   subscriber;
+  rcl_allocator_t      allocator;
+  rclc_support_t       support;
+  rcl_node_t           node;
+  rclc_executor_t      executor;
+
+  printf("microros_sub: starting\n");
+
+  if (microros_transport_init() != 0)
+    {
+      printf("microros_sub: transport init failed\n");
+      return 1;
+    }
+
+  allocator = rcl_get_default_allocator();
+
+  if (rclc_support_init(&support, 0, NULL, &allocator) != RCL_RET_OK)
+    {
+      printf("microros_sub: rclc_support_init failed\n");
+      return 1;
+    }
+
+  if (rclc_node_init_default(&node, "nuttx_sub_node", "", &support)
+      != RCL_RET_OK)
+    {
+      printf("microros_sub: node init failed\n");
+      return 1;
+    }
+
+  if (rclc_subscription_init_default(
+        &subscriber,
+        &node,
+        ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Int32),
+        "nuttx_sub") != RCL_RET_OK)
+    {
+      printf("microros_sub: subscription init failed\n");
+      return 1;
+    }
+
+  executor = rclc_executor_get_zero_initialized_executor();
+  if (rclc_executor_init(&executor, &support.context, 1, &allocator)
+      != RCL_RET_OK)
+    {
+      printf("microros_sub: executor init failed\n");
+      return 1;
+    }
+
+  if (rclc_executor_add_subscription(&executor,
+                                     &subscriber,
+                                     &g_rx_msg,
+                                     &sub_callback,
+                                     ON_NEW_DATA) != RCL_RET_OK)
+    {
+      printf("microros_sub: add_subscription failed\n");
+      return 1;
+    }
+
+  printf("microros_sub: spinning on /nuttx_sub\n");
+
+  rclc_executor_spin(&executor);
+
+  rclc_executor_fini(&executor);
+  rcl_subscription_fini(&subscriber, &node);
+  rcl_node_fini(&node);
+  rclc_support_fini(&support);
+
+  printf("microros_sub: done\n");
+  return 0;
+}


### PR DESCRIPTION

## Summary

Phase 7 of the micro-ROS on NuttX integration. Adds `apps/examples/microros_sub`,
a minimal Int32 subscriber that mirrors the `microros_pub` example merged in
[#3512](https://github.com/apache/nuttx-apps/pull/3512) for the receive direction.

The example creates a `nuttx_sub_node`, subscribes to `/nuttx_sub` with
`std_msgs/msg/Int32`, registers a callback via `rclc_executor_add_subscription`,
and enters `rclc_executor_spin`. Each received value is printed via NSH. It
exercises the rclc_executor + subscription callback path on top of the
NuttX-native `microros_transport` library that was wired up in Phase 6.

Depends on:
- apache/nuttx-apps#3512 (transport + pub example) — merged
- apache/nuttx#19001 (CMake plumbing) — merged

## Impact

- **User**: new opt-in `EXAMPLES_MICROROS_SUB` Kconfig entry under
  `Application Configuration > Examples`, gated on `SYSTEM_MICROROS`.
  Default `n`; existing configs are unaffected.
- **Build**: no changes to the libmicroros build pipeline; reuses the existing
  `microros_transport` library and `SYSTEM_MICROROS` include layout.
- **Hardware**: none. Sim and any board with the existing micro-ROS transport
  enabled (UDP via NuttX sockets or serial via TERMIOS) can run the example.
- **Docs / security / compatibility**: none.

## Testing

Host: Ubuntu 22.04.5 LTS (jammy), x86_64, Linux 6.8.0-1055-aws,
gcc 11.4.0, AWS EC2 m7i-flex.large (2 vCPU, 7.6 GB RAM).

Target: NuttX `sim:nsh` on Linux, UDP transport over TAP.

### 1. checkpatch

```
$ ./tools/checkpatch.sh -f ../apps/examples/microros_sub/microros_sub_main.c
(clean)
```

### 2. Build with pub + sub both enabled

```
$ tools/configure.sh sim:nsh
$ cat ~/microros_extra_config >> .config
$ make olddefconfig
$ make -j2
...
LD: nuttx
SIM elf with dynamic libs archive in nuttx.tgz
```

Result: `nuttx` ELF produced, both `microros_pub_main` and `microros_sub_main`
linked.

### 3. Sub-only build (pub disabled)

Verifies the new example does not regress when the existing publisher example
is turned off and that `microros_transport` still links cleanly with just the
subscriber as a consumer.

```
$ kconfig-tweak --disable EXAMPLES_MICROROS_PUB
$ kconfig-tweak --enable  EXAMPLES_MICROROS_SUB
$ make olddefconfig && make -j2
...
LD: nuttx
SIM elf with dynamic libs archive in nuttx.tgz
$ nm nuttx | grep -E 'microros_sub_main|sub_callback'
00000000400a9d89 T microros_sub_main
00000000400a9d30 t sub_callback
```

### 4. End-to-end runtime against a micro-ROS agent

Agent (host, separate terminal):

```
$ docker run -it --rm --network host microros/micro-ros-agent:jazzy \
      udp4 --port 8888
[INFO] [Root.Agent]: Running.
```

NuttX sim:

```
nsh> ifconfig
eth0    Link encap:Ethernet HWaddr 42:0a:bc:cd:ef:02 at UP
        inet addr:192.168.10.2 DRaddr:192.168.10.1 Mask:255.255.255.0
nsh> microros_sub &
microros_sub: starting
microros_sub: spinning on /nuttx_sub
```

Host publishes (in another terminal):

```
$ ros2 topic pub --once /nuttx_sub std_msgs/msg/Int32 "{data: 42}"
$ for v in 100 200 300 400 500; do
    ros2 topic pub --once /nuttx_sub std_msgs/msg/Int32 "{data: $v}"; done
```

NuttX sim output:

```
microros_sub: got 42
microros_sub: got 42
microros_sub: got 42
microros_sub: got 42
microros_sub: got 42
microros_sub: got 42
microros_sub: got 42
microros_sub: got 100
microros_sub: got 200
microros_sub: got 300
microros_sub: got 400
microros_sub: got 500
```

All values delivered in order to the registered callback via
`rclc_executor_spin`, confirming the agent → client direction of the
NuttX-native transport plus the rclc_executor subscription path works
end-to-end.