### PR TITLE
apps/rust: Add dependencies for Rust cargo in make builds

### DIFF
--- a/examples/rust/hello/Makefile
+++ b/examples/rust/hello/Makefile
@@ -27,8 +27,15 @@ PRIORITY  = $(CONFIG_EXAMPLES_HELLO_RUST_CARGO_PRIORITY)
 STACKSIZE = $(CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE)
 MODULE    = $(CONFIG_EXAMPLES_HELLO_RUST_CARGO)
 
-context::
+RUST_LIB  := $(call RUST_GET_BINDIR,hello,$(APPDIR)/examples/rust)
+RUST_SRCS := $(call RUST_CARGO_SRCS,hello,$(APPDIR)/examples/rust)
+
+$(RUST_LIB): $(RUST_SRCS)
 	$(call RUST_CARGO_BUILD,hello,$(APPDIR)/examples/rust)
+
+context:: $(RUST_LIB)
+
+all:: $(RUST_LIB)
 
 clean::
 	$(call RUST_CARGO_CLEAN,hello,$(APPDIR)/examples/rust)

--- a/examples/rust/slint/Makefile
+++ b/examples/rust/slint/Makefile
@@ -25,8 +25,15 @@ PRIORITY  = $(CONFIG_EXAMPLES_RUST_SLINT_PRIORITY)
 STACKSIZE = $(CONFIG_EXAMPLES_RUST_SLINT_STACKSIZE)
 MODULE    = $(CONFIG_EXAMPLES_RUST_SLINT)
 
-context::
+RUST_LIB  := $(call RUST_GET_BINDIR,slint,$(APPDIR)/examples/rust)
+RUST_SRCS := $(call RUST_CARGO_SRCS,slint,$(APPDIR)/examples/rust)
+
+$(RUST_LIB): $(RUST_SRCS)
 	$(call RUST_CARGO_BUILD,slint,$(APPDIR)/examples/rust)
+
+context:: $(RUST_LIB)
+
+all:: $(RUST_LIB)
 
 clean::
 	$(call RUST_CARGO_CLEAN,slint,$(APPDIR)/examples/rust)

--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -144,3 +144,18 @@ $(2)/$(1)/target/$(strip $(if $(findstring .json,$(call RUST_TARGET_TRIPLE)), \
 	$(basename $(notdir $(call RUST_TARGET_TRIPLE))), \
 	$(call RUST_TARGET_TRIPLE)))/$(if $(CONFIG_DEBUG_FULLOPT),release,debug)/lib$(1).a
 endef
+
+# Collect crate input files for a crate
+#
+# Usage:   $(call RUST_CARGO_SRCS,cratename,prefix)
+#
+# Inputs:
+#   cratename - Name of the Rust crate (e.g. hello)
+#   prefix    - Path prefix to the crate (e.g. path/to/project)
+#
+# Output:
+#   List of crate input files (excluding the cargo target directory)
+
+define RUST_CARGO_SRCS
+$(shell find $(2)/$(1) -type f -not -path '$(2)/$(1)/target/*' 2>/dev/null)
+endef


### PR DESCRIPTION
## Summary

This updates the Rust example Makefiles so Cargo builds participate in normal Make dependency tracking.

The change adds a `RUST_CARGO_SRCS` helper in `tools/Rust.mk` to collect crate input files. The `hello` and `slint` Rust examples now use that file list as prerequisites for their generated static libraries.

The examples also hook the generated Rust library into both `context` and `all`.
As a result, editing Rust sources, manifests, build scripts, causes Cargo to rebuild when `make` is run again.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration and Build:

```
make distclean
./tools/configure.sh sim:nsh
make menuconfig
# Quit using the `Q` command.

printf 'CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
' >> .config

make olddefconfig
make

LN: platform/board to /Users/toku/nuttxspace/apps/platform/dummy
Register: gpio
Register: hello
Register: hello_rust_cargo
Register: dd
Register: dumpstack
Register: nsh
Register: sh
Register: ostest
CP:  /Users/toku/nuttxspace/nuttx/include/nuttx/config.h
CP:  /Users/toku/nuttxspace/nuttx/include/nuttx/fs/hostfs.h
Building Rust code with cargo...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.26s
LD:  nuttx
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
