### PR TITLE
system/nxinit: skip empty lines in init.rc parser

### DIFF
--- a/system/nxinit/parser.c
+++ b/system/nxinit/parser.c
@@ -179,6 +179,16 @@ int init_parse_config_file(FAR const struct parser_s *parser,
           n -= nl - buf;
           init_debug("Line %3d: '%s'", ++line, buf);
 
+          /* Skip empty lines and lines containing only whitespace */
+
+          for (ret = 0; buf[ret] && isblank(buf[ret]); ret++);
+
+          if (buf[ret] == '\0')
+            {
+              memmove(buf, nl, n);
+              continue;
+            }
+
           for (ret = 0; parser[ret].key; ret++)
             {
               if (!strncmp(parser[ret].key, buf, strlen(parser[ret].key)))


### PR DESCRIPTION
## Description

Empty lines in init.rc caused parsing to fail with `-EINVAL` because `init_parse_arguments()` returns 0 for empty strings, triggering the `argc < 1` error path in `init_action_parse()` and accessing uninitialized `argv[0]` in `init_service_parse()`.

Fix by skipping empty lines and lines containing only whitespace before attempting to match section keywords or calling parser callbacks.

Fixes #3513

## Changes

- `system/nxinit/parser.c`: Add empty/whitespace-only line skip logic in `init_parse_config_file()`

## Testing

Verified on `sim:nsh` with NXINIT enabled and an init.rc containing empty lines:

```
on boot
    start console
    sleep 1
                    ← empty line (previously caused -EINVAL)
service console sh
    class core
    restart_period 1000
```

**Before fix:**
```
Error Parse /etc/init.d/init.rc -22
```

**After fix:**
```
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    4     4     0 100 FIFO     Task      - Waiting  Signal    0000000000000000 0067496 init_main
    5     5     4 100 FIFO     Task      - Running            0000000000000000 0067504 sh
    6     6     4 100 FIFO     Task      - Ready              0000000000000000 0067464 system -c sleep 1
```

NXInit successfully parsed the init.rc with empty lines and started the console service.