### PR TITLE
system/uorb: Show listener data without CONFIG_DEBUG_UORB

### DIFF
--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -18,12 +18,18 @@ config UORB_STACKSIZE
 	int "stack size"
 	default DEFAULT_TASK_STACKSIZE
 
+config UORB_FORMAT
+	bool
+	default n
+
 config UORB_LISTENER
 	bool "uorb listener"
+	select UORB_FORMAT
 	default n
 
 config UORB_GENERATOR
 	bool "uorb generator"
+	select UORB_FORMAT
 	default n
 
 config UORB_TESTS
@@ -46,6 +52,7 @@ endif # UORB_TESTS
 config DEBUG_UORB
 	bool "uorb debug output"
 	select LIBC_PRINT_EXTENSION
+	select UORB_FORMAT
 	depends on LIBC_FLOATINGPOINT && SENSORS_USE_FLOAT
 	default n
 

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -49,7 +49,7 @@
 #define ORB_TOP_WAIT_TIME  1000
 #define ORB_DATA_DIR       "/data/uorb/"
 
-#if defined(CONFIG_DEBUG_UORB) && !defined(CONFIG_LIBC_FLOATINGPOINT)
+#if defined(CONFIG_UORB_FORMAT) && !defined(CONFIG_LIBC_FLOATINGPOINT)
 #error "Enable CONFIG_LIBC_FLOATINGPOINT, required to see debug output"
 #endif
 
@@ -551,7 +551,7 @@ static int listener_print(FAR const struct orb_metadata *meta, int fd)
   int ret;
 
   ret = orb_copy(meta, fd, buffer);
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
   if (ret == OK && meta->o_format != NULL)
     {
       orb_info(meta->o_format, meta->o_name, buffer);
@@ -774,7 +774,7 @@ static int listener_record(FAR const struct orb_metadata *meta, int fd,
   int ret;
 
   ret = orb_copy(meta, fd, buffer);
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
   if (ret == OK && meta->o_format != NULL)
     {
       ret = orb_fprintf(file, meta->o_format, buffer);
@@ -876,7 +876,7 @@ static void listener_monitor(FAR struct listen_list_s *objlist,
           tmp->file = fopen(path, "w");
           if (tmp->file != NULL)
             {
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
               fprintf(tmp->file, "%s,%d,%d,%s\n", tmp->object.meta->o_format,
                       tmp->object.meta->o_size, tmp->object.instance,
                       tmp->object.meta->o_name);
@@ -1129,7 +1129,7 @@ int main(int argc, FAR char *argv[])
             }
           break;
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
         case 's':
           record = true;
           break;

--- a/system/uorb/sensor/accel.c
+++ b/system/uorb/sensor/accel.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_accel_format[] =
   "timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf";
 

--- a/system/uorb/sensor/angle.c
+++ b/system/uorb/sensor/angle.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_angle_format[] = "timestamp:%" PRIu64 ",angle:%hf";
 #endif
 

--- a/system/uorb/sensor/baro.c
+++ b/system/uorb/sensor/baro.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_baro_format[] =
   "timestamp:%" PRIu64 ",pressure:%hf,temperature:%hf";
 #endif

--- a/system/uorb/sensor/cap.c
+++ b/system/uorb/sensor/cap.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_cap_format[] =
   "timestamp:%" PRIu64 ",status:%" PRIu32 ",rawdata0:%" PRIu32 ","
   "rawdata1:%" PRIu32 ",rawdata2:%" PRIu32 ",rawdata3:%" PRIu32 "";

--- a/system/uorb/sensor/co2.c
+++ b/system/uorb/sensor/co2.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_co2_format[] = "timestamp:%" PRIu64 ",co2:%hf";
 #endif
 

--- a/system/uorb/sensor/dust.c
+++ b/system/uorb/sensor/dust.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_dust_format[] = "timestamp:%" PRIu64 ",dust:%hf";
 #endif
 

--- a/system/uorb/sensor/ecg.c
+++ b/system/uorb/sensor/ecg.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_ecg_format[] =
   "timestamp:%" PRIu64 ",ecg:%hf,status:%" PRIx32 "";
 #endif

--- a/system/uorb/sensor/eng.c
+++ b/system/uorb/sensor/eng.c
@@ -28,7 +28,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_eng_format[] =
   "timestamp:%" PRIu64 ",eng0:%hf,eng1:%hf,eng2:%hf,eng3:%hf,"
   "status:0x%" PRIx32 "";

--- a/system/uorb/sensor/force.c
+++ b/system/uorb/sensor/force.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_force_format[] =
   "timestamp:%" PRIu64 ",force:%hf,event:%" PRIi32 "";
 #endif

--- a/system/uorb/sensor/gas.c
+++ b/system/uorb/sensor/gas.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_gas_format[] =
   "timestamp:%" PRIu64 ",gas_resistance:%hf";
 #endif

--- a/system/uorb/sensor/gesture.c
+++ b/system/uorb/sensor/gesture.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_gesture_format[] =
   "timestamp:%" PRIu64 ",event:%" PRIu32 "";
 #endif

--- a/system/uorb/sensor/gnss.c
+++ b/system/uorb/sensor/gnss.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 #define UORB_DEBUG_FORMAT_SENSOR_GNSS     \
   "timestamp:%" PRIu64                    \
   ",time_utc:%" PRIu64                    \

--- a/system/uorb/sensor/gyro.c
+++ b/system/uorb/sensor/gyro.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_gyro_format[] =
   "timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf";
 #endif

--- a/system/uorb/sensor/hall.c
+++ b/system/uorb/sensor/hall.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_hall_format[] =
   "timestamp:%" PRIu64 ",hall:%" PRIi32 "";
 #endif

--- a/system/uorb/sensor/hbeat.c
+++ b/system/uorb/sensor/hbeat.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_hbeat_format[] =
   "timestamp:%" PRIu64 ",heart beat:%hf";
 #endif

--- a/system/uorb/sensor/hcho.c
+++ b/system/uorb/sensor/hcho.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_hcho_format[] = "timestamp:%" PRIu64 ",hcho:%hf";
 #endif
 

--- a/system/uorb/sensor/hrate.c
+++ b/system/uorb/sensor/hrate.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_hrate_format[] = "timestamp:%" PRIu64 ",bpm:%hf";
 #endif
 

--- a/system/uorb/sensor/humi.c
+++ b/system/uorb/sensor/humi.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_humi_format[] = "timestamp:%" PRIu64 ",humi:%hf";
 #endif
 

--- a/system/uorb/sensor/impd.c
+++ b/system/uorb/sensor/impd.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_impd_format[] =
   "timestamp:%" PRIu64 ",real:%hf,imaginary:%hf";
 #endif

--- a/system/uorb/sensor/ir.c
+++ b/system/uorb/sensor/ir.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_ir_format[] = "timestamp:%" PRIu64 ",ir:%hf";
 #endif
 

--- a/system/uorb/sensor/light.c
+++ b/system/uorb/sensor/light.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_light_format[] =
   "timestamp:%" PRIu64 ",light:%hf,ir:%hf";
 #endif

--- a/system/uorb/sensor/mag.c
+++ b/system/uorb/sensor/mag.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_mag_format[] =
   "timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf,"
   "status:%" PRId32 "";

--- a/system/uorb/sensor/motion.c
+++ b/system/uorb/sensor/motion.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_event_format[] =
   "timestamp:%" PRIu64 ",event:%" PRIu32 "";
 #endif

--- a/system/uorb/sensor/noise.c
+++ b/system/uorb/sensor/noise.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_noise_format[] =
   "timestamp:%" PRIu64 ",noise:%hf";
 #endif

--- a/system/uorb/sensor/ots.c
+++ b/system/uorb/sensor/ots.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_ots_format[] =
   "timestamp:%" PRIu64 ",x:%" PRIi32 ",y:%" PRIi32 "";
 #endif

--- a/system/uorb/sensor/ph.c
+++ b/system/uorb/sensor/ph.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_ph_format[] = "timestamp:%" PRIu64 ",ph:%hf";
 #endif
 

--- a/system/uorb/sensor/pm10.c
+++ b/system/uorb/sensor/pm10.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_pm10_format[] = "timestamp:%" PRIu64 ",pm10:%hf";
 #endif
 

--- a/system/uorb/sensor/pm1p0.c
+++ b/system/uorb/sensor/pm1p0.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_pm1p0_format[] = "timestamp:%" PRIu64 ",pm1p0:%hf";
 #endif
 

--- a/system/uorb/sensor/pm25.c
+++ b/system/uorb/sensor/pm25.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_pm25_format[] = "timestamp:%" PRIu64 ",pm25:%hf";
 #endif
 

--- a/system/uorb/sensor/pose_6dof.c
+++ b/system/uorb/sensor/pose_6dof.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_pose_6dof_format[] =
   "timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,w:%hf,tx:%hf,ty:%hf,tz:%hf,"
   "dx:%hf,dy:%hf,dz:%hf,dw:%hf,dtx:%hf,dty:%hf,dtz:%hf,number:%" PRIu64 "";

--- a/system/uorb/sensor/ppgd.c
+++ b/system/uorb/sensor/ppgd.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_ppgd_format[] =
   "timestamp:%" PRIu64 ",ppg0:%" PRIu32 ",ppg1:%" PRIu32 ","
   "current:%" PRIu32 ",gain0:%hu,gain1:%hu";

--- a/system/uorb/sensor/ppgq.c
+++ b/system/uorb/sensor/ppgq.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_ppgq_format[] =
   "timestamp:%" PRIu64 ",ppg0:%" PRIu32 ",ppg1:%" PRIu32 ",ppg2:%" PRIu32 ","
   "ppg3:%" PRIu32 ",current:%" PRIu32 ",gain0:%hu,gain1:%hu,gain2:%hu,"

--- a/system/uorb/sensor/prox.c
+++ b/system/uorb/sensor/prox.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_prox_format[] =
   "timestamp:%" PRIu64 ",proximity:%hf";
 #endif

--- a/system/uorb/sensor/rgb.c
+++ b/system/uorb/sensor/rgb.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_rgb_format[] =
   "timestamp:%" PRIu64 ",r:%hf,g:%hf,b:%hf";
 #endif

--- a/system/uorb/sensor/rotation.c
+++ b/system/uorb/sensor/rotation.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_rotation_format[] =
   "timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf";
 static const char sensor_orientation_format[] =

--- a/system/uorb/sensor/step_counter.c
+++ b/system/uorb/sensor/step_counter.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_step_counter_format[] =
   "timestamp:%" PRIu64 ",event:%" PRIu32 ",cadence:%" PRIu32 "";
 #endif

--- a/system/uorb/sensor/temp.c
+++ b/system/uorb/sensor/temp.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_temp_format[] =
   "timestamp:%" PRIu64 ",temperature:%hf";
 #endif

--- a/system/uorb/sensor/tvoc.c
+++ b/system/uorb/sensor/tvoc.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_tvoc_format[] = "timestamp:%" PRIu64 ",tvoc:%hf";
 #endif
 

--- a/system/uorb/sensor/uv.c
+++ b/system/uorb/sensor/uv.c
@@ -30,7 +30,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char sensor_uv_format[] = "timestamp:%" PRIu64 ",uvi:%hf";
 #endif
 

--- a/system/uorb/test/utility.c
+++ b/system/uorb/test/utility.c
@@ -33,7 +33,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 static const char orb_test_format[] =
   "timestamp:%" PRIu64 ",val:%" PRId32 "";
 #endif

--- a/system/uorb/uORB/uORB.c
+++ b/system/uorb/uORB/uORB.c
@@ -372,7 +372,7 @@ int orb_group_count(FAR const struct orb_metadata *meta)
   return instance;
 }
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 int orb_sscanf(FAR const char *buf, FAR const char *format, FAR void *data)
 {
   struct lib_meminstream_s meminstream;

--- a/system/uorb/uORB/uORB.h
+++ b/system/uorb/uORB/uORB.h
@@ -57,7 +57,7 @@ struct orb_metadata
 {
   FAR const char   *o_name;     /* Unique object name */
   uint16_t          o_size;     /* Object size */
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
   FAR const char   *o_format;   /* Format string used for structure input and
                                  * output.
                                  */
@@ -165,7 +165,7 @@ struct orb_loop_s
 #  define uorbinfo             uorbnone
 #endif
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 #  define uorbdebug(fmt, ...)  syslog(LOG_INFO, fmt "\n", ##__VA_ARGS__)
 #else
 #  define uorbdebug            uorbnone
@@ -207,7 +207,7 @@ struct orb_loop_s
  * struct  The structure the topic provides.
  * cb      The function pointer of output topic message.
  */
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 #define ORB_DEFINE(name, structure, format) \
   const struct orb_metadata g_orb_##name = \
   { \
@@ -898,7 +898,7 @@ int orb_group_count(FAR const struct orb_metadata *meta);
 
 FAR const struct orb_metadata *orb_get_meta(FAR const char *name);
 
-#ifdef CONFIG_DEBUG_UORB
+#ifdef CONFIG_UORB_FORMAT
 /****************************************************************************
  * Name: orb_scanf
  *


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx-apps/blob/master/CONTRIBUTING.md).*

## Summary

Currently, format strings (`o_format`), `orb_info()`, `orb_fprintf()`, and `orb_sscanf()` are guarded by `#ifdef CONFIG_DEBUG_UORB`. This prevents `uorb_listener` from displaying sensor data when debug output is disabled.

Introduce a new `CONFIG_UORB_FORMAT` Kconfig option to control whether format strings are compiled in. `UORB_LISTENER`, `UORB_GENERATOR`, and `DEBUG_UORB` all `select UORB_FORMAT` automatically, so format strings are included when any of these features are enabled. Users who don't need any of these features get no image size increase.

Fixes [apache/nuttx-apps#3201](https://github.com/apache/nuttx-apps/issues/3201).

## Impact

- Is new feature?: YES (new Kconfig option CONFIG_UORB_FORMAT)
- Impact on user?: YES (users can now see sensor data with `uorb_listener` without enabling `CONFIG_DEBUG_UORB`)
- Impact on build?: NO (only adds a new Kconfig option, no build system changes)
- Impact on hardware?: NO
- Impact on documentation?: NO
- Impact on security?: NO
- Impact on compatibility?: NO (existing configs with `CONFIG_DEBUG_UORB` or `CONFIG_UORB_LISTENER` continue to work as before)

## Testing

Host: Linux x86_64, sim:nsh

Config:
```
CONFIG_USENSOR=y
CONFIG_UORB=y
CONFIG_UORB_LISTENER=y
CONFIG_UORB_GENERATOR=y
CONFIG_SENSORS=y
CONFIG_SENSORS_FAKESENSOR=y
CONFIG_LINE_MAX=256
CONFIG_NSH_MAXARGUMENTS=16
```

Steps:
```
nsh> uorb_generator -n 100000 -r 10 -s -t sensor_accel0 timestamp:1,x:1,y:1,z:1,temperature:1 &
nsh> sleep 3
nsh> uorb_listener -T -l
```

Before fix (with CONFIG_DEBUG_UORB disabled):
```
current objects: 1
NAME                           INST #SUB RATE #Q SIZE
sensor_accel                    0    0    0  0   24
```

After fix:
```
current objects: 1
NAME                           INST #SUB RATE #Q SIZE
sensor_accel                    0    0    8  1   24
```

Also verified: with only `CONFIG_UORB` enabled (no LISTENER/GENERATOR/DEBUG_UORB), `CONFIG_UORB_FORMAT` is not selected and format strings are excluded from the build.