### PR TITLE
system/uorb: fix listener_top not showing topic data

### DIFF
--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -330,24 +330,25 @@ static int listener_update(FAR struct listen_list_s *objlist,
 
       delta_time       = now_time - old->timestamp;
       delta_generation = state.generation - old->generation;
+
+      unsigned long frequency = 0;
       if (delta_generation && delta_time)
         {
-          unsigned long frequency;
-
           frequency = (state.max_frequency ? state.max_frequency : 1000000)
                       * delta_generation / delta_time;
-          uorbinfo_raw("\033[K" "%-*s %2u %4" PRIu32 " %4lu "
-                       "%2" PRIu32 " %4u",
-                       ORB_MAX_PRINT_NAME,
-                       object->meta->o_name,
-                       object->instance,
-                       state.nsubscribers,
-                       frequency,
-                       state.queue_size,
-                       object->meta->o_size);
-          old->generation = state.generation;
-          old->timestamp  = now_time;
         }
+
+      uorbinfo_raw("\033[K" "%-*s %2u %4" PRIu32 " %4lu "
+                   "%2" PRIu32 " %4u",
+                   ORB_MAX_PRINT_NAME,
+                   object->meta->o_name,
+                   object->instance,
+                   state.nsubscribers,
+                   frequency,
+                   state.queue_size,
+                   object->meta->o_size);
+      old->generation = state.generation;
+      old->timestamp  = now_time;
     }
   else
     {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx-apps/blob/master/CONTRIBUTING.md).*

## Summary

`uorb_listener -T` (top mode) only displays the header row but no topic data. This is because `listener_update()` only prints topic data when `delta_generation && delta_time` is true (new data arrived since the last check). On the first iteration, objects are added to the list but no data is printed. On subsequent iterations, if no new data has been published between calls, `delta_generation == 0` and the topic row is silently skipped.

Fix by moving the `uorbinfo_raw()` call and timestamp/generation update outside the conditional block, and initializing `frequency = 0` before the check. This ensures the topic row is always printed, with frequency showing 0 when no new data is available.

Fixes [apache/nuttx-apps#3202](https://github.com/apache/nuttx-apps/issues/3202).

## Impact

- Is new feature?: NO (bug fix)
- Impact on user?: YES (users can now see topic data in `uorb_listener -T` top mode)
- Impact on build?: NO
- Impact on hardware?: NO
- Impact on documentation?: NO
- Impact on security?: NO
- Impact on compatibility?: NO

## Testing

Host: Linux x86_64, sim:nsh

Config:
```
CONFIG_USENSOR=y
CONFIG_UORB=y
CONFIG_UORB_LISTENER=y
CONFIG_UORB_GENERATOR=y
CONFIG_SENSORS=y
CONFIG_SENSORS_FAKESENSOR=y
CONFIG_DEBUG_UORB=y
CONFIG_LINE_MAX=256
CONFIG_NSH_MAXARGUMENTS=16
```

Steps:
```
nsh> uorb_generator -n 100000 -r 10 -s -t sensor_accel0 timestamp:1,x:1,y:1,z:1,temperature:1 &
nsh> sleep 3
nsh> uorb_listener -T -l
```

Before fix:
```
current objects: 1
NAME                           INST #SUB RATE #Q SIZE
```

After fix:
```
current objects: 1
NAME                           INST #SUB RATE #Q SIZE
sensor_accel                    0    0    8  1   24
```