### PR TITLE
workflows/build.yml: Fix Skipping sim\windows in the MSVC job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,7 +435,7 @@ jobs:
   msvc:
     needs: msvc-Arch
     if: ${{ needs.msvc-Arch.outputs.skip_all_builds != '1' }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       # Set up Python environment and install kconfiglib


### PR DESCRIPTION
## Summary

Fix

```
====================================================================================
Cmake in present: sim\windows
Configuration/Tool: sim\windows
2026-06-05 16:01:37
------------------------------------------------------------------------------------
  Cleaning...
  Skipping: sim\windows
------------------------------------------------------------------------------------
 End: 2026-06-05 16:01:37
====================================================================================
```

Breaking changes

The "windows-latest" and “windows-2025” labels in GitHub Actions will be migrated to use Visual Studio 2026 by default. Customers needing Visual Studio 2022 must migrate to the windows-2022 image.

Target date
This change will be rolled out over **a week beginning June 8, 2026 and will complete by June 15, 2026.**

https://github.com/actions/runner-images/issues/14017

Apparently, the change has already taken place! :)


PR https://github.com/apache/nuttx/pull/19025

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub

```
====================================================================================
Cmake in present: sim\windows
Configuration/Tool: sim\windows
2026-06-05 18:06:27
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
   TOOLS_DIR path is "D:/a/nuttx-testing-ci/nuttx-testing-ci/sources/nuttx"
   HOST = WINDOWS NATIVE
  CMake configuration completed successfully.
  Building NuttX...
  Build completed successfully.
  Refresh completed successfully.
------------------------------------------------------------------------------------
End: 2026-06-05 18:07:38
====================================================================================
```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/27031362329/job/79784387207

