### PR TITLE
examples/rng90: add Microchip RNG90 example application

### DIFF
--- a/examples/rng90/CMakeLists.txt
+++ b/examples/rng90/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/rng90/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RNG90)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_RNG90_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_RNG90_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_RNG90_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RNG90}
+    SRCS
+    rng90_main.c)
+endif()

--- a/examples/rng90/Kconfig
+++ b/examples/rng90/Kconfig
@@ -1,0 +1,37 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_RNG90
+	tristate "Microchip RNG90 TRNG example"
+	default n
+	depends on DEV_RNG90
+	---help---
+		Enable the RNG90 example.  It opens the RNG90 character device,
+		runs the built-in self-test and reads random bytes from it.
+
+if EXAMPLES_RNG90
+
+config EXAMPLES_RNG90_PROGNAME
+	string "Program name"
+	default "rng90"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_RNG90_DEVPATH
+	string "RNG90 device path"
+	default "/dev/rng0"
+	---help---
+		The default path of the RNG90 character device.
+
+config EXAMPLES_RNG90_PRIORITY
+	int "RNG90 task priority"
+	default 100
+
+config EXAMPLES_RNG90_STACKSIZE
+	int "RNG90 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/rng90/Make.defs
+++ b/examples/rng90/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/rng90/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_RNG90),)
+CONFIGURED_APPS += $(APPDIR)/examples/rng90
+endif

--- a/examples/rng90/Makefile
+++ b/examples/rng90/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/examples/rng90/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Microchip RNG90 TRNG example built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_RNG90_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_RNG90_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_RNG90_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_RNG90)
+
+# Microchip RNG90 TRNG example
+
+MAINSRC = rng90_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/rng90/rng90_main.c
+++ b/examples/rng90/rng90_main.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * apps/examples/rng90/rng90_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <nuttx/crypto/rng90.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_EXAMPLES_RNG90_DEVPATH
+#  define CONFIG_EXAMPLES_RNG90_DEVPATH "/dev/rng0"
+#endif
+
+#define RNG90_MAX_BYTES 32
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: print_hex
+ *
+ * Description:
+ *   Dump a buffer as a hex string, 16 bytes per line.
+ *
+ ****************************************************************************/
+
+static void print_hex(FAR const uint8_t *buf, size_t len)
+{
+  size_t i;
+
+  for (i = 0; i < len; i++)
+    {
+      printf("%02x", buf[i]);
+      if ((i & 0x0f) == 0x0f)
+        {
+          printf("\n");
+        }
+      else
+        {
+          printf(" ");
+        }
+    }
+
+  if ((len & 0x0f) != 0)
+    {
+      printf("\n");
+    }
+}
+
+/****************************************************************************
+ * Name: usage
+ ****************************************************************************/
+
+static void usage(FAR const char *progname)
+{
+  printf("Usage: %s [<devpath>] [<count>]\n", progname);
+  printf("  <devpath>  RNG90 device (default %s)\n",
+         CONFIG_EXAMPLES_RNG90_DEVPATH);
+  printf("  <count>    number of random bytes to read, 1..%d (default %d)\n",
+         RNG90_MAX_BYTES, RNG90_MAX_BYTES);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * rng90_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  FAR const char *devpath = CONFIG_EXAMPLES_RNG90_DEVPATH;
+  int count = RNG90_MAX_BYTES;
+  uint8_t buf[RNG90_MAX_BYTES];
+  int fd;
+  int ret;
+
+  /* Parse the optional command line arguments */
+
+  if (argc > 1)
+    {
+      if (argv[1][0] == '-')
+        {
+          usage(argv[0]);
+          return EXIT_FAILURE;
+        }
+
+      devpath = argv[1];
+    }
+
+  if (argc > 2)
+    {
+      count = atoi(argv[2]);
+      if (count < 1 || count > RNG90_MAX_BYTES)
+        {
+          printf("Invalid count %d, clamping to %d\n", count,
+                 RNG90_MAX_BYTES);
+          count = RNG90_MAX_BYTES;
+        }
+    }
+
+  /* Opening the device wakes the RNG90 up; closing puts it to sleep. */
+
+  fd = open(devpath, O_RDONLY);
+  if (fd < 0)
+    {
+      printf("ERROR: Failed to open %s: %d\n", devpath, errno);
+      return EXIT_FAILURE;
+    }
+
+  printf("RNG90 example: device %s\n", devpath);
+
+  /* Read random bytes from the device */
+
+  ret = read(fd, buf, (size_t)count);
+  if (ret < 0)
+    {
+      printf("ERROR: read failed: %d\n", errno);
+      close(fd);
+      return EXIT_FAILURE;
+    }
+
+  printf("Read %d random byte(s):\n", ret);
+  print_hex(buf, (size_t)ret);
+
+  close(fd);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

This PR adds a new RNG90 example application in apps.

Changes included:
- New RNG90 example source: examples/rng90/rng90_main.c
- Build integration files for Make and CMake:
  - examples/rng90/Makefile
  - examples/rng90/Make.defs
  - examples/rng90/CMakeLists.txt
- Kconfig integration:
  - examples/rng90/Kconfig

The example opens the RNG90 character device, reads random bytes, and prints
hex output. It supports optional command-line arguments for device path and
requested byte count.

How to enable via Kconfig:
- In nuttx (driver side), enable: `Device Drivers -> Cryptographic Device Drivers -> RNG90` (`CONFIG_DEV_RNG90=y`)
- In apps, enable: `Application Configuration -> Examples -> Microchip RNG90 TRNG example` (`CONFIG_EXAMPLES_RNG90=y`)
- Optional app settings:
  - `CONFIG_EXAMPLES_RNG90_PROGNAME`
  - `CONFIG_EXAMPLES_RNG90_DEVPATH`
  - `CONFIG_EXAMPLES_RNG90_PRIORITY`
  - `CONFIG_EXAMPLES_RNG90_STACKSIZE`

## Impact

- Adds a new user-space example under apps/examples.
- No changes to existing examples behavior.
- Requires RNG90 driver support in nuttx (CONFIG_DEV_RNG90) to run.

## Testing

Host:
- macOS

Target:
- esp32c3-devkit
- RNG90 connected and enabled
- Serial settings: 115200 8N1

Build/flash used for validation:
- make -j4
- make flash ESPTOOL_PORT=<your device>

Hardware validation transcript:

```text
nsh> uname -a
NuttX 12.6.0-RC1 4423760152-dirty Jun  7 2026 23:00:02 risc-v esp32c3-devkit

nsh> ls /dev/rng0
 /dev/rng0

nsh> rng90
RNG90 example: device /dev/rng0
Read 32 random byte(s):
4f fc 96 27 91 99 95 32 90 b4 46 3c 3d a0 4c e9
ce 86 6d 41 7e a4 ab 02 4f 3a fe 34 ef c8 d0 15

nsh> rng90 /dev/rng0 16
RNG90 example: device /dev/rng0
Read 16 random byte(s):
82 6e 45 0b 1c f1 df d3 75 32 19 32 eb a5 e6 cc

nsh> rng90 /dev/rng0 64
Invalid count 64, clamping to 32
RNG90 example: device /dev/rng0
Read 32 random byte(s):
8d 8d fb 91 07 01 41 e7 54 e4 8b 77 9a 1d e9 2b
83 55 18 b9 79 0b 26 1c 52 07 56 77 f7 34 aa 77
```