### PR TITLE
apps/tools: Enable Rust sim builds on Intel Macs

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -34,7 +34,8 @@ include(nuttx_parse_function_args)
 #   - riscv32: riscv32imc/imac/imafc-unknown-nuttx-elf
 #   - riscv64: riscv64imac/imafdc-unknown-nuttx-elf
 #   - x86: i686-unknown-nuttx
-#   - x86_64: x86_64-unknown-nuttx
+#   - x86_64: x86_64-unknown-nuttx-macho for sim on macOS,
+#              x86_64-unknown-nuttx otherwise
 #   - aarch64: aarch64-unknown-nuttx-macho for sim on macOS,
 #              aarch64-unknown-nuttx otherwise
 #
@@ -50,7 +51,12 @@ include(nuttx_parse_function_args)
 
 function(nuttx_rust_target_triple ARCHTYPE ABITYPE CPUTYPE OUTPUT)
   if(ARCHTYPE STREQUAL "x86_64")
-    set(TARGET_TRIPLE "${PROJECT_SOURCE_DIR}/tools/x86_64-unknown-nuttx.json")
+    if(CONFIG_ARCH_SIM AND CONFIG_HOST_MACOS)
+      set(TARGET_TRIPLE
+          "${PROJECT_SOURCE_DIR}/tools/x86_64-unknown-nuttx-macho.json")
+    else()
+      set(TARGET_TRIPLE "${PROJECT_SOURCE_DIR}/tools/x86_64-unknown-nuttx.json")
+    endif()
   elseif(ARCHTYPE STREQUAL "x86")
     set(TARGET_TRIPLE "${PROJECT_SOURCE_DIR}/tools/i486-unknown-nuttx.json")
   elseif(ARCHTYPE STREQUAL "aarch64")

--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -27,7 +27,8 @@
 #
 # Supported architectures and their target triples:
 #   - x86: i686-unknown-nuttx
-#   - x86_64: x86_64-unknown-nuttx
+#   - x86_64: x86_64-unknown-nuttx-macho for sim on macOS,
+#              x86_64-unknown-nuttx otherwise
 #   - armv7a: armv7a-nuttx-eabi, armv7a-nuttx-eabihf
 #   - thumbv6m: thumbv6m-nuttx-eabi
 #   - thumbv7a: thumbv7a-nuttx-eabi, thumbv7a-nuttx-eabihf
@@ -49,13 +50,16 @@
 define RUST_TARGET_TRIPLE
 $(or \
   $(and $(filter x86_64,$(LLVM_ARCHTYPE)), \
-    $(TOPDIR)/tools/x86_64-unknown-nuttx.json \
+    $(if $(and $(filter y,$(CONFIG_ARCH_SIM)),$(filter y,$(CONFIG_HOST_MACOS))), \
+      $(TOPDIR)/tools/x86_64-unknown-nuttx-macho.json, \
+      $(TOPDIR)/tools/x86_64-unknown-nuttx.json \
+    ) \
   ), \
   $(and $(filter x86,$(LLVM_ARCHTYPE)), \
     $(TOPDIR)/tools/i486-unknown-nuttx.json \
   ), \
   $(and $(filter aarch64,$(LLVM_ARCHTYPE)), \
-    $(if $(and $(filter sim,$(CONFIG_ARCH)),$(filter y,$(CONFIG_HOST_MACOS))), \
+    $(if $(and $(filter y,$(CONFIG_ARCH_SIM)),$(filter y,$(CONFIG_HOST_MACOS))), \
       $(TOPDIR)/tools/aarch64-unknown-nuttx-macho.json, \
       $(TOPDIR)/tools/aarch64-unknown-nuttx.json \
     ) \


### PR DESCRIPTION
## Summary

Make the Rust app build pick the correct x86_64 target triple for the NuttX simulator on Intel macOS.
This complements the corresponding nuttx repo change that adds the x86_64 Mach-O Rust target.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 14.8), CPU(Intel Core i7), compiler(Apple clang version 16.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.
* Depends on the corresponding nuttx side PR. [#19058](https://github.com/apache/nuttx/pull/19058)

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
