### PR TITLE
benchmarks/mtd: use uniform output style for numbers

### DIFF
--- a/benchmarks/mtd/mtd.c
+++ b/benchmarks/mtd/mtd.c
@@ -102,10 +102,10 @@ int main(int argc, FAR char *argv[])
   /* Report the device structure */
 
   printf("FLASH device parameters:\n");
-  printf("   Sector size:  %10d\n", info.sectorsize);
-  printf("   Sector count: %10d\n", info.numsectors);
-  printf("   Erase block:  %10" PRIx32 "\n", geo.erasesize);
-  printf("   Total size:   %10d\n", info.sectorsize * info.numsectors);
+  printf("   Sector size:      %10d\n", info.sectorsize);
+  printf("   Sector count:     %10d\n", info.numsectors);
+  printf("   Erase block size: %10" PRIu32 "\n", geo.erasesize);
+  printf("   Total size:       %10d\n", info.sectorsize * info.numsectors);
 
   if (info.sectorsize != geo.erasesize)
     {
@@ -124,7 +124,7 @@ int main(int argc, FAR char *argv[])
       goto errout_with_driver;
     }
 
-  /* Fill the buffer with known data and print it in hex format */
+  /* Fill the buffer with known data */
 
   for (int i = 0; i < info.sectorsize; i++)
     {


### PR DESCRIPTION
## Summary

Previously the output of the `mtd` benchmark tool looked like this:

```
FLASH device parameters:
   Sector size:         256
   Sector count:       2048
   Erase block:        1000
   Total size:       524288
```

The third line sneakily deviated from the format of the other lines:
- The value `1000` is a hexadecimal number.
- The three other values are decimal numbers.

There is no good reason for using the hexadecimal representation for this specific value.

## Impact

The change influences only the human readable output of the interactive `mtd` benchmark tool.

## Testing

I tried the `mtd` tool before and after on my `rp2040` board.
The numbers looked much better afterwards.

