### PR TITLE
interpreters/python: Optmize Python for size

### DIFF
--- a/interpreters/python/Makefile
+++ b/interpreters/python/Makefile
@@ -163,7 +163,7 @@ $(TARGETBUILD)/Makefile: $(HOSTPYTHON) $(CONFIG_SITE) $(SETUP_LOCAL)
 			AR="$(AR)" \
 			ARFLAGS=" " \
 			MACHDEP="$(MACHDEP)" \
-			OPT="-O3" \
+			OPT="-Os" \
 			CONFIG_SITE="$(CONFIG_SITE)" \
 			$(CPYTHON_PATH)/configure \
 			 --prefix=${TARGETINSTALL} \


### PR DESCRIPTION
## Summary

Reduce general firmware size by optimizing Python-related sources.

## Impact

Impact on user: Yes. Enable reducing firmware size when `CONFIG_INTERPRETERS_CPYTHON` is enabled.

Impact on build: Yes. Reduce firmware size by ~6% (tested on ESP32-P4)

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

Build `esp32p4-function-ev-board:python` defconfig before and after applying this patch.

### Building

```
make -j distclean && ./tools/configure.sh -S esp32p4-function-ev-board:python && make -s -j$(nproc)
```

### Running

After flashing the device, just run `python` on NSH to ensure that it's being properly initialized.

### Results

Comparison between the firmwares built before and after applying this patch:

#### Before

```
Memory region         Used Size  Region Size  %age Used
   tcm_idram_seg:         136 B         8 KB      1.66%
        irom_seg:     3159284 B        64 MB      4.71%
        sram_seg:      374776 B     978880 B     38.29%
        drom_seg:    16062776 B        64 MB     23.94%
rev3_mspi_workaround_seg:           0 B          0 B
      lp_ram_seg:         104 B      32744 B      0.32%
 lp_reserved_seg:          24 B         24 B    100.00%
  extern_ram_seg:          2 MB        64 MB      3.12%
CP: nuttx.hex
```

And the final firmware size:
```
-rw-r--r-- 1 tiago tiago 16454900 jun 15 11:32 nuttx.bin
```

#### After

```
Memory region         Used Size  Region Size  %age Used
   tcm_idram_seg:         136 B         8 KB      1.66%
        irom_seg:     2192720 B        64 MB      3.27%
        sram_seg:      374776 B     978880 B     38.29%
        drom_seg:    15034520 B        64 MB     22.40%
rev3_mspi_workaround_seg:           0 B          0 B
      lp_ram_seg:         104 B      32744 B      0.32%
 lp_reserved_seg:          24 B         24 B    100.00%
  extern_ram_seg:          2 MB        64 MB      3.12%
CP: nuttx.hex
```

And the final firmware size:
```
-rw-r--r-- 1 tiago tiago 15422800 jun 15 11:41 nuttx.bin
```