### PR TITLE
examples/rust: Avoid the infinite loop on sim for hello_rust_cargo

### DIFF
--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -130,6 +130,8 @@ endfunction()
 #    hello
 #    CRATE_PATH
 #    ${CMAKE_CURRENT_SOURCE_DIR}/hello
+#    FEATURES
+#    sim
 #  )
 # ~~~
 
@@ -142,6 +144,8 @@ function(nuttx_add_rust)
     ONE_VALUE
     CRATE_NAME
     CRATE_PATH
+    MULTI_VALUE
+    FEATURES
     REQUIRED
     CRATE_NAME
     CRATE_PATH
@@ -158,6 +162,10 @@ function(nuttx_add_rust)
     set(RUST_PROFILE "debug")
     set(RUST_PANIC_FLAGS "")
   endif()
+
+  foreach(feature ${FEATURES})
+    list(APPEND RUST_FEATURE_FLAGS --features ${feature})
+  endforeach()
 
   # Get the Rust target triple
   nuttx_rust_target_triple(${LLVM_ARCHTYPE} ${LLVM_ABITYPE} ${LLVM_CPUTYPE}
@@ -198,7 +206,7 @@ function(nuttx_add_rust)
       RUSTFLAGS=${RUST_PANIC_FLAGS} cargo build ${RUST_PROFILE_FLAG}
       -Zbuild-std=std,panic_abort -Zjson-target-spec --manifest-path
       ${CRATE_PATH}/Cargo.toml --target ${RUST_TARGET} --target-dir
-      ${RUST_BUILD_DIR}
+      ${RUST_BUILD_DIR} ${RUST_FEATURE_FLAGS}
     DEPENDS ${RUST_CRATE_SOURCES}
     COMMENT "Building Rust crate ${CRATE_NAME}"
     VERBATIM)

--- a/examples/rust/hello/CMakeLists.txt
+++ b/examples/rust/hello/CMakeLists.txt
@@ -21,7 +21,12 @@
 if(CONFIG_EXAMPLES_HELLO_RUST_CARGO)
 
   # Build the Rust crate using nuttx_add_rust
-  nuttx_add_rust(CRATE_NAME hello CRATE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+  if(CONFIG_ARCH_SIM)
+    nuttx_add_rust(CRATE_NAME hello CRATE_PATH ${CMAKE_CURRENT_SOURCE_DIR}
+                   FEATURES sim)
+  else()
+    nuttx_add_rust(CRATE_NAME hello CRATE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
 
   nuttx_add_application(
     NAME ${CONFIG_EXAMPLES_HELLO_RUST_CARGO_PROGNAME} STACKSIZE

--- a/examples/rust/hello/Cargo.toml
+++ b/examples/rust/hello/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["staticlib"]
 
+[features]
+sim = []
+
 [profile.dev]
 panic = "abort"
 

--- a/examples/rust/hello/Makefile
+++ b/examples/rust/hello/Makefile
@@ -30,8 +30,12 @@ MODULE    = $(CONFIG_EXAMPLES_HELLO_RUST_CARGO)
 RUST_LIB  := $(call RUST_GET_BINDIR,hello,$(APPDIR)/examples/rust)
 RUST_SRCS := $(call RUST_CARGO_SRCS,hello,$(APPDIR)/examples/rust)
 
+ifeq ($(CONFIG_ARCH_SIM),y)
+HELLO_RUST_FEATURES := sim
+endif
+
 $(RUST_LIB): $(RUST_SRCS)
-	$(call RUST_CARGO_BUILD,hello,$(APPDIR)/examples/rust)
+	$(call RUST_CARGO_BUILD,hello,$(APPDIR)/examples/rust,$(HELLO_RUST_FEATURES))
 
 context:: $(RUST_LIB)
 

--- a/examples/rust/hello/src/lib.rs
+++ b/examples/rust/hello/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate serde;
 extern crate serde_json;
 
+use core::ffi::{c_char, c_int};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -11,7 +12,7 @@ struct Person {
 
 // Function hello_rust_cargo without manglng
 #[no_mangle]
-pub extern "C" fn hello_rust_cargo_main() {
+pub extern "C" fn hello_rust_cargo_main(_argc: c_int, _argv: *mut *mut c_char) -> c_int {
     // Print hello world to stdout
 
     let john = Person {
@@ -50,7 +51,11 @@ pub extern "C" fn hello_rust_cargo_main() {
             println!("Hello world from tokio!");
         });
 
+    #[cfg(not(feature = "sim"))]
     loop {
         // Do nothing
     }
+
+    #[cfg(feature = "sim")]
+    0
 }

--- a/examples/rust/hello/src/lib.rs
+++ b/examples/rust/hello/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate serde;
 extern crate serde_json;
 
-use core::ffi::{c_char, c_int};
+use core::ffi::{c_char, c_int, CStr};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -10,10 +10,29 @@ struct Person {
     age: u8,
 }
 
-// Function hello_rust_cargo without manglng
+fn print_args(argc: c_int, argv: *mut *mut c_char) {
+    if argv.is_null() {
+        return;
+    }
+
+    for i in 1..argc {
+        let arg = unsafe { *argv.add(i as usize) };
+        if arg.is_null() {
+            continue;
+        }
+
+        let arg = unsafe { CStr::from_ptr(arg) }.to_string_lossy();
+        println!("{}: {}", i, arg);
+    }
+}
+
+// Function hello_rust_cargo without mangling
 #[no_mangle]
-pub extern "C" fn hello_rust_cargo_main(_argc: c_int, _argv: *mut *mut c_char) -> c_int {
-    // Print hello world to stdout
+pub extern "C" fn hello_rust_cargo_main(argc: c_int, argv: *mut *mut c_char) -> c_int {
+    print_args(argc, argv);
+
+    #[cfg(feature = "sim")]
+    println!("On simulator");
 
     let john = Person {
         name: "John".to_string(),
@@ -50,12 +69,5 @@ pub extern "C" fn hello_rust_cargo_main(_argc: c_int, _argv: *mut *mut c_char) -
         .block_on(async {
             println!("Hello world from tokio!");
         });
-
-    #[cfg(not(feature = "sim"))]
-    loop {
-        // Do nothing
-    }
-
-    #[cfg(feature = "sim")]
     0
 }

--- a/tools/Rust.mk
+++ b/tools/Rust.mk
@@ -90,11 +90,12 @@ endef
 
 # Build Rust project using cargo
 #
-# Usage:   $(call RUST_CARGO_BUILD,cratename,prefix)
+# Usage:   $(call RUST_CARGO_BUILD,cratename,prefix[,features])
 #
 # Inputs:
 #   cratename - Name of the Rust crate (e.g. hello)
 #   prefix    - Path prefix to the crate (e.g. path/to/project)
+#   features  - Optional Cargo features to enable
 #
 # Output:
 #   None, builds the Rust project
@@ -105,7 +106,8 @@ define RUST_CARGO_BUILD
     RUSTFLAGS="-Zunstable-options -Cpanic=immediate-abort" \
     cargo build --release -Zbuild-std=std,panic_abort -Zjson-target-spec \
 		--manifest-path $(2)/$(1)/Cargo.toml \
-		--target $(call RUST_TARGET_TRIPLE)
+		--target $(call RUST_TARGET_TRIPLE) \
+		$(if $(strip $(3)),--features $(3),)
 endef
 else
 define RUST_CARGO_BUILD
@@ -113,7 +115,8 @@ define RUST_CARGO_BUILD
 	NUTTX_INCLUDE_DIR=$(TOPDIR)/include:$(TOPDIR)/include/arch \
     cargo build -Zbuild-std=std,panic_abort -Zjson-target-spec \
 		--manifest-path $(2)/$(1)/Cargo.toml \
-		--target $(call RUST_TARGET_TRIPLE)
+		--target $(call RUST_TARGET_TRIPLE) \
+		$(if $(strip $(3)),--features $(3),)
 endef
 endif
 


### PR DESCRIPTION
## Summary

On the sim target, `hello_rust_cargo_main()` finished with an infinite `loop {}`.
As a result the example never returned to NSH and the prompt appeared to hang after running `hello_rust_cargo`.

This PR makes the example return cleanly to NSH on sim (Windows/macOS/Linux) while preserving the original looping behavior on real targets.

- Add a Cargo `sim` feature to the hello crate.
- Enable the feature only when `CONFIG_ARCH_SIM` is set, from both the CMake and Make build paths.
- In `lib.rs`, compile out the trailing `loop {}` when the `sim` feature is active and return `0` instead.
- Plumb a generic features mechanism through the Rust build helpers so the feature can be passed to `cargo build` consistently.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration and Build:

### with make

```
make distclean
./tools/configure.sh sim:nsh

printf 'CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
' >> .config

make olddefconfig
make

...
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.52s
LN: platform/board to /Users/toku/nuttxspace/apps/platform/dummy
Register: gpio
Register: hello
Register: hello_rust_cargo
Register: dd
Register: dumpstack
Register: nsh
Register: sh
Register: ostest
CP:  /Users/toku/nuttxspace/nuttx/include/nuttx/config.h
CP:  /Users/toku/nuttxspace/nuttx/include/nuttx/fs/hostfs.h
Building Rust code with cargo...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.78s
LD:  nuttx
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
```

### with CMake

```
rm -rf build-debug
make distclean
cmake -S . -B build-debug -DBOARD_CONFIG=sim:nsh -GNinja

printf 'CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
' >> build-debug/.config

cmake --build build-debug -t olddefconfig
cmake --build build-debug

...
   Compiling pin-project-lite v0.2.17
   Compiling memchr v2.8.0
   Compiling itoa v1.0.18
   Compiling tokio v1.52.3
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 35.66s
[1225/1230] Linking C executable nuttx
ld: warning: -ld_classic is deprecated and will be removed in a future release
[1227/1230] Patching Mach-O init section type flags
```

Execute:

```
NuttShell (NSH) NuttX-12.13.0
nsh> help
help usage:  help [-v] [<cmd>]

    .           cmp         false       mkfifo      readlink    time
    [           dirname     fdinfo      mkrd        rm          true
    ?           date        free        mount       rmdir       truncate
    alias       df          help        mv          set         uname
    unalias     dmesg       hexdump     pidof       kill        umount
    basename    echo        losetup     poweroff    pkill       unset
    break       env         ln          quit        sleep       uptime
    cat         exec        ls          printf      usleep      watch
    cd          exit        mkdir       ps          source      xd
    cp          expr        mkfatfs     pwd         test        wait

Builtin Apps:
    dd                  nsh                 ostest              hello
    dumpstack           sh                  gpio                hello_rust_cargo
nsh> uname -a
NuttX 12.13.0 82fb723bde-dirty Jun 16 2026 10:16:16 sim sim
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}
Hello world from tokio!
nsh> poweroff
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
