### PR TITLE
{bp-3527} system/uorb: fix listener_top not showing topic data

### DIFF
--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -330,24 +330,25 @@ static int listener_update(FAR struct listen_list_s *objlist,
 
       delta_time       = now_time - old->timestamp;
       delta_generation = state.generation - old->generation;
+
+      unsigned long frequency = 0;
       if (delta_generation && delta_time)
         {
-          unsigned long frequency;
-
           frequency = (state.max_frequency ? state.max_frequency : 1000000)
                       * delta_generation / delta_time;
-          uorbinfo_raw("\033[K" "%-*s %2u %4" PRIu32 " %4lu "
-                       "%2" PRIu32 " %4u",
-                       ORB_MAX_PRINT_NAME,
-                       object->meta->o_name,
-                       object->instance,
-                       state.nsubscribers,
-                       frequency,
-                       state.queue_size,
-                       object->meta->o_size);
-          old->generation = state.generation;
-          old->timestamp  = now_time;
         }
+
+      uorbinfo_raw("\033[K" "%-*s %2u %4" PRIu32 " %4lu "
+                   "%2" PRIu32 " %4u",
+                   ORB_MAX_PRINT_NAME,
+                   object->meta->o_name,
+                   object->instance,
+                   state.nsubscribers,
+                   frequency,
+                   state.queue_size,
+                   object->meta->o_size);
+      old->generation = state.generation;
+      old->timestamp  = now_time;
     }
   else
     {


### PR DESCRIPTION
## Summary

listener_update() only prints topic data when delta_generation is non-zero (i.e., new data arrived since last check). In listener_top, the first call adds objects to the list, and subsequent calls only print if new data was published between iterations. This results in listener_top -T showing only the header with no topic rows.

Fix by always printing the current topic state in listener_update, setting frequency to 0 when no new data arrives. This ensures listener_top displays all topics every iteration.

Fixes apache/nuttx-apps#3202

## Impact

RELEASE

## Testing

CI