### PR TITLE
examples/userfs: use designated initializers for struct dirent

### DIFF
--- a/examples/userfs/userfs_main.c
+++ b/examples/userfs/userfs_main.c
@@ -142,19 +142,28 @@ static char g_file3_data[UFSTEST_FILE3_MXSIZE] = "This is file 3";
 static struct ufstest_file_s g_rootdir[UFSTEST_NFILES] =
 {
     {
-      { DTYPE_FILE, "File1" },
+      {
+        .d_type = DTYPE_FILE,
+        .d_name = "File1"
+      },
       UFSTEST_INIT_FILE1_SIZE,
       UFSTEST_FILE1_MXSIZE,
       g_file1_data
     },
     {
-      { DTYPE_FILE, "File2" },
+      {
+        .d_type = DTYPE_FILE,
+        .d_name = "File2"
+      },
       UFSTEST_INIT_FILE2_SIZE,
       UFSTEST_FILE2_MXSIZE,
       g_file2_data
     },
     {
-      { DTYPE_FILE, "File3" },
+      {
+        .d_type = DTYPE_FILE,
+        .d_name = "File3"
+      },
       UFSTEST_INIT_FILE3_SIZE,
       UFSTEST_FILE3_MXSIZE,
       g_file3_data
@@ -247,7 +256,7 @@ static int ufstest_open(FAR void *volinfo, FAR const char *relpath,
 
       opriv->file = file;
 
-      /* Initiallly, there is one reference count on the open data.  This may
+      /* Initially, there is one reference count on the open data.  This may
        * be incremented in the event that the file is dup'ed.
        */
 


### PR DESCRIPTION
## Summary

The `userfs` example initialized each `g_rootdir[]` entry's
`struct dirent` member positionally as `{ DTYPE_FILE, "FileN" }`, which
assumes `d_type` is the first field of `struct dirent`.

apache/nuttx PR #19179 ("fs: widen ino_t to uint32_t and add d_ino to
struct dirent") adds the POSIX `d_ino` member as the first field of
`struct dirent`.  With that change the positional initializer assigns the
file-name string to `d_type` (a `uint8_t`), producing
`-Wint-conversion` warnings and an
`error: initializer element is not computable at load time`, which broke
the CI build.

This change converts the three initializers to designated initializers
(`.d_type` / `.d_name`) so the table is robust against the field order of
`struct dirent`.

## Impact

* `examples/userfs` only. No functional change; the same `d_type`/`d_name`
  values are assigned. `d_ino` is left zero-initialized, which is fine for
  this in-memory test filesystem.

## Testing

* `checkpatch.sh -f examples/userfs/userfs_main.c` → all checks pass.
* A standalone host program reproducing the table against a `d_ino`-first
  `struct dirent` compiles cleanly with `-Wall -Wextra -Werror` and assigns
  `d_type=DTYPE_FILE`, `d_name="File1"` as expected.

## Related

* Companion to apache/nuttx#19179. That PR's CI build fails on the current
  positional initializer; this PR fixes it. They should be merged together.
