### PR TITLE
Rexec rexecd dpopen

### DIFF
--- a/netutils/rexec/rexec.c
+++ b/netutils/rexec/rexec.c
@@ -87,7 +87,7 @@ static int do_rexec(FAR struct rexec_arg_s *arg)
   char buffer[REXEC_BUFSIZE];
   struct pollfd fds[2];
   int sock;
-  int ret;
+  int ret = 0;
 
   sock = rexec_af(&arg->host, htons(arg->port), arg->user,
                   arg->password, arg->command,

--- a/netutils/rexecd/rexecd.c
+++ b/netutils/rexecd/rexecd.c
@@ -25,9 +25,11 @@
  ****************************************************************************/
 
 #include <errno.h>
+#include <fcntl.h>
 #include <netdb.h>
 #include <pthread.h>
 #include <netpacket/rpmsg.h>
+#include <sys/socket.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -84,7 +86,7 @@ static FAR void *doit(pthread_addr_t pvarg)
 {
   char buf[REXECD_BUFSIZE];
   struct pollfd fds[2];
-  FAR FILE *fp;
+  pid_t pid;
   int sock = (long)pvarg;
   int ret;
 
@@ -97,17 +99,17 @@ static FAR void *doit(pthread_addr_t pvarg)
   /* we need to read command */
 
   getstr(sock, buf);
-  fp = popen(buf, "r+");
-  if (!fp)
-    {
-      goto errout;
-    }
 
   memset(fds, 0, sizeof(fds));
-  fds[0].fd = fileno(fp);
   fds[0].events = POLLIN;
   fds[1].fd = sock;
   fds[1].events = POLLIN;
+
+  fds[0].fd = dpopen(buf, O_RDWR, &pid);
+  if (fds[0].fd < 0)
+    {
+      goto errout;
+    }
 
   while (1)
     {
@@ -119,7 +121,7 @@ static FAR void *doit(pthread_addr_t pvarg)
 
       if (fds[0].revents & POLLIN)
         {
-          ret = read(fileno(fp), buf, REXECD_BUFSIZE);
+          ret = read(fds[0].fd, buf, REXECD_BUFSIZE);
           if (ret <= 0)
             {
               break;
@@ -140,7 +142,7 @@ static FAR void *doit(pthread_addr_t pvarg)
               break;
             }
 
-          ret = write(fileno(fp), buf, ret);
+          ret = write(fds[0].fd, buf, ret);
           if (ret < 0)
             {
               break;
@@ -154,7 +156,7 @@ static FAR void *doit(pthread_addr_t pvarg)
         }
     }
 
-  pclose(fp);
+  dpclose(fds[0].fd, pid);
 errout:
   close(sock);
   return NULL;


### PR DESCRIPTION
## Summary

This PR contains two fixes for the `rexecd`/`rexec` utilities under `netutils/`.

1. **netutils/rexecd: use dpopen() instead of popen() to get raw fd**
    `popen()` now returns a `fopencookie()`-backed `FILE*`. On such a stream
   `fileno()` returns the cookie pointer instead of a real file descriptor,
   which is typically negative. `rexecd`'s relay loop feeds that value into
   `poll()`, where a negative `fd` is silently ignored, so the loop never sees
   the child's `POLLIN`/`POLLHUP`/EOF and blocks forever waiting for the command
   to finish. (Related upstream change: apache/nuttx-apps#3511.)
3. **netutils/rexec: initialize ret to avoid maybe-uninitialized**

## Impact

- **Users**: `rexecd` no longer hangs after the remote command finishes; the
  command-completion (EOF/`POLLHUP`) path works again. No API or CLI change.
- **Build**: removes a potential `-Werror=maybe-uninitialized` build break in
  `rexec.c`.
- **Dependencies**: `rexecd` now depends on `dpopen()`/`dpclose()`
  (`CONFIG_SYSTEM_POPEN`), the descriptor-based counterparts of
  `popen()`/`pclose()`.
- **Hardware / Security / Compatibility**: no change. Documentation: none needed.

## Testing

Built with the standard nuttx-apps toolchain; warning-as-error build of
`netutils/rexec` and `netutils/rexecd` passes after the `ret` initialization fix.

Runtime verified by running `rexecd` on the target and issuing a remote command
from `rexec`:

- Before: `rexec <host> <cmd>` printed the command output but then hung; the
  session never returned to the prompt because `poll()` ignored the negative
  `fileno()` and the relay loop never observed command completion.
- After: the same `rexec <host> <cmd>` prints the output, receives EOF/`POLLHUP`
  when the child exits, and the session terminates cleanly.