### PR TITLE
Replace O_RDOK with O_RDONLY after alias removal

### DIFF
--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -664,7 +664,7 @@ int main(int argc, FAR char *argv[])
 
   /* Open the /dev/config device */
 
-  g_fd = open("/dev/config", O_RDOK);
+  g_fd = open("/dev/config", O_RDONLY);
   if (g_fd == -1)
     {
       printf("ERROR: Failed to open /dev/config %d\n", -errno);

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -121,7 +121,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
 
       /* Open the file containing the script */
 
-      vtbl->np.np_fd = open(fullpath, O_RDOK | O_CLOEXEC);
+      vtbl->np.np_fd = open(fullpath, O_RDONLY | O_CLOEXEC);
       if (vtbl->np.np_fd < 0)
         {
           if (log)

--- a/platform/mikroe-stm32f4/mikroe_configdata.c
+++ b/platform/mikroe-stm32f4/mikroe_configdata.c
@@ -86,7 +86,7 @@ int platform_setconfig(enum config_data_e id, int instance,
 
   /* Try to open the /dev/config device file */
 
-  if ((fd = open("/dev/config", O_RDOK)) == -1)
+  if ((fd = open("/dev/config", O_RDONLY)) == -1)
     {
       /* Error opening the config device */
 
@@ -209,7 +209,7 @@ int platform_getconfig(enum config_data_e id, int instance,
 
   /* Try to open the /dev/config device file */
 
-  if ((fd = open("/dev/config", O_RDOK)) == -1)
+  if ((fd = open("/dev/config", O_RDONLY)) == -1)
     {
       /* Error opening the config device */
 


### PR DESCRIPTION
## Summary

The non-standard `O_RDOK`/`O_WROK` aliases are being removed from NuttX's `include/fcntl.h` (separate nuttx PR). They were simply aliases for `O_RDONLY`/`O_WRONLY`. This change replaces all remaining `O_RDOK` usage in the apps repository with the standard `O_RDONLY`.

Affected files:
- `examples/configdata/configdata_main.c`
- `nshlib/nsh_script.c`
- `platform/mikroe-stm32f4/mikroe_configdata.c`

## Impact

No functional change. `O_RDOK` was defined as `O_RDONLY`, so this is a pure text substitution that keeps the same behavior while using the standard POSIX flag name. Safe to merge independently — `O_RDONLY` is and remains defined in upstream nuttx.

## Testing

- `tools/checkpatch.sh -f` passes on all three changed files.
- Builds cleanly against apache/nuttx master.