### PR TITLE
 apps: Replace O_RDOK with O_RDONLY after alias removal

### DIFF
--- a/examples/userfs/userfs_main.c
+++ b/examples/userfs/userfs_main.c
@@ -245,7 +245,7 @@ static int ufstest_open(FAR void *volinfo, FAR const char *relpath,
           file->inuse = 0;
         }
 
-      if ((oflags & (O_WROK | O_APPEND)) == (O_WROK | O_APPEND))
+      if ((oflags & (O_WRONLY | O_APPEND)) == (O_WRONLY | O_APPEND))
         {
           opriv->pos = file->inuse;
         }

--- a/system/usbmsc/usbmsc_main.c
+++ b/system/usbmsc/usbmsc_main.c
@@ -581,7 +581,7 @@ int main(int argc, FAR char *argv[])
              num_luns, luns[num_luns].path);
 
       ret = usbmsc_bindlun(handle, luns[num_luns].path, 0, 0, 0,
-                           luns[num_luns].flags & O_WROK ? false : true);
+                           luns[num_luns].flags & O_WRONLY ? false : true);
       if (ret < 0)
         {
           printf("mcsonn_main: usbmsc_bindlun failed for LUN %d using %s: "


### PR DESCRIPTION
## Summary

The O_RDOK/O_WROK aliases have been removed from fcntl.h.  Replace all remaining O_RDOK usage with O_RDONLY in the apps repository.

miss from https://github.com/apache/nuttx-apps/pull/3566.

## Impact

Fix ci error like this: https://github.com/apache/nuttx/pull/19234

## Testing

pass build
