### PR TITLE
nshlib/nsh_fscmds: Display modification time in ls -l output

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <time.h>
 #include <string.h>
 #include <fcntl.h>
 #include <dirent.h>
@@ -598,6 +599,19 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
             {
               nsh_output(vtbl, "%12" PRIdOFF, buf.st_size);
             }
+        }
+
+      /* Display modification time in long format */
+
+      if ((lsflags & LSFLAGS_LONG) != 0 && buf.st_mtime != 0)
+        {
+          struct tm tm;
+          char timebuf[20];
+          time_t mtime = (time_t)buf.st_mtime;
+
+          gmtime_r(&mtime, &tm);
+          strftime(timebuf, sizeof(timebuf), "%Y-%m-%d %H:%M", &tm);
+          nsh_output(vtbl, " %s", timebuf);
         }
     }
 


### PR DESCRIPTION
## Summary

Add modification time display to `ls -l` long format output.

**Fixes #17063**

## Details

The `ls -l` command now shows the modification time (`st_mtime`) in
`YYYY-MM-DD HH:MM` format (ISO long-iso style) between the permission
string and the file size.

Files with `st_mtime == 0` (e.g., procfs, tmpfs pseudo-entries) skip
the timestamp display to avoid showing a meaningless epoch time.

## Changes

- `nshlib/nsh_fscmds.c`: Add `#include <time.h>` and timestamp display
  logic in `ls_handler()` after the permission details output.

## Verification

Built and tested on `sim:nsh` configuration.

**ls -l /**:
```
 dr-xr-xr-x           0 bin/
 drwxr-xr-x 2026-06-29 11:21        4096 data/
 drwxrwxrwx           0 dev/
 dr-xr-xr-x           0 etc/
```

**ls -l /data**:
```
 -rw-r--r-- 2026-06-29 11:20         152 .version
 -rw-r--r-- 2026-06-29 11:20        1883 .config.backup
 drwxr-xr-x 2026-06-29 11:21        4096 binfmt/
 -rw-r--r-- 2026-06-01 08:56        3107 NOTICE
 -rw-r--r-- 2026-06-05 15:33           6 hello.txt
```

**ls -l /proc** (procfs, st_mtime == 0, timestamp correctly skipped):
```
 dr--r--r--           0 0/
 dr--r--r--           0 1/
 -r--r--r--           0 cpuinfo
```

**ls -l /dev** (pseudo-devices, st_mtime set to boot time):
```
 crw-rw-rw- 2026-06-29 11:21           0 console
 crw-rw-rw-           0 rtc0
```

`rtc0` has `st_mtime == 0` so the timestamp is correctly omitted.

Signed-off-by: hanzhijian <hanzhijian@zepp.com>