### PR TITLE
apps: Fix O_ACCMODE bitmask checks after Linux flag alignment

### DIFF
--- a/examples/usrsocktest/usrsocktest_noblock_connect.c
+++ b/examples/usrsocktest/usrsocktest_noblock_connect.c
@@ -120,13 +120,13 @@ TEST(no_block_connect, instant_connect)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Do connect, should succeed instantly. */
@@ -188,13 +188,13 @@ TEST(no_block_connect, delayed_connect)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until
@@ -290,13 +290,13 @@ TEST(no_block_connect, close_not_connected)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until
@@ -363,13 +363,13 @@ TEST(no_block_connect, early_drop)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until
@@ -443,24 +443,24 @@ TEST(no_block_connect, multiple)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   flags = fcntl(sd2, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd2, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd2, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempts, daemon delays actual connection until
@@ -552,24 +552,24 @@ TEST(no_block_connect, multiple)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   flags = fcntl(sd2, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd2, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd2, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempts, daemon delays actual connection until
@@ -637,24 +637,24 @@ TEST(no_block_connect, multiple)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   flags = fcntl(sd2, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd2, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd2, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until
@@ -758,13 +758,13 @@ TEST(no_block_connect, basic_daemon_dup2)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until

--- a/examples/usrsocktest/usrsocktest_noblock_recv.c
+++ b/examples/usrsocktest/usrsocktest_noblock_recv.c
@@ -114,13 +114,13 @@ static void receive(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Do connect, should succeed instantly. */
@@ -310,13 +310,13 @@ static void delayed_connect(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until

--- a/examples/usrsocktest/usrsocktest_noblock_send.c
+++ b/examples/usrsocktest/usrsocktest_noblock_send.c
@@ -110,13 +110,13 @@ static void _send(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Do connect, should succeed instantly. */
@@ -231,13 +231,13 @@ static void connect_send(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Launch connect attempt, daemon delays actual connection until

--- a/examples/usrsocktest/usrsocktest_poll.c
+++ b/examples/usrsocktest/usrsocktest_poll.c
@@ -115,13 +115,13 @@ static void connectreceive(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* poll for input (instant timeout). */
@@ -321,13 +321,13 @@ static void connectsend(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* poll for input (instant timeout). */
@@ -454,13 +454,13 @@ static void daemonabort(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* poll for input (instant timeout). */

--- a/examples/usrsocktest/usrsocktest_remote_disconnect.c
+++ b/examples/usrsocktest/usrsocktest_remote_disconnect.c
@@ -151,13 +151,13 @@ static void unreachable(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Try connect, connection in progress. */
@@ -670,13 +670,13 @@ static void remote_disconnect_poll(struct usrsocktest_daemon_conf_s *dconf)
 
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
   TEST_ASSERT_EQUAL(0, ret);
   flags = fcntl(sd, F_GETFL, 0);
   TEST_ASSERT_TRUE(flags >= 0);
-  TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+  TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
   TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
   /* Poll for input (instant timeout). */
@@ -797,13 +797,13 @@ static void remote_disconnect_poll2(struct usrsocktest_daemon_conf_s *dconf)
 
       flags = fcntl(sd, F_GETFL, 0);
       TEST_ASSERT_TRUE(flags >= 0);
-      TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+      TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
       TEST_ASSERT_EQUAL(0, flags & O_NONBLOCK);
       ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
       TEST_ASSERT_EQUAL(0, ret);
       flags = fcntl(sd, F_GETFL, 0);
       TEST_ASSERT_TRUE(flags >= 0);
-      TEST_ASSERT_EQUAL(O_RDWR, flags & O_RDWR);
+      TEST_ASSERT_EQUAL(O_RDWR, flags & O_ACCMODE);
       TEST_ASSERT_EQUAL(O_NONBLOCK, flags & O_NONBLOCK);
 
       /* Poll for input (instant timeout). */

--- a/system/dd/dd_main.c
+++ b/system/dd/dd_main.c
@@ -356,7 +356,7 @@ int main(int argc, FAR char **argv)
         }
       else if (strncmp(argv[i], "verify", 6) == 0)
         {
-          dd.oflags |= O_RDONLY;
+          dd.oflags = (dd.oflags & ~O_ACCMODE) | O_RDWR;
         }
       else if (strncmp(argv[i], "conv=", 5) == 0)
         {
@@ -409,7 +409,8 @@ int main(int argc, FAR char **argv)
 
   /* If verify enabled, infile and outfile are mandatory */
 
-  if ((dd.oflags & O_RDONLY) && (infile == NULL || outfile == NULL))
+  if ((dd.oflags & O_ACCMODE) == O_RDWR &&
+      (infile == NULL || outfile == NULL))
     {
       fprintf(stderr, "%s: invalid parameters: %s\n", g_dd,
           strerror(EINVAL));
@@ -519,7 +520,7 @@ int main(int argc, FAR char **argv)
          / ((double)elapsed / USEC_PER_SEC)));
 #endif
 
-  if (ret == 0 && (dd.oflags & O_RDONLY) != 0)
+  if (ret == 0 && (dd.oflags & O_ACCMODE) == O_RDWR)
     {
       ret = dd_verify(&dd);
     }

--- a/system/popen/dpopen.c
+++ b/system/popen/dpopen.c
@@ -112,7 +112,7 @@ int dpopen(FAR const char *command, int oflag, FAR pid_t *pid)
    * pipe; fd[1] refers to the write end of the pipe.
    */
 
-  if ((oflag & O_RDWR) == O_RDWR)
+  if ((oflag & O_ACCMODE) == O_RDWR)
     {
 #if defined(CONFIG_NET_LOCAL) && defined(CONFIG_NET_LOCAL_STREAM)
       /* Create a socketpair for bidirectional communication */
@@ -215,7 +215,7 @@ int dpopen(FAR const char *command, int oflag, FAR pid_t *pid)
 
   /* Redirect child's stdin or stdout to the pipe */
 
-  if ((oflag & O_RDWR) == O_RDWR)
+  if ((oflag & O_ACCMODE) == O_RDWR)
     {
       errcode = posix_spawn_file_actions_adddup2(&file_actions, childfd,
                                                  STDIN_FILENO);

--- a/system/usbmsc/usbmsc_main.c
+++ b/system/usbmsc/usbmsc_main.c
@@ -581,7 +581,7 @@ int main(int argc, FAR char *argv[])
              num_luns, luns[num_luns].path);
 
       ret = usbmsc_bindlun(handle, luns[num_luns].path, 0, 0, 0,
-                           luns[num_luns].flags & O_WRONLY ? false : true);
+                           (luns[num_luns].flags & O_ACCMODE) == O_RDONLY);
       if (ret < 0)
         {
           printf("mcsonn_main: usbmsc_bindlun failed for LUN %d using %s: "

--- a/testing/testsuites/kernel/syscall/cases/fcntl_test.c
+++ b/testing/testsuites/kernel/syscall/cases/fcntl_test.c
@@ -90,35 +90,36 @@ void test_nuttx_syscall_fcntl01(FAR void **state)
   /* //block1: */
 
   flags = fcntl(fd[2], F_GETFL, 0);
-  assert_false((flags & O_WRONLY) == 0);
+  assert_false((flags & O_ACCMODE) == O_RDONLY);
 
   /* Check setting of no_delay flag */
 
   assert_false(fcntl(fd[2], F_SETFL, O_NDELAY) == -1);
 
   flags = fcntl(fd[2], F_GETFL, 0);
-  assert_false((flags & (O_NDELAY | O_WRONLY)) == 0);
+  assert_false((flags & O_NDELAY) == 0 && (flags & O_ACCMODE) == O_RDONLY);
 
   /* Check of setting append flag */
 
   assert_false(fcntl(fd[2], F_SETFL, O_APPEND) == -1);
 
   flags = fcntl(fd[2], F_GETFL, 0);
-  assert_false((flags & (O_APPEND | O_WRONLY)) == 0);
+  assert_false((flags & O_APPEND) == 0 && (flags & O_ACCMODE) == O_RDONLY);
 
   /* Check setting flags together */
 
   assert_false(fcntl(fd[2], F_SETFL, O_NDELAY | O_APPEND) < 0);
 
   flags = fcntl(fd[2], F_GETFL, 0);
-  assert_false((flags & (O_NDELAY | O_APPEND | O_WRONLY)) == 0);
+  assert_false((flags & (O_NDELAY | O_APPEND)) == 0 &&
+               (flags & O_ACCMODE) == O_RDONLY);
 
   /* Check that flags are not cumulative */
 
   assert_false(fcntl(fd[2], F_SETFL, 0) == -1);
 
   flags = fcntl(fd[2], F_GETFL, 0);
-  assert_false((flags & O_WRONLY) == 0);
+  assert_false((flags & O_ACCMODE) == O_RDONLY);
   assert_false((flags = fcntl(fd[2], F_GETFD, 0)) < 0);
   assert_false(flags != 0);
   assert_false((flags = fcntl(fd[2], F_SETFD, 1)) == -1);


### PR DESCRIPTION
## Summary

Companion to apache/nuttx#19238 ("include/fcntl.h: align open flags with Linux values").

After aligning the NuttX `open()` flag constants with Linux (`O_RDONLY=0`, `O_WRONLY=1`, `O_RDWR=2`), code that used `(flags & O_RDONLY)` or `(flags & O_WRONLY)` as a bitmask check is broken because `O_RDONLY` is now `0`.  This PR fixes all such sites in `apps/` by using `(flags & O_ACCMODE)` comparisons instead.

*   **usrsocktest** (`examples/usrsocktest/`): replace `flags & O_RDWR` with `flags & O_ACCMODE` in `fcntl(F_GETFL)` assertions across 5 test files.
*   **dd** (`system/dd/dd_main.c`): verify mode used `(oflags & O_RDONLY)` to detect verify; replace with `(oflags & O_ACCMODE) == O_RDWR`.
*   **dpopen** (`system/popen/dpopen.c`): replace `(oflag & O_RDWR) == O_RDWR` with `(oflag & O_ACCMODE) == O_RDWR`.
*   **usbmsc** (`system/usbmsc/usbmsc_main.c`): replace `flags & O_WRONLY` with `(flags & O_ACCMODE) == O_RDONLY`.
*   **fcntl_test** (`testing/testsuites/kernel/syscall/cases/fcntl_test.c`): replace `(flags & O_WRONLY) == 0` with `(flags & O_ACCMODE) == O_RDONLY`.

## Impact

*   **Correctness:** Without these fixes, the affected code silently misbehaves when `O_RDONLY == 0` (e.g. `dd verify` never triggers, dpopen bidirectional detection fails, usbmsc read-only detection is wrong).
*   **Dependency:** Must be merged together with (or after) apache/nuttx#19238. Standalone this PR has no effect since apache/nuttx still uses the old flag values.

## Testing

Tested on the `sim:nsh` target (Linux x86_64 host, gcc) together with apache/nuttx#19238.

**Boot log:**

```
NuttShell (NSH) NuttX-10.4.0
nsh> uname -a
NuttX 10.4.0 6bb526f459a Jun 29 2026 23:37:06 sim sim
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK
 STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0
069584 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0
067456 sim_loop_wq
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0
067472 hpwork
    4     4     0 100 FIFO     Task      - Running            0000000000000000 0
067496 nsh_main
```

**OSTest:** ran `ostest` from the NSH prompt — all tests passed with no failures or panics.