### PR TITLE
nshlib/nsh_fscmds: Fix potential NULL pointer dereferences

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -739,13 +739,14 @@ static int fdinfo_callback(FAR struct nsh_vtbl_s *vtbl,
   if (ret < 0)
     {
       nsh_error(vtbl, g_fmtcmdfailed, "fdinfo", "asprintf", NSH_ERRNO);
+      return ret;
     }
 
   nsh_output(vtbl, "\npid:%s", entryp->d_name);
   ret = nsh_catfile(vtbl, "fdinfo", filepath);
   if (ret < 0)
     {
-      nsh_error(vtbl, g_fmtcmdfailed, "fdinfo", "nsh_catfaile", NSH_ERRNO);
+      nsh_error(vtbl, g_fmtcmdfailed, "fdinfo", "nsh_catfile", NSH_ERRNO);
     }
 
   free(filepath);
@@ -857,6 +858,10 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (argc == 1)
     {
       char *buf = malloc(BUFSIZ);
+      if (buf == NULL)
+        {
+          return -ENOMEM;
+        }
 
       /* Dump from input */
 


### PR DESCRIPTION
## Summary

Fix two potential NULL pointer dereferences in `nshlib/nsh_fscmds.c`.

## Changes

### 1. `fdinfo_callback` — NULL deref after asprintf failure

When `asprintf()` fails (returns < 0), `filepath` may be NULL. The code logged an error but did **not** return — it fell through and passed the NULL `filepath` to `nsh_catfile()`, causing a NULL pointer dereference.

**Fix**: Add `return ret;` after the asprintf error path.

Also fixed a typo in the error message: `"nsh_catfaile"` → `"nsh_catfile"`.

### 2. `cmd_cat` — NULL deref after malloc failure

When `argc == 1` (reading from stdin), `malloc(BUFSIZ)` was called but the return value was never checked. If malloc fails, `buf` is NULL and `nsh_read(vtbl, buf, BUFSIZ)` would dereference it.

**Fix**: Add `if (buf == NULL) return -ENOMEM;` after the malloc call.

## Verification

Built and tested on `sim:nsh` configuration:

```
nsh> cat /data/hello.txt
hello

nsh> cat /etc/group
root:*:0:root,admin

nsh> fdinfo 0
FD  OFLAGS  TYPE POS       PATH
0   3       1    0         /dev/console
1   3       1    0         /dev/console
2   3       1    0         /dev/console

nsh> fdinfo 1
FD  OFLAGS  TYPE POS       PATH
0   3       1    0         /dev/console
1   3       1    0         /dev/console
2   3       1    0         /dev/console

nsh> ls -l /data
 -rw-r--r--         152 .version
 -rw-r--r--        1883 .config.backup
 drwxr-xr-x        4096 binfmt/

nsh> help
    .           cmp         false       mkfifo      readlink    time
    [           dirname     fdinfo      mkrd        rm          true
```

Signed-off-by: hanzhijian <hanzhijian@zepp.com>