### PR TITLE
games/NXDoom: Fix build warnings

### DIFF
--- a/games/NXDoom/src/doom/am_map.c
+++ b/games/NXDoom/src/doom/am_map.c
@@ -607,6 +607,7 @@ static boolean stopped = true;
  *
  ****************************************************************************/
 
+#if 0 /* UNUSED */
 static void am_get_i_slope(mline_t *ml, islope_t *is)
 {
   int dx;
@@ -623,6 +624,7 @@ static void am_get_i_slope(mline_t *ml, islope_t *is)
   else
     is->slp = fixed_div(dy, dx);
 }
+#endif
 
 /****************************************************************************
  * Name: am_activate_new_scale
@@ -1004,6 +1006,7 @@ static void am_do_follow_player(void)
  * Name: am_update_light_lev
  ****************************************************************************/
 
+#if 0 /* UNUSED */
 static void am_update_light_lev(void)
 {
   static int nexttic = 0;
@@ -1026,6 +1029,7 @@ static void am_update_light_lev(void)
       nexttic = amclock + 6 - (amclock % 6);
     }
 }
+#endif
 
 /****************************************************************************
  * Name: am_clear_fb

--- a/games/NXDoom/src/doom/d_think.h
+++ b/games/NXDoom/src/doom/d_think.h
@@ -35,7 +35,7 @@
  * various action functions cleanly.
  */
 
-typedef void (*actionf_v)();
+typedef void (*actionf_v)(void);
 typedef void (*actionf_p1)(void *);
 typedef void (*actionf_p2)(void *, void *);
 

--- a/games/NXDoom/src/doom/g_game.c
+++ b/games/NXDoom/src/doom/g_game.c
@@ -394,6 +394,7 @@ static int g_next_weapon(int direction)
   return weapon_order_table[i].weapon_num;
 }
 
+#if 0 /* UNUSED */
 static int g_cmd_checksum(ticcmd_t *cmd)
 {
   size_t i;
@@ -404,6 +405,7 @@ static int g_cmd_checksum(ticcmd_t *cmd)
 
   return sum;
 }
+#endif
 
 static void g_do_load_level(void)
 {
@@ -815,7 +817,7 @@ static void g_do_save_game(void)
 
 static const char *demo_version_description(int version)
 {
-  static char resultbuf[16];
+  static char resultbuf[24];
 
   switch (version)
     {
@@ -1281,12 +1283,14 @@ static void g_write_demo_ticcmd(ticcmd_t *cmd)
  * Called by the game initialization functions.
  */
 
+#if 0 /* UNUSED */
 static void g_init_player(int player)
 {
   /* clear everything else to defaults */
 
   g_player_reborn(player);
 }
+#endif
 
 /****************************************************************************
  * Public Functions

--- a/games/NXDoom/src/doom/info.c
+++ b/games/NXDoom/src/doom/info.c
@@ -63,7 +63,7 @@
       .sprite = (s),                                                         \
       .frame = (f),                                                          \
       .tics = (t),                                                           \
-      .action = {(a)},                                                       \
+      .action = {(void *)(a)},                                                       \
       .nextstate = (ns),                                                     \
   }
 #endif
@@ -98,80 +98,80 @@ const char *sprnames[] =
 
 /* Doesn't work with g++, needs actionf_p1 */
 
-void a_light0();
-void a_weapon_ready();
-void a_lower();
-void a_raise();
-void a_punch();
-void a_refire();
-void a_fire_pistol();
-void a_light1();
-void a_fire_shotgun();
-void a_light2();
-void a_fire_shotgun2();
-void a_check_reload();
-void a_open_shotgun2();
-void a_load_shotgun2();
-void a_close_shotgun2();
-void a_fire_cgun();
-void a_gun_flash();
-void a_fire_missile();
-void a_saw();
-void a_fire_plasma();
-void a_bfg_sound();
-void a_fire_bfg();
-void a_bfg_spray();
-void a_explode();
-void a_pain();
-void a_player_screm();
-void a_fall();
-void a_xscream();
-void a_look();
-void a_chase();
-void a_face_target();
-void a_pos_attack();
-void a_scream();
-void a_s_pos_attack();
-void a_vile_chase();
-void a_vile_start();
-void a_vile_target();
-void a_vile_attack();
-void a_start_fire();
-void a_fire();
-void a_fire_crackle();
-void a_tracer();
-void a_skel_woosh();
-void a_skel_fist();
-void a_skel_missile();
-void a_fat_raise();
-void a_fat_attack1();
-void a_fat_attack2();
-void a_fat_attack3();
-void a_boss_death();
-void a_c_pos_attack();
-void a_c_pos_refire();
-void a_troop_attack();
-void a_sarg_attack();
-void a_head_attack();
-void a_bruis_attack();
-void a_skull_attack();
-void a_metal();
-void a_spid_refire();
-void a_baby_metal();
-void a_bspi_attack();
-void a_hoof();
-void a_cyber_attack();
-void a_pain_attack();
-void a_pain_die();
-void a_keen_die();
-void a_brain_pain();
-void a_brain_scream();
-void a_brain_die();
-void a_brain_awake();
-void a_brain_split();
-void a_spawn_sound();
-void a_spawn_fly();
-void a_brain_explode();
+void a_light0(void *, void *);
+void a_weapon_ready(void *, void *);
+void a_lower(void *, void *);
+void a_raise(void *, void *);
+void a_punch(void *, void *);
+void a_refire(void *, void *);
+void a_fire_pistol(void *, void *);
+void a_light1(void *, void *);
+void a_fire_shotgun(void *, void *);
+void a_light2(void *, void *);
+void a_fire_shotgun2(void *, void *);
+void a_check_reload(void *, void *);
+void a_open_shotgun2(void *, void *);
+void a_load_shotgun2(void *, void *);
+void a_close_shotgun2(void *, void *);
+void a_fire_cgun(void *, void *);
+void a_gun_flash(void *, void *);
+void a_fire_missile(void *, void *);
+void a_saw(void *, void *);
+void a_fire_plasma(void *, void *);
+void a_bfg_sound(void *, void *);
+void a_fire_bfg(void *, void *);
+void a_bfg_spray(void *);
+void a_explode(void *);
+void a_pain(void *);
+void a_player_screm(void *);
+void a_fall(void *);
+void a_xscream(void *);
+void a_look(void *);
+void a_chase(void *);
+void a_face_target(void *);
+void a_pos_attack(void *);
+void a_scream(void *);
+void a_s_pos_attack(void *);
+void a_vile_chase(void *);
+void a_vile_start(void *);
+void a_vile_target(void *);
+void a_vile_attack(void *);
+void a_start_fire(void *);
+void a_fire(void *);
+void a_fire_crackle(void *);
+void a_tracer(void *);
+void a_skel_woosh(void *);
+void a_skel_fist(void *);
+void a_skel_missile(void *);
+void a_fat_raise(void *);
+void a_fat_attack1(void *);
+void a_fat_attack2(void *);
+void a_fat_attack3(void *);
+void a_boss_death(void *);
+void a_c_pos_attack(void *);
+void a_c_pos_refire(void *);
+void a_troop_attack(void *);
+void a_sarg_attack(void *);
+void a_head_attack(void *);
+void a_bruis_attack(void *);
+void a_skull_attack(void *);
+void a_metal(void *);
+void a_spid_refire(void *);
+void a_baby_metal(void *);
+void a_bspi_attack(void *);
+void a_hoof(void *);
+void a_cyber_attack(void *);
+void a_pain_attack(void *);
+void a_pain_die(void *);
+void a_keen_die(void *);
+void a_brain_pain(void *);
+void a_brain_scream(void *);
+void a_brain_die(void *);
+void a_brain_awake(void *);
+void a_brain_split(void *);
+void a_spawn_sound(void *);
+void a_spawn_fly(void *);
+void a_brain_explode(void *);
 
 /****************************************************************************
  * Public Data

--- a/games/NXDoom/src/doom/info.h
+++ b/games/NXDoom/src/doom/info.h
@@ -1154,9 +1154,7 @@ typedef enum
   NUMSTATES
 } statenum_t;
 
-/* Tightly packed to save space! */
-
-begin_packed_struct struct state_t
+struct state_t
 {
   actionf_t action; /* void (*action) (); */
   spritenum_t sprite;
@@ -1179,7 +1177,7 @@ begin_packed_struct struct state_t
   int misc1;
   int misc2;
 #endif
-} end_packed_struct;
+};
 
 typedef struct state_t state_t;
 

--- a/games/NXDoom/src/doom/m_menu.c
+++ b/games/NXDoom/src/doom/m_menu.c
@@ -223,11 +223,9 @@ static void m_quit_doom(int choice);
 
 static void m_change_messages(int choice);
 static void m_change_sensitivity(int choice);
-static void m_sfx_vol(int choice);
-static void m_music_vol(int choice);
+static void m_sound(int choice);
 static void m_change_detail(int choice);
 static void m_size_display(int choice);
-static void m_sound(int choice);
 
 static void m_finish_read_this(int choice);
 static void m_load_select(int choice);
@@ -242,7 +240,6 @@ static void m_draw_read_this2(void);
 static void m_draw_new_game(void);
 static void m_draw_episode(void);
 static void m_draw_options(void);
-static void m_draw_sound(void);
 static void m_draw_load(void);
 static void m_draw_save(void);
 
@@ -255,6 +252,12 @@ static int m_string_height(const char *string);
 static void m_start_message(const char *string,
         void *routine, boolean input);
 static void m_clear_menus(void);
+
+#ifdef CONFIG_GAMES_NXDOOM_SOUND
+static void m_sfx_vol(int choice);
+static void m_music_vol(int choice);
+static void m_draw_sound(void);
+#endif
 
 /****************************************************************************
  * Public Data
@@ -282,8 +285,6 @@ boolean inhelpscreens;
 
 /* message x & y */
 
-static int g_messx;
-static int g_messy;
 static int g_message_last_menu_active;
 
 /* timed message = no input from user */
@@ -915,7 +916,7 @@ void m_quick_save(void)
   m_start_message(g_tempstring, m_quick_save_response, true);
 }
 
-void m_quick_load(void)
+static void m_quick_load(void)
 {
   if (netgame)
     {
@@ -938,7 +939,7 @@ void m_quick_load(void)
  * Had a "quick hack to fix romero bug"
  */
 
-void m_draw_read_this1(void)
+static void m_draw_read_this1(void)
 {
   inhelpscreens = true;
 
@@ -947,7 +948,7 @@ void m_draw_read_this1(void)
 
 /* Read This Menus - optional second page. */
 
-void m_draw_read_this2(void)
+static void m_draw_read_this2(void)
 {
   inhelpscreens = true;
 
@@ -960,11 +961,11 @@ void m_draw_read_this2(void)
 
 /* Change Sfx & Music volumes */
 
-void m_draw_sound(void)
+#ifdef CONFIG_GAMES_NXDOOM_SOUND
+static void m_draw_sound(void)
 {
   v_draw_patch_direct(60, 38, w_cache_lump_name(("M_SVOL"), PU_CACHE));
 
-#ifdef CONFIG_GAMES_NXDOOM_SOUND
   m_draw_thermo(g_sound_def.x,
                 g_sound_def.y + LINEHEIGHT * (SOUND_SFXVOL + 1), 16,
                 g_sfx_volume);
@@ -972,19 +973,19 @@ void m_draw_sound(void)
   m_draw_thermo(g_sound_def.x,
                 g_sound_def.y + LINEHEIGHT * (SOUND_MUSICVOL + 1), 16,
                 g_music_volume);
-#endif
 }
+#endif
 
-void m_sound(int choice)
+static void m_sound(int choice)
 {
 #ifdef CONFIG_GAMES_NXDOOM_SOUND
   m_setup_next_menu(&g_sound_def);
 #endif
 }
 
-void m_sfx_vol(int choice)
-{
 #ifdef CONFIG_GAMES_NXDOOM_SOUND
+static void m_sfx_vol(int choice)
+{
   switch (choice)
     {
     case 0:
@@ -996,12 +997,12 @@ void m_sfx_vol(int choice)
     }
 
   s_set_sfx_volume(g_sfx_volume * 8);
-#endif
 }
+#endif
 
-void m_music_vol(int choice)
-{
 #ifdef CONFIG_GAMES_NXDOOM_SOUND
+static void m_music_vol(int choice)
+{
   switch (choice)
     {
     case 0:
@@ -1013,8 +1014,8 @@ void m_music_vol(int choice)
     }
 
   s_set_music_volume(g_music_volume * 8);
-#endif
 }
+#endif
 
 void m_drawmain_menu(void)
 {

--- a/games/NXDoom/src/doom/p_pspr.c
+++ b/games/NXDoom/src/doom/p_pspr.c
@@ -118,6 +118,7 @@ static void p_set_psprite(player_t *player, int position, statenum_t stnum)
   /* an initial state of 0 could cycle through */
 }
 
+#if 0 /* UNUSED */
 static void p_calc_swing(player_t *player)
 {
   fixed_t swing;
@@ -135,6 +136,7 @@ static void p_calc_swing(player_t *player)
   angle = (FINEANGLES / 70 * leveltime + FINEANGLES / 2) & FINEMASK;
   swingy = -fixed_mul(swingx, finesine[angle]);
 }
+#endif
 
 /* p_bringup_weapon
  * Starts bringing the pending weapon up from the bottom of the screen. Uses

--- a/games/NXDoom/src/doom/r_main.c
+++ b/games/NXDoom/src/doom/r_main.c
@@ -139,6 +139,7 @@ int setdetail;
  *
  ****************************************************************************/
 
+#if 0 /* UNUSED */
 static void r_add_point_to_box(int x, int y, fixed_t *box)
 {
   if (x < box[BOXLEFT]) box[BOXLEFT] = x;
@@ -146,6 +147,7 @@ static void r_add_point_to_box(int x, int y, fixed_t *box)
   if (y < box[BOXBOTTOM]) box[BOXBOTTOM] = y;
   if (y > box[BOXTOP]) box[BOXTOP] = y;
 }
+#endif
 
 /****************************************************************************
  * Name: r_setup_frame

--- a/games/NXDoom/src/doom/st_stuff.c
+++ b/games/NXDoom/src/doom/st_stuff.c
@@ -958,6 +958,7 @@ static void st_load_data(void)
   st_load_graphics();
 }
 
+#if 0 /* UNUSED */
 static void st_unload_callback(const char *lumpname, patch_t **variable)
 {
   w_release_lump_name(lumpname);
@@ -968,6 +969,7 @@ static void st_unload_graphics(void)
 {
   st_load_unload_graphics(st_unload_callback);
 }
+#endif
 
 static void st_init_data(void)
 {

--- a/games/NXDoom/src/doom/wi_stuff.c
+++ b/games/NXDoom/src/doom/wi_stuff.c
@@ -479,7 +479,7 @@ static void wi_load_unload_data(load_callback_t callback)
 {
   int8_t i;
   int8_t j;
-  char name[9];
+  char name[23];
   anim_t *a;
 
   if (gamemode == commercial)

--- a/games/NXDoom/textscreen/txt_desktop.c
+++ b/games/NXDoom/textscreen/txt_desktop.c
@@ -63,6 +63,7 @@ static void txt_exit_mainloop(void)
   g_main_loop_running = 0;
 }
 
+#if 0 /* UNUSED */
 static int txt_raise_window(txt_window_t *window)
 {
   int i;
@@ -88,6 +89,7 @@ static int txt_raise_window(txt_window_t *window)
 
   return 0;
 }
+#endif
 
 static void draw_desktop_background(const char *title)
 {
@@ -201,6 +203,7 @@ static void desktop_input_event(int c)
     }
 }
 
+#if 0 /* UNUSED */
 static void txt_draw_ascii_table(void)
 {
   unsigned char *screendata;
@@ -232,6 +235,7 @@ static void txt_draw_ascii_table(void)
 
   txt_update_screen();
 }
+#endif
 
 /****************************************************************************
  * Public Functions

--- a/games/NXDoom/textscreen/txt_fileselect.c
+++ b/games/NXDoom/textscreen/txt_fileselect.c
@@ -104,6 +104,7 @@ txt_widget_class_t txt_fileselect_class =
  * Private Functions
  ****************************************************************************/
 
+#if 0 /* UNUSED */
 static char *exec_read_output(char **argv)
 {
   char *result;
@@ -261,6 +262,7 @@ static char *txt_select_file(const char *window_title,
 {
   return NULL;
 }
+#endif
 
 static void txt_file_select_size_calc(TXT_UNCAST_ARG(fileselect))
 {

--- a/games/NXDoom/textscreen/txt_sdl.c
+++ b/games/NXDoom/textscreen/txt_sdl.c
@@ -73,6 +73,7 @@ static const short g_code_page_to_unicode[] = CODE_PAGE_TO_UNICODE;
  * blinking characters.
  */
 
+#if 0 /* UNUSED */
 static int txt_has_blinking_chars(void)
 {
   int x;
@@ -111,6 +112,7 @@ static void txt_string_concat(char *dest, const char *src, size_t dest_len)
 
   txt_string_copy(dest + offset, src, dest_len - offset);
 }
+#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary

This commit resolves all of the build warnings that were preventing NXDoom from compiling in CI runs.

Fixes the issues in https://github.com/apache/nuttx/pull/19239.

## Impact

NXDoom can build in CI! Only this application is affected.

Removes packed struct optimization from state lookup table and extends a few
buffers used by snprintf.

## Testing

Ran CI build manually to verify pass: https://github.com/linguini1/manual-nuttx-ci/actions/runs/28522157686/job/84549082064

Also re-ran DOOM on sim:nxdoom and it works.