### PR TITLE
{bp-3571} nshlib/nsh_fscmds: Display modification time in ls -l output

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <time.h>
 #include <string.h>
 #include <fcntl.h>
 #include <dirent.h>
@@ -598,6 +599,19 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
             {
               nsh_output(vtbl, "%12" PRIdOFF, buf.st_size);
             }
+        }
+
+      /* Display modification time in long format */
+
+      if ((lsflags & LSFLAGS_LONG) != 0 && buf.st_mtime != 0)
+        {
+          struct tm tm;
+          char timebuf[20];
+          time_t mtime = (time_t)buf.st_mtime;
+
+          gmtime_r(&mtime, &tm);
+          strftime(timebuf, sizeof(timebuf), "%Y-%m-%d %H:%M", &tm);
+          nsh_output(vtbl, " %s", timebuf);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #17063

Add modification time display to ls -l long format output. The timestamp is shown as 'YYYY-MM-DD HH:MM' between the permission string and the file size, following the ISO long-iso format.

Files with st_mtime == 0 (e.g., procfs, tmpfs pseudo-entries) skip the timestamp display to avoid showing a meaningless epoch time.

## Impact

RELEASE

## Testing

CI