### PR TITLE
{bp-3568} apps: Replace O_RDOK with O_RDONLY after alias removal

### DIFF
--- a/examples/configdata/configdata_main.c
+++ b/examples/configdata/configdata_main.c
@@ -664,7 +664,7 @@ int main(int argc, FAR char *argv[])
 
   /* Open the /dev/config device */
 
-  g_fd = open("/dev/config", O_RDOK);
+  g_fd = open("/dev/config", O_RDONLY);
   if (g_fd == -1)
     {
       printf("ERROR: Failed to open /dev/config %d\n", -errno);

--- a/examples/userfs/userfs_main.c
+++ b/examples/userfs/userfs_main.c
@@ -236,7 +236,7 @@ static int ufstest_open(FAR void *volinfo, FAR const char *relpath,
           file->inuse = 0;
         }
 
-      if ((oflags & (O_WROK | O_APPEND)) == (O_WROK | O_APPEND))
+      if ((oflags & (O_WRONLY | O_APPEND)) == (O_WRONLY | O_APPEND))
         {
           opriv->pos = file->inuse;
         }

--- a/nshlib/nsh_script.c
+++ b/nshlib/nsh_script.c
@@ -121,7 +121,7 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const FAR char *cmd,
 
       /* Open the file containing the script */
 
-      vtbl->np.np_fd = open(fullpath, O_RDOK | O_CLOEXEC);
+      vtbl->np.np_fd = open(fullpath, O_RDONLY | O_CLOEXEC);
       if (vtbl->np.np_fd < 0)
         {
           if (log)

--- a/platform/mikroe-stm32f4/mikroe_configdata.c
+++ b/platform/mikroe-stm32f4/mikroe_configdata.c
@@ -86,7 +86,7 @@ int platform_setconfig(enum config_data_e id, int instance,
 
   /* Try to open the /dev/config device file */
 
-  if ((fd = open("/dev/config", O_RDOK)) == -1)
+  if ((fd = open("/dev/config", O_RDONLY)) == -1)
     {
       /* Error opening the config device */
 
@@ -209,7 +209,7 @@ int platform_getconfig(enum config_data_e id, int instance,
 
   /* Try to open the /dev/config device file */
 
-  if ((fd = open("/dev/config", O_RDOK)) == -1)
+  if ((fd = open("/dev/config", O_RDONLY)) == -1)
     {
       /* Error opening the config device */
 

--- a/system/usbmsc/usbmsc_main.c
+++ b/system/usbmsc/usbmsc_main.c
@@ -581,7 +581,7 @@ int main(int argc, FAR char *argv[])
              num_luns, luns[num_luns].path);
 
       ret = usbmsc_bindlun(handle, luns[num_luns].path, 0, 0, 0,
-                           luns[num_luns].flags & O_WROK ? false : true);
+                           luns[num_luns].flags & O_WRONLY ? false : true);
       if (ret < 0)
         {
           printf("mcsonn_main: usbmsc_bindlun failed for LUN %d using %s: "


### PR DESCRIPTION
## Summary

The O_RDOK/O_WROK aliases have been removed from fcntl.h.  Replace all remaining O_RDOK usage with O_RDONLY in the apps repository.

includes 
https://github.com/apache/nuttx-apps/pull/3566

## Impact

RELEASE

## Testing

CI