### PR TITLE
interpreters/python: Disable `no-maybe-uninitialized` warning

### DIFF
--- a/interpreters/python/Makefile
+++ b/interpreters/python/Makefile
@@ -56,7 +56,7 @@ CFLAGS += -Wno-shadow -Wno-undef -Wno-format -Wno-builtin-macro-redefined
 CFLAGS += -Wno-type-limits -Wno-implicit-fallthrough -Wno-char-subscripts
 CFLAGS += -Wno-sign-compare -Wno-unused-const-variable -Wno-unused-function
 CFLAGS += -Wno-unused-variable -Wno-overflow -Wno-unused-but-set-variable
-CFLAGS += -Wno-strict-prototypes -nostdlib
+CFLAGS += -Wno-strict-prototypes -Wno-maybe-uninitialized -nostdlib
 
 DEPPATH += --dep-path $(CPYTHON_UNPACKNAME)$(DELIM)Programs
 VPATH   += :$(CPYTHON_UNPACKNAME)$(DELIM)Programs


### PR DESCRIPTION
## Summary

* interpreters/python: Disable `no-maybe-uninitialized` warning
  * Disables the `no-maybe-uninitialized` warning because it's wrongly evaluated after increasing the optimization level of
the Python's library.

## Impact

Impact on user: No.

Impact on build: Yes, enables building `esp32s3-devkit:python` with `EXTRAFLAGS="-Wno-cpp -Werror"`

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

### Building

```
make -j distclean && ./tools/configure.sh esp32s3-devkit:python && make EXTRAFLAGS="-Wno-cpp -Werror" -j$(nproc)
```

### Running

Simply check build outputs.

### Results

Check whether it's built properly.