### PR TITLE
apps: fix distclean for partial builds and residual .kconfig files

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -393,6 +393,7 @@ clean::
 	$(call CLEANAROBJS)
 	$(call CLEAN)
 distclean:: clean
+	$(call DELFILE, .kconfig)
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/audioutils/lame/Makefile
+++ b/audioutils/lame/Makefile
@@ -102,6 +102,6 @@ ifneq ($(PREFIX),)
 endif
 
 distclean::
-	$(Q)cd $(DST_PATH) && make distclean
+	$(Q)if [ -d $(DST_PATH) ]; then cd $(DST_PATH) && $(MAKE) distclean; fi
 
 include $(APPDIR)/Application.mk

--- a/crypto/wolfssl/Makefile
+++ b/crypto/wolfssl/Makefile
@@ -168,7 +168,7 @@ distclean::
 	$(call DELDIR, $(WOLFSSL_UNPACKNAME))
 	$(call DELDIR, $(WOLFSSL_EXAMPLESNAME))
 else
-distclean:
+distclean::
 	$(call DELDIR, $(WOLFSSL_UNPACKNAME))
 endif
 

--- a/netutils/libshvc/Makefile
+++ b/netutils/libshvc/Makefile
@@ -82,7 +82,7 @@ ifeq ($(wildcard $(SHVDIR)/.git),)
 $(eval $(call RUN_OMK_MAKE, context, default-config include-pass))
 
 distclean::
-	make -C $(SHVDIR) distclean
+	if [ -d $(SHVDIR) ]; then make -C $(SHVDIR) distclean; fi
 	$(call DELDIR, $(SHVDIR))
 	$(call DELFILE, $(SHV_LIBS4C_TARGZ))
 endif

--- a/netutils/libulut/Makefile
+++ b/netutils/libulut/Makefile
@@ -82,7 +82,7 @@ ifeq ($(wildcard $(ULUTDIR)/.git),)
 $(eval $(call RUN_OMK_MAKE, context, default-config include-pass))
 
 distclean::
-	make -C $(ULUTDIR) distclean
+	if [ -d $(ULUTDIR) ]; then make -C $(ULUTDIR) distclean; fi
 	$(call DELDIR, $(ULUTDIR))
 	$(call DELFILE, $(ULUT_TARGZ))
 endif


### PR DESCRIPTION
## Summary

`Directory.mk`'s `distclean` only traverses `CLEANSUBDIRS` — directories with `.built`, `.depend`, or `.kconfig` markers. When a build fails before these markers are written (e.g. Python configure succeeds but compilation fails), `distclean` skips the directory entirely, leaving behind `build/`, `config.site`, and other artifacts.

Fix: use `SUBDIRS` (all directories with Makefiles) for `distclean`. It is idempotent, so calling it on un-built directories is harmless.

## Changes

| File | Change |
|------|--------|
| `Directory.mk` | distclean traverse `SUBDIRS` instead of `CLEANSUBDIRS`; inline target definitions with `TOPDIR`; `-` prefix for error resilience |
| `Application.mk` | distclean: add `$(call DELFILE, .kconfig)` |
| `audioutils/lame/Makefile` | guard `cd $(DST_PATH)` against already-deleted directory |
| `crypto/wolfssl/Makefile` | `distclean:` -> `distclean::` (conflicted with Application.mk) |

## Companion PR

Requires [nuttx#19310](https://github.com/apache/nuttx/pull/19310) which passes `TOPDIR` in `SDIR_template` / `MAKE_template`.

## Verification

The bug: when a build fails between `context::` and `depend::` phases, `.built` and `.depend` markers are never written. The old distclean uses `CLEANSUBDIRS` which requires these markers, so it skips the directory and leaves artifacts behind.

To reproduce, simulate a partial build by creating the residual files a failed Python configure would leave, **without** `.built`/`.depend` markers:

```
$ cd ~/workspace/nuttx-apps/interpreters/python
$ rm -rf build install .kconfig .built .depend
$ mkdir -p build/target/{Modules,Objects,Parser,Python}
$ touch build/target/{Makefile,pyconfig.h,config.log}
$ touch config.site Setup.local .kconfig
$ test -f .built && echo "exists" || echo "not exists"
not exists
$ test -f .depend && echo "exists" || echo "not exists"
not exists
```

Run distclean through the NuttX build system (note: `apps` is a symlink to `nuttx-apps`):

```
$ cd ~/workspace/nuttx
$ make -C apps/interpreters/python distclean TOPDIR=$(pwd) APPDIR=$(pwd)/apps V=1
make: Entering directory '/home/hanzj-mi/workspace/nuttx-apps/interpreters/python'
rm -rf  /home/hanzj-mi/workspace/nuttx-apps/interpreters/python/build
rm -rf  /home/hanzj-mi/workspace/nuttx-apps/interpreters/python/install
rm -rf  Python
rm -f  v3.13.0.zip
rm -f  romfs_cpython_modules.img
rm -f  romfs_cpython_modules.h
rm -f  config.site
rm -f  Setup.local
rm -f  .built
rm -f *.o *.a *~ .*.swp  /home/hanzj-mi/workspace/nuttx/apps/libapps.a /home/hanzj-mi/workspace/nuttx/apps/libapps.a.lock
rm -f  .kconfig
rm -f  Make.dep
rm -f  .depend
make: Leaving directory '/home/hanzj-mi/workspace/nuttx-apps/interpreters/python'
```

Verify all residuals are cleaned:

```
$ cd ~/workspace/nuttx-apps/interpreters/python
$ test ! -d build && echo "build/ cleaned" || echo "build/ still exists"
build/ cleaned
$ test ! -f config.site && echo "config.site cleaned" || echo "config.site still exists"
config.site cleaned
$ test ! -f Setup.local && echo "Setup.local cleaned" || echo "Setup.local still exists"
Setup.local cleaned
$ test ! -f .kconfig && echo ".kconfig cleaned" || echo ".kconfig still exists"
.kconfig cleaned
```

Without this patch, `make distclean` produces **no output** (CLEANSUBDIRS is empty, nothing is traversed) and all residuals remain.

Fixes #2895
