### PR TITLE
apps/nsh: Don't disable error by default

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -456,7 +456,7 @@ config NSH_DISABLE_HELP
 
 config NSH_DISABLE_ERROR_PRINT
 	bool "Disable NSH Error Printing"
-	default DEFAULT_SMALL
+	default n
 
 config NSH_DISABLE_HEXDUMP
 	bool "Disable hexdump"


### PR DESCRIPTION
## Summary

NSH error shouldn't be disabled by default, even when in SMALL Memory because it will make difficult to discover why things are not working. It should be disabled manually by experienced dev.

Cross dependency: https://github.com/apache/nuttx/pull/19318

## Impact

Disabling nsh error will mask issues, because by default Unix systems (like NuttX) doesn't print error on success, on the other hand we don't expect silence on error. And this is what happens when NSH errors are disabled. 

## Testing

stm32f103-minimum:audio_tone


