### PR TITLE
README: Fix application directory wording.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ NuttX directory. Like:
 
 If all of the above conditions are TRUE, then NuttX will be able to find the
 application directory. If your application directory has a different name or is
-location at a different position, then you will have to inform the NuttX build
+located at a different position, then you will have to inform the NuttX build
 system of that location. There are several ways to do that:
 
 1) You can define `CONFIG_APPS_DIR` to be the full path to your application
@@ -140,7 +140,7 @@ project. One must:
     main()
     ```
 
- 4. Set the requirements in the file: `Makefile`, specially the lines:
+ 4. Set the requirements in the file: `Makefile`, specifically the lines:
 
     ```makefile
     PROGNAME   = progname


### PR DESCRIPTION
## Summary

Fix two wording issues in the top-level apps README:

- `is location` -> `is located`
- `specially the lines` -> `specifically the lines`

The change is limited to README text.

## Impact

Documentation-only change. No build, runtime, API, ABI, hardware, security, or compatibility impact.

## Testing

Host: Windows 11, PowerShell.

- `git diff --check origin/master...HEAD`
- `git show --stat --check --format=fuller HEAD`
- searched the edited README to confirm the old phrases no longer remain

Not run: application build, because this change only updates README wording.