### PR TITLE
examples: nrf24l01_btle: Fix RX terminator bounds

### DIFF
--- a/examples/nrf24l01_btle/nrf24l01_btle.c
+++ b/examples/nrf24l01_btle/nrf24l01_btle.c
@@ -484,9 +484,9 @@ int nrf24_read(int wl_fd)
 {
   int ret;
   uint32_t pipeno;
-  uint8_t rbuf[32];
+  uint8_t rbuf[NRF24L01_MAX_PAYLOAD_LEN + 1];
 
-  ret = read(wl_fd, rbuf, sizeof(rbuf));
+  ret = read(wl_fd, rbuf, NRF24L01_MAX_PAYLOAD_LEN);
   if (ret < 0)
     {
       perror("Error reading packet\n");
@@ -512,7 +512,7 @@ int nrf24_read(int wl_fd)
 
 #ifdef CONFIG_DEBUG_WIRELESS
   syslog(LOG_INFO, "Message received : (on pipe %d)\n",  pipeno);
-  nrf24_dumpbuffer("Hex Dump", &rbuf[0], 32);
+  nrf24_dumpbuffer("Hex Dump", &rbuf[0], ret);
 #endif
   return 0;
 }


### PR DESCRIPTION
## Summary
- reserve one extra byte for the RX buffer terminator
- keep the nRF24L01 read length capped at `NRF24L01_MAX_PAYLOAD_LEN`
- dump only the bytes actually received in the debug path

## Why
`nrf24_read()` appends a NUL terminator after reading a packet. The local buffer was exactly 32 bytes, which is the nRF24L01 maximum payload length. A full-size payload can therefore return 32 and make `rbuf[ret] = '\0'` write one byte past the buffer.

## Testing
- `git diff --check origin/master..HEAD`
- `git show --check --stat --oneline HEAD`
- local compile/checkpatch not run: this Windows environment has no usable `gcc`/`clang`/`make` or WSL/bash shell