### PR TITLE
examples: Fix network echo receive terminators

### DIFF
--- a/examples/netloop/lo_listener.c
+++ b/examples/netloop/lo_listener.c
@@ -64,7 +64,7 @@ struct net_listener_s
   struct sockaddr_in addr;
   fd_set          master;
   fd_set          working;
-  char            buffer[IOBUFFER_SIZE];
+  char            buffer[IOBUFFER_SIZE + 1];
   int             listensd;
   int             mxsd;
 };

--- a/examples/netloop/lo_main.c
+++ b/examples/netloop/lo_main.c
@@ -63,7 +63,7 @@ static int lo_client(void)
 {
   struct sockaddr_in myaddr;
   char outbuf[IOBUFFER_SIZE];
-  char inbuf[IOBUFFER_SIZE];
+  char inbuf[IOBUFFER_SIZE + 1];
   int sockfd;
   int len;
   int nbytessent;

--- a/examples/poll/host.c
+++ b/examples/poll/host.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv, char **envp)
 {
   struct sockaddr_in myaddr;
   char outbuf[IOBUFFER_SIZE];
-  char inbuf[IOBUFFER_SIZE];
+  char inbuf[IOBUFFER_SIZE + 1];
   int sockfd;
   int len;
   int nbytessent;

--- a/examples/poll/net_listener.c
+++ b/examples/poll/net_listener.c
@@ -64,7 +64,7 @@ struct net_listener_s
   struct sockaddr_in addr;
   fd_set          master;
   fd_set          working;
-  char            buffer[IOBUFFER_SIZE];
+  char            buffer[IOBUFFER_SIZE + 1];
   int             listensd;
   int             mxsd;
 };

--- a/examples/poll/net_reader.c
+++ b/examples/poll/net_reader.c
@@ -121,7 +121,7 @@ static void net_configure(void)
 static void net_receive(int sd)
 {
   struct timeval timeout;
-  char buffer[IOBUFFER_SIZE];
+  char buffer[IOBUFFER_SIZE + 1];
   char *ptr;
   fd_set readset;
   int nbytes;


### PR DESCRIPTION
## Summary

The netloop and poll TCP echo examples receive up to `IOBUFFER_SIZE` bytes and then append a NUL terminator before logging the received data. A full-size receive can therefore write one byte past the input buffer.

Reserve one extra byte for the buffers that are terminated after `recv()`, while keeping the receive limit and echo length capped at `IOBUFFER_SIZE`.

## Validation

- `git diff --check origin/master..HEAD`
- `git show --check --stat --oneline HEAD`
- `git ls-files --eol examples/netloop/lo_main.c examples/netloop/lo_listener.c examples/poll/host.c examples/poll/net_listener.c examples/poll/net_reader.c`