### PR TITLE
testing: nettest: Fix TCP server terminator bounds

### DIFF
--- a/testing/nettest/utils/nettest_tcpserver.c
+++ b/testing/nettest/utils/nettest_tcpserver.c
@@ -47,7 +47,7 @@ struct nettest_listener_s
 {
   fd_set master;
   fd_set working;
-  char   buffer[TEST_BUFFER_SIZE];
+  char   buffer[TEST_BUFFER_SIZE + 1];
   int    listensdv4;
   int    listensdv6;
   int    mxsd;


### PR DESCRIPTION
## Summary

The TCP nettest server receives up to `TEST_BUFFER_SIZE` bytes and then appends a NUL terminator before checking for the `exit` command. A full-size receive can therefore write one byte past the receive buffer.

Reserve one extra byte for the terminator while keeping the `recv()` limit and echo length capped at `TEST_BUFFER_SIZE`.

## Validation

- `git diff --check origin/master..HEAD`
- `git show --check --stat --oneline HEAD`
- `git ls-files --eol testing/nettest/utils/nettest_tcpserver.c`