### PR TITLE
examples: fix local socket address lengths

### DIFF
--- a/examples/udgram/udgram_client.c
+++ b/examples/udgram/udgram_client.c
@@ -100,7 +100,7 @@ int main(int argc, FAR char *argv[])
       server.sun_family = AF_LOCAL;
       strlcpy(server.sun_path, CONFIG_EXAMPLES_UDGRAM_ADDR, addrlen);
 
-      addrlen += sizeof(sa_family_t) + 1;
+      addrlen += sizeof(sa_family_t);
 
       /* Send the message */
 

--- a/examples/udgram/udgram_server.c
+++ b/examples/udgram/udgram_server.c
@@ -102,7 +102,7 @@ int main(int argc, FAR char *argv[])
   server.sun_family = AF_LOCAL;
   strlcpy(server.sun_path, CONFIG_EXAMPLES_UDGRAM_ADDR, addrlen);
 
-  addrlen += sizeof(sa_family_t) + 1;
+  addrlen += sizeof(sa_family_t);
 
   if (bind(sockfd, (struct sockaddr *)&server, addrlen) < 0)
     {

--- a/examples/ustream/ustream_client.c
+++ b/examples/ustream/ustream_client.c
@@ -88,10 +88,9 @@ int main(int argc, FAR char *argv[])
 
   myaddr.sun_family = AF_LOCAL;
   strlcpy(myaddr.sun_path, CONFIG_EXAMPLES_USTREAM_ADDR, addrlen);
-  myaddr.sun_path[addrlen] = '\0';
 
   printf("client: Connecting to %s...\n", CONFIG_EXAMPLES_USTREAM_ADDR);
-  addrlen += sizeof(sa_family_t) + 1;
+  addrlen += sizeof(sa_family_t);
   ret = connect(sockfd, (struct sockaddr *)&myaddr, addrlen);
   if (ret < 0)
     {

--- a/examples/ustream/ustream_server.c
+++ b/examples/ustream/ustream_server.c
@@ -88,9 +88,8 @@ int main(int argc, char *argv[])
 
   myaddr.sun_family = AF_LOCAL;
   strlcpy(myaddr.sun_path, CONFIG_EXAMPLES_USTREAM_ADDR, addrlen);
-  myaddr.sun_path[addrlen] = '\0';
 
-  addrlen += sizeof(sa_family_t) + 1;
+  addrlen += sizeof(sa_family_t);
   ret = bind(listensd, (struct sockaddr *)&myaddr, addrlen);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
- Keep the existing compile-time `sizeof(CONFIG_EXAMPLES_*_ADDR)` path size, which already includes the terminating NUL.
- Pass that bounded path size plus `sizeof(sa_family_t)` to `bind()`, `connect()`, and `sendto()` without adding a second NUL byte.
- Remove the redundant manual terminator writes from the stream examples; `strlcpy()` already terminates the bounded destination.

## Why
The examples treated `sizeof(CONFIG_EXAMPLES_*_ADDR)` as the pathname size, including its NUL terminator, and then added another byte to the socket address length. At the maximum pathname size, the supplied length could exceed `struct sockaddr_un` by one byte.

The stream examples also wrote `sun_path[addrlen] = '\0'` after clamping `addrlen` to `UNIX_PATH_MAX`, which could write one byte past `sun_path`.

## Testing
- Checked short, exact-capacity, and overlong configured paths: the bounded copy remains NUL-terminated and the resulting address length does not exceed `sizeof(struct sockaddr_un)`.
- `git diff origin/master...HEAD --check`
- Confirmed all four rebased source blobs and the stable patch-id exactly match the previous implementation.
- Rebased current head `4ed4f10e` directly onto master `62b7e955`.

## CI notes
- The previous `Linux (sim-02)` failure was in unrelated `sim/login`: `CONFIG_BOARD_ETC_ROMFS_PASSWD_PASSWORD is not set`.
- Current master contains `1d15c81f` (`ci: supply sim/login ROMFS passwd credential in build jobs`), which directly fixes that base CI configuration.
- `Linux (sim-02)` and all other runnable matrix jobs pass on current head `4ed4f10e`; macOS was skipped by workflow selection.