### PR TITLE
examples: xmlrpc: bound header value copy

### DIFF
--- a/examples/xmlrpc/xmlrpc_main.c
+++ b/examples/xmlrpc/xmlrpc_main.c
@@ -134,6 +134,11 @@ static int xmlrpc_getheader(FAR char *buffer, FAR char *header,
   FAR char *temp;
   int i = 0;
 
+  if (size <= 0)
+    {
+      return -1;
+    }
+
   temp = strstr(buffer, header);
   if (temp)
     {
@@ -150,7 +155,7 @@ static int xmlrpc_getheader(FAR char *buffer, FAR char *header,
 
       /* Copy the rest to the value parameter */
 
-      while ((*temp != ' ') && (*temp != '\n') && (i < size))
+      while ((*temp != ' ') && (*temp != '\n') && (i < size - 1))
         {
           value[i++] = *temp++;
         }
@@ -213,7 +218,7 @@ static void xmlrpc_handler(int fd)
                   buffer[max] = 0;
 
                   ret = xmlrpc_getheader(buffer, "Content-Length:", value,
-                                         CONFIG_EXAMPLES_XMLRPC_BUFFERSIZE);
+                                         sizeof(value));
                   if (ret > 0)
                     loadlen = atoi(value);
                 }


### PR DESCRIPTION
## Summary
- make `xmlrpc_getheader()` treat its size argument as the destination capacity
- reserve one byte for the terminating NUL while copying the header value
- pass `sizeof(value)` from `xmlrpc_handler()` instead of the HTTP request buffer size

## Why
`xmlrpc_handler()` stores `Content-Length` in `value`, which is sized as `CONFIG_XMLRPC_STRINGSIZE + 1`. The previous call passed `CONFIG_EXAMPLES_XMLRPC_BUFFERSIZE` to `xmlrpc_getheader()`; with the defaults, that permits copying up to 1024 bytes into a 65 byte destination.

The helper also wrote the terminator after allowing `i == size`, so the capacity contract should reserve space for the NUL byte.

## Testing
- `git diff --check HEAD~1..HEAD`
- `git show --stat --check --format=fuller HEAD`
- Not run: local NuttX apps build, because this Windows workstation does not have `gcc`, `clang`, or `cc` installed.