### PR TITLE
examples: nrf24l01_term: reserve RX terminator

### DIFF
--- a/examples/nrf24l01_term/nrf24l01_term.c
+++ b/examples/nrf24l01_term/nrf24l01_term.c
@@ -221,7 +221,7 @@ int read_pkt(int wl_fd)
   int ret;
   uint32_t pipeno;
 
-  ret = read(wl_fd, buff, sizeof(buff));
+  ret = read(wl_fd, buff, sizeof(buff) - 1);
   if (ret < 0)
     {
       perror("Error reading packet\n");


### PR DESCRIPTION
## Summary
- Limit nrf24l01_term RX reads to `sizeof(buff) - 1`.
- Keep the trailing byte available for the `buff[ret] = '\0'` terminator.

## Root cause
`buff` is declared as `NRF24L01_MAX_PAYLOAD_LEN + 1`, but `read_pkt()` requested `sizeof(buff)` bytes before appending a NUL terminator. A full-length read could write the terminator one byte past `buff`.

## Testing
- `git diff --check`
- `git show --stat --check --format=fuller HEAD`

Not run: local compile, because this environment does not have `make`, `cmake`, `gcc`, `clang`, or `cc` available.