### PR TITLE
system: resmonitor: check CPU load reads

### DIFF
--- a/system/resmonitor/fillcpu.c
+++ b/system/resmonitor/fillcpu.c
@@ -97,8 +97,11 @@ static float get_cpu(int pid)
     }
 
   char buf[8];
-  fgets(buf, 8, fp);
-  sscanf(buf, "%f", &cpu);
+  if (fgets(buf, 8, fp) != NULL)
+    {
+      sscanf(buf, "%f", &cpu);
+    }
+
   fclose(fp);
   return cpu;
 }

--- a/system/resmonitor/showinfo.c
+++ b/system/resmonitor/showinfo.c
@@ -131,11 +131,16 @@ static void get_cpu(int pid, char *buf)
       return;
     }
 
-  fgets(buf, 8, fp);
+  if (fgets(buf, 8, fp) == NULL)
+    {
+      snprintf(buf, 8, "%.1f%%", 0.0);
+      fclose(fp);
+      return;
+    }
 
   /* sscanf(buf, "%f", &cpu); */
 
-  buf[strlen(buf) - 1] = '\0';
+  buf[strcspn(buf, "\n")] = '\0';
   fclose(fp);
 }
 


### PR DESCRIPTION
## Summary
- keep the default zero CPU value when resmonitor CPU load reads fail
- trim only the newline returned by showinfo CPU load reads
- avoid parsing uninitialized fillcpu stack data when fgets returns no data

## Testing
- git diff --check
- git show --stat --check --format=fuller HEAD