### PR TITLE
system: fastboot: bound filedump path parsing

### DIFF
--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -871,6 +871,7 @@ static void fastboot_filedump(FAR struct fastboot_ctx_s *ctx,
                               FAR const char *arg)
 {
   struct stat sb;
+  size_t len;
   int ret;
 
   if (!arg)
@@ -879,14 +880,30 @@ static void fastboot_filedump(FAR struct fastboot_ctx_s *ctx,
       return;
     }
 
-  ret = sscanf(arg, "%s %" PRIdOFF " %zu", ctx->upload_param.u.file.path,
-               &ctx->upload_param.u.file.offset, &ctx->upload_param.size);
-  if (ret != 1 && ret != 3)
+  arg += strspn(arg, " \t\r\n");
+  len = strcspn(arg, " \t\r\n");
+  if (len == 0)
     {
       fastboot_fail(ctx, "Failed to parse arguments");
       return;
     }
-  else if (ret == 1)
+
+  if (len >= sizeof(ctx->upload_param.u.file.path))
+    {
+      len = sizeof(ctx->upload_param.u.file.path) - 1;
+    }
+
+  memcpy(ctx->upload_param.u.file.path, arg, len);
+  ctx->upload_param.u.file.path[len] = '\0';
+
+  ret = sscanf(arg + len, "%" PRIdOFF " %zu",
+               &ctx->upload_param.u.file.offset, &ctx->upload_param.size);
+  if (ret != EOF && ret != 0 && ret != 2)
+    {
+      fastboot_fail(ctx, "Failed to parse arguments");
+      return;
+    }
+  else if (ret != 2)
     {
       ret = stat(ctx->upload_param.u.file.path, &sb);
       if (ret < 0)


### PR DESCRIPTION
## Summary
- Tokenize the `fastboot filedump` path argument into the existing `PATH_MAX` upload path buffer before parsing optional offset and size values.
- Preserve the existing accepted filedump argument forms: `path` and `path offset size`.
- Keep the optional offset and size parsing behavior unchanged.

## Testing
- `git diff upstream/master...HEAD --check`
- Confirmed the rebased `system/fastboot/fastboot.c` blob and stable patch-id exactly match the previously approved implementation.
- Rebased current head `c47b230e` directly onto master `62b7e955`.

## CI notes
- The previous `Linux (sim-02)` failure was in unrelated `sim/login`: `CONFIG_BOARD_ETC_ROMFS_PASSWD_PASSWORD is not set`.
- Current master contains `1d15c81f` (`ci: supply sim/login ROMFS passwd credential in build jobs`), which directly fixes that base CI configuration.
- `Linux (sim-02)` and all other runnable matrix jobs pass on current head `c47b230e`; macOS was skipped by workflow selection.