### PR TITLE
system: audio: bound command filenames

### DIFF
--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -317,10 +317,21 @@ static int nxplayer_cmd_playraw(FAR struct nxplayer_s *pplayer, char *parg)
   int bpsamp = 0;
   int samprate = 0;
   int chmap = 0;
-  char filename[128];
+  size_t len;
+  char filename[PATH_MAX];
 
-  sscanf(parg, "%s %d %d %d %d", filename, &channels, &bpsamp,
-                                 &samprate, &chmap);
+  parg += strspn(parg, " \t\r\n");
+  len = strcspn(parg, " \t\r\n");
+  if (len >= sizeof(filename))
+    {
+      len = sizeof(filename) - 1;
+    }
+
+  memcpy(filename, parg, len);
+  filename[len] = '\0';
+
+  sscanf(parg + len, "%d %d %d %d", &channels, &bpsamp,
+         &samprate, &chmap);
 
   /* Try to play the file specified */
 

--- a/system/nxrecorder/nxrecorder_main.c
+++ b/system/nxrecorder/nxrecorder_main.c
@@ -190,10 +190,21 @@ static int nxrecorder_cmd_recordraw(FAR struct nxrecorder_s *precorder,
   int bpsamp = 0;
   int samprate = 0;
   int chmap = 0;
-  char filename[128];
+  size_t len;
+  char filename[PATH_MAX];
 
-  sscanf(parg, "%s %d %d %d %d", filename, &channels, &bpsamp,
-                                 &samprate, &chmap);
+  parg += strspn(parg, " \t\r\n");
+  len = strcspn(parg, " \t\r\n");
+  if (len >= sizeof(filename))
+    {
+      len = sizeof(filename) - 1;
+    }
+
+  memcpy(filename, parg, len);
+  filename[len] = '\0';
+
+  sscanf(parg + len, "%d %d %d %d", &channels, &bpsamp,
+         &samprate, &chmap);
 
   /* Try to record the file specified */
 
@@ -259,10 +270,21 @@ static int nxrecorder_cmd_record(FAR struct nxrecorder_s *precorder,
   int bpsamp = 0;
   int samprate = 0;
   int chmap = 0;
-  char filename[128];
+  size_t len;
+  char filename[PATH_MAX];
 
-  sscanf(parg, "%s %d %d %d %d", filename, &channels, &bpsamp,
-                                 &samprate, &chmap);
+  parg += strspn(parg, " \t\r\n");
+  len = strcspn(parg, " \t\r\n");
+  if (len >= sizeof(filename))
+    {
+      len = sizeof(filename) - 1;
+    }
+
+  memcpy(filename, parg, len);
+  filename[len] = '\0';
+
+  sscanf(parg + len, "%d %d %d %d", &channels, &bpsamp,
+         &samprate, &chmap);
 
   /* Try to record the file specified */
 


### PR DESCRIPTION
## Summary
- Tokenize the nxplayer `playraw` filename argument into a `PATH_MAX` buffer before parsing optional raw audio parameters.
- Tokenize the nxrecorder `recordraw` and `record` filename arguments into `PATH_MAX` buffers before parsing optional raw audio parameters.
- Preserve the existing optional raw audio parameter parsing behavior.

## Testing
- `git diff --check`
- `git show --stat --check --format=fuller HEAD`
- GitHub Actions `check`, `Lint`, `Fetch-Source`, and `labeler` passed after the latest update.

## CI notes
- Current `Linux (sim-02)` failure is in NuttX `sim/login`: `CONFIG_BOARD_ETC_ROMFS_PASSWD_PASSWORD is not set`. That configuration is outside this PR's `nxplayer` / `nxrecorder` parsing diff; later matrix jobs were cancelled after that failure.
- Thread-aware review collection shows no active unresolved review threads after the `PATH_MAX` tokenization update, although GitHub can continue to show the prior changes-requested decision until reviewer state refreshes.