### PR TITLE
system: nxinit: bound debug argv dump

### DIFF
--- a/system/nxinit/service.c
+++ b/system/nxinit/service.c
@@ -677,7 +677,7 @@ void init_dump_service(FAR struct service_s *s)
 
   init_debug("  pid: %d", s->pid);
   init_debug("  arguments:");
-  for (i = 0; s->argv[i] && i < nitems(s->argv); i++)
+  for (i = 0; i < nitems(s->argv) && s->argv[i]; i++)
     {
       init_debug("      [%d] '%s'", i, s->argv[i]);
     }


### PR DESCRIPTION
## Summary
- check the service argv bound before reading the current debug-dump entry
- keep the existing NULL-terminated dump behavior once the index is in range

## Root cause
`init_dump_service()` evaluated `s->argv[i]` before checking `i < nitems(s->argv)`. Service argument arrays are zero-initialized, but a full parsed argument list can fill the array without an in-array NULL terminator. With `CONFIG_SYSTEM_NXINIT_DEBUG` enabled, the dump loop could then read one entry past the array.

## Testing
- `git diff --check`
- `git show --stat --check --format=fuller HEAD`

Build not run locally because this Windows machine does not have `make`, `cmake`, `gcc`, `clang`, or `cc` installed.