### PR TITLE
{bp-3589} apps/nsh: Don't disable error by default

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -456,7 +456,7 @@ config NSH_DISABLE_HELP
 
 config NSH_DISABLE_ERROR_PRINT
 	bool "Disable NSH Error Printing"
-	default DEFAULT_SMALL
+	default n
 
 config NSH_DISABLE_HEXDUMP
 	bool "Disable hexdump"


### PR DESCRIPTION
## Summary

NSH error shouldn't be disabled by default, even when in SMALL Memory because it will make difficult to discover why things are not working. It should be disabled manually by experienced dev.

## Impact

RELEASE

## Testing

CI