### PR TITLE
system/ping: Fix a segmentation fault when using ping

### DIFF
--- a/system/ping/ping.c
+++ b/system/ping/ping.c
@@ -345,6 +345,8 @@ int main(int argc, FAR char *argv[])
   int exitcode;
   int option;
 
+  memset(&info, 0, sizeof(info));
+
   info.count     = ICMP_NPINGS;
   info.datalen   = ICMP_PING_DATALEN;
   info.delay     = ICMP_POLL_DELAY;

--- a/system/ping6/ping6.c
+++ b/system/ping6/ping6.c
@@ -286,6 +286,8 @@ int main(int argc, FAR char *argv[])
   int exitcode;
   int option;
 
+  memset(&info, 0, sizeof(info));
+
   info.count     = ICMPv6_NPINGS;
   info.datalen   = ICMPv6_PING6_DATALEN;
   info.delay     = ICMPv6_POLL_DELAY;


### PR DESCRIPTION
## Summary

nsh> ping google.com
[   37.180000] dns_query_error: ERROR: IPv4 dns_recv_response fa: -84,
               server address: 8.8.8.8
Segmentation fault.

## Impact

BUG Fix!

## Testing

```
$ sudo ./nuttx 
[sudo] password for alan: 

NuttShell (NSH) NuttX-13.0.0-RC2
nsh> ifup eth0
ifup eth0...OK
nsh> ping google.com
PING 172.217.29.78 56 bytes of data
56 bytes from 172.217.29.78: icmp_seq=0 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=1 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=2 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=3 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=4 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=5 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=6 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=7 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=8 time=20.0 ms
56 bytes from 172.217.29.78: icmp_seq=9 time=20.0 ms
10 packets transmitted, 10 received, 0% packet loss, time 10100 ms
rtt min/avg/max/mdev = 20.000/20.000/20.000/0.000 ms
nsh> 
```
