### PR TITLE
examples: Implement drivers for microwindows

### DIFF
--- a/examples/microwindows/Kconfig
+++ b/examples/microwindows/Kconfig
@@ -1,0 +1,26 @@
+config EXAMPLES_MICROWINDOWS
+	tristate "Microwindows example"
+	default n
+	depends on GRAPHICS_MICROWINDOWS
+	depends on MICROWINDOWS_MWIN
+	---help---
+		Enable the Microwindows example application
+
+if EXAMPLES_MICROWINDOWS
+
+config EXAMPLES_MICROWINDOWS_PROGNAME
+	string "Program name"
+	default "mwexample"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_MICROWINDOWS_PRIORITY
+	int "Microwindows task priority"
+	default 100
+
+config EXAMPLES_MICROWINDOWS_STACKSIZE
+	int "Microwindows stack size"
+	default 32768
+
+endif

--- a/examples/microwindows/Make.defs
+++ b/examples/microwindows/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/microwindows/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_MICROWINDOWS),)
+CONFIGURED_APPS += $(APPDIR)/examples/microwindows
+endif

--- a/examples/microwindows/Makefile
+++ b/examples/microwindows/Makefile
@@ -1,0 +1,55 @@
+############################################################################
+# apps/examples/microwindows/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_MICROWINDOWS_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_MICROWINDOWS_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_MICROWINDOWS_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_MICROWINDOWS)
+
+MAINSRC = mwdemo_main.c
+CSRCS += mwdemo.c
+MW_IMAGES = penguin microwin
+CSRCS += $(MW_IMAGES:%=$(MW_IMGDIR)/%.c)
+
+# Generate image .c files from .bmp
+MW_SRC = $(APPDIR)/graphics/microwindows/microwindows/src
+MW_IMGDIR = images
+MW_CONVBMP = convbmp$(HOSTEXEEXT)
+
+$(MW_CONVBMP): $(MW_SRC)/images/tools/convbmp.c
+	$(HOSTCC) $(HOSTCFLAGS) -I$(MW_SRC)/include $< -o $@
+
+$(MW_IMGDIR)/%.c: $(MW_SRC)/images/demos/mwin/%.bmp $(MW_CONVBMP)
+	mkdir -p $(MW_IMGDIR)
+	$(CURDIR)/$(MW_CONVBMP) -o $@ $<
+
+clean::
+	$(call DELFILE, $(MW_IMAGES:%=$(MW_IMGDIR)/%.c))
+	$(Q) rmdir $(MW_IMGDIR) 2>/dev/null || true
+	$(call DELFILE, $(MW_CONVBMP))
+
+CFLAGS += -Wno-undef 
+CFLAGS += -DNOGDI
+
+include $(APPDIR)/Application.mk

--- a/examples/microwindows/mwdemo.c
+++ b/examples/microwindows/mwdemo.c
@@ -1,0 +1,333 @@
+/****************************************************************************
+ * apps/examples/microwindows/mwdemo.c
+ *
+ * Copyright (c) 1999, 2000, 2001, 2010 Greg Haerr <greg@censoft.com>
+ * Portions Copyright (c) 2002 by Koninklijke Philips Electronics N.V.
+ *
+ * Demo program for Microwindows
+ *
+ *  GB: 10-14-2004: Modified to store degrees data on each window,
+ *                  for new Timers features.
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <uni_std.h>
+#define MWINCLUDECOLORS
+#include <windows.h>
+#include <device.h>
+#include <graph3d.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef struct
+{
+  int startdegrees;
+  int enddegrees;
+} demoWndData;
+
+typedef demoWndData *pdemoWndData;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+extern MWIMAGEHDR image_penguin;
+PMWIMAGEHDR g_image = &image_penguin;
+
+#define APPCLASS    "test"
+#define APPCHILD    "test2"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wp, LPARAM lp);
+
+LRESULT CALLBACK ChildWndProc(HWND hwnd, UINT uMsg, WPARAM wp, LPARAM lp);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+int MwUserInit(int ac, char **av)
+{
+  /* test user init procedure - do nothing */
+
+  return 0;
+}
+
+int RegisterAppClass(HINSTANCE hInstance)
+{
+  WNDCLASS wc;
+
+  /* register builtin controls and dialog classes */
+
+  MwInitializeDialogs(hInstance);
+
+  wc.style = CS_DBLCLKS | CS_VREDRAW | CS_HREDRAW;
+  wc.lpfnWndProc = (WNDPROC) WndProc;
+  wc.cbClsExtra = 0;
+  wc.cbWndExtra = sizeof(LONG_PTR);
+  wc.hInstance = 0;
+  wc.hIcon = 0;                 /* LoadIcon(GetHInstance(), MAKEINTRESOURCE(
+                                 * 1)); */
+  wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+  wc.hbrBackground = (HBRUSH) GetStockObject(LTGRAY_BRUSH);
+  wc.lpszMenuName = NULL;
+  wc.lpszClassName = APPCLASS;
+  RegisterClass(&wc);
+
+  wc.lpfnWndProc = (WNDPROC) ChildWndProc;
+  wc.lpszClassName = APPCHILD;
+  return RegisterClass(&wc);
+}
+
+HWND CreateAppWindow(void)
+{
+  HWND hwnd;
+  static int nextid = 1;
+  int width;
+  int height;
+  RECT r;
+  GetWindowRect(GetDesktopWindow(), &r);
+  width = height = r.right / 2;
+
+  hwnd = CreateWindowEx(0L, APPCLASS,
+                        "Microwindows Application",
+                        WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                        CW_USEDEFAULT, CW_USEDEFAULT,
+                        width, height,
+                        NULL, (HMENU)(LONG_PTR)nextid++, NULL, NULL);
+
+  if (hwnd && (nextid & 03) != 2)
+    {
+      CreateWindowEx(0L, APPCHILD,
+                     "",
+                     WS_BORDER | WS_CHILD | WS_VISIBLE,
+                     4, 4, width / 3 - 6, height / 3,
+                     hwnd, (HMENU)2, NULL, NULL);
+      CreateWindowEx(0L, APPCHILD,
+                     "",
+                     WS_BORDER | WS_CHILD | WS_VISIBLE,
+                     width / 3, height / 3,
+                     width / 3 - 6, height / 3,
+                     hwnd, (HMENU)3, NULL, NULL);
+      CreateWindowEx(0L, APPCHILD,
+                     "",
+                     WS_BORDER | WS_CHILD | WS_VISIBLE,
+                     width * 3 / 5, height * 3 / 5,
+                     width * 2 / 3, height * 2 / 3,
+                     hwnd, (HMENU)4, NULL, NULL);
+      CreateWindowEx(0L, "EDIT",
+                     "OK",
+                     WS_BORDER | WS_CHILD | WS_VISIBLE,
+                     width * 5 / 8, 10,
+                     100, 18,
+                     hwnd, (HMENU)5, NULL, NULL);
+      CreateWindowEx(0L, "PROGBAR",
+                     "OK",
+                     WS_BORDER | WS_CHILD | WS_VISIBLE,
+                     width * 5 / 8, 32,
+                     100, 18,
+                     hwnd, (HMENU)6, NULL, NULL);
+
+      HWND hlist = CreateWindowEx(0L, "LISTBOX",
+                                  "OK",
+                                  WS_HSCROLL | WS_VSCROLL |
+                                  WS_BORDER | WS_CHILD |
+                                  WS_VISIBLE,
+                                  width * 5 / 8, 54,
+                                  100, 48,
+                                  hwnd, (HMENU)7, NULL, NULL);
+      SendMessage(hlist, LB_ADDSTRING, 0,
+                  (LPARAM)(LPSTR)"Cherry");
+      SendMessage(hlist, LB_ADDSTRING, 0,
+                  (LPARAM)(LPSTR)"Apple");
+      SendMessage(hlist, LB_ADDSTRING, 0,
+                  (LPARAM)(LPSTR)"Orange");
+
+      CreateWindowEx(0L, "BUTTON",
+                     "Cancel",
+                     BS_AUTOCHECKBOX | WS_CHILD | WS_VISIBLE,
+                     width * 5 / 8 + 50, 106,
+                     50, 14,
+                     hwnd, (HMENU)8, NULL, NULL);
+    }
+
+  return hwnd;
+}
+
+LRESULT CALLBACK ChildWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+  RECT rc;
+  PAINTSTRUCT ps;
+
+  switch (msg)
+    {
+    case WM_PAINT:
+      BeginPaint(hwnd, &ps);
+      GetClientRect(hwnd, &rc);
+
+      HDC hdcMem;
+      HBITMAP hbmp, hbmpOrg;
+
+      /* redirect painting to offscreen dc, then use blit function */
+
+      hdcMem = CreateCompatibleDC(ps.hdc);
+
+      /* Note: rc.right, rc.bottom happens to be smaller than image
+       * width/height.  We use the image size, so we can stretchblit
+       * from the whole image.
+       */
+
+      hbmp = CreateCompatibleBitmap(hdcMem, g_image->width,
+                                    g_image->height);
+      hbmpOrg = SelectObject(hdcMem, hbmp);
+
+      /* draw onto offscreen dc */
+
+      DrawDIB(hdcMem, 0, 0, g_image);
+
+      /* blit offscreen with physical screen */
+
+      StretchBlt(ps.hdc, 0, 0, rc.right * 4 / 5,
+                 rc.bottom * 4 / 5, hdcMem,
+                 0, 0, g_image->width, g_image->height, MWROP_COPY);
+      DeleteObject(SelectObject(hdcMem, hbmpOrg));
+      DeleteDC(hdcMem);
+      EndPaint(hwnd, &ps);
+      break;
+    default:
+      return DefWindowProc(hwnd, msg, wp, lp);
+    }
+
+  return 0;
+}
+
+LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+  PAINTSTRUCT ps;
+  HDC hdc;
+  RECT rc;
+  static int countup = 1;
+  int id;
+  static vec1 gx;
+  static vec1 gy;
+  static POINT mousept;
+  pdemoWndData pData;
+
+  switch (msg)
+    {
+    case WM_CREATE:
+      pData = (pdemoWndData) malloc(sizeof(demoWndData));
+      SetWindowLongPtr(hwnd, 0, (LONG_PTR) pData);
+      mousept.x = 60;
+      mousept.y = 20;
+      pData->startdegrees = 0;
+      pData->enddegrees = 30;
+      SetTimer(hwnd, 1, (50 + random() % 250), NULL);
+      break;
+
+    case WM_TIMER:
+      pData = (pdemoWndData)(LONG_PTR)GetWindowLongPtr(hwnd, 0);
+      GetClientRect(hwnd, &rc);
+      if (countup)
+        {
+          mousept.y += 20;
+          if (mousept.y >= rc.bottom)
+            {
+              mousept.y -= 20;
+              countup = 0;
+            }
+        }
+      else
+        {
+          mousept.y -= 20;
+          if (mousept.y < 20)
+            {
+              mousept.y += 20;
+              countup = 1;
+            }
+        }
+
+      SendMessage(hwnd, WM_MOUSEMOVE, 0,
+                  MAKELONG(mousept.x, mousept.y));
+      break;
+    case WM_DESTROY:
+      KillTimer(hwnd, 1);
+      pData = (pdemoWndData)(LONG_PTR)GetWindowLongPtr(hwnd, 0);
+      free(pData);
+      SetWindowLongPtr(hwnd, 0, (LONG_PTR)0);
+      break;
+    case WM_SIZE:
+      break;
+    case WM_MOVE:
+      break;
+
+    case WM_ERASEBKGND:
+      if ((GetWindowLong(hwnd, GWL_ID) & 03) == 1)
+        {
+          return 1;
+        }
+
+      return DefWindowProc(hwnd, msg, wp, lp);
+    case WM_PAINT:
+      hdc = BeginPaint(hwnd, &ps);
+      id = (int)GetWindowLong(hwnd, GWL_ID) & 03;
+      init3(hdc, id == 1 ? hwnd : NULL);
+      switch (id)
+        {
+        case 0:
+          rose(1.0, 7, 13);
+          break;
+        case 1:
+          look3(-2 * gx, -2 * gy, 1.2);
+          drawgrid(-8.0, 8.0, 10, -8.0, 8.0, 10);
+          break;
+        case 2:
+          setcolor3(BLACK);
+          circle3(1.0);
+          break;
+        case 3:
+          setcolor3(BLUE);
+          daisy(1.0, 20);
+          break;
+        }
+
+      paint3(hdc);
+      EndPaint(hwnd, &ps);
+      break;
+
+    case WM_MOUSEMOVE:
+      pData = (pdemoWndData)(LONG_PTR)GetWindowLongPtr(hwnd, 0);
+      if ((GetWindowLong(hwnd, GWL_ID) & 03) == 1)
+        {
+          POINT pt;
+
+          POINTSTOPOINT(pt, lp);
+          GetClientRect(hwnd, &rc);
+          gx = (vec1) pt.x / rc.right;
+          gy = (vec1) pt.y / rc.bottom;
+          InvalidateRect(hwnd, NULL, FALSE);
+          mousept.x = pt.x;
+          mousept.y = pt.y;
+        }
+      break;
+    case WM_LBUTTONDOWN:
+      break;
+    case WM_LBUTTONUP:
+      break;
+    case WM_RBUTTONDOWN:
+      break;
+    default:
+      return DefWindowProc(hwnd, msg, wp, lp);
+    }
+
+  return 0;
+}

--- a/examples/microwindows/mwdemo_main.c
+++ b/examples/microwindows/mwdemo_main.c
@@ -1,0 +1,101 @@
+/****************************************************************************
+ * apps/examples/microwindows/mwdemo_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <time.h>
+#include <stdlib.h>
+#include <uni_std.h>
+#include <windows.h>
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+extern MWIMAGEHDR image_microwin;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+extern int RegisterAppClass(HINSTANCE hInstance);
+extern HWND CreateAppWindow(void);
+
+#define APPCLASS    "test"
+#define APPCHILD    "test2"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  MSG msg;
+  HWND hwnd;
+  RECT rc;
+
+  invoke_WinMain_Start(argc, argv);
+
+  srandom(time(NULL));
+  RegisterAppClass(0);
+  GetWindowRect(GetDesktopWindow(), &rc);
+
+  /* create penguin window */
+
+  CreateWindowEx(0L, APPCHILD, "",
+                 WS_BORDER | WS_VISIBLE,
+                 rc.right - 130 - 1, rc.bottom - 153 - 1,
+                 130, 153,
+                 GetDesktopWindow(), (HMENU)1000, NULL, NULL);
+
+  CreateAppWindow();
+  CreateAppWindow();
+  CreateAppWindow();
+  CreateAppWindow();
+  CreateAppWindow();
+  CreateAppWindow();
+  CreateAppWindow();
+  CreateAppWindow();
+
+  /* set background wallpaper */
+
+  MwSetDesktopWallpaper(&image_microwin);
+  hwnd = CreateAppWindow();
+  GetWindowRect(hwnd, &rc);
+  OffsetRect(&rc, 50, 50);
+  MoveWindow(hwnd, rc.left, rc.top,
+             rc.bottom - rc.top,
+             rc.right - rc.left, TRUE);
+
+  while (GetMessage(&msg, NULL, 0, 0))
+    {
+      TranslateMessage(&msg);
+      DispatchMessage(&msg);
+    }
+
+  invoke_WinMain_End();
+
+  return 0;
+}

--- a/graphics/microwindows/.gitignore
+++ b/graphics/microwindows/.gitignore
@@ -1,0 +1,2 @@
+/microwindows
+/*.zip

--- a/graphics/microwindows/Kconfig
+++ b/graphics/microwindows/Kconfig
@@ -1,0 +1,131 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig GRAPHICS_MICROWINDOWS
+	bool "Microwindows or the Nano-X Window System"
+	default n
+	depends on VIDEO_FB
+	---help---
+		Enable Microwindows or the Nano-X Window System
+
+if GRAPHICS_MICROWINDOWS
+
+config MICROWINDOWS_FB_PATH
+	string "Framebuffer device path"
+	default "/dev/fb0"
+	---help---
+		Path to the NuttX framebuffer device.
+
+choice
+	prompt "Keyboard driver"
+	default MICROWINDOWS_KBD_EVENT
+	---help---
+		Select the keyboard input driver for Microwindows.
+
+config MICROWINDOWS_KBD_EVENT
+	bool "Event-mode keyboard driver"
+	---help---
+		Reads keyboard_event_s events from a NuttX keyboard device
+		(e.g., /dev/kbd).  Supports key press/release tracking and
+		modifier keys (Shift, Ctrl, Alt).
+
+config MICROWINDOWS_KBD_RAW
+	bool "Raw-mode keyboard driver"
+	depends on LIBC_KBDCODEC
+	---help---
+		Reads raw byte stream from a character device (e.g., /dev/kbda)
+		and decodes escape sequences via the kbd_codec library.  Suitable
+		for USB HID keyboards on QEMU.
+
+config MICROWINDOWS_KBD_NONE
+	bool "No keyboard driver"
+	---help---
+		No keyboard driver is compiled.  Microwindows will use a null
+		keyboard driver that never produces input.  Suitable for
+		display-only applications.
+
+config MICROWINDOWS_KBD_CUSTOM
+	bool "Custom keyboard driver"
+	---help---
+		No built-in keyboard driver is compiled.  The application or BSP
+		must provide its own kbddev symbol and KBDDEVICE implementation,
+		and add the source file to the build (e.g., via CSRCS in its
+		Makefile).  See the Microwindows documentation for details.
+
+endchoice
+
+config MICROWINDOWS_KBD_EVENT_PATH
+	string "Event keyboard device path"
+	default "/dev/kbd"
+	depends on MICROWINDOWS_KBD_EVENT
+	---help---
+		Device path for the event-mode keyboard driver.
+
+config MICROWINDOWS_KBD_RAW_PATH
+	string "Raw keyboard device path"
+	default "/dev/kbda"
+	depends on MICROWINDOWS_KBD_RAW
+	---help---
+		Device path for the raw-mode keyboard driver.
+
+choice
+	prompt "Mouse/touchscreen driver"
+	default MICROWINDOWS_MOUSE_RELATIVE
+	---help---
+		Select the pointing device driver for Microwindows.
+
+config MICROWINDOWS_MOUSE_RELATIVE
+	bool "Relative mouse driver"
+	---help---
+		Reads mouse_report_s events from a NuttX mouse device
+		(e.g., /dev/mouse0).  Supports three buttons and scroll wheel.
+
+config MICROWINDOWS_MOUSE_TS
+	bool "Touchscreen driver"
+	---help---
+		Reads touch_sample_s events from a NuttX touchscreen device
+		(e.g., /dev/input0).  Supports absolute positioning.
+
+config MICROWINDOWS_MOUSE_NONE
+	bool "No mouse/touchscreen driver"
+	---help---
+		No pointing device driver is compiled.  Microwindows will use a
+		null mouse driver that never produces input and hides the cursor.
+		Suitable for display-only applications.
+
+config MICROWINDOWS_MOUSE_CUSTOM
+	bool "Custom mouse/touchscreen driver"
+	---help---
+		No built-in pointing device driver is compiled.  The application
+		or BSP must provide its own mousedev symbol and MOUSEDEVICE
+		implementation, and add the source file to the build (e.g., via
+		CSRCS in its Makefile).  See the Microwindows documentation for
+		details.
+
+endchoice
+
+config MICROWINDOWS_MOUSE_PATH
+	string "Mouse device path"
+	default "/dev/mouse0"
+	depends on MICROWINDOWS_MOUSE_RELATIVE
+	---help---
+		Device path for the relative mouse driver.
+
+config MICROWINDOWS_TS_PATH
+	string "Touchscreen device path"
+	default "/dev/input0"
+	depends on MICROWINDOWS_MOUSE_TS
+	---help---
+		Device path for the touchscreen driver.
+
+config MICROWINDOWS_MWIN
+	bool "Win32 API (mwin) support"
+	default n
+	---help---
+		Build the Microwindows Win32 (mwin) API library.  This provides
+		a high-level windowing API similar to the Microsoft Windows API
+		with window management, controls, and standard dialogs.
+
+endif # GRAPHICS_MICROWINDOWS

--- a/graphics/microwindows/Make.defs
+++ b/graphics/microwindows/Make.defs
@@ -1,0 +1,33 @@
+############################################################################
+# apps/graphics/microwindows/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_GRAPHICS_MICROWINDOWS),)
+CONFIGURED_APPS += $(APPDIR)/graphics/microwindows
+
+# It allows `microwindows/src/include` import.
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/graphics/microwindows/microwindows/src/include
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/graphics/microwindows/microwindows/src/include
+
+CFLAGS += -DMWCONFIG_FILE='"mwconfig.nuttx"'
+
+endif

--- a/graphics/microwindows/Makefile
+++ b/graphics/microwindows/Makefile
@@ -1,0 +1,154 @@
+############################################################################
+# apps/graphics/microwindows/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Microwindows graphic library
+
+MICROWINDOWS_DIR = .
+MICROWINDOWS_DIR_NAME = microwindows
+
+# Set up build configuration and environment
+
+WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
+
+MICROWINDOWS_COMMIT_HASH := 1f269127b991d01dea5784eacee321a23e34d3d5
+
+CONFIG_GRAPH_MICROWINDOWS_URL ?= https://codeload.github.com/ghaerr/microwindows/zip/$(MICROWINDOWS_COMMIT_HASH)
+
+MICROWINDOWS_TARBALL := microwindows-$(MICROWINDOWS_COMMIT_HASH).zip
+
+MICROWINDOWS_UNPACKNAME = microwindows
+UNPACK ?= unzip -o $(if $(V),,-q)
+CURL ?= curl -L $(if $(V),,-Ss)
+
+MICROWINDOWS_UNPACKDIR =  $(WD)/$(MICROWINDOWS_UNPACKNAME)
+
+$(MICROWINDOWS_TARBALL):
+	$(ECHO_BEGIN)"Downloading: $(MICROWINDOWS_TARBALL)"
+	$(Q) $(CURL) -o $(MICROWINDOWS_TARBALL) $(CONFIG_GRAPH_MICROWINDOWS_URL)
+	$(ECHO_END)
+
+$(MICROWINDOWS_UNPACKNAME): $(MICROWINDOWS_TARBALL)
+	$(ECHO_BEGIN)"Unpacking: $(MICROWINDOWS_TARBALL) -> $(MICROWINDOWS_UNPACKNAME)"
+	$(Q) $(UNPACK) $(MICROWINDOWS_TARBALL)
+	$(Q) mv	microwindows-$(MICROWINDOWS_COMMIT_HASH) $(MICROWINDOWS_UNPACKNAME)
+	$(Q) touch $(MICROWINDOWS_UNPACKNAME)
+	$(ECHO_END)
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(MICROWINDOWS_UNPACKNAME)/.git),)
+context:: $(MICROWINDOWS_UNPACKNAME)
+
+distclean::
+	$(call DELDIR, $(MICROWINDOWS_UNPACKNAME))
+	$(call DELFILE, $(MICROWINDOWS_TARBALL))
+endif
+
+CFLAGS += -Wno-undef
+CFLAGS += -Wno-shadow
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/graphics/microwindows/microwindows/src/drivers
+
+CFLAGS += -DNUTTX_FB_PATH=\"$(CONFIG_MICROWINDOWS_FB_PATH)\"
+ifdef CONFIG_MICROWINDOWS_KBD_EVENT_PATH
+CFLAGS += -DNUTTX_KBD_EVENT_PATH=\"$(CONFIG_MICROWINDOWS_KBD_EVENT_PATH)\"
+endif
+ifdef CONFIG_MICROWINDOWS_KBD_RAW_PATH
+CFLAGS += -DNUTTX_KBD_RAW_PATH=\"$(CONFIG_MICROWINDOWS_KBD_RAW_PATH)\"
+endif
+ifdef CONFIG_MICROWINDOWS_MOUSE_PATH
+CFLAGS += -DNUTTX_MOUSE_PATH=\"$(CONFIG_MICROWINDOWS_MOUSE_PATH)\"
+endif
+ifdef CONFIG_MICROWINDOWS_TS_PATH
+CFLAGS += -DNUTTX_TOUCHSCREEN_PATH=\"$(CONFIG_MICROWINDOWS_TS_PATH)\"
+endif
+
+MW_DIR_OBJ = $(WD)/$(MICROWINDOWS_DIR_NAME)/src
+
+# Select NuttX drivers via Microwindows Objects.rules
+ARCH = NUTTX
+
+ifeq ($(CONFIG_MICROWINDOWS_KBD_EVENT),y)
+KEYBOARD = NUTTXKBD
+else ifeq ($(CONFIG_MICROWINDOWS_KBD_RAW),y)
+KEYBOARD = NUTTXRAWKBD
+else ifeq ($(CONFIG_MICROWINDOWS_KBD_NONE),y)
+KEYBOARD = NOKBD
+else ifeq ($(CONFIG_MICROWINDOWS_KBD_CUSTOM),y)
+KEYBOARD = CUSTOM
+endif
+
+ifeq ($(CONFIG_MICROWINDOWS_MOUSE_RELATIVE),y)
+MOUSE = NUTTXMOUSE
+else ifeq ($(CONFIG_MICROWINDOWS_MOUSE_TS),y)
+MOUSE = NUTTXTOUCH
+else ifeq ($(CONFIG_MICROWINDOWS_MOUSE_NONE),y)
+MOUSE = NOMOUSE
+else ifeq ($(CONFIG_MICROWINDOWS_MOUSE_CUSTOM),y)
+MOUSE = CUSTOM
+endif
+
+-include microwindows/src/engine/Objects.rules
+-include microwindows/src/drivers/Objects.rules
+-include microwindows/src/fonts/Objects.rules
+
+CSRCS += $(MW_CORE_OBJS:%.o=%.c)
+
+ifneq ($(CONFIG_MICROWINDOWS_MWIN),)
+
+# Win32 API
+MWIN_CORE_SRCS  = microwindows/src/mwin/winmain.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winuser.c
+MWIN_CORE_SRCS += microwindows/src/mwin/wingdi.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winexpos.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winclip.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winevent.c
+MWIN_CORE_SRCS += microwindows/src/mwin/windefw.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winrgn.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winfont.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winsbar.c
+MWIN_CORE_SRCS += microwindows/src/mwin/winres.c
+
+# mwin winlib
+WINLIB_SRCS  = microwindows/src/mwin/winlib/draw3d.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/fastfill.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/windlg.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/graph3d.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/caret.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/static.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/button.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/newedit.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/newlistbox.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/combobox.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/progbar.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/scrlbar.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/medit.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/ptinsid.c
+WINLIB_SRCS += microwindows/src/mwin/winlib/insetr.c
+
+CSRCS += $(MWIN_CORE_SRCS) $(WINLIB_SRCS)
+CFLAGS += -DNOGDI
+
+endif
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
Hello the community! Here is the work I have done for the first half of GSoC, now complete and ready for review.

## Work Completed

The GDI-level Microwindows core, drivers, and `mwdemo` are functional on QEMU x86-64 and the simulator.

### Build System Integration

- Based on the initial proof-of-concept branch by @ppisa, the Microwindows core (engine, drivers, precompiled bitmap fonts) has been successfully compiled into the NuttX apps library.
- Uses `MWCONFIG_FILE="mwconfig.nuttx"` to inject NuttX-specific configuration into Microwindows without touching upstream headers.
- Image resources used by `mwdemo.c` are compiled into binary using the `convbmp` tool during the build.

### NuttX Hardware Drivers

Framebuffer driver (`scr_nuttx.c`), keyboard drivers (`kbd_nuttx_event.c` for event-mode and `kbd_nuttx_raw.c` for raw byte-stream), mouse driver (`mou_nuttx_mouse.c`), and touchscreen driver (`mou_nuttx_ts.c`) have been implemented and submitted to upstream Microwindows mainline https://github.com/ghaerr/microwindows/pull/193. The `graphics/microwindows/Makefile` selects the appropriate drivers via `ARCH=NUTTX` and Kconfig-driven `KEYBOARD`/`MOUSE` variables.

### Kconfig Options

Flexible Kconfig for keyboard driver: event-mode (`/dev/kbd`), raw byte-stream via kbd_codec (`/dev/kbda`), none, or custom. For mouse/touchscreen: relative mouse (`/dev/mouse0`), touchscreen (`/dev/input0`), none, or custom. Custom options allow BSP/app-level overrides without modifying the Microwindows build logic.

### Demo Application

Ported `mwdemo.c` (a complex Windows-like demo) into a standalone NuttX example application. The demo runs successfully on both `qemu-intel64:mw` and the NuttX simulator (`sim:mw`).

I have also tested the demo with `#define CONTROL 1` enabled in `mwdemo.c`, which represents a more complex use case.

### Upstream Bug Fixes

Several issues were discovered, analysed, and most of them already fixed:

| Issue | Root Cause | Fix |
|-------|-----------|-----|
| Animation freezing in mwdemo | `MwSelect()` blocked forever when a timer had already expired, because the code assumed no timer existed when `GdGetNextTimeout` returned false. | Patch by ppisa, correctly handle the case where `timeout == 0` and return immediately. |
| Cursor leaving a blue ghost image | `#if defined(ELKS)` in `mwtypes.h` forced `MWPIXELVALHW` to `unsigned char` even when `ELKS=0` (intended to disable it). This truncated 32-bit pixel values read from the framebuffer. | Changed to `#if ELKS` |
| System freeze when dragging a window caption | During drag, `MwSelect` switches to polling (`select(…, timeout=0)`). The USB input thread had a lower priority (50) than the application (100), so it never got CPU time to generate events. | Short-term: adjusted thread priorities in defconfigs. A permanent solution in Microwindows may be discussed later. |
| Mouse drift in simulator after dragging | `TOUCH_POS_VALID` flag was not being checked in the touchscreen driver, causing uninitialized coordinate values to be used. | Fixed in `mou_nuttx.c` by checking `TOUCH_POS_VALID` before using touch coordinates. |
| KEYCODE_xxx and ASCII range conflict |NuttX's `KEYCODE_xxx` macros (e.g., `KEYCODE_PAUSE = 0x20`) overlap with ASCII characters, making it impossible to distinguish special keys from normal input in the event-mode keyboard driver.| **Still under discussions**  https://github.com/apache/nuttx/issues/19527|

## How to Reproduce (QEMU / Simulator)

### qemu-intel64:mw

```
make distclean
./tools/configure.sh qemu-intel64:mw
make -j$(nproc)
```

Then create a bootable disk following the [documentation](https://nuttx.apache.org/docs/12.5.0/platforms/x86_64/qemu/boards/qemu-intel64/index.html) and run:

```
qemu-system-x86_64 -cpu host -enable-kvm -m 2G \
        -cdrom boot_mw.iso \
        -serial stdio -monitor none -no-reboot -device qemu-xhci -device usb-kbd -device usb-mouse
```

### sim:mw

```
make distclean
./tools/configure.sh sim:mw
make -j$(nproc)
./nuttx
```

### Notice

- You can set `#define CONTROL 1` manually in `mwdemo.c` to test more complex case.
- Most of the `nxstyle` problems in mwdemo.c are fixed, except the names of Win32 API.
- A draft document for microwindows is at https://github.com/Acfboy/nuttx/commit/f4d9316acd629f60783fc83df7f8c031c9754c19
- The Nano-X X11 supprot is still work in progress.
