### PR TITLE
crypto: Fix CRC-32 test case 8

### DIFF
--- a/testing/drivers/crypto/crc32.c
+++ b/testing/drivers/crypto/crc32.c
@@ -258,15 +258,15 @@ int main(void)
 
   /* testcase 8: test segmented computing capabilities in crc32 mode */
 
+  ret = syscrc32_start(&crc32_ctx, &startval);
+  if (ret != 0)
+    {
+      printf("syscrc32 start failed\n");
+      goto err;
+    }
+
   for (i = 0; i < 8; i++)
     {
-      ret = syscrc32_start(&crc32_ctx, &startval);
-      if (ret != 0)
-        {
-          printf("syscrc32 start failed\n");
-          goto err;
-        }
-
       ret = syscrc32_update(&crc32_ctx, g_crc32_testcase[7].data,
                             g_crc32_testcase[7].datalen);
       if (ret)
@@ -274,13 +274,13 @@ int main(void)
           printf("syscrc32 update failed\n");
           goto err;
         }
+    }
 
-      ret = syscrc32_finish(&crc32_ctx, &startval);
-      if (ret)
-        {
-          printf("syscrc32 finish failed\n");
-          goto err;
-        }
+  ret = syscrc32_finish(&crc32_ctx, &startval);
+  if (ret)
+    {
+      printf("syscrc32 finish failed\n");
+      goto err;
     }
 
   ret = match(g_crc32_testcase[7].result, startval);


### PR DESCRIPTION
## Summary

Normal Crypto API usage is to call ioctl(CGCGSESSION) to initialize the session, then one (or more) calls to ioctl(CIOCCRYPT) with flag bit COP_FLAG_UPDATE set to append to the hash/xform calculation, then a call to ioctl(CIOCCRYPT) with flag bit COP_FLAG_UPDATE cleared to extract the result, and finally ioctl(CIOCFSESSION) to finish the session. This follows the classic init / update* / finish data processing model.

However crc32.c test case 8 precedes ioctl(CIOCCRYPT) with COP_FLAG_UPDATE set with ioctl(CIOCGSESSION) and follows it with ioctl(CIOCCRYPT) with COP_FLAG_UPDATE cleared to extract the CRC, and then ioctl(CIOCFSESSION) to finish the session, all _within_ the loop to CRC eight segments.  This works with the software implementation since the intermediate CRC-32 is carried forward out of one session to seed the next session. Fix by moving the init and finish portions out of the loop in test case 8.

## Impact

- User experience: No adaptation required. This fix corrects intended Crypto API usage in testing.
- Build: No impact.
- Hardware: No impact.
- Documentation: No impact.
- Security: No impact.
- Compatibility: Backward compatible - fixes intended crypto API testing usage.


## Testing

Build Host:

    OS: Ubuntu 24.04.4 LTS
    Compiler: arm-none-eabi-gcc 13.2.1

Target:

- Architecture: ARM (STM32H753ZI)
- Board: Nucleo-h753zi
- Configuration: nucleo-h753zi:crypto - then "make menuconfig":
    - Under Crypto API:
        - Disable cryptodev hardware support
        - Enable Software AES library
        - Enable cryptodev software cipher support
    - In Application Configuration:
        - Under Testing/drivers/crypto:
            - Enable crc32 crypto test

Testing performed:

Booted board and ran crc32 test utilities; verify crc32 test utilities with cryptodev software implementation.

Runtime testing:

From target console:

```
NuttShell (NSH) NuttX-13.0.0-RC2
nsh> uname -a
NuttX 13.0.0-RC2 1fc6f2bac8-dirty Jul  9 2026 16:15:11 arm nucleo-h753zi
nsh> crc32
crc32 test case 1 success
crc32 test case 2 success
crc32 test case 3 success
crc32 test case 4 success
crc32 test case 5 success
crc32 test case 6 success
crc32 test case 7 success
crc32 test case 8 success
nsh>

```