### PR TITLE
apps/dropbear: using nuttx crypto chachapoly

### DIFF
--- a/netutils/dropbear/CMakeLists.txt
+++ b/netutils/dropbear/CMakeLists.txt
@@ -68,6 +68,11 @@ if(CONFIG_NETUTILS_DROPBEAR)
           patch -s -N -l -p1 -d "${DROPBEAR_UNPACKNAME}" -i
           "${CMAKE_CURRENT_SOURCE_DIR}/patch/0005-use-nuttx-sha256-hmac.patch"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+      execute_process(
+        COMMAND
+          patch -s -N -l -p1 -d "${DROPBEAR_UNPACKNAME}" -i
+          "${CMAKE_CURRENT_SOURCE_DIR}/patch/0006-use-nuttx-chachapoly-cryptodev.patch"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
       message(STATUS "Generating default_options_guard.h")
       execute_process(
         COMMAND
@@ -151,6 +156,12 @@ if(CONFIG_NETUTILS_DROPBEAR)
          port/dropbear_ltc_hmac_sha256.c)
   endif()
 
+  if(CONFIG_NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY)
+    # Replace the bundled chacha20-poly1305 with the /dev/crypto adapter.
+    list(REMOVE_ITEM DROPBEAR_SRCS dropbear/src/chachapoly.c)
+    list(APPEND DROPBEAR_SRCS port/dropbear_chachapoly.c)
+  endif()
+
   list(APPEND DROPBEAR_SRCS ${LIBTOMCRYPT_SRCS})
 
   if(CONFIG_NETUTILS_DROPBEAR_SCP)
@@ -216,6 +227,10 @@ if(CONFIG_NETUTILS_DROPBEAR)
                                                    DROPBEAR_NUTTX_HMAC_SHA256=1)
   endif()
 
+  if(CONFIG_NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY)
+    target_compile_definitions(${PROGNAME} PRIVATE DROPBEAR_NUTTX_CHACHAPOLY=1)
+  endif()
+
   if(CONFIG_NETUTILS_DROPBEAR_SCP)
     target_compile_definitions(
       scp PRIVATE LOCALOPTIONS_H_EXISTS=1 DROPBEAR_NUTTX=1
@@ -245,6 +260,17 @@ if(CONFIG_NETUTILS_DROPBEAR)
   # LTC_SOURCE must be set only for libtomcrypt sources.
   set_source_files_properties(${LIBTOMCRYPT_SRCS} PROPERTIES COMPILE_DEFINITIONS
                                                              LTC_SOURCE=1)
+
+  if(CONFIG_NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY)
+    # The NuttX crypto backend pulled in by /dev/crypto also exports
+    # ecc_make_key.  Dropbear only uses libtomcrypt's ecc_make_key_ex, so rename
+    # the unused plain wrapper to avoid a multiple definition.  Append so the
+    # LTC_SOURCE define set above is preserved.
+    set_property(
+      SOURCE dropbear/libtomcrypt/src/pk/ecc/ecc_make_key.c
+      APPEND
+      PROPERTY COMPILE_DEFINITIONS ecc_make_key=dropbear_ltc_ecc_make_key)
+  endif()
 
   target_compile_options(${PROGNAME} PRIVATE -Wno-pointer-sign -Wno-format)
 

--- a/netutils/dropbear/CMakeLists.txt
+++ b/netutils/dropbear/CMakeLists.txt
@@ -63,6 +63,11 @@ if(CONFIG_NETUTILS_DROPBEAR)
           patch -s -N -l -p1 -d "${DROPBEAR_UNPACKNAME}" -i
           "${CMAKE_CURRENT_SOURCE_DIR}/patch/0004-use-nuttx-unused-macro.patch"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+      execute_process(
+        COMMAND
+          patch -s -N -l -p1 -d "${DROPBEAR_UNPACKNAME}" -i
+          "${CMAKE_CURRENT_SOURCE_DIR}/patch/0005-use-nuttx-sha256-hmac.patch"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
       message(STATUS "Generating default_options_guard.h")
       execute_process(
         COMMAND
@@ -135,6 +140,17 @@ if(CONFIG_NETUTILS_DROPBEAR)
   file(GLOB_RECURSE LIBTOMCRYPT_SRCS CONFIGURE_DEPENDS
        "${CMAKE_CURRENT_SOURCE_DIR}/dropbear/libtomcrypt/src/*.c")
   list(FILTER LIBTOMCRYPT_SRCS EXCLUDE REGEX ".*/prngs/sober128tab\\.c$")
+
+  if(CONFIG_NETUTILS_DROPBEAR_NUTTX_CRYPTO)
+    # Drop the bundled libtomcrypt modules replaced by the NuttX adapters.
+    list(FILTER LIBTOMCRYPT_SRCS EXCLUDE REGEX ".*/hashes/sha2/sha256\\.c$")
+    list(FILTER LIBTOMCRYPT_SRCS EXCLUDE REGEX ".*/mac/hmac/hmac_init\\.c$")
+    list(FILTER LIBTOMCRYPT_SRCS EXCLUDE REGEX ".*/mac/hmac/hmac_process\\.c$")
+    list(FILTER LIBTOMCRYPT_SRCS EXCLUDE REGEX ".*/mac/hmac/hmac_done\\.c$")
+    list(APPEND DROPBEAR_SRCS port/dropbear_ltc_sha256.c
+         port/dropbear_ltc_hmac_sha256.c)
+  endif()
+
   list(APPEND DROPBEAR_SRCS ${LIBTOMCRYPT_SRCS})
 
   if(CONFIG_NETUTILS_DROPBEAR_SCP)
@@ -194,6 +210,11 @@ if(CONFIG_NETUTILS_DROPBEAR)
   target_compile_definitions(
     ${PROGNAME} PRIVATE LOCALOPTIONS_H_EXISTS=1 DROPBEAR_NUTTX=1
                         DROPBEAR_NUTTX_PASSWD=1)
+
+  if(CONFIG_NETUTILS_DROPBEAR_NUTTX_CRYPTO)
+    target_compile_definitions(${PROGNAME} PRIVATE DROPBEAR_NUTTX_SHA256=1
+                                                   DROPBEAR_NUTTX_HMAC_SHA256=1)
+  endif()
 
   if(CONFIG_NETUTILS_DROPBEAR_SCP)
     target_compile_definitions(

--- a/netutils/dropbear/Kconfig
+++ b/netutils/dropbear/Kconfig
@@ -90,6 +90,16 @@ config NETUTILS_DROPBEAR_SCP_PRIORITY
 	default 100
 	depends on NETUTILS_DROPBEAR_SCP
 
+config NETUTILS_DROPBEAR_NUTTX_CRYPTO
+	bool "Use NuttX kernel crypto primitives"
+	default y
+	depends on BUILD_FLAT
+	---help---
+		Back Dropbear's SHA-256 and HMAC-SHA256 primitives with the NuttX
+		kernel crypto implementation instead of the bundled libtomcrypt
+		modules, reducing flash usage.  This requires a flat build because
+		Dropbear calls the kernel crypto functions directly.
+
 config NETUTILS_DROPBEAR_PORT
 	int "Dropbear listen port"
 	default 2222

--- a/netutils/dropbear/Kconfig
+++ b/netutils/dropbear/Kconfig
@@ -100,6 +100,19 @@ config NETUTILS_DROPBEAR_NUTTX_CRYPTO
 		modules, reducing flash usage.  This requires a flat build because
 		Dropbear calls the kernel crypto functions directly.
 
+config NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY
+	bool "Use NuttX /dev/crypto for chacha20-poly1305"
+	default y
+	depends on NETUTILS_DROPBEAR_NUTTX_CRYPTO
+	select CRYPTO_CRYPTODEV
+	select CRYPTO_SW_AES
+	select CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO
+	---help---
+		Implement the chacha20-poly1305@openssh.com cipher through the NuttX
+		crypto device (/dev/crypto) using the CRYPTO_CHACHA20 and
+		CRYPTO_POLY1305 algorithms instead of the bundled libtomcrypt
+		implementation.
+
 config NETUTILS_DROPBEAR_PORT
 	int "Dropbear listen port"
 	default 2222

--- a/netutils/dropbear/Kconfig
+++ b/netutils/dropbear/Kconfig
@@ -10,17 +10,17 @@ menuconfig NETUTILS_DROPBEAR
 	depends on !DISABLE_PSEUDOFS_OPERATIONS
 	depends on !DISABLE_PTHREAD
 	depends on SCHED_WAITPID
+	depends on SCHED_HAVE_PARENT
 	depends on NSH_LIBRARY
 	depends on FSUTILS_PASSWD
 	depends on PSEUDOTERM
 	depends on SERIAL
-	depends on ARCH_HAVE_RNG
-	depends on DEV_RANDOM
 	depends on DEV_URANDOM
 	depends on LIBC_NETDB
 	depends on LIBC_GAISTRERROR
 	select CRYPTO
 	select CRYPTO_RANDOM_POOL
+	select SCHED_CHILD_STATUS
 	---help---
 		Enable a minimal Dropbear SSH server port for NuttX.  This initial
 		port is based on the ESP-IDF MCU test port and provides a single

--- a/netutils/dropbear/Makefile
+++ b/netutils/dropbear/Makefile
@@ -63,6 +63,11 @@ CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX=1
 CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX_PASSWD=1
 CFLAGS += -Wno-pointer-sign -Wno-format
 
+ifneq ($(CONFIG_NETUTILS_DROPBEAR_NUTTX_CRYPTO),)
+CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX_SHA256=1
+CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX_HMAC_SHA256=1
+endif
+
 dropbear_nshsession.c_CFLAGS += ${DEFINE_PREFIX}Channel=dropbear_channel
 dropbear_nshsession.c_CFLAGS += ${DEFINE_PREFIX}ChanType=dropbear_chantype
 
@@ -119,6 +124,20 @@ CSRCS += \
 TOMMATH_SRCS = $(shell if [ -d "$(DROPBEAR_UNPACKNAME)/libtommath" ]; then find "$(DROPBEAR_UNPACKNAME)/libtommath" -name "*.c"; fi)
 TOMCRYPT_SRCS = $(shell if [ -d "$(DROPBEAR_UNPACKNAME)/libtomcrypt/src" ]; then find "$(DROPBEAR_UNPACKNAME)/libtomcrypt/src" -name "*.c" ! -name "sober128tab.c"; fi)
 
+ifneq ($(CONFIG_NETUTILS_DROPBEAR_NUTTX_CRYPTO),)
+# Drop the bundled libtomcrypt modules replaced by the NuttX adapters.
+
+TOMCRYPT_SRCS := $(filter-out \
+	%/hashes/sha2/sha256.c \
+	%/mac/hmac/hmac_init.c \
+	%/mac/hmac/hmac_process.c \
+	%/mac/hmac/hmac_done.c, \
+	$(TOMCRYPT_SRCS))
+
+CSRCS += port/dropbear_ltc_sha256.c
+CSRCS += port/dropbear_ltc_hmac_sha256.c
+endif
+
 CSRCS += $(TOMMATH_SRCS)
 CSRCS += $(TOMCRYPT_SRCS)
 
@@ -161,6 +180,7 @@ $(DROPBEAR_UNPACKNAME): $(DROPBEAR_ZIP)
 	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0002-use-nuttx-passwd-auth.patch; true
 	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0003-allow-localoptions-to-override-tracking-malloc.patch; true
 	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0004-use-nuttx-unused-macro.patch; true
+	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0005-use-nuttx-sha256-hmac.patch; true
 	@echo "Generating default_options_guard.h"
 	$(Q) sh $(DROPBEAR_UNPACKNAME)$(DELIM)src$(DELIM)ifndef_wrapper.sh \
 		< $(DROPBEAR_UNPACKNAME)$(DELIM)src$(DELIM)default_options.h \

--- a/netutils/dropbear/Makefile
+++ b/netutils/dropbear/Makefile
@@ -68,6 +68,10 @@ CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX_SHA256=1
 CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX_HMAC_SHA256=1
 endif
 
+ifneq ($(CONFIG_NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY),)
+CFLAGS += ${DEFINE_PREFIX}DROPBEAR_NUTTX_CHACHAPOLY=1
+endif
+
 dropbear_nshsession.c_CFLAGS += ${DEFINE_PREFIX}Channel=dropbear_channel
 dropbear_nshsession.c_CFLAGS += ${DEFINE_PREFIX}ChanType=dropbear_chantype
 
@@ -138,6 +142,13 @@ CSRCS += port/dropbear_ltc_sha256.c
 CSRCS += port/dropbear_ltc_hmac_sha256.c
 endif
 
+ifneq ($(CONFIG_NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY),)
+# Replace the bundled chacha20-poly1305 with the /dev/crypto adapter.
+
+CSRCS := $(filter-out dropbear/src/chachapoly.c,$(CSRCS))
+CSRCS += port/dropbear_chachapoly.c
+endif
+
 CSRCS += $(TOMMATH_SRCS)
 CSRCS += $(TOMCRYPT_SRCS)
 
@@ -148,6 +159,13 @@ endif
 
 # Match the ESP-IDF port behavior: LTC_SOURCE is only for libtomcrypt sources.
 $(foreach src,$(TOMCRYPT_SRCS),$(eval $(src)_CFLAGS += ${DEFINE_PREFIX}LTC_SOURCE=1))
+
+ifneq ($(CONFIG_NETUTILS_DROPBEAR_NUTTX_CHACHAPOLY),)
+# The NuttX crypto backend pulled in by /dev/crypto also exports ecc_make_key.
+# Dropbear only uses libtomcrypt's ecc_make_key_ex, so rename the unused plain
+# wrapper to avoid a link-time multiple definition.
+dropbear/libtomcrypt/src/pk/ecc/ecc_make_key.c_CFLAGS += ${DEFINE_PREFIX}ecc_make_key=dropbear_ltc_ecc_make_key
+endif
 
 MAINSRC = dropbear_main.c
 
@@ -181,6 +199,7 @@ $(DROPBEAR_UNPACKNAME): $(DROPBEAR_ZIP)
 	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0003-allow-localoptions-to-override-tracking-malloc.patch; true
 	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0004-use-nuttx-unused-macro.patch; true
 	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0005-use-nuttx-sha256-hmac.patch; true
+	$(Q) $(PATCH) -s -N -l -p1 -d $(DROPBEAR_UNPACKNAME) -i $(APPDIR)$(DELIM)netutils$(DELIM)dropbear$(DELIM)patch$(DELIM)0006-use-nuttx-chachapoly-cryptodev.patch; true
 	@echo "Generating default_options_guard.h"
 	$(Q) sh $(DROPBEAR_UNPACKNAME)$(DELIM)src$(DELIM)ifndef_wrapper.sh \
 		< $(DROPBEAR_UNPACKNAME)$(DELIM)src$(DELIM)default_options.h \

--- a/netutils/dropbear/patch/0005-use-nuttx-sha256-hmac.patch
+++ b/netutils/dropbear/patch/0005-use-nuttx-sha256-hmac.patch
@@ -1,0 +1,45 @@
+--- a/libtomcrypt/src/headers/tomcrypt_hash.h
++++ b/libtomcrypt/src/headers/tomcrypt_hash.h
+@@ -30,11 +30,18 @@ struct sha512_state {
+ #endif
+ 
+ #ifdef LTC_SHA256
++#ifdef DROPBEAR_NUTTX_SHA256
++#include <crypto/sha2.h>
++struct sha256_state {
++    SHA2_CTX ctx;
++};
++#else
+ struct sha256_state {
+     ulong64 length;
+     ulong32 state[8], curlen;
+     unsigned char buf[64];
+ };
++#endif
+ #endif
+ 
+ #ifdef LTC_SHA1
+--- a/libtomcrypt/src/headers/tomcrypt_mac.h
++++ b/libtomcrypt/src/headers/tomcrypt_mac.h
+@@ -7,6 +7,13 @@
+  */
+ 
+ #ifdef LTC_HMAC
++#ifdef DROPBEAR_NUTTX_HMAC_SHA256
++#include <crypto/hmac.h>
++typedef struct Hmac_state {
++     HMAC_SHA256_CTX ctx;
++     int             hash;
++} hmac_state;
++#else
+ typedef struct Hmac_state {
+      hash_state     md;
+      int            hash;
+@@ -14,6 +21,7 @@ typedef struct Hmac_state {
+      unsigned char  *key;
+ } hmac_state;
+ 
++#endif
+ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned long keylen);
+ int hmac_process(hmac_state *hmac, const unsigned char *in, unsigned long inlen);
+ int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen);

--- a/netutils/dropbear/patch/0006-use-nuttx-chachapoly-cryptodev.patch
+++ b/netutils/dropbear/patch/0006-use-nuttx-chachapoly-cryptodev.patch
@@ -1,0 +1,20 @@
+--- a/src/chachapoly.h
++++ b/src/chachapoly.h
+@@ -31,10 +31,17 @@
+
+ #if DROPBEAR_CHACHA20POLY1305
+
++#ifdef DROPBEAR_NUTTX_CHACHAPOLY
++typedef struct {
++	unsigned char key_main[32];
++	unsigned char key_header[32];
++} dropbear_chachapoly_state;
++#else
+ typedef struct {
+ 	chacha_state chacha;
+ 	chacha_state header;
+ } dropbear_chachapoly_state;
++#endif
+
+ extern const struct dropbear_cipher dropbear_chachapoly;
+ extern const struct dropbear_cipher_mode dropbear_mode_chachapoly;

--- a/netutils/dropbear/port/dropbear_chachapoly.c
+++ b/netutils/dropbear/port/dropbear_chachapoly.c
@@ -1,0 +1,328 @@
+/****************************************************************************
+ * apps/netutils/dropbear/port/dropbear_chachapoly.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "includes.h"
+
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <crypto/cryptodev.h>
+
+#include "algo.h"
+#include "dbutil.h"
+#include "chachapoly.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CHACHA20_KEY_LEN   32
+#define CHACHA20_BLOCKSIZE 8
+#define CHACHA20_IV_LEN    16
+#define POLY1305_KEY_LEN   32
+#define POLY1305_TAG_LEN   16
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct ltc_cipher_descriptor g_dropbear_chachapoly_dummy =
+{
+  .name = NULL
+};
+
+static const struct dropbear_hash g_dropbear_chachapoly_mac =
+{
+  NULL,
+  POLY1305_KEY_LEN,
+  POLY1305_TAG_LEN
+};
+
+static int g_dropbear_cryptofd = -1;
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct dropbear_cipher dropbear_chachapoly =
+{
+  &g_dropbear_chachapoly_dummy,
+  CHACHA20_KEY_LEN * 2,
+  CHACHA20_BLOCKSIZE
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int dropbear_cryptodev_fd(void)
+{
+  int fd;
+  int cfd;
+
+  if (g_dropbear_cryptofd >= 0)
+    {
+      return g_dropbear_cryptofd;
+    }
+
+  fd = open("/dev/crypto", O_RDWR);
+  if (fd < 0)
+    {
+      return -1;
+    }
+
+  if (ioctl(fd, CRIOGET, &cfd) < 0)
+    {
+      close(fd);
+      return -1;
+    }
+
+  close(fd);
+  g_dropbear_cryptofd = cfd;
+  return g_dropbear_cryptofd;
+}
+
+static int dropbear_chacha(FAR const unsigned char *key, unsigned int seq,
+                           uint64_t counter, FAR const unsigned char *in,
+                           FAR unsigned char *out, size_t len)
+{
+  struct session_op session;
+  struct crypt_op cryp;
+  unsigned char iv[CHACHA20_IV_LEN];
+  int cfd;
+  int ret = CRYPT_ERROR;
+  int i;
+
+  cfd = dropbear_cryptodev_fd();
+  if (cfd < 0)
+    {
+      return CRYPT_ERROR;
+    }
+
+  memset(iv, 0, sizeof(iv));
+  for (i = 0; i < 8; i++)
+    {
+      iv[i] = (unsigned char)(counter >> (8 * i));
+    }
+
+  STORE64H((uint64_t)seq, iv + 8);
+
+  memset(&session, 0, sizeof(session));
+  session.cipher = CRYPTO_CHACHA20;
+  session.key = (caddr_t)key;
+  session.keylen = CHACHA20_KEY_LEN;
+  if (ioctl(cfd, CIOCGSESSION, &session) < 0)
+    {
+      return CRYPT_ERROR;
+    }
+
+  memset(&cryp, 0, sizeof(cryp));
+  cryp.ses = session.ses;
+  cryp.op = COP_ENCRYPT;
+  cryp.len = len;
+  cryp.src = (caddr_t)in;
+  cryp.dst = (caddr_t)out;
+  cryp.iv = (caddr_t)iv;
+  cryp.ivlen = sizeof(iv);
+  if (ioctl(cfd, CIOCCRYPT, &cryp) == 0)
+    {
+      ret = CRYPT_OK;
+    }
+
+  ioctl(cfd, CIOCFSESSION, &session.ses);
+  return ret;
+}
+
+static int dropbear_poly1305(FAR const unsigned char *key,
+                             FAR const unsigned char *in, size_t len,
+                             FAR unsigned char *tag)
+{
+  struct session_op session;
+  struct crypt_op cryp;
+  int cfd;
+  int ret = CRYPT_ERROR;
+
+  cfd = dropbear_cryptodev_fd();
+  if (cfd < 0)
+    {
+      return CRYPT_ERROR;
+    }
+
+  memset(&session, 0, sizeof(session));
+  session.mac = CRYPTO_POLY1305;
+  session.mackey = (caddr_t)key;
+  session.mackeylen = POLY1305_KEY_LEN;
+  if (ioctl(cfd, CIOCGSESSION, &session) < 0)
+    {
+      return CRYPT_ERROR;
+    }
+
+  memset(&cryp, 0, sizeof(cryp));
+  cryp.ses = session.ses;
+  cryp.op = COP_ENCRYPT;
+  cryp.flags = COP_FLAG_UPDATE;
+  cryp.len = len;
+  cryp.src = (caddr_t)in;
+  if (ioctl(cfd, CIOCCRYPT, &cryp) == 0)
+    {
+      cryp.flags = 0;
+      cryp.len = 0;
+      cryp.mac = (caddr_t)tag;
+      if (ioctl(cfd, CIOCCRYPT, &cryp) == 0)
+        {
+          ret = CRYPT_OK;
+        }
+    }
+
+  ioctl(cfd, CIOCFSESSION, &session.ses);
+  return ret;
+}
+
+static int dropbear_chachapoly_start(int cipher,
+                                     FAR const unsigned char *iv,
+                                     FAR const unsigned char *key,
+                                     int keylen, int num_rounds,
+                                     FAR dropbear_chachapoly_state *state)
+{
+  UNUSED(cipher);
+  UNUSED(iv);
+
+  if (keylen != CHACHA20_KEY_LEN * 2 || num_rounds != 0)
+    {
+      return CRYPT_ERROR;
+    }
+
+  if (dropbear_cryptodev_fd() < 0)
+    {
+      return CRYPT_ERROR;
+    }
+
+  memcpy(state->key_main, key, CHACHA20_KEY_LEN);
+  memcpy(state->key_header, key + CHACHA20_KEY_LEN, CHACHA20_KEY_LEN);
+  return CRYPT_OK;
+}
+
+static int dropbear_chachapoly_crypt(unsigned int seq,
+                                     FAR const unsigned char *in,
+                                     FAR unsigned char *out,
+                                     unsigned long len, unsigned long taglen,
+                                     FAR dropbear_chachapoly_state *state,
+                                     int direction)
+{
+  unsigned char key[POLY1305_KEY_LEN];
+  unsigned char tag[POLY1305_TAG_LEN];
+  unsigned char zero[POLY1305_KEY_LEN];
+  int ret = CRYPT_ERROR;
+
+  if (len < 4 || taglen != POLY1305_TAG_LEN)
+    {
+      return CRYPT_ERROR;
+    }
+
+  memset(zero, 0, sizeof(zero));
+  if (dropbear_chacha(state->key_main, seq, 0, zero, key,
+                      sizeof(key)) != CRYPT_OK)
+    {
+      goto out;
+    }
+
+  if (direction == LTC_DECRYPT)
+    {
+      if (dropbear_poly1305(key, in, len, tag) != CRYPT_OK)
+        {
+          goto out;
+        }
+
+      if (constant_time_memcmp(in + len, tag, sizeof(tag)) != 0)
+        {
+          goto out;
+        }
+    }
+
+  if (dropbear_chacha(state->key_header, seq, 0, in, out, 4) != CRYPT_OK)
+    {
+      goto out;
+    }
+
+  if (dropbear_chacha(state->key_main, seq, 1, in + 4, out + 4,
+                      len - 4) != CRYPT_OK)
+    {
+      goto out;
+    }
+
+  if (direction == LTC_ENCRYPT)
+    {
+      if (dropbear_poly1305(key, out, len, out + len) != CRYPT_OK)
+        {
+          goto out;
+        }
+    }
+
+  ret = CRYPT_OK;
+
+out:
+  zeromem(key, sizeof(key));
+  zeromem(tag, sizeof(tag));
+  return ret;
+}
+
+static int
+dropbear_chachapoly_getlength(unsigned int seq, FAR const unsigned char *in,
+                              FAR unsigned int *outlen, unsigned long len,
+                              FAR dropbear_chachapoly_state *state)
+{
+  unsigned char buf[4];
+
+  if (len < sizeof(buf))
+    {
+      return CRYPT_ERROR;
+    }
+
+  if (dropbear_chacha(state->key_header, seq, 0, in, buf,
+                      sizeof(buf)) != CRYPT_OK)
+    {
+      return CRYPT_ERROR;
+    }
+
+  LOAD32H(*outlen, buf);
+  return CRYPT_OK;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct dropbear_cipher_mode dropbear_mode_chachapoly =
+{
+  (void *)dropbear_chachapoly_start,
+  NULL,
+  NULL,
+  (void *)dropbear_chachapoly_crypt,
+  (void *)dropbear_chachapoly_getlength,
+  &g_dropbear_chachapoly_mac
+};

--- a/netutils/dropbear/port/dropbear_ltc_hmac_sha256.c
+++ b/netutils/dropbear/port/dropbear_ltc_hmac_sha256.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * apps/netutils/dropbear/port/dropbear_ltc_hmac_sha256.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ****************************************************************************/
+
+/* LibTomCrypt-compatible HMAC API backed by NuttX crypto/hmac.  The NuttX
+ * Dropbear configuration only enables hmac-sha2-256.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "includes.h"
+
+#include <crypto/hmac.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int dropbear_hmac_hash_is_sha256(int hash)
+{
+  int ret;
+
+  ret = hash_is_valid(hash);
+  if (ret != CRYPT_OK)
+    {
+      return ret;
+    }
+
+  if (hash_descriptor[hash].hashsize != SHA256_DIGEST_LENGTH ||
+      hash_descriptor[hash].blocksize != SHA256_BLOCK_LENGTH)
+    {
+      return CRYPT_INVALID_HASH;
+    }
+
+  return CRYPT_OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int hmac_init(hmac_state *hmac, int hash, const unsigned char *key,
+              unsigned long keylen)
+{
+  int ret;
+
+  LTC_ARGCHK(hmac != NULL);
+  LTC_ARGCHK(key != NULL);
+
+  if (keylen == 0)
+    {
+      return CRYPT_INVALID_KEYSIZE;
+    }
+
+  ret = dropbear_hmac_hash_is_sha256(hash);
+  if (ret != CRYPT_OK)
+    {
+      return ret;
+    }
+
+  hmac->hash = hash;
+  hmac_sha256_init(&hmac->ctx, key, (u_int)keylen);
+  return CRYPT_OK;
+}
+
+int hmac_process(hmac_state *hmac, const unsigned char *in,
+                 unsigned long inlen)
+{
+  LTC_ARGCHK(hmac != NULL);
+  LTC_ARGCHK(in != NULL || inlen == 0);
+
+  hmac_sha256_update(&hmac->ctx, in, (u_int)inlen);
+  return CRYPT_OK;
+}
+
+int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen)
+{
+  uint8_t digest[SHA256_DIGEST_LENGTH];
+  unsigned long copylen;
+
+  LTC_ARGCHK(hmac != NULL);
+  LTC_ARGCHK(out != NULL);
+  LTC_ARGCHK(outlen != NULL);
+
+  if (dropbear_hmac_hash_is_sha256(hmac->hash) != CRYPT_OK)
+    {
+      return CRYPT_INVALID_HASH;
+    }
+
+  hmac_sha256_final(digest, &hmac->ctx);
+
+  copylen = MIN(*outlen, SHA256_DIGEST_LENGTH);
+  memcpy(out, digest, copylen);
+  *outlen = copylen;
+
+  zeromem(digest, sizeof(digest));
+  zeromem(hmac, sizeof(*hmac));
+  return CRYPT_OK;
+}

--- a/netutils/dropbear/port/dropbear_ltc_sha256.c
+++ b/netutils/dropbear/port/dropbear_ltc_sha256.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * apps/netutils/dropbear/port/dropbear_ltc_sha256.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ****************************************************************************/
+
+/* LibTomCrypt-compatible SHA256 descriptor backed by NuttX crypto/sha2.
+ * Dropbear still expects the libtomcrypt hash API for KEX and HMAC.  This
+ * adapter keeps that API while avoiding the bundled SHA256 implementation.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "includes.h"
+
+#include <crypto/sha2.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct ltc_hash_descriptor sha256_desc =
+{
+  "sha256",
+  0,
+  SHA256_DIGEST_LENGTH,
+  SHA256_BLOCK_LENGTH,
+  { 2, 16, 840, 1, 101, 3, 4, 2, 1 },
+  9,
+
+  sha256_init,
+  sha256_process,
+  sha256_done,
+  sha256_test,
+  NULL
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int sha256_init(hash_state *md)
+{
+  LTC_ARGCHK(md != NULL);
+
+  sha256init(&md->sha256.ctx);
+  return CRYPT_OK;
+}
+
+int sha256_process(hash_state *md, const unsigned char *in,
+                   unsigned long inlen)
+{
+  LTC_ARGCHK(md != NULL);
+  LTC_ARGCHK(in != NULL || inlen == 0);
+
+  sha256update(&md->sha256.ctx, in, inlen);
+  return CRYPT_OK;
+}
+
+int sha256_done(hash_state *md, unsigned char *out)
+{
+  LTC_ARGCHK(md != NULL);
+  LTC_ARGCHK(out != NULL);
+
+  sha256final(out, &md->sha256.ctx);
+  zeromem(md, sizeof(*md));
+  return CRYPT_OK;
+}
+
+int sha256_test(void)
+{
+  return CRYPT_NOP;
+}


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Backs Dropbear's SHA-256 and HMAC-SHA-256 with NuttX's native crypto (crypto/sha2.h, crypto/hmac.h) instead of the bundled libtomcrypt implementation, avoiding duplicate crypto code and reducing flash usage.

`port/dropbear_ltc_sha256.c` / `port/dropbear_ltc_hmac_sha256.c ` implement libtomcrypt's expected SHA-256/HMAC API, backed internally by NuttX calls.

`patch/0005-use-nuttx-sha256-hmac.patch` adjusts libtomcrypt's internal sha256_state/hmac_state struct layout so it matches NuttX's context size instead of libtomcrypt's own.

## Impact

Dropbear application start to use NuttX crypto native. ( libs migration not finished yet, this is first step ).
./nuttx 

## Testing

Test done using Linux Ubuntu 22.04 using 2 terminals

Use the config:
`./tools/configure.sh sim:dropbear`

Build and follow steps below to execute nuttx in the first terminal:

`sudo setcap cap_net_admin+ep ./nuttx
./nuttx 
`

The expected output is:
```
nuttx git:(feature/crypto-chacha20-ocf) ./nuttx 
dropbear [6:100]

NuttShell (NSH) NuttX-13.0.0-RC2
nsh> [6] Jun 01 00:00:00 using NuttX passwd auth at /tmp/passwd
dropbear: listening on port 2222

```

create a user and password to receive connection, use the example below:
`nsh> useradd testuser testpass`


In the second terminal
`ssh -p 2222 -o StrictHostKeyChecking=no -c chacha20-poly1305@openssh.com testuser@10.0.0.2`

After follow steps the remote connection will be available.