### PR TITLE
netutils/mdns: raise responder stack size default to 8KiB

### DIFF
--- a/netutils/mdns/Kconfig
+++ b/netutils/mdns/Kconfig
@@ -51,11 +51,11 @@ config NETUTILS_MDNS_PRIORITY
 
 config NETUTILS_MDNS_STACKSIZE
 	int "mDNS stack size"
-	default DEFAULT_TASK_STACKSIZE
+	default 8192
 	---help---
-		The default (4KiB) is adequate for simple networks but this will
-		most likely need to be increased if there are many network devices
-		attached that could send queries.
+		Stack size for the mDNS responder task.  8KiB is adequate for
+		typical networks; increase it if many network devices send
+		queries.
 
 config NETUTILS_MDNS_VERBOSE
 	bool "Enable verbose printf output from built-in mdns demo"


### PR DESCRIPTION
## Summary

`CONFIG_NETUTILS_MDNS_STACKSIZE` defaulted to `DEFAULT_TASK_STACKSIZE`,
which resolves to as little as 2KiB on some targets. The bundled mjansson
mDNS responder needs a deeper stack than that — DNS record parsing with
name decompression, plus the send/receive buffers — so on those targets it
overflows its stack and hardfaults at startup, before it can answer a
single query.

This raises the default to 8KiB (the value that reliably runs the
responder) and corrects the help text, which previously claimed a "4KiB"
default that did not match `DEFAULT_TASK_STACKSIZE`.

## Impact

- Fixes a startup hardfault when the mDNS app/daemon is enabled on targets
  with a small `DEFAULT_TASK_STACKSIZE`.
- No API change; configurations that already set an explicit stack size are
  unaffected.

## Testing

Reproduced and fixed on a Raspberry Pi Pico 2 W (RP2350, NuttX). With the
old default (2KiB on this target) the responder overflowed its stack and
hardfaulted at startup; with the new 8KiB default it runs and answers mDNS
queries normally (verified with `avahi-resolve`/`avahi-browse` from a host).

Here are on-hardware test logs from a Raspberry Pi Pico 2 W (RP2350), NuttX 13.0.0-RC0.

The mDNS responder was built with `CONFIG_NETUTILS_MDNS_STACKSIZE=8192` — the value this PR makes the default — and run over a USB CDC-NCM link (board `eth0` 192.168.7.1 ⇆ Linux host `usb0` 192.168.7.2).

**Board — responder starts and answers a live query:**
```
nsh> mdnsd_start
Local IPv4 address: 192.168.7.1
Opened 1 socket for mDNS service
Service mDNS: _http._tcp.local.:80
Hostname: nuttx
Sending announce
...
Query PTR _http._tcp.local.
  --> answer nuttx._http._tcp.local. (multicast)
```

**Board — responder task running at the 8 KiB stack, no overflow (`ps`):**
```
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK          STACK COMMAND
    8     8     0 100 RR       Task      - Waiting  Semaphore 000...0000       0008080 --service _http._tcp.local --hostname nuttx --port 80
```
(The responder task shows an ~8 KiB stack; other tasks are ~2 KiB.)

**Host — discovery / resolution / reachability:**
```
$ avahi-browse -rt _http._tcp
=   usb0 IPv4 nuttx                     Web Site         local
   hostname = [nuttx.local]
   address = [192.168.7.1]
   port = [80]
   txt = ["other=value" "test=1"]

$ avahi-resolve -n nuttx.local
nuttx.local	192.168.7.1

$ ping nuttx.local          # name resolved via the board's responder
64 bytes from 192.168.7.1: icmp_seq=3 ttl=64 time=16.9 ms
3 packets transmitted, 3 received, 0% packet loss
```

The responder runs, advertises, and answers queries at the 8 KiB stack without overflowing.

---

*Disclosure: this change was prepared by an AI agent (Claude Code) at the
direction of the author (@ricardgb), who reviewed it before submission.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
