### PR TITLE
dropbear/Kconfig: Relax RNG to SW allowing sim environment

### DIFF
--- a/netutils/dropbear/Kconfig
+++ b/netutils/dropbear/Kconfig
@@ -14,8 +14,6 @@ menuconfig NETUTILS_DROPBEAR
 	depends on FSUTILS_PASSWD
 	depends on PSEUDOTERM
 	depends on SERIAL
-	depends on ARCH_HAVE_RNG
-	depends on DEV_RANDOM
 	depends on DEV_URANDOM
 	depends on LIBC_NETDB
 	depends on LIBC_GAISTRERROR


### PR DESCRIPTION
## Summary

`NETUTILS_DROPBEAR` currently depends on `ARCH_HAVE_RNG` and `DEV_RANDOM`,
i.e. it requires a hardware TRNG. Dropbear does not actually use
`/dev/random`: its entropy comes from `/dev/urandom` (libtomcrypt's
`rng_get_bytes()` tries `/dev/urandom` first and only falls back to
`/dev/random`, and libtommath's `s_read_urandom()` uses `/dev/urandom`
directly).

Requiring a hardware TRNG shuts the port out of every target without one —
including the simulator, where a dropbear configuration silently loses
`CONFIG_NETUTILS_DROPBEAR=y` at configure time because the dependency can
never be satisfied (`sim` does not select `ARCH_HAVE_RNG`). This is easy to
miss: the build succeeds, but the resulting image has no SSH server, no
`useradd` command (since `NSH_LOGIN` is no longer selected), etc.

This PR drops the `ARCH_HAVE_RNG` and `DEV_RANDOM` dependencies and keeps
`DEV_URANDOM`, which is what the port really needs. Boards that do have a
TRNG are unaffected: they can continue to enable `DEV_RANDOM`, and
`/dev/urandom` can be backed by the strong entropy pool
(`CONFIG_DEV_URANDOM_RANDOM_POOL`).

This also unblocks a companion nuttx PR adding a `sim:dropbear`
configuration for testing the SSH server on the simulator.

## Impact

- **Users**: none on existing working configurations (they already satisfy
  the relaxed dependency set). Targets without a hardware TRNG can now
  enable the Dropbear port.
- **Build**: Kconfig-only change, no source changes.
- **Hardware**: none.
- **Security**: `/dev/urandom` quality is a board configuration decision;
  selecting `CONFIG_DEV_URANDOM_RANDOM_POOL` provides a cryptographically
  strong CSPRNG. This matches what the port already used in practice on
  targets with a TRNG, since Dropbear read `/dev/urandom` there too.

## Testing

Host: Ubuntu 24.04 (aarch64), GCC 13.3.0
Target: NuttX simulator, `sim:dropbear` configuration (from the companion
nuttx PR), which previously lost `NETUTILS_DROPBEAR` silently at configure
time and now resolves it:

```console
$ ./tools/configure.sh sim:dropbear
$ make -j4
```

Boot, with Dropbear started automatically by NSH (the defconfig presets the
address 10.0.1.2, matching `tools/simhostroute.sh`), then create a user:

```console
$ sudo ./tools/simhostroute.sh eth0 on
$ ./nuttx
NuttShell (NSH) NuttX-12.6.0-RC1
nsh> [6] Jun 01 00:00:00 using NuttX passwd auth at /tmp/passwd
dropbear: listening on port 2222
nsh> useradd admin nuttx2026
```

In a second terminal:
```
$ ssh -p 2222 admin@10.0.1.2
admin@10.0.1.2's password:
nsh> uname -a
NuttX  12.6.0-RC1 5ebe305b23 Jul 11 2026 18:43:50 sim sim
nsh> free
      total       used       free    maxused    maxfree  nused  nfree name
   67108864    2115832   64993032    2183104   64983816    138      5 Umem
nsh> exit
Connection to 10.0.1.2 closed.
```