### PR TITLE
interpreters/berry: Fix raw console input

### DIFF
--- a/interpreters/berry/0002-Use-NuttX-console-reader.patch
+++ b/interpreters/berry/0002-Use-NuttX-console-reader.patch
@@ -1,0 +1,134 @@
+diff --git a/default/be_port.c b/default/be_port.c
+index be19394..7d52aeb 100644
+--- a/default/be_port.c
++++ b/default/be_port.c
+@@ -13,0 +14,7 @@
++#if defined(USE_NUTTX_CONSOLE)
++#include <errno.h>
++#include <poll.h>
++#include <termios.h>
++#include <unistd.h>
++#endif
++
+@@ -17,0 +25,20 @@
++#if defined(USE_NUTTX_CONSOLE)
++static pid_t console_pid = -1;
++static int skip_lf_after_cr;
++
++static void console_write(const char *buffer, size_t length)
++{
++    while (length > 0) {
++        ssize_t result = write(STDOUT_FILENO, buffer, length);
++        if (result > 0) {
++            buffer += result;
++            length -= (size_t)result;
++        } else if (result < 0 && errno == EINTR) {
++            continue;
++        } else {
++            break;
++        }
++    }
++}
++#endif
++
+@@ -24,0 +52,98 @@ BERRY_API char* be_readstring(char *buffer, size_t size)
++#if defined(USE_NUTTX_CONSOLE)
++    struct termios attr = { 0 };
++    size_t length = 0;
++    int echo = 0;
++    int map_newline = 0;
++    int pending = -1;
++    int tty = 0;
++
++    if (size > 0) {
++        buffer[0] = '\0';
++    }
++    if (size < 2) {
++        return NULL;
++    }
++    if (tcgetattr(STDIN_FILENO, &attr) == 0) {
++        tty = 1;
++        echo = (attr.c_lflag & ECHO) == 0;
++        map_newline = (attr.c_oflag & (OPOST | ONLCR)) ==
++            (OPOST | ONLCR);
++    }
++    be_fflush(stdout);
++    if (console_pid != getpid()) {
++        console_pid = getpid();
++        skip_lf_after_cr = 0;
++        if (tty) {
++            struct pollfd pfd = { STDIN_FILENO, POLLIN, 0 };
++            if (poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN) != 0) {
++                char ch;
++                if (read(STDIN_FILENO, &ch, 1) == 1 && ch != '\n') {
++                    pending = (unsigned char)ch;
++                }
++            }
++        }
++    }
++    while (length + 1 < size) {
++        char ch;
++        ssize_t result;
++        if (pending >= 0) {
++            ch = (char)pending;
++            pending = -1;
++            result = 1;
++        } else {
++            result = read(STDIN_FILENO, &ch, 1);
++        }
++        if (result == 0) {
++            skip_lf_after_cr = 0;
++            if (length > 0) {
++                buffer[length] = '\0';
++                return buffer;
++            }
++            return NULL;
++        }
++        if (result < 0) {
++            skip_lf_after_cr = 0;
++            return NULL;
++        }
++        if (skip_lf_after_cr) {
++            skip_lf_after_cr = 0;
++            if (ch == '\n') {
++                continue;
++            }
++        }
++        if (ch == '\x03') {
++            skip_lf_after_cr = 0;
++            if (echo) {
++                console_write("^C", 2);
++                console_write(map_newline ? "\n" : "\r\n",
++                    map_newline ? 1 : 2);
++            }
++            return NULL;
++        }
++        if (ch == '\r' || ch == '\n') {
++            skip_lf_after_cr = ch == '\r';
++            buffer[length++] = '\n';
++            buffer[length] = '\0';
++            if (echo) {
++                console_write(map_newline ? "\n" : "\r\n",
++                    map_newline ? 1 : 2);
++            }
++            return buffer;
++        }
++        if (ch == '\b' || ch == '\x7f') {
++            if (length > 0) {
++                --length;
++                if (echo) {
++                    console_write("\b \b", 3);
++                }
++            }
++            continue;
++        }
++        buffer[length++] = ch;
++        if (echo) {
++            console_write(&ch, 1);
++        }
++    }
++    buffer[length] = '\0';
++    return buffer;
++#else
+@@ -25,0 +151 @@ BERRY_API char* be_readstring(char *buffer, size_t size)
++#endif

--- a/interpreters/berry/CMakeLists.txt
+++ b/interpreters/berry/CMakeLists.txt
@@ -35,6 +35,8 @@ if(CONFIG_INTERPRETERS_BERRY)
       PATCH_COMMAND
         patch -l -p1 -d ${CMAKE_CURRENT_LIST_DIR}/berry -i
         ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-Berry-default-port-for-NuttX.patch
+        COMMAND patch -l -p1 -d ${CMAKE_CURRENT_LIST_DIR}/berry -i
+        ${CMAKE_CURRENT_LIST_DIR}/0002-Use-NuttX-console-reader.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -54,7 +56,7 @@ if(CONFIG_INTERPRETERS_BERRY)
   set(BERRY_CONFIG ${BERRY_CONFIG_DIR}/berry_conf.h)
   set(BERRY_GENERATE ${BERRY_DIR}/generate)
   set(BERRY_GEN_STAMP ${BERRY_GENERATE}/.generated)
-  set(BERRY_FLAGS -Wno-unused-but-set-variable -Wno-shadow)
+  set(BERRY_FLAGS -Wno-unused-but-set-variable -Wno-shadow -DUSE_NUTTX_CONSOLE)
   set(BERRY_INCDIR ${BERRY_CONFIG_DIR} ${BERRY_DIR}/src ${BERRY_DIR}/default)
 
   set(BERRY_CSRCS

--- a/interpreters/berry/Makefile
+++ b/interpreters/berry/Makefile
@@ -57,6 +57,7 @@ CFLAGS += ${INCDIR_PREFIX}$(APPDIR)$(DELIM)interpreters$(DELIM)berry$(DELIM)$(BE
 CFLAGS += ${INCDIR_PREFIX}$(APPDIR)$(DELIM)interpreters$(DELIM)berry$(DELIM)$(BERRY_UNPACK)$(DELIM)default
 CFLAGS += -Wno-unused-but-set-variable
 CFLAGS += -Wno-shadow
+CFLAGS += -DUSE_NUTTX_CONSOLE
 
 PROGNAME  = $(CONFIG_INTERPRETERS_BERRY_PROGNAME)
 PRIORITY  = $(CONFIG_INTERPRETERS_BERRY_PRIORITY)
@@ -73,6 +74,7 @@ $(BERRY_UNPACK): $(BERRY_ARCHIVE)
 	$(call DELDIR, $(BERRY_UNPACK))
 	$(Q) mv berry-$(BERRY_COMMIT_ID) $(BERRY_UNPACK)
 	$(Q) patch -l -d $(BERRY_UNPACK) -p1 < 0001-Fix-Berry-default-port-for-NuttX.patch
+	$(Q) patch -l -d $(BERRY_UNPACK) -p1 < 0002-Use-NuttX-console-reader.patch
 
 $(BERRY_GEN_STAMP): $(BERRY_UNPACK) $(BERRY_CONFIG)
 	$(Q) echo "Generating Berry constant objects"


### PR DESCRIPTION
## Summary

Fix the Berry interactive console on raw NuttX terminals, including USB CDC ACM consoles that do not provide canonical input, CR-to-LF conversion, or driver echo.

The pinned Berry default port uses `fgets()`. On a raw console, Enter commonly arrives as CR rather than LF, so the REPL and `input()` wait indefinitely. Routing Berry through the shared NuttX readline implementation also leaks NSH history and tab completion into the interpreter.

This change:

- adds an opt-in `USE_NUTTX_CONSOLE` reader to the pinned Berry source;
- accepts CR, LF, and CRLF line endings;
- handles a queued LF left by a CRLF command that launched Berry from NSH;
- provides termios-aware local echo and BS/DEL editing without double echo;
- treats ETX or an interrupted read as console termination so Ctrl-C returns to NSH;
- keeps Berry input isolated from NSH readline history, completion, and prompt state; and
- enables the reader in both Make and CMake builds.

The normal Berry `fgets()` path remains unchanged when `USE_NUTTX_CONSOLE` is not defined.

The equivalent source fix is also proposed upstream in [berry-lang/berry#539](https://github.com/berry-lang/berry/pull/539). This local patch is needed for the Berry commit currently pinned by NuttX Apps.

## Impact

- User impact: Berry REPL and `input()` work on raw serial and USB CDC terminals.
- Build impact: Berry alone receives one additional compile definition and pinned-source patch.
- Other applications: unchanged; `system/readline` is not modified.
- Compatibility: the existing stdio fallback is preserved.

## Verification

Fruit Jam RP2350 hardware, minimal NuttX image over raw USB CDC ACM:

- CR-only, LF-only, and CRLF input all complete.
- A CRLF launch no longer leaves an empty line for the first `input()` call.
- Piped `berry\r\n6*7\r\n` preserves the first expression byte and evaluates to `42`.
- CRLF `10+5` evaluates to `15` with one following prompt.
- A following CR-only `2+3` evaluates to `5`.
- LF-only empty input remains valid.
- Berry input is not recalled by NSH history, and Tab does not expose NSH completions.
- Ctrl-C exits Berry and returns to the NSH prompt.

Build and local checks:

- Exact patched `default/be_port.c` blob: `7d52aebe055b098febec472f32690c1ef71780e3`.
- Strict standalone Berry build with `-Wall -Wextra -std=c99 -pedantic-errors -DUSE_NUTTX_CONSOLE` passed.
- `sim:berry` Make build passed; `berry -e "print(6*7)"` returned `42`.
- CMake FetchContent applied both patches and compiled the final `be_port.c` successfully; the full `sim:berry` CMake/Ninja path passed before the final hardware-only handoff addition.
- Pipe and raw-PTY tests covered CR, LF, delayed CRLF, non-LF after CR, empty LF input, BS, DEL, ETX, queued first input, echo, and `input()` prompt flushing.
- `git diff --check` passed.
- NuttX `checkpatch.sh` and `cmake-format` passed.
