### PR TITLE
nshlib: apply configured priority/stacksize under CONFIG_BUILD_KERNEL

### DIFF
--- a/builtin/CMakeLists.txt
+++ b/builtin/CMakeLists.txt
@@ -20,7 +20,7 @@
 #
 # ##############################################################################
 
-if(CONFIG_BUILTIN)
+if(CONFIG_APP_REGISTRY)
 
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
@@ -54,8 +54,11 @@ if(CONFIG_BUILTIN)
 
   set(CSRCS)
 
-  list(APPEND CSRCS builtin_list.c exec_builtin.c builtin_list.h
-       builtin_proto.h)
+  list(APPEND CSRCS builtin_list.c builtin_list.h builtin_proto.h)
+
+  if(CONFIG_BUILTIN)
+    list(APPEND CSRCS exec_builtin.c)
+  endif()
 
   # target_sources(apps PRIVATE ${CSRCS})
   nuttx_add_library(apps_builtin ${CSRCS})

--- a/builtin/Make.defs
+++ b/builtin/Make.defs
@@ -20,6 +20,6 @@
 #
 ############################################################################
 
-ifneq ($(CONFIG_BUILTIN),)
+ifneq ($(CONFIG_APP_REGISTRY),)
 CONFIGURED_APPS += $(APPDIR)/builtin
 endif

--- a/builtin/Makefile
+++ b/builtin/Makefile
@@ -24,7 +24,10 @@ include $(APPDIR)/Make.defs
 
 # Source and object files
 
-CSRCS = builtin_list.c exec_builtin.c
+CSRCS = builtin_list.c
+ifeq ($(CONFIG_BUILTIN),y)
+CSRCS += exec_builtin.c
+endif
 
 # Registry entry lists
 

--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -79,7 +79,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
   pid_t pid;
   int rc = 0;
   int ret;
-#ifdef CONFIG_BUILTIN
+#ifdef CONFIG_APP_REGISTRY
   FAR char *appname;
   int index;
 #endif
@@ -212,7 +212,7 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
         }
     }
 
-#ifdef CONFIG_BUILTIN
+#ifdef CONFIG_APP_REGISTRY
   /* Check if a builtin application with this name exists */
 
   appname = basename((FAR char *)cmd);


### PR DESCRIPTION
## Summary

Companion to [NuttX#19412](https://github.com/apache/nuttx/pull/19412), which splits the compile-time
name/priority/stacksize registry table (`struct builtin_s` / `g_builtins[]`) out of
`CONFIG_BUILTIN` into a new hidden symbol, `CONFIG_APP_REGISTRY`
(`default y if BUILTIN || BUILD_KERNEL`).

This PR switches `builtin/Make.defs` and `nshlib/nsh_fileapps.c` from `CONFIG_BUILTIN` to
`CONFIG_APP_REGISTRY`, so `nsh_fileapp()` can apply an app's configured priority/stacksize
via `posix_spawn()` under `CONFIG_BUILD_KERNEL`. `exec_builtin.c` stays on `CONFIG_BUILTIN`.

**Must be merged after apache/nuttx#<TODO-PR-NUMBER>** — `CONFIG_APP_REGISTRY` doesn't
exist on `nuttx` `master` yet; merging this first would drop `apps/builtin` out of the
build even for existing `CONFIG_BUILTIN=y` configs.

## Testing

See [NuttX#19412](https://github.com/apache/nuttx/pull/19412) for full before/after logs (`rv-virt`, `knsh_romfs`,
modified `examples/hello`). Also re-verified `rv-virt:nsh` (`CONFIG_BUILTIN=y`, no
`CONFIG_BUILD_KERNEL`) is unaffected.