### PR TITLE
interpreters/python: support build without network

### DIFF
--- a/interpreters/python/Makefile
+++ b/interpreters/python/Makefile
@@ -119,6 +119,13 @@ ifeq ($(CONFIG_SYSTEM_SYSTEM),y)
 else
 	@echo "export ac_cv_func_system=\"no\"" >> $@
 endif
+ifeq ($(CONFIG_NET),y)
+	@echo "export ac_cv_func_getaddrinfo=\"yes\"" >> $@
+	@echo "export ac_cv_func_getnameinfo=\"yes\"" >> $@
+else
+	@echo "export ac_cv_func_getaddrinfo=\"no\"" >> $@
+	@echo "export ac_cv_func_getnameinfo=\"no\"" >> $@
+endif
 
 # The `Setup.local` file enables or disables Python modules.
 # Depending on the features enabled on NuttX, this file may need to be
@@ -134,6 +141,9 @@ endif
 ifneq ($(CONFIG_LIBC_DLFCN),y)
 	@echo "_ctypes" >> $@
 endif
+ifneq ($(CONFIG_NET),y)
+	@echo "_socket" >> $@
+endif
 
 # For the Python's `configure` script, please consider the following
 # when building for NuttX:
@@ -145,6 +155,12 @@ endif
 # Also, use -O0 for OPT because -Os is causing problems in
 # Python/Modules/getpath.c (issue will be filed soon to track this
 # problem).
+
+ifneq ($(CONFIG_NET),y)
+PYTHON_CONFIGURE_EXTRAS = --disable-ipv6
+else
+PYTHON_CONFIGURE_EXTRAS =
+endif
 
 $(TARGETBUILD)/Makefile: $(HOSTPYTHON) $(CONFIG_SITE) $(SETUP_LOCAL)
 	$(Q) mkdir -p $(TARGETBUILD)/Modules
@@ -175,6 +191,7 @@ $(TARGETBUILD)/Makefile: $(HOSTPYTHON) $(CONFIG_SITE) $(SETUP_LOCAL)
 			 --without-pymalloc \
 			 --disable-test-modules \
 			 --with-ensurepip=no \
+			 $(PYTHON_CONFIGURE_EXTRAS) \
 		)
 	$(Q) sed -i 's/^#define HAVE_LIBB2 1/\/* #undef HAVE_LIBB2 *\//' $(TARGETBUILD)/pyconfig.h
 	$(Q) sed -i 's/-lb2//g' $(TARGETBUILD)/Makefile


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* interpreters/python: support build without network

Adds options to support building when CONFIG_NET is not set.
This allows building Python for boards that do not have networking support.


## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No.
<!-- Does it impact user's applications? How? -->

Impact on build: Allows building if `CONFIG_NET` is not set.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->
Tested on M5 Stack ESP32-P4 Tab 5 board which does not have ethernet and Wi-Fi is not yet supported.
This requires changes on NuttX of this [MR](https://github.com/apache/nuttx/pull/19458).

### Building
<!-- Provide how to build the test for each SoC being tested -->
- `./tools/configure.sh -S esp32p4-tab5:python`
- Make and flash

### Results
<!-- Provide tests' results and runtime logs -->
Device boots and Python is available.
```
*** Booting NuttX ***
tcm: lma 0x00002020 vma 0x30100000 len 0x68     (104)
dram: lma 0x00002090 vma 0x4ff00000 len 0xa5ec   (42476)
dram: lma 0x0000c684 vma 0x4ff40000 len 0x22c2c  (142380)
padd: lma 0x0002f2c8 vma 0x00000000 len 0xd50    (3408)
imap: lma 0x00030020 vma 0x40200020 len 0xc29060 (12750944)
padd: lma 0x00c59088 vma 0x00000000 len 0x6f70   (28528)
imap: lma 0x00c60000 vma 0x40000000 len 0x1f315c (2044252)
total segments stored 7
WARNING: NuttX supports ESP32-P4 chip revision > v3.0 (chip revision is v1.3).
Ignoring this error and continuing because `CONFIG_ESP32P4_SELECTS_REV_LESS_V3` is set...
THIS MAY NOT WORK! DON'T USE THIS CHIP IN PRODUCTION!

NuttShell (NSH) NuttX-10.4.0
nsh> python
Python 3.13.0 (main, Jul 15 2026, 14:31:34) [GCC 14.2.0] on nuttx
Type "help", "copyright", "credits" or "license" for more information.
>>> print("Hello NuttX!")
Hello NuttX!
>>> 
```