### PR TITLE
interpreters: add Tcl support

### DIFF
--- a/interpreters/jimtcl/CMakeLists.txt
+++ b/interpreters/jimtcl/CMakeLists.txt
@@ -1,0 +1,48 @@
+if(CONFIG_INTERPRETERS_JIMTCL)
+  set(JIMTCL_VERSION 0.83)
+  set(JIMTCL_TARBALL ${JIMTCL_VERSION}.tar.gz)
+  set(JIMTCL_UNPACK jimtcl)
+  set(JIMTCL_URL_BASE https://github.com/msteveb/jimtcl/archive/refs/tags)
+  set(JIMTCL_URL ${JIMTCL_URL_BASE}/${JIMTCL_TARBALL})
+  set(JIMTCL_SRC ${CMAKE_CURRENT_BINARY_DIR}/${JIMTCL_UNPACK})
+
+  # We need the source available before declaring the application, because
+  # jimsh.c is added as an application source, so we can not integrate download
+  # into the external project.
+  FetchContent_Declare(jimtcl_fetch URL ${JIMTCL_URL} SOURCE_DIR
+                                        ${JIMTCL_UNPACK})
+
+  FetchContent_MakeAvailable(jimtcl_fetch)
+
+  ExternalProject_Add(
+    jimtcl_build
+    SOURCE_DIR ${JIMTCL_SRC}
+    PATCH_COMMAND sed -i -e "/^void Jim_SetEnviron/,/^/{s/^/\\/* /}" -e
+                  "/^void Jim_SetEnviron/,/^/{s/\$/ *\\//}" jim.c
+    CONFIGURE_COMMAND
+      ./configure --host=${CMAKE_C_COMPILER_TARGET}
+      "CFLAGS=$<JOIN:$<TARGET_PROPERTY:apps_jimsh,COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:apps_jimsh,COMPILE_DEFINITIONS>, -D> -I$<JOIN:$<TARGET_PROPERTY:apps_jimsh,INCLUDE_DIRECTORIES>, -I> -isystem ${CMAKE_SOURCE_DIR}/include -isystem ${CMAKE_BINARY_DIR}/include"
+    BUILD_COMMAND make libjim.a initjimsh.o
+    INSTALL_COMMAND ""
+    BUILD_IN_SOURCE TRUE
+    BUILD_BYPRODUCTS ${JIMTCL_SRC}/libjim.a ${JIMTCL_SRC}/_initjimsh.c)
+
+  nuttx_add_application(
+    NAME
+    jimsh
+    PRIORITY
+    100
+    STACKSIZE
+    8192
+    INCLUDE_DIRECTORIES
+    ${JIMTCL_SRC}
+    DEPENDS
+    jimtcl_build
+    SRCS
+    ${JIMTCL_SRC}/jimsh.c
+    ${JIMTCL_SRC}/_initjimsh.c)
+
+  set_property(GLOBAL APPEND PROPERTY NUTTX_EXTRA_LIBRARIES
+                                      ${JIMTCL_SRC}/libjim.a)
+
+endif()

--- a/interpreters/jimtcl/Kconfig
+++ b/interpreters/jimtcl/Kconfig
@@ -1,0 +1,12 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config INTERPRETERS_JIMTCL
+	bool "The Jim (TCL) Interpreter"
+	default n
+	---help---
+		Enable support for The Jim interpreter.
+		Jim is an opensource small-footprint implementation of the
+		Tcl programming language.

--- a/interpreters/jimtcl/Make.defs
+++ b/interpreters/jimtcl/Make.defs
@@ -1,0 +1,3 @@
+ifneq ($(CONFIG_INTERPRETERS_JIMTCL),)
+CONFIGURED_APPS += $(APPDIR)/interpreters/jimtcl
+endif

--- a/interpreters/jimtcl/Makefile
+++ b/interpreters/jimtcl/Makefile
@@ -1,0 +1,64 @@
+include $(APPDIR)/Make.defs
+
+PROGNAME  = jimsh
+PRIORITY  = 100
+STACKSIZE = 8192
+
+JIMTCL_VERSION  = 0.83
+JIMTCL_TARBALL  = $(JIMTCL_VERSION).tar.gz
+JIMTCL_UNPACK   = jimtcl
+JIMTCL_URL_BASE = https://github.com/msteveb/jimtcl/archive/refs/tags
+JIMTCL_URL      = $(JIMTCL_URL_BASE)/$(JIMTCL_TARBALL)
+JIMTCL_SRC      = $(JIMTCL_UNPACK)
+
+MAINSRC = $(JIMTCL_SRC)$(DELIM)jimsh.c
+
+# Obtain object list from jimtcl Makefile
+JIMTCL_OBJS := $(shell test -f $(JIMTCL_SRC)$(DELIM)Makefile		\
+                       && ( cat $(JIMTCL_SRC)$(DELIM)Makefile;		\
+                            printf 'print-%%:\n\techo $$($$*)' )	\
+                       | $(MAKE) -f - -s print-OBJS) initjimsh.o
+
+EXTOBJS = $(addprefix $(JIMTCL_SRC)$(DELIM), $(JIMTCL_OBJS))
+
+CFLAGS += -I$(JIMTCL_SRC)
+
+$(JIMTCL_SRC)$(DELIM)%.o: $(JIMTCL_SRC)$(DELIM)Makefile
+	$(Q) $(MAKE) -C $(JIMTCL_SRC) $*.o
+
+$(JIMTCL_SRC)$(DELIM)jimsh.c: $(JIMTCL_SRC)$(DELIM)Makefile
+
+$(JIMTCL_SRC)$(DELIM)_initjimsh.c: $(JIMTCL_SRC)$(DELIM)Makefile
+	$(Q) $(MAKE) -C $(JIMTCL_SRC) $(notdir $@)
+
+$(JIMTCL_SRC)$(DELIM)Makefile:
+	$(Q) cd $(dir $@)					\
+	  && ./configure --host=$(patsubst %-,%,$(CROSSDEV))	\
+	                 CFLAGS="$(CFLAGS)"
+
+# Get the source code and apply a small patch because environ is
+# not settable in Nuttx. This is not required for basic jimtcl
+# but build would fail without commenting it out.
+$(JIMTCL_TARBALL):
+	$(Q) echo "Downloading $(JIMTCL_TARBALL)"
+	$(Q) curl -O -L $(JIMTCL_URL)
+	$(Q) echo "Unpacking $(JIMTCL_TARBALL) to $(JIMTCL_UNPACK)"
+	$(Q) tar -xvzf $(JIMTCL_TARBALL)
+	$(Q) mv jimtcl-$(JIMTCL_VERSION) $(JIMTCL_UNPACK)
+	$(Q) sed -i '/^void Jim_SetEnviron/,/^}/{s/^/\/* /;s/$$/ *\//}'	\
+	  $(JIMTCL_SRC)$(DELIM)jim.c
+
+# Download and unpack tarball if no git repo found
+ifeq ($(wildcard $(JIMTCL_UNPACK)/.git),)
+context:: $(JIMTCL_TARBALL)
+endif
+
+clean::
+	$(Q) test -f $(JIMTCL_SRC)$(DELIM)Makefile	\
+	  && $(MAKE) -C $(JIMTCL_SRC) clean
+
+distclean:: clean
+	$(call DELDIR, $(JIMTCL_UNPACK))
+	$(call DELFILE, $(JIMTCL_TARBALL))
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary

Tcl is added using The Jim Interpreter. Jim is an opensource small-footprint implementation of the Tcl programming language. It implements a large subset of Tcl and adds new features like references with garbage collection, closures, built-in Object Oriented Programming system, Functional Programming commands, first-class arrays and UTF-8 support.

## Impact

Build should be straightforward, just enable the application inside the "Interpreters" section of the configuration. You need to make sure you have `setjmp` support, so consider enabling it in "Build Setup" -> "Customize Header Files".

## Testing

Tested on master, with a minimal custom board with a STM32H5. Planning to test on a nucleo as soon as I can get one.

```
NuttShell (NSH) NuttX-13.0.0
nsh> jimsh
Welcome to Jim version 0.83
. puts "hello world"
. exit
hello world
nsh> jimsh
Welcome to Jim version 0.83
. foreach i {a b c} {
{> puts $i
{> }
. exit
a
b
c
nsh> 
```



