### PR TITLE
Application.mk: Sanitize PROGNAME to a valid identifier for _main symbol

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -122,6 +122,7 @@ ifneq ($(strip $(PROGNAME)),)
   NLIST := $(shell seq 1 $(words $(PROGNAME)))
   $(foreach i, $(NLIST), \
     $(eval PROGNAME_$(word $i,$(PROGOBJ)) := $(word $i,$(PROGNAME))) \
+    $(eval PROGSYM_$(word $i,$(PROGOBJ)) := $(subst -,_,$(word $i,$(PROGNAME)))) \
     $(eval PROGOBJ_$(word $i,$(PROGLIST)) := $(word $i,$(PROGOBJ))) \
     $(eval PRIORITY_$(word $i,$(REGLIST)) := \
         $(if $(word $i,$(PRIORITY)),$(word $i,$(PRIORITY)),$(lastword $(PRIORITY)))) \
@@ -223,7 +224,7 @@ endef
 # rename "main()" in $1 to "xxx_main()" and save to $2
 define RENAMEMAIN
 	$(ECHO_BEGIN)"Rename main() in $1 and save to $2"
-	$(Q) ${shell cat $1 | sed -e "s/fn[ ]\+main/fn $(addsuffix _main,$(PROGNAME_$@))/" > $2}
+	$(Q) ${shell cat $1 | sed -e "s/fn[ ]\+main/fn $(addsuffix _main,$(PROGSYM_$@))/" > $2}
 	$(ECHO_END)
 endef
 
@@ -319,14 +320,14 @@ install:: $(PROGLIST)
 else
 
 $(MAINCXXOBJ): $(PREFIX)%$(CXXEXT)$(SUFFIX)$(OBJEXT): %$(CXXEXT)
-	$(eval $<_CXXFLAGS += ${shell $(DEFINE) "$(CXX)" main=$(addsuffix _main,$(PROGNAME_$@))})
-	$(eval $<_CXXELFFLAGS += ${shell $(DEFINE) "$(CXX)" main=$(addsuffix _main,$(PROGNAME_$@))})
+	$(eval $<_CXXFLAGS += ${shell $(DEFINE) "$(CXX)" main=$(addsuffix _main,$(PROGSYM_$@))})
+	$(eval $<_CXXELFFLAGS += ${shell $(DEFINE) "$(CXX)" main=$(addsuffix _main,$(PROGSYM_$@))})
 	$(if $(and $(CONFIG_MODULES),$(MODCXXFLAGS)), \
 		$(call ELFCOMPILEXX, $<, $@), $(call COMPILEXX, $<, $@))
 
 $(MAINCOBJ): $(PREFIX)%.c$(SUFFIX)$(OBJEXT): %.c
-	$(eval $<_CFLAGS += ${DEFINE_PREFIX}main=$(addsuffix _main,$(PROGNAME_$@)))
-	$(eval $<_CELFFLAGS += ${DEFINE_PREFIX}main=$(addsuffix _main,$(PROGNAME_$@)))
+	$(eval $<_CFLAGS += ${DEFINE_PREFIX}main=$(addsuffix _main,$(PROGSYM_$@)))
+	$(eval $<_CELFFLAGS += ${DEFINE_PREFIX}main=$(addsuffix _main,$(PROGSYM_$@)))
 	$(if $(and $(CONFIG_MODULES),$(MODCFLAGS)), \
 		$(call ELFCOMPILE, $<, $@), $(call COMPILE, $<, $@))
 
@@ -362,10 +363,11 @@ ifeq ($(DO_REGISTRATION),y)
 
 $(REGLIST): $(DEPCONFIG) Makefile
 	$(eval PROGNAME_$@ := $(basename $(notdir $@)))
+	$(eval PROGSYM_$@ := $(subst -,_,$(PROGNAME_$@)))
 ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
-	$(call REGISTER,$(PROGNAME_$@),$(PRIORITY_$@),$(STACKSIZE_$@),$(if $(BUILD_MODULE),,$(PROGNAME_$@)_main),$(UID_$@),$(GID_$@),$(MODE_$@))
+	$(call REGISTER,$(PROGNAME_$@),$(PRIORITY_$@),$(STACKSIZE_$@),$(if $(BUILD_MODULE),,$(PROGSYM_$@)_main),$(UID_$@),$(GID_$@),$(MODE_$@))
 else
-	$(call REGISTER,$(PROGNAME_$@),$(PRIORITY_$@),$(STACKSIZE_$@),$(if $(BUILD_MODULE),,$(PROGNAME_$@)_main))
+	$(call REGISTER,$(PROGNAME_$@),$(PRIORITY_$@),$(STACKSIZE_$@),$(if $(BUILD_MODULE),,$(PROGSYM_$@)_main))
 endif
 
 register:: $(REGLIST)


### PR DESCRIPTION
## Summary

The build system generates an internal entry-point symbol by concatenating `PROGNAME` with `_main`. If `PROGNAME` contains `-` (for example, `hello-world`), the generated symbol (`hello-world_main`) is not a valid C identifier, causing the build to fail.

This can be reproduced by simply setting `CONFIG_EXAMPLES_HELLO_PROGNAME="hello-world"`.

## Changes

Introduce `PROGSYM`, a sanitized copy of `PROGNAME` (`-` replaced with `_`), and use it only where an internal identifier is generated.

- Use `PROGSYM` for the `-Dmain=` compiler define used by C/C++
- Use `PROGSYM` in the Zig `RENAMEMAIN` path
- Use `PROGSYM` for the builtin entry-point symbol passed to `REGISTER`

The registered application name is unchanged, so applications continue to be invoked using their configured `PROGNAME`.

## Issues

Fixes apache/nuttx#19447

## Test log

Host: WSL2 Ubuntu 24.04 x86_64

Configuration: `sim:nsh`

Configured the hello example with a hyphenated program name:

```bash
kconfig-tweak --enable CONFIG_EXAMPLES_HELLO
kconfig-tweak --set-str CONFIG_EXAMPLES_HELLO_PROGNAME "hello-world"
make olddefconfig
make -j$(nproc)
```

Before this change, the build failed because `hello-world_main` is not a valid C identifier.

After applying this change, the build completed successfully:

```text
Register: hello-world
...
LD:  nuttx
Pac SIM with dynamic libs..
SIM elf with dynamic libs archive in nuttx.tgz
```

Verified the application from NSH:

```text
nsh> hello-world
Hello, World!!
```

Regression test:

```bash
kconfig-tweak --set-str CONFIG_EXAMPLES_HELLO_PROGNAME "hello"
make olddefconfig
make clean
make -j$(nproc)
```

Verified the default configuration still works:

```text
nsh> hello
Hello, World!!
```