### PR TITLE
netutils/dropbear: retain child exit status for NSH PTY session

### DIFF
--- a/netutils/dropbear/Kconfig
+++ b/netutils/dropbear/Kconfig
@@ -10,6 +10,8 @@ menuconfig NETUTILS_DROPBEAR
 	depends on !DISABLE_PSEUDOFS_OPERATIONS
 	depends on !DISABLE_PTHREAD
 	depends on SCHED_WAITPID
+	depends on SCHED_HAVE_PARENT
+	depends on SCHED_CHILD_STATUS
 	depends on NSH_LIBRARY
 	depends on FSUTILS_PASSWD
 	depends on PSEUDOTERM


### PR DESCRIPTION
## Summary

Dropbear reaps the per-session NSH task with `waitpid()` in
`dropbear_nshsession.c`. Without `CONFIG_SCHED_CHILD_STATUS` the kernel does
not retain the child exit status, so `waitpid()` returns `ECHILD` right after
authentication and the interactive session never starts
(`NSH session wait failed: Unknown error 10`).
The issue was reported here: https://github.com/apache/nuttx/pull/19209

Depend on `SCHED_HAVE_PARENT` (required by `SCHED_CHILD_STATUS`) and select
`SCHED_CHILD_STATUS` so any Dropbear build gets a working interactive session.

## Impact

Kconfig-only, 2 lines. Fixes interactive SSH sessions for `NETUTILS_DROPBEAR`.
No dependency on other in-flight work.

## Testing

Built `sim:dropbear` (nuttx master + this change) and connected over SSH:

on device side:
```
➜  ~ sudo setcap cap_net_admin+ep /home/felipe-moura/nuttx-space/pr-pure-test/nuttx/nuttx

[sudo] password for felipe-moura: 
➜  ~ cd /home/felipe-moura/nuttx-space/pr-pure-test/nuttx
./nuttx

dropbear [6:100]

NuttShell (NSH) NuttX-13.0.0
nsh> [6] Jun 01 00:00:00 using NuttX passwd auth at /tmp/passwd
dropbear: listening on port 2222
useradd felipe test1234
nsh> [6] Jun 01 00:00:24 connection from 10.0.1.1:54398
[6] Jun 01 00:00:33 Password auth succeeded for 'felipe' from 10.0.1.1:54398
[6] Jun 01 00:00:33 NSH PTY session started
ls
/:
 bin/
 dev/
 etc/
 proc/
 tmp/
 var/
nsh> poweroff
nsh: poweroff: command not found
nsh> 
```

On host side:
```
➜  ~ sudo ip addr add 10.0.1.1/24 dev tap0
sudo ip link set tap0 up

[sudo] password for felipe-moura: 
➜  ~ ssh-keygen -R '[10.0.1.2]:2222'
ssh -p 2222 felipe@10.0.1.2

# Host [10.0.1.2]:2222 found: line 9
/home/felipe-moura/.ssh/known_hosts updated.
Original contents retained as /home/felipe-moura/.ssh/known_hosts.old
The authenticity of host '[10.0.1.2]:2222 ([10.0.1.2]:2222)' can't be established.
ECDSA key fingerprint is SHA256:wRi61vyuX697dPhP5kny+tVZ1gyIgS7qgQ3s23PrQOk.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[10.0.1.2]:2222' (ECDSA) to the list of known hosts.
felipe@10.0.1.2's password: 
nsh> ls
/:
 bin/
 dev/
 etc/
 proc/
 tmp/
 var/
nsh>
```