### PR TITLE
dropbear: rename libtomcrypt symbols to avoid NuttX collisions

### DIFF
--- a/netutils/dropbear/CMakeLists.txt
+++ b/netutils/dropbear/CMakeLists.txt
@@ -192,8 +192,13 @@ if(CONFIG_NETUTILS_DROPBEAR)
   endif()
 
   target_compile_definitions(
-    ${PROGNAME} PRIVATE LOCALOPTIONS_H_EXISTS=1 DROPBEAR_NUTTX=1
-                        DROPBEAR_NUTTX_PASSWD=1)
+    ${PROGNAME}
+    PRIVATE LOCALOPTIONS_H_EXISTS=1
+            DROPBEAR_NUTTX=1
+            DROPBEAR_NUTTX_PASSWD=1
+            base64_encode=dropbear_ltc_base64_encode
+            base64_decode=dropbear_ltc_base64_decode
+            ecc_make_key=dropbear_ltc_ecc_make_key)
 
   if(CONFIG_NETUTILS_DROPBEAR_SCP)
     target_compile_definitions(

--- a/netutils/dropbear/Makefile
+++ b/netutils/dropbear/Makefile
@@ -130,6 +130,13 @@ endif
 # Match the ESP-IDF port behavior: LTC_SOURCE is only for libtomcrypt sources.
 $(foreach src,$(TOMCRYPT_SRCS),$(eval $(src)_CFLAGS += ${DEFINE_PREFIX}LTC_SOURCE=1))
 
+# Avoid duplicate symbols when NuttX/apps also provide these APIs.
+# Apply to all dropbear sources so libtomcrypt definitions and dropbear
+# callers (e.g. signkey.c) use the same renamed symbols.
+CFLAGS += ${DEFINE_PREFIX}base64_encode=dropbear_ltc_base64_encode
+CFLAGS += ${DEFINE_PREFIX}base64_decode=dropbear_ltc_base64_decode
+CFLAGS += ${DEFINE_PREFIX}ecc_make_key=dropbear_ltc_ecc_make_key
+
 MAINSRC = dropbear_main.c
 
 ifneq ($(CONFIG_NETUTILS_DROPBEAR_SCP),)


### PR DESCRIPTION
## Summary

Rename base64_encode, base64_decode, and ecc_make_key in bundled libtomcrypt to avoid duplicate symbol link errors when dropbear is built alongside netutils/codecs and NuttX crypto (e.g., sim:dropbear).

## Impact

Fixes linker failures (multiple definitions of base64_encode, etc.) on dropbear configs that enable CODECS and CRYPTO. No functional change to dropbear behavior.

## Testing

- Host: Linux (WSL2), x86_64, gcc
- `./tools/configure.sh sim:dropbear` && `make`
- Result: Build succeeds; dropbear starts and SSH password auth works