### PR TITLE
netutils/rexecd: forward PRIORITY/STACKSIZE config in CMake build

### DIFF
--- a/netutils/rexecd/CMakeLists.txt
+++ b/netutils/rexecd/CMakeLists.txt
@@ -21,5 +21,13 @@
 # ##############################################################################
 
 if(CONFIG_NETUTILS_REXECD)
-  nuttx_add_application(NAME rexecd SRCS rexecd.c)
+  nuttx_add_application(
+    NAME
+    rexecd
+    SRCS
+    rexecd.c
+    STACKSIZE
+    ${CONFIG_NETUTILS_REXECD_STACKSIZE}
+    PRIORITY
+    ${CONFIG_NETUTILS_REXECD_PRIORITY})
 endif()


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The Makefile build of `netutils/rexecd` already forwards the configured
task priority and stack size via the `PRIORITY` / `STACKSIZE` variables,
but the CMake build did not. As a result, `CONFIG_NETUTILS_REXECD_PRIORITY`
and `CONFIG_NETUTILS_REXECD_STACKSIZE` had no effect when building with CMake.

This change updates `netutils/rexecd/CMakeLists.txt` to pass `STACKSIZE`
(`${CONFIG_NETUTILS_REXECD_STACKSIZE}`) and `PRIORITY`
(`${CONFIG_NETUTILS_REXECD_PRIORITY}`) to `nuttx_add_application()`, aligning
the CMake build behavior with the existing Makefile build.

## Impact
- CMake build only; no new dependencies.

## Testing
- Before change: CMake build ignored the priority/stacksize config values.
- After change: CMake build uses the configured priority/stacksize, consistent
with the Makefile build.