### PR TITLE
apps/nsh: Add support to command line editing on NSH

### DIFF
--- a/include/system/readline.h
+++ b/include/system/readline.h
@@ -88,8 +88,9 @@ extern "C"
  *
  *   If a prompt string is used by the application, then the application
  *   must provide the prompt string to readline() by calling this function.
- *   This is needed only for tab completion in cases where is it necessary
- *   to reprint the prompt string.
+ *   This is needed for tab completion, and for line editing's full-line
+ *   redraws (Home, End, history recall, ...), in cases where it is
+ *   necessary to reprint the prompt string.
  *
  * Input Parameters:
  *   prompt    - The prompt string. This function may then be
@@ -108,7 +109,7 @@ extern "C"
  *
  ****************************************************************************/
 
-#ifdef CONFIG_READLINE_TABCOMPLETION
+#if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
 FAR const char *readline_prompt(FAR const char *prompt);
 #else
 #  define readline_prompt(p)

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -223,6 +223,12 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 
       write(OUTFD(pstate), nsh_prompt(), strlen(nsh_prompt()));
 
+#ifdef CONFIG_READLINE_TABCOMPLETION
+      /* Set the prompt so readline can redraw it for editing features */
+
+      readline_prompt(nsh_prompt());
+#endif
+
       /* readline() normally returns the number of characters read, but
        * will return EOF on end of file or if an error occurs.  EOF
        * will cause the session to terminate.

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -223,7 +223,7 @@ int nsh_session(FAR struct console_stdio_s *pstate,
 
       write(OUTFD(pstate), nsh_prompt(), strlen(nsh_prompt()));
 
-#ifdef CONFIG_READLINE_TABCOMPLETION
+#if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
       /* Set the prompt so readline can redraw it for editing features */
 
       readline_prompt(nsh_prompt());

--- a/system/readline/Kconfig
+++ b/system/readline/Kconfig
@@ -54,6 +54,25 @@ config READLINE_MAX_EXTCMDS
 
 endif # READLINE_TABCOMPLETION
 
+config READLINE_EDIT
+	bool "Command line editing"
+	default y if !DEFAULT_SMALL
+	---help---
+		Build in support for full command-line editing using cursor keys,
+		Home/End, Delete. Requires a VT100/ANSI-compatible terminal.
+
+if READLINE_EDIT
+
+config READLINE_EDIT_EMACS
+	bool "Emacs-style control keys"
+	default n
+	---help---
+		Enable emacs-style control key bindings:
+		Ctrl+A Home, Ctrl+E End, Ctrl+K kill-to-end,
+		Ctrl+U kill-to-start, Ctrl+Left/Right word movement.
+
+endif # READLINE_EDIT
+
 config READLINE_CMD_HISTORY
 	bool "Command line history"
 	default n
@@ -95,6 +114,17 @@ config READLINE_CMD_HISTORY_LEN
 		memory array.  The total memory usage for the command line array
 		will be READLINE_CMD_HISTORY_LINELEN x READLINE_CMD_HISTORY_LEN.
 		Default: 16
+
+config READLINE_EDIT_EMACS_REVERSE_SEARCH
+	bool "Reverse incremental search (Ctrl+R)"
+	default y
+	depends on READLINE_EDIT_EMACS
+	---help---
+		Enable bash-style Ctrl+R reverse incremental search through the
+		command history.  Typing narrows the search to the most recent
+		matching command; Ctrl+R again searches further back; Enter
+		submits the match; Ctrl+G/Ctrl+C cancels back to the line being
+		edited before Ctrl+R was pressed.
 
 endif # READLINE_CMD_HISTORY
 endif # READLINE_ECHO

--- a/system/readline/Kconfig
+++ b/system/readline/Kconfig
@@ -61,17 +61,14 @@ config READLINE_EDIT
 		Build in support for full command-line editing using cursor keys,
 		Home/End, Delete. Requires a VT100/ANSI-compatible terminal.
 
-if READLINE_EDIT
-
 config READLINE_EDIT_EMACS
 	bool "Emacs-style control keys"
 	default n
+	depends on READLINE_EDIT
 	---help---
 		Enable emacs-style control key bindings:
 		Ctrl+A Home, Ctrl+E End, Ctrl+K kill-to-end,
 		Ctrl+U kill-to-start, Ctrl+Left/Right word movement.
-
-endif # READLINE_EDIT
 
 config READLINE_CMD_HISTORY
 	bool "Command line history"

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -543,7 +543,7 @@ static int word_skip(FAR const char *buf, int cursor, int bound,
 #endif
 
 #ifdef CONFIG_READLINE_ECHO
-#ifdef CONFIG_READLINE_EDIT
+#  ifdef CONFIG_READLINE_EDIT
 /****************************************************************************
  * Name: redraw_line
  *
@@ -621,9 +621,9 @@ static void redraw_tail(FAR struct rl_common_s *vtbl, FAR const char *buf,
         }
     }
 }
-#endif /* CONFIG_READLINE_EDIT */
+#  endif /* CONFIG_READLINE_EDIT */
 
-#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+#  ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
 /****************************************************************************
  * Name: isearch_redraw
  *
@@ -669,7 +669,7 @@ static void isearch_redraw(FAR struct rl_common_s *vtbl,
       RL_WRITE(vtbl, buf, nch);
     }
 }
-#endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
+#  endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
 #endif /* CONFIG_READLINE_ECHO */
 
 /****************************************************************************
@@ -799,13 +799,13 @@ FAR const char *readline_prompt(FAR const char *prompt)
 FAR const struct extmatch_vtable_s *
   readline_extmatch(FAR const struct extmatch_vtable_s *vtbl)
 {
-#if (CONFIG_READLINE_MAX_EXTCMDS > 0)
+#  if (CONFIG_READLINE_MAX_EXTCMDS > 0)
   FAR const struct extmatch_vtable_s *ret = g_extmatch_vtbl;
   g_extmatch_vtbl = vtbl;
   return ret;
-#else
+#  else
   return NULL;
-#endif
+#  endif
 }
 #endif
 
@@ -934,9 +934,9 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
               bool found = isearch_find(search, searchlen, searchoffset,
                                          &searchoffset, buf, buflen, &nch);
-#ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_ECHO
               isearch_redraw(vtbl, search, searchlen, buf, nch, !found);
-#endif
+#  endif
             }
           else if (ch == ASCII_BS || ch == ASCII_DEL)
             {
@@ -956,10 +956,10 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                     }
                 }
 
-#ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_ECHO
               isearch_redraw(vtbl, search, searchlen, buf, nch,
                               searchlen > 0 && nch == 0);
-#endif
+#  endif
             }
           else if (ch == CTRL_G || ch == ASCII_ETX)  /* ^G or ^C: cancel */
             {
@@ -978,9 +978,9 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
               buf[nch] = '\0';
 
-#ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_ECHO
               redraw_line(vtbl, buf, nch, cursor);
-#endif
+#  endif
             }
           else if (ch == '\n')
             {
@@ -1009,9 +1009,9 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
               bool found = isearch_find(search, searchlen, searchoffset,
                                          &searchoffset, buf, buflen, &nch);
-#ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_ECHO
               isearch_redraw(vtbl, search, searchlen, buf, nch, !found);
-#endif
+#  endif
             }
           else
             {
@@ -1023,14 +1023,14 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
               insearch = false;
               cursor   = nch;
 
-#ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_ECHO
               redraw_line(vtbl, buf, nch, cursor);
-#endif
+#  endif
             }
 
           continue;
         }
-#endif
+#endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
 
       /* Are we processing a VT100 escape sequence */
 
@@ -1042,19 +1042,44 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           if (escape == 3)
             {
               escape = 0;
-              if (ch == '~' && cursor < nch)
+              if (ch == '~')
                 {
-                  int k;
-                  for (k = cursor + 1; k < nch; k++)
-                    buf[k - 1] = buf[k];
-                  nch--;
-#  ifdef CONFIG_READLINE_ECHO
-                  /* Back up 1 — terminal echo of '~' advanced cursor */
+                  if (cursor < nch)
+                    {
+                      int k;
+                      for (k = cursor + 1; k < nch; k++)
+                        buf[k - 1] = buf[k];
+                      nch--;
+                    }
 
-                  RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-                  redraw_tail(vtbl, buf, nch, cursor);
+#  ifdef CONFIG_READLINE_ECHO
+                  /* Delete arrives as the 4-byte sequence "ESC [ 3 ~".
+                   * Some serial drivers only know how to suppress
+                   * local echo for fixed 3-byte "ESC [ x" sequences
+                   * and leak the trailing '~' as a literal character,
+                   * silently advancing the terminal's real cursor by
+                   * one column.  redraw_line() is immune to this (and
+                   * to any other such drift) because it always
+                   * returns to column 0 with '\r' first, rather than
+                   * assuming where the cursor currently is -- unlike
+                   * a plain erase-and-rewrite-the-tail redraw, which
+                   * only works relative to the cursor's last known
+                   * position and has no way to recover if that
+                   * assumption turns out to be wrong.
+                   *
+                   * This redraw is unconditional -- even when there
+                   * was nothing to delete (cursor already at the true
+                   * end, including an empty line) -- specifically so
+                   * it also cleans up a leaked '~' in that case; only
+                   * skipping the redraw when there is "nothing to do"
+                   * is exactly what left a stray '~' visible on
+                   * screen with an unpatched driver.
+                   */
+
+                  redraw_line(vtbl, buf, nch, cursor);
 #  endif
                 }
+
               continue;
             }
 
@@ -1116,6 +1141,35 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
               continue;
             }
 #endif /* CONFIG_READLINE_EDIT */
+
+          if (escape == 10)    /* Unrecognized CSI -- consume to final byte */
+            {
+              if (ch >= 0x20 && ch <= 0x3f)
+                {
+                  continue;    /* still a parameter/intermediate byte */
+                }
+
+              /* ch is the final byte (0x40-0x7e), or something
+               * malformed -- either way the sequence is over now and
+               * is discarded; nothing was ever inserted into the
+               * buffer.  Still issue a corrective redraw: some serial
+               * drivers only know how to suppress local echo for
+               * fixed 3-byte "ESC [ x" sequences and leak bytes from
+               * any longer, unrecognized sequence as literal
+               * characters, the same class of issue Delete has for
+               * its own "ESC [ 3 ~".  redraw_line() cleans up any
+               * such leaked characters even though the buffer itself
+               * was never affected by them.
+               */
+
+              escape = 0;
+#  ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_EDIT
+              redraw_line(vtbl, buf, nch, cursor);
+#  endif
+#  endif
+              continue;
+            }
 
           /* Some terminals (e.g. xterm) use the SS3 introducer "ESC O"
            * rather than CSI "ESC [" for Home/End (and, in application
@@ -1196,10 +1250,10 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
                   nch = 0;
 
-#ifdef CONFIG_READLINE_ECHO
+#  ifdef CONFIG_READLINE_ECHO
                   RL_PUTC(vtbl, '\r');
                   RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-#if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
+#    if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
                   if (g_readline_prompt != NULL)
                     {
                       int k;
@@ -1208,8 +1262,8 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                           RL_PUTC(vtbl, g_readline_prompt[k]);
                         }
                     }
-#endif
-#endif
+#    endif
+#  endif
 
                   if (g_cmdhist.offset != 1)
                     {
@@ -1244,9 +1298,9 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                    * using a stale, out-of-range cursor value.
                    */
 
-#ifdef CONFIG_READLINE_EDIT
+#  ifdef CONFIG_READLINE_EDIT
                   cursor = nch;
-#endif
+#  endif
                 }
 #endif /* CONFIG_READLINE_CMD_HISTORY */
 
@@ -1314,6 +1368,22 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                   continue;
                 }
 #endif
+
+              /* Not one of the specific sequences recognized above.  If
+               * this still looks like a CSI parameter or intermediate
+               * byte (0x20-0x3f: digits, ';', and similar), this is
+               * some other CSI sequence this code doesn't specifically
+               * know about -- keep consuming bytes until the real final
+               * byte (0x40-0x7e) ends it, rather than treating this
+               * byte as the end of the sequence and leaking whatever
+               * comes after it as literal input.
+               */
+
+              if (ch >= 0x20 && ch <= 0x3f)
+                {
+                  escape = 10;
+                  continue;
+                }
 
               escape = 0;
               ch = 'a';
@@ -1450,19 +1520,34 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           buf[nch] = '\0';
           redraw_line(vtbl, buf, nch, cursor);
         }
-      else if (ch == CTRL_W)           /* Ctrl+W = Kill word backward (FIXME) */
+      else if (ch == CTRL_W)           /* Ctrl+W = Kill word backward */
         {
           int start, k;
           start = word_skip(buf, cursor, 0, false);
-          for (k = start; k < nch; k++)
+          for (k = cursor; k < nch; k++)
             buf[k - (cursor - start)] = buf[k];
           nch -= (cursor - start);
           cursor = start;
           buf[nch] = '\0';
-          redraw_tail(vtbl, buf, nch, cursor);
+
+          /* Unlike Ctrl+K (which never moves the cursor, so erasing
+           * from wherever it already is is correct) and Backspace
+           * (which moves it by exactly one column and compensates
+           * with a single explicit backspace byte), Ctrl+W can move
+           * the cursor back by any number of columns depending on how
+           * long the killed word was.  redraw_tail() has no way to
+           * express "also move left by N first"; it just erases from
+           * wherever the terminal's cursor already happens to be.
+           * Using redraw_line() instead sidesteps the whole problem
+           * the same way it does for Delete: it returns to column 0
+           * with '\r' first, so it is correct regardless of how far
+           * the cursor moved.
+           */
+
+          redraw_line(vtbl, buf, nch, cursor);
         }
 
-#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+#  ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
       else if (ch == CTRL_R && g_cmdhist.len > 0)
         {
           /* Ctrl+R = start a reverse incremental search through the
@@ -1489,11 +1574,11 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           savedcursor = cursor;
           nch         = 0;
 
-#ifdef CONFIG_READLINE_ECHO
+#    ifdef CONFIG_READLINE_ECHO
           isearch_redraw(vtbl, search, searchlen, buf, nch, false);
-#endif
+#    endif
         }
-#endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
+#  endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
 #endif /* CONFIG_READLINE_EDIT_EMACS */
 
       /* Otherwise, put the character in the line buffer if the
@@ -1526,7 +1611,11 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           if (nch + 1 < buflen)
             {
               int j;
-              for (j = nch; j > cursor; j--) buf[j] = buf[j - 1];
+              for (j = nch; j > cursor; j--)
+                {
+                  buf[j] = buf[j - 1];
+                }
+
               buf[cursor] = (char)ch; nch++; cursor++;
 #  ifdef CONFIG_READLINE_ECHO
               redraw_tail(vtbl, buf, nch, cursor);
@@ -1534,7 +1623,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
             }
 #else
           buf[nch++] = ch;
-#endif
+#endif  /* CONFIG_READLINE_EDIT */
 
           /* Check if there is room for another character and the line's
            * null terminator.  If not then we have to end the line now.
@@ -1569,14 +1658,14 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
            * only in the opposite direction.
            */
 
-#ifdef CONFIG_READLINE_EDIT
+#  ifdef CONFIG_READLINE_EDIT
           if (tab_completion(vtbl, buf, buflen, &nch))
             {
               cursor = nch;
             }
-#else
+#  else
           tab_completion(vtbl, buf, buflen, &nch);
-#endif
+#  endif
         }
 #endif
     }

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -73,8 +73,15 @@ struct cmdhist_s
 static const char g_erasetoeol[] = VT100_CLEAREOL;
 #endif
 #ifdef CONFIG_READLINE_EDIT
-static const char g_curleft[]  = {ASCII_ESC, '[', 'D'};
-static const char g_curright[] = {ASCII_ESC, '[', 'C'};
+static const char g_curleft[]  =
+                                  {
+                                    ASCII_ESC, '[', 'D'
+                                  };
+
+static const char g_curright[] =
+                                  {
+                                    ASCII_ESC, '[', 'C'
+                                  };
 #endif
 
 #ifdef CONFIG_READLINE_EDIT_EMACS
@@ -94,15 +101,20 @@ static const char g_curright[] = {ASCII_ESC, '[', 'C'};
 #  endif
 #endif
 
-#ifdef CONFIG_READLINE_TABCOMPLETION
-/* Prompt string to present at the beginning of the line */
+#if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
+/* Prompt string to present at the beginning of the line.  Needed by tab
+ * completion (to reprint the prompt after listing multiple matches) and
+ * by line editing's full-line redraws (Home, End, history recall, ...),
+ * so this is available whenever either feature is enabled, not just
+ * when both are.
+ */
 
 static FAR const char *g_readline_prompt = NULL;
+#endif
 
-#ifdef CONFIG_READLINE_HAVE_EXTMATCH
+#if defined(CONFIG_READLINE_TABCOMPLETION) && defined(CONFIG_READLINE_HAVE_EXTMATCH)
 static FAR const struct extmatch_vtable_s *g_extmatch_vtbl = NULL;
 #endif
-#endif /* CONFIG_READLINE_TABCOMPLETION */
 
 #ifdef CONFIG_READLINE_CMD_HISTORY
 static struct cmdhist_s g_cmdhist;
@@ -559,7 +571,6 @@ static void redraw_line(FAR struct rl_common_s *vtbl, FAR const char *buf,
   RL_PUTC(vtbl, '\r');
   RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
 
-#ifdef CONFIG_READLINE_TABCOMPLETION
   if (g_readline_prompt != NULL)
     {
       for (i = 0; g_readline_prompt[i] != '\0'; i++)
@@ -567,7 +578,6 @@ static void redraw_line(FAR struct rl_common_s *vtbl, FAR const char *buf,
           RL_PUTC(vtbl, g_readline_prompt[i]);
         }
     }
-#endif
 
   if (nch > 0)
     {
@@ -731,8 +741,9 @@ static ssize_t submit_line(FAR char *buf, int nch)
  *
  *   If a prompt string is used by the application, then the application
  *   must provide the prompt string to readline() by calling this function.
- *   This is needed only for tab completion in cases where is it necessary
- *   to reprint the prompt string.
+ *   This is needed for tab completion, and for line editing's full-line
+ *   redraws (Home, End, history recall, ...), in cases where it is
+ *   necessary to reprint the prompt string.
  *
  * Input Parameters:
  *   prompt    - The prompt string. This function may then be
@@ -751,7 +762,7 @@ static ssize_t submit_line(FAR char *buf, int nch)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_READLINE_TABCOMPLETION
+#if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
 FAR const char *readline_prompt(FAR const char *prompt)
 {
   FAR const char *ret = g_readline_prompt;
@@ -1188,7 +1199,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 #ifdef CONFIG_READLINE_ECHO
                   RL_PUTC(vtbl, '\r');
                   RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-#ifdef CONFIG_READLINE_TABCOMPLETION
+#if defined(CONFIG_READLINE_TABCOMPLETION) || defined(CONFIG_READLINE_EDIT)
                   if (g_readline_prompt != NULL)
                     {
                       int k;

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -72,6 +72,27 @@ struct cmdhist_s
 #ifdef CONFIG_READLINE_ECHO
 static const char g_erasetoeol[] = VT100_CLEAREOL;
 #endif
+#ifdef CONFIG_READLINE_EDIT
+static const char g_curleft[]  = {ASCII_ESC, '[', 'D'};
+static const char g_curright[] = {ASCII_ESC, '[', 'C'};
+#endif
+
+#ifdef CONFIG_READLINE_EDIT_EMACS
+/* Emacs-style control key codes */
+
+#  define CTRL_A  1   /* ^A - Home */
+#  define CTRL_B  2   /* ^B - Left */
+#  define CTRL_D  4   /* ^D - Delete at cursor */
+#  define CTRL_E  5   /* ^E - End */
+#  define CTRL_F  6   /* ^F - Right */
+#  define CTRL_K  11  /* ^K - Kill to end of line */
+#  define CTRL_U  21  /* ^U - Kill to beginning of line */
+#  define CTRL_W  23  /* ^W - Kill word backward */
+#  ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+#    define CTRL_G  7   /* ^G - Cancel incremental search */
+#    define CTRL_R  18  /* ^R - Reverse incremental search */
+#  endif
+#endif
 
 #ifdef CONFIG_READLINE_TABCOMPLETION
 /* Prompt string to present at the beginning of the line */
@@ -150,12 +171,18 @@ static int count_builtin_matches(FAR char *buf, FAR int *matches,
  *   nch     - the number of characters.
  *
  * Returned Value:
- *   None.
+ *   True if the completion changed 'buf'/'*nch' and/or echoed anything
+ *   to the terminal (a single unambiguous match was appended, or the
+ *   multiple-match list was printed -- which always ends with a full
+ *   reprint of the prompt and buffer, even if the common prefix did
+ *   not grow).  False if nothing happened at all (no match, or an
+ *   exact single match with nothing left to add), in which case the
+ *   terminal's cursor never moved.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_READLINE_TABCOMPLETION
-static void tab_completion(FAR struct rl_common_s *vtbl, char *buf,
+static bool tab_completion(FAR struct rl_common_s *vtbl, char *buf,
                            int buflen, int *nch)
 {
   FAR const char *name = NULL;
@@ -247,7 +274,10 @@ static void tab_completion(FAR struct rl_common_s *vtbl, char *buf,
           if (len < name_len)
             {
               *nch = name_len;
+              return true;
             }
+
+          return false;
         }
 
       /* Are there multiple matching names? */
@@ -359,14 +389,291 @@ static void tab_completion(FAR struct rl_common_s *vtbl, char *buf,
            * if any
            */
 
+          /* Don't remove extra characters after the completed word,
+           * if any
+           */
+
           if (len < name_len)
             {
               *nch = name_len;
             }
+
+          /* Whether or not the common prefix grew, the prompt and
+           * buffer were just reprinted from scratch above, so the
+           * terminal's cursor is now at the end of the line either
+           * way.
+           */
+
+          return true;
         }
     }
+
+  return false;
 }
 #endif
+
+#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+/****************************************************************************
+ * Name: isearch_find
+ *
+ * Description:
+ *   Used by Ctrl+R (reverse incremental search).  Search backward
+ *   through the command history, starting just before 'startoffset',
+ *   for the most recent entry containing 'search' as a substring (using
+ *   the same head/offset addressing as the up/down arrow history
+ *   recall code above).  If a match is found, it is copied into 'buf'
+ *   (updating '*nch'), and its offset is returned via '*foundoffset' so
+ *   that a subsequent call can continue the search further back in
+ *   history.  If no match is found, 'buf'/'*nch' are left unmodified.
+ *
+ * Returned Value:
+ *   True if a match was found, false otherwise.
+ *
+ ****************************************************************************/
+
+static bool isearch_find(FAR const char *search, int searchlen,
+                          int startoffset, FAR int *foundoffset,
+                          FAR char *buf, int buflen, FAR int *nch)
+{
+  int minoffset;
+  int offset;
+  int idx;
+  int len;
+  int i;
+  int j;
+  bool matched;
+
+  if (searchlen == 0 || g_cmdhist.len == 0)
+    {
+      return false;
+    }
+
+  minoffset = -(g_cmdhist.len - 1);
+
+  for (offset = startoffset - 1; offset >= minoffset; offset--)
+    {
+      idx = g_cmdhist.head + offset;
+
+      if (idx < 0)
+        {
+          idx += RL_CMDHIST_LEN;
+        }
+      else if (idx >= RL_CMDHIST_LEN)
+        {
+          idx -= RL_CMDHIST_LEN;
+        }
+
+      len = strlen(g_cmdhist.buf[idx]);
+
+      /* Does this history entry contain 'search' anywhere?  'search'
+       * is a raw character buffer that is never null-terminated (the
+       * caller only tracks its length in 'searchlen'), so this cannot
+       * use strstr() -- do a plain bounded substring search instead.
+       */
+
+      matched = false;
+
+      for (i = 0; i + searchlen <= len; i++)
+        {
+          for (j = 0; j < searchlen; j++)
+            {
+              if (g_cmdhist.buf[idx][i + j] != search[j])
+                {
+                  break;
+                }
+            }
+
+          if (j == searchlen)
+            {
+              matched = true;
+              break;
+            }
+        }
+
+      if (!matched)
+        {
+          continue;
+        }
+
+      if (len > buflen - 1)
+        {
+          len = buflen - 1;
+        }
+
+      for (i = 0; i < len; i++)
+        {
+          buf[i] = g_cmdhist.buf[idx][i];
+        }
+
+      buf[len]     = '\0';
+      *nch         = len;
+      *foundoffset = offset;
+      return true;
+    }
+
+  return false;
+}
+#endif
+
+#ifdef CONFIG_READLINE_ECHO
+#ifdef CONFIG_READLINE_EDIT
+/****************************************************************************
+ * Name: redraw_line
+ *
+ * Description:
+ *   Redraw the prompt and the line buffer from scratch: return to the
+ *   true start of the terminal line, erase to the end of line, reprint
+ *   the prompt (if any), reprint the buffer, then move the cursor left
+ *   as many times as needed to visually land on 'cursor'.  This does
+ *   not depend on where the terminal's cursor happened to be beforehand
+ *   -- unlike a backspace-based erase, it is correct no matter where
+ *   the cursor was left by whatever came before it.
+ *
+ *   This is the common tail end of every full-line redraw in this file
+ *   (Home, End, Ctrl+Left/Right, history recall, ...); consolidating it
+ *   here instead of repeating the same half-dozen lines at each call
+ *   site saves a fair amount of code space.
+ *
+ ****************************************************************************/
+
+static void redraw_line(FAR struct rl_common_s *vtbl, FAR const char *buf,
+                         int nch, int cursor)
+{
+  int i;
+
+  RL_PUTC(vtbl, '\r');
+  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+
+#ifdef CONFIG_READLINE_TABCOMPLETION
+  if (g_readline_prompt != NULL)
+    {
+      for (i = 0; g_readline_prompt[i] != '\0'; i++)
+        {
+          RL_PUTC(vtbl, g_readline_prompt[i]);
+        }
+    }
+#endif
+
+  if (nch > 0)
+    {
+      RL_WRITE(vtbl, buf, nch);
+    }
+
+  for (i = nch; i > cursor; i--)
+    {
+      RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+    }
+}
+#endif /* CONFIG_READLINE_EDIT */
+
+#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+/****************************************************************************
+ * Name: isearch_redraw
+ *
+ * Description:
+ *   Redraw the reverse-incremental-search prompt line:
+ *   "(reverse-i-search)`<search>': <match>", or
+ *   "(failed reverse-i-search)`<search>': <match>" if the current
+ *   search string has no match (in which case 'buf'/'nch' still hold
+ *   whatever the last successful match was, exactly as bash does).
+ *
+ ****************************************************************************/
+
+static void isearch_redraw(FAR struct rl_common_s *vtbl,
+                            FAR const char *search, int searchlen,
+                            FAR const char *buf, int nch, bool failed)
+{
+  static const char matchlabel[] = "(reverse-i-search)`";
+  static const char faillabel[]  = "(failed reverse-i-search)`";
+
+  RL_PUTC(vtbl, '\r');
+  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+
+  if (failed)
+    {
+      RL_WRITE(vtbl, faillabel, sizeof(faillabel) - 1);
+    }
+  else
+    {
+      RL_WRITE(vtbl, matchlabel, sizeof(matchlabel) - 1);
+    }
+
+  if (searchlen > 0)
+    {
+      RL_WRITE(vtbl, search, searchlen);
+    }
+
+  RL_PUTC(vtbl, '\'');
+  RL_PUTC(vtbl, ':');
+  RL_PUTC(vtbl, ' ');
+
+  if (nch > 0)
+    {
+      RL_WRITE(vtbl, buf, nch);
+    }
+}
+#endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
+#endif /* CONFIG_READLINE_ECHO */
+
+/****************************************************************************
+ * Name: submit_line
+ *
+ * Description:
+ *   Finish a line of input: record it in the command history (if
+ *   enabled and it isn't a duplicate of the most recent entry),
+ *   terminate 'buf' with '\n' and a null terminator, and return the
+ *   number of characters in 'buf' (including the trailing '\n').  This
+ *   is shared by the normal Enter key handling and by Ctrl+R
+ *   (reverse-i-search), which also submits the matched line directly
+ *   on Enter.
+ *
+ ****************************************************************************/
+
+static ssize_t submit_line(FAR char *buf, int nch)
+{
+#ifdef CONFIG_READLINE_CMD_HISTORY
+  int i;
+
+  /* Save history of command, only if there was something typed besides
+   * the return character.
+   */
+
+  if (nch >= 1)
+    {
+      /* If this command is the one at the top of the circular buffer,
+       * don't save it again.
+       */
+
+      if (strncmp(buf, g_cmdhist.buf[g_cmdhist.head], nch + 1) != 0)
+        {
+          g_cmdhist.head = (g_cmdhist.head + 1) % RL_CMDHIST_LEN;
+
+          for (i = 0; (i < nch) && i < (RL_CMDHIST_LINELEN - 1); i++)
+            {
+              g_cmdhist.buf[g_cmdhist.head][i] = buf[i];
+            }
+
+          g_cmdhist.buf[g_cmdhist.head][i] = '\0';
+
+          if (g_cmdhist.len < RL_CMDHIST_LEN)
+            {
+              g_cmdhist.len++;
+            }
+        }
+
+      g_cmdhist.offset = 1;
+    }
+#endif /* CONFIG_READLINE_CMD_HISTORY */
+
+  /* The newline is stored in the buffer along with the null
+   * terminator.
+   */
+
+  buf[nch++] = '\n';
+  buf[nch]   = '\0';
+
+  return nch;
+}
 
 /****************************************************************************
  * Public Functions
@@ -481,6 +788,18 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 #ifdef CONFIG_READLINE_CMD_HISTORY
   int i;
 #endif
+#ifdef CONFIG_READLINE_EDIT
+  volatile int cursor;
+#endif
+#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+  bool insearch;
+  char search[RL_CMDHIST_LINELEN];
+  int  searchlen;
+  int  searchoffset;
+  char savedbuf[RL_CMDHIST_LINELEN];
+  int  savednch;
+  int  savedcursor;
+#endif
 
   /* Sanity checks */
 
@@ -505,6 +824,13 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
   escape = 0;
   nch    = 0;
+#ifdef CONFIG_READLINE_EDIT
+  cursor  = 0;
+#endif
+#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+  insearch  = false;
+  searchlen = 0;
+#endif
 
   for (; ; )
     {
@@ -534,20 +860,255 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
           return EOF;
         }
 
+#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+      /* Are we in reverse incremental search mode (Ctrl+R)?  If so,
+       * every subsequent keystroke is interpreted as part of the
+       * search until it is accepted, submitted, or cancelled.
+       */
+
+      else if (insearch)
+        {
+          if (ch == CTRL_R)
+            {
+              /* Repeat: search further back for another match of the
+               * same search string.
+               */
+
+              bool found = isearch_find(search, searchlen, searchoffset,
+                                         &searchoffset, buf, buflen, &nch);
+#ifdef CONFIG_READLINE_ECHO
+              isearch_redraw(vtbl, search, searchlen, buf, nch, !found);
+#endif
+            }
+          else if (ch == ASCII_BS || ch == ASCII_DEL)
+            {
+              if (searchlen > 0)
+                {
+                  searchlen--;
+                  searchoffset = 1;
+
+                  if (searchlen > 0)
+                    {
+                      isearch_find(search, searchlen, searchoffset,
+                                    &searchoffset, buf, buflen, &nch);
+                    }
+                  else
+                    {
+                      nch = 0;
+                    }
+                }
+
+#ifdef CONFIG_READLINE_ECHO
+              isearch_redraw(vtbl, search, searchlen, buf, nch,
+                              searchlen > 0 && nch == 0);
+#endif
+            }
+          else if (ch == CTRL_G || ch == ASCII_ETX)  /* ^G or ^C: cancel */
+            {
+              /* Cancel: restore the line exactly as it was before
+               * Ctrl+R was pressed.
+               */
+
+              insearch = false;
+              nch      = savednch;
+              cursor   = savedcursor;
+
+              for (i = 0; i < nch; i++)
+                {
+                  buf[i] = savedbuf[i];
+                }
+
+              buf[nch] = '\0';
+
+#ifdef CONFIG_READLINE_ECHO
+              redraw_line(vtbl, buf, nch, cursor);
+#endif
+            }
+          else if (ch == '\n')
+            {
+              /* Accept the current match and submit it immediately,
+               * exactly as bash does.
+               */
+
+              insearch = false;
+              return submit_line(buf, nch);
+            }
+          else if (ch == ASCII_ESC)
+            {
+              /* Accept the current match into the line, then let the
+               * escape sequence that follows (if any) be processed
+               * normally against it on the next iteration(s).
+               */
+
+              insearch = false;
+              cursor   = nch;
+              escape   = 1;
+            }
+          else if (!iscntrl(ch & 0xff) && searchlen < RL_CMDHIST_LINELEN - 1)
+            {
+              search[searchlen++] = (char)ch;
+              searchoffset = 1;
+
+              bool found = isearch_find(search, searchlen, searchoffset,
+                                         &searchoffset, buf, buflen, &nch);
+#ifdef CONFIG_READLINE_ECHO
+              isearch_redraw(vtbl, search, searchlen, buf, nch, !found);
+#endif
+            }
+          else
+            {
+              /* Anything else (an unhandled control character) just
+               * accepts the current match and returns to normal
+               * editing.
+               */
+
+              insearch = false;
+              cursor   = nch;
+
+#ifdef CONFIG_READLINE_ECHO
+              redraw_line(vtbl, buf, nch, cursor);
+#endif
+            }
+
+          continue;
+        }
+#endif
+
       /* Are we processing a VT100 escape sequence */
 
       else if (escape)
         {
+#ifdef CONFIG_READLINE_EDIT
+          /* Delete key: ESC [ 3 ~ — waiting for '~' */
+
+          if (escape == 3)
+            {
+              escape = 0;
+              if (ch == '~' && cursor < nch)
+                {
+                  int k;
+                  for (k = cursor + 1; k < nch; k++)
+                    buf[k - 1] = buf[k];
+                  nch--;
+#  ifdef CONFIG_READLINE_ECHO
+                  /* Back up 1 — terminal echo of '~' advanced cursor */
+
+                  RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+                  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+                  if (cursor < nch)
+                    {
+                      RL_WRITE(vtbl, buf + cursor, nch - cursor);
+                      for (k = nch; k > cursor; k--)
+                        RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+                    }
+#  endif
+                }
+              continue;
+            }
+
+          if (escape == 4 || escape == 5)
+            {
+              if (ch == '~')
+                {
+                  /* Home (1~) or End (4~) */
+
+                  cursor = (escape == 4) ? 0 : nch;
+                  redraw_line(vtbl, buf, nch, cursor);
+                }
+
+              if (ch == ';')
+                {
+                  escape = 8;
+                  continue;
+                }
+
+              escape = 0;
+              continue;
+            }
+#endif
+
+#ifdef CONFIG_READLINE_EDIT
+          if (escape == 8)          /* CSI ; — waiting for modifier digit */
+            {
+              if (ch == '5')
+                {
+                  escape = 9;       /* Ready for final char */
+                  continue;
+                }
+
+              if (ch == ';')
+                {
+                  escape = 8;
+                  continue;
+                }
+
+              escape = 0;
+              continue;
+            }
+
+          if (escape == 9)          /* CSI ;5 — waiting for D or C */
+            {
+              escape = 0;
+
+              if (ch == 'D')        /* Ctrl+Left */
+                {
+                  while (cursor > 0 && buf[cursor - 1] == ' ')
+                    cursor--;
+                  while (cursor > 0 && buf[cursor - 1] != ' ')
+                    cursor--;
+
+                  redraw_line(vtbl, buf, nch, cursor);
+                }
+              else if (ch == 'C')   /* Ctrl+Right */
+                {
+                  while (cursor < nch && buf[cursor] != ' ')
+                    cursor++;
+                  while (cursor < nch && buf[cursor] == ' ')
+                    cursor++;
+
+                  redraw_line(vtbl, buf, nch, cursor);
+                }
+
+              continue;
+            }
+#endif /* CONFIG_READLINE_EDIT */
+
+          /* Some terminals (e.g. xterm) use the SS3 introducer "ESC O"
+           * rather than CSI "ESC [" for Home/End (and, in application
+           * cursor key mode, for the arrow keys too).  Recognize the
+           * "ESC O" prefix here and fall into exactly the same
+           * "terminator character" handling used for "ESC [ <x>" below,
+           * by advancing to a dedicated state (6) that is treated the
+           * same way state 2 (saw "ESC [") is treated once the final
+           * byte arrives.  Without this, the 'O' is silently dropped
+           * (falling through the unrecognized-sequence path below) and
+           * the *next* byte (e.g. 'F' for End, 'H' for Home) is left to
+           * be reprocessed as an ordinary printable character, which is
+           * what produced the stray inserted "OF"/"OH" text.
+           */
+
+          if (escape == 1 && ch == ASCII_O)
+            {
+              escape = 6;
+              continue;
+            }
+
           /* Yes, is it an <esc>[, 3 byte sequence */
 
-          if (ch != ASCII_LBRACKET || escape == 2)
+          if (ch != ASCII_LBRACKET || escape == 2 || escape == 6)
             {
               /* We are finished with the escape sequence */
 
 #ifdef CONFIG_READLINE_CMD_HISTORY
-              /* Intercept up and down arrow keys */
+              /* Intercept up and down arrow keys.  This must only run
+               * for the up/down arrow keys themselves -- previously the
+               * clear-and-reload logic below ran for *any* completed
+               * escape sequence (Left, Right, Home, End, Delete, ...)
+               * as long as some history existed, silently wiping
+               * whatever the user was currently typing.
+               */
 
-              if (g_cmdhist.len > 0)
+              if (g_cmdhist.len > 0 && (ch == 'A' || ch == 'B'))
                 {
                   if (ch == 'A') /* up arrow */
                     {
@@ -560,7 +1121,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                           g_cmdhist.offset = -(g_cmdhist.len - 1);
                         }
                     }
-                  else if (ch == 'B') /* down arrow */
+                  else /* down arrow */
                     {
                       /* Go to the recent command in history */
 
@@ -572,17 +1133,39 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                         }
                     }
 
-                  /* Clear out current command from the prompt */
+                  /* Clear out current command from the prompt.
+                   *
+                   * This cannot assume the terminal's cursor is
+                   * sitting at the end of the currently displayed
+                   * text (i.e. at column 'nch') and simply backspace
+                   * 'nch' times -- the cursor can be anywhere in the
+                   * line (e.g. the user pressed Left one or more
+                   * times before pressing Up/Down again), and
+                   * backspacing more times than the cursor's actual
+                   * distance from the end of the prompt walks back
+                   * into and erases part of the prompt itself.
+                   * Instead, return to the true start of the
+                   * terminal line and erase to the end of line, then
+                   * reprint the prompt -- this does not depend on
+                   * where the cursor happened to be.
+                   */
 
-                  while (nch > 0)
-                    {
-                      nch--;
+                  nch = 0;
 
 #ifdef CONFIG_READLINE_ECHO
-                      RL_PUTC(vtbl, ASCII_BS);
-                      RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-#endif
+                  RL_PUTC(vtbl, '\r');
+                  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+#ifdef CONFIG_READLINE_TABCOMPLETION
+                  if (g_readline_prompt != NULL)
+                    {
+                      int k;
+                      for (k = 0; g_readline_prompt[k] != '\0'; k++)
+                        {
+                          RL_PUTC(vtbl, g_readline_prompt[k]);
+                        }
                     }
+#endif
+#endif
 
                   if (g_cmdhist.offset != 1)
                     {
@@ -599,7 +1182,10 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                           idx = idx - RL_CMDHIST_LEN;
                         }
 
-                      for (i = 0; g_cmdhist.buf[idx][i] != '\0'; i++)
+                      for (i = 0;
+                           g_cmdhist.buf[idx][i] != '\0' &&
+                           nch + 1 < buflen;
+                           i++)
                         {
                           buf[nch++] = g_cmdhist.buf[idx][i];
                           RL_PUTC(vtbl, g_cmdhist.buf[idx][i]);
@@ -607,8 +1193,83 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
                       buf[nch] = '\0';
                     }
+
+                  /* The line was just wholesale replaced -- the cursor
+                   * must always end up in sync with the new length, or
+                   * later edits (insert/delete) will index into buf[]
+                   * using a stale, out-of-range cursor value.
+                   */
+
+#ifdef CONFIG_READLINE_EDIT
+                  cursor = nch;
+#endif
                 }
 #endif /* CONFIG_READLINE_CMD_HISTORY */
+
+#ifdef CONFIG_READLINE_EDIT
+              if (ch == '1')
+                {
+                  escape = 4;
+                  continue;
+                }
+
+              if (ch == ';')
+                {
+                  escape = 8;
+                  continue;
+                }
+
+              if (ch == '3')
+                {
+                  escape = 3;
+                  continue;
+                }
+
+              if (ch == '4')
+                {
+                  escape = 5;
+                  continue;
+                }
+
+              if (ch == 'F')
+                {
+                  escape = 0;
+                  cursor = nch;
+
+                  /* Redraw full line — cursor ends at end */
+
+                  redraw_line(vtbl, buf, nch, cursor);
+                  continue;
+                }
+
+              if (ch == 'D' && cursor > 0)
+                {
+                  cursor--;
+                  escape = 0;
+                  RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+                  continue;
+                }
+
+              if (ch == 'C' && cursor < nch)
+                {
+                  cursor++;
+                  escape = 0;
+                  RL_WRITE(vtbl, g_curright, sizeof(g_curright));
+                  continue;
+                }
+
+              if (ch == 'H')
+                {
+                  escape = 0;
+                  cursor = 0;
+
+                  /* Redraw full line from column 0 */
+
+                  redraw_line(vtbl, buf, nch, cursor);
+
+                  continue;
+                }
+#endif
 
               escape = 0;
               ch = 'a';
@@ -636,22 +1297,41 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
       else if (ch == ASCII_BS || ch == ASCII_DEL)
         {
-          /* Eliminate that last character in the buffer. */
+#ifdef CONFIG_READLINE_EDIT
+          /* Delete character before cursor */
 
+          if (cursor > 0)
+            {
+              int k;
+              for (k = cursor; k < nch; k++)
+                buf[k - 1] = buf[k];
+              cursor--;
+              nch--;
+
+#  ifdef CONFIG_READLINE_ECHO
+              /* Redraw: backspace, clear EOL, redraw tail, restore cursor */
+
+              RL_PUTC(vtbl, ASCII_BS);
+              RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+              if (cursor < nch)
+                {
+                  RL_WRITE(vtbl, buf + cursor, nch - cursor);
+                  for (k = nch; k > cursor; k--)
+                    RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+                }
+#  endif
+            }
+#else
           if (nch > 0)
             {
               nch--;
 
-#ifdef CONFIG_READLINE_ECHO
-              /* Echo the backspace character on the console.  Always output
-               * the backspace character because the VT100 terminal doesn't
-               * understand DEL properly.
-               */
-
+#  ifdef CONFIG_READLINE_ECHO
               RL_PUTC(vtbl, ASCII_BS);
               RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-#endif
+#  endif
             }
+#endif
         }
 
       /* Check for the beginning of a VT100 escape sequence */
@@ -670,47 +1350,129 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
       else if (ch == '\n')
         {
-#ifdef CONFIG_READLINE_CMD_HISTORY
-          /* Save history of command, only if there was something
-           * typed besides return character.
-           */
-
-          if (nch >= 1)
-            {
-              /* If this command is the one at the top of the circular
-               * buffer, don't save it again.
-               */
-
-              if (strncmp(buf, g_cmdhist.buf[g_cmdhist.head], nch + 1) != 0)
-                {
-                  g_cmdhist.head = (g_cmdhist.head + 1) % RL_CMDHIST_LEN;
-
-                  for (i = 0; (i < nch) && i < (RL_CMDHIST_LINELEN - 1); i++)
-                    {
-                      g_cmdhist.buf[g_cmdhist.head][i] = buf[i];
-                    }
-
-                  g_cmdhist.buf[g_cmdhist.head][i] = '\0';
-
-                  if (g_cmdhist.len < RL_CMDHIST_LEN)
-                    {
-                      g_cmdhist.len++;
-                    }
-                }
-
-              g_cmdhist.offset = 1;
-            }
-#endif /* CONFIG_READLINE_CMD_HISTORY */
-
-          /* The newline is stored in the buffer along with the null
-           * terminator.
-           */
-
-          buf[nch++] = '\n';
-          buf[nch]   = '\0';
-
-          return nch;
+          return submit_line(buf, nch);
         }
+
+      /* Emacs-style control keys */
+
+#ifdef CONFIG_READLINE_EDIT_EMACS
+      else if (ch == CTRL_A)        /* Ctrl+A = Home */
+        {
+          cursor = 0;
+          redraw_line(vtbl, buf, nch, cursor);
+        }
+      else if (ch == CTRL_B)            /* Ctrl+B = Left */
+        {
+          if (cursor > 0)
+            {
+              cursor--;
+              RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+            }
+        }
+      else if (ch == CTRL_D)            /* Ctrl+D = Delete at cursor */
+        {
+          if (cursor < nch)
+            {
+              int k;
+              for (k = cursor + 1; k < nch; k++)
+                buf[k - 1] = buf[k];
+              nch--;
+              RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+              if (cursor < nch)
+                {
+                  RL_WRITE(vtbl, buf + cursor, nch - cursor);
+                  for (k = nch; k > cursor; k--)
+                    RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+                }
+            }
+        }
+      else if (ch == CTRL_E)            /* Ctrl+E = End */
+        {
+          while (cursor < nch)
+            {
+              cursor++;
+              RL_WRITE(vtbl, g_curright, sizeof(g_curright));
+            }
+        }
+      else if (ch == CTRL_F)            /* Ctrl+F = Right */
+        {
+          if (cursor < nch)
+            {
+              cursor++;
+              RL_WRITE(vtbl, g_curright, sizeof(g_curright));
+            }
+        }
+      else if (ch == CTRL_K)           /* Ctrl+K = Kill to EOL */
+        {
+          nch = cursor;
+          buf[nch] = '\0';
+          RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+        }
+      else if (ch == CTRL_U)           /* Ctrl+U = Kill to BOL */
+        {
+          int j;
+          for (j = cursor; j < nch; j++)
+            buf[j - cursor] = buf[j];
+          nch -= cursor;
+          cursor = 0;
+          buf[nch] = '\0';
+          redraw_line(vtbl, buf, nch, cursor);
+        }
+      else if (ch == CTRL_W)           /* Ctrl+W = Kill word backward (FIXME) */
+        {
+          int start, k;
+          start = cursor;
+          while (start > 0 && buf[start - 1] == ' ')
+            start--;
+          while (start > 0 && buf[start - 1] != ' ')
+            start--;
+          for (k = start; k < nch; k++)
+            buf[k - (cursor - start)] = buf[k];
+          nch -= (cursor - start);
+          cursor = start;
+          buf[nch] = '\0';
+          RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+          if (cursor < nch)
+            {
+              RL_WRITE(vtbl, buf + cursor, nch - cursor);
+              for (k = nch; k > cursor; k--)
+                RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+            }
+        }
+
+#ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
+      else if (ch == CTRL_R && g_cmdhist.len > 0)
+        {
+          /* Ctrl+R = start a reverse incremental search through the
+           * command history, bash-style.  Save the line currently
+           * being edited so it can be restored if the search is
+           * cancelled (Ctrl+G).
+           */
+
+          insearch     = true;
+          searchlen    = 0;
+          searchoffset = 1;
+
+          savednch = nch;
+          if (savednch > RL_CMDHIST_LINELEN - 1)
+            {
+              savednch = RL_CMDHIST_LINELEN - 1;
+            }
+
+          for (i = 0; i < savednch; i++)
+            {
+              savedbuf[i] = buf[i];
+            }
+
+          savedcursor = cursor;
+          nch         = 0;
+
+#ifdef CONFIG_READLINE_ECHO
+          isearch_redraw(vtbl, search, searchlen, buf, nch, false);
+#endif
+        }
+#endif /* CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH */
+#endif /* CONFIG_READLINE_EDIT_EMACS */
 
       /* Otherwise, put the character in the line buffer if the
        * character is not a control byte
@@ -718,7 +1480,45 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
       else if (!iscntrl(ch & 0xff))
         {
+#ifdef CONFIG_READLINE_EDIT
+          /* Defensive check: 'cursor' must always satisfy
+           * 0 <= cursor <= nch.  It should never be able to get out of
+           * that range now, but clamp it rather than trust it blindly
+           * -- indexing buf[] with an out-of-range cursor is a
+           * memory-safety bug (a stale cursor previously let this
+           * write arbitrarily far past the end of the caller's
+           * buffer).
+           */
+
+          if (cursor < 0 || cursor > nch)
+            {
+              cursor = nch;
+            }
+
+          /* Only insert if there is room for the new character plus
+           * the line's null terminator.  Checking this before writing
+           * (rather than only after, as the non-editing path below
+           * does) is what actually prevents the out-of-bounds write.
+           */
+
+          if (nch + 1 < buflen)
+            {
+              int j;
+              for (j = nch; j > cursor; j--) buf[j] = buf[j - 1];
+              buf[cursor] = (char)ch; nch++; cursor++;
+#  ifdef CONFIG_READLINE_ECHO
+              if (cursor < nch)
+                {
+                  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+                  RL_WRITE(vtbl, buf + cursor, nch - cursor);
+                  for (j = nch; j > cursor; j--)
+                    RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+                }
+#  endif
+            }
+#else
           buf[nch++] = ch;
+#endif
 
           /* Check if there is room for another character and the line's
            * null terminator.  If not then we have to end the line now.
@@ -733,7 +1533,34 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 #ifdef CONFIG_READLINE_TABCOMPLETION
       else if (ch == '\t') /* TAB character */
         {
+          /* When tab_completion() finds a match (or lists several), it
+           * always leaves the terminal's real cursor at the end of the
+           * (possibly completed) line -- either by echoing the
+           * appended characters one at a time, or, when it lists
+           * multiple matches, by reprinting the prompt and the whole
+           * buffer from scratch.  'cursor' has to be resynced to
+           * match in that case, or the very next Left/Right/Home/End
+           * keypress will move the terminal's cursor from column
+           * 'nch' while still believing it is moving from wherever
+           * 'cursor' was left (typically the length of the word
+           * before completion) -- the two then stay out of sync for
+           * the rest of the line.
+           *
+           * But if there was no match at all, tab_completion() does
+           * not touch the terminal or the buffer, and 'cursor' must
+           * be left exactly where it was -- unconditionally resyncing
+           * it here would be just as wrong as never resyncing it,
+           * only in the opposite direction.
+           */
+
+#ifdef CONFIG_READLINE_EDIT
+          if (tab_completion(vtbl, buf, buflen, &nch))
+            {
+              cursor = nch;
+            }
+#else
           tab_completion(vtbl, buf, buflen, &nch);
+#endif
         }
 #endif
     }

--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -158,6 +158,36 @@ static int count_builtin_matches(FAR char *buf, FAR int *matches,
 }
 #endif
 
+#if defined(CONFIG_READLINE_TABCOMPLETION) && \
+    (defined(CONFIG_BUILTIN) || defined(CONFIG_READLINE_HAVE_EXTMATCH))
+static void tab_print_match(FAR struct rl_common_s *vtbl,
+                             FAR const char *name, FAR char *tmp_name,
+                             size_t tmp_size)
+{
+  size_t j;
+
+  if (tmp_name[0] == '\0')
+    {
+      strlcpy(tmp_name, name, tmp_size);
+    }
+
+  RL_PUTC(vtbl, ' ');
+  RL_PUTC(vtbl, ' ');
+
+  for (j = 0; j < strlen(name); j++)
+    {
+      if (j < tmp_size && name[j] != tmp_name[j])
+        {
+          tmp_name[j] = '\0';
+        }
+
+      RL_PUTC(vtbl, name[j]);
+    }
+
+  RL_PUTC(vtbl, '\n');
+}
+#endif
+
 /****************************************************************************
  * Name: tab_completion
  *
@@ -303,32 +333,7 @@ static bool tab_completion(FAR struct rl_common_s *vtbl, char *buf,
           for (i = 0; i < nr_ext_matches; i++)
             {
               name = g_extmatch_vtbl->getname(ext_matches[i]);
-
-              /* Initialize temp */
-
-              if (tmp_name[0] == '\0')
-                {
-                  strlcpy(tmp_name, name, sizeof(tmp_name));
-                }
-
-              RL_PUTC(vtbl, ' ');
-              RL_PUTC(vtbl, ' ');
-
-              for (j = 0; j < (int)strlen(name); j++)
-                {
-                  /* Removing characters that aren't common to all the
-                   * matches.
-                   */
-
-                  if (j < (int)sizeof(tmp_name) && name[j] != tmp_name[j])
-                    {
-                      tmp_name[j] = '\0';
-                    }
-
-                  RL_PUTC(vtbl, name[j]);
-                }
-
-              RL_PUTC(vtbl, '\n');
+              tab_print_match(vtbl, name, tmp_name, sizeof(tmp_name));
             }
 #endif
 
@@ -338,32 +343,7 @@ static bool tab_completion(FAR struct rl_common_s *vtbl, char *buf,
           for (i = 0; i < nr_builtin_matches; i++)
             {
               name = builtin_getname(builtin_matches[i]);
-
-              /* Initialize temp */
-
-              if (tmp_name[0] == '\0')
-                {
-                  strlcpy(tmp_name, name, sizeof(tmp_name));
-                }
-
-              RL_PUTC(vtbl, ' ');
-              RL_PUTC(vtbl, ' ');
-
-              for (j = 0; j < strlen(name); j++)
-                {
-                  /* Removing characters that aren't common to all the
-                   * matches.
-                   */
-
-                  if (j < sizeof(tmp_name) && name[j] != tmp_name[j])
-                    {
-                      tmp_name[j] = '\0';
-                    }
-
-                  RL_PUTC(vtbl, name[j]);
-                }
-
-              RL_PUTC(vtbl, '\n');
+              tab_print_match(vtbl, name, tmp_name, sizeof(tmp_name));
             }
 
 #endif
@@ -515,6 +495,41 @@ static bool isearch_find(FAR const char *search, int searchlen,
 }
 #endif
 
+#ifdef CONFIG_READLINE_EDIT
+/****************************************************************************
+ * Name: word_skip
+ *
+ * Description:
+ *   Used by Ctrl+Left/Ctrl+Right.  Starting from 'cursor', skip over any
+ *   run of spaces then the following word (or, going backward, the
+ *   preceding word then any run of spaces before it), stopping at
+ *   'bound' (0 going backward, 'nch' going forward).  Returns the new
+ *   cursor position.
+ *
+ ****************************************************************************/
+
+static int word_skip(FAR const char *buf, int cursor, int bound,
+                      bool forward)
+{
+  if (forward)
+    {
+      while (cursor < bound && buf[cursor] != ' ')
+        cursor++;
+      while (cursor < bound && buf[cursor] == ' ')
+        cursor++;
+    }
+  else
+    {
+      while (cursor > bound && buf[cursor - 1] == ' ')
+        cursor--;
+      while (cursor > bound && buf[cursor - 1] != ' ')
+        cursor--;
+    }
+
+  return cursor;
+}
+#endif
+
 #ifdef CONFIG_READLINE_ECHO
 #ifdef CONFIG_READLINE_EDIT
 /****************************************************************************
@@ -562,6 +577,38 @@ static void redraw_line(FAR struct rl_common_s *vtbl, FAR const char *buf,
   for (i = nch; i > cursor; i--)
     {
       RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+    }
+}
+
+/****************************************************************************
+ * Name: redraw_tail
+ *
+ * Description:
+ *   Redraw just the tail of the line, from 'cursor' to 'nch': erase to
+ *   the end of line, rewrite whatever remains after the cursor (if
+ *   any), then move the cursor back left to where it started.  This is
+ *   the shared tail end of every edit that only changes content at or
+ *   after the cursor without moving it (Delete, Backspace, Ctrl+D,
+ *   Ctrl+W, inserting a character) -- unlike redraw_line(), it does
+ *   not touch the prompt or anything before the cursor, since none of
+ *   those callers need to.
+ *
+ ****************************************************************************/
+
+static void redraw_tail(FAR struct rl_common_s *vtbl, FAR const char *buf,
+                         int nch, int cursor)
+{
+  int j;
+
+  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
+
+  if (cursor < nch)
+    {
+      RL_WRITE(vtbl, buf + cursor, nch - cursor);
+      for (j = nch; j > cursor; j--)
+        {
+          RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
+        }
     }
 }
 #endif /* CONFIG_READLINE_EDIT */
@@ -994,13 +1041,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
                   /* Back up 1 — terminal echo of '~' advanced cursor */
 
                   RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-                  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-                  if (cursor < nch)
-                    {
-                      RL_WRITE(vtbl, buf + cursor, nch - cursor);
-                      for (k = nch; k > cursor; k--)
-                        RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-                    }
+                  redraw_tail(vtbl, buf, nch, cursor);
 #  endif
                 }
               continue;
@@ -1052,20 +1093,12 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
               if (ch == 'D')        /* Ctrl+Left */
                 {
-                  while (cursor > 0 && buf[cursor - 1] == ' ')
-                    cursor--;
-                  while (cursor > 0 && buf[cursor - 1] != ' ')
-                    cursor--;
-
+                  cursor = word_skip(buf, cursor, 0, false);
                   redraw_line(vtbl, buf, nch, cursor);
                 }
               else if (ch == 'C')   /* Ctrl+Right */
                 {
-                  while (cursor < nch && buf[cursor] != ' ')
-                    cursor++;
-                  while (cursor < nch && buf[cursor] == ' ')
-                    cursor++;
-
+                  cursor = word_skip(buf, cursor, nch, true);
                   redraw_line(vtbl, buf, nch, cursor);
                 }
 
@@ -1312,13 +1345,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
               /* Redraw: backspace, clear EOL, redraw tail, restore cursor */
 
               RL_PUTC(vtbl, ASCII_BS);
-              RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-              if (cursor < nch)
-                {
-                  RL_WRITE(vtbl, buf + cursor, nch - cursor);
-                  for (k = nch; k > cursor; k--)
-                    RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-                }
+              redraw_tail(vtbl, buf, nch, cursor);
 #  endif
             }
 #else
@@ -1377,13 +1404,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
               for (k = cursor + 1; k < nch; k++)
                 buf[k - 1] = buf[k];
               nch--;
-              RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-              if (cursor < nch)
-                {
-                  RL_WRITE(vtbl, buf + cursor, nch - cursor);
-                  for (k = nch; k > cursor; k--)
-                    RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-                }
+              redraw_tail(vtbl, buf, nch, cursor);
             }
         }
       else if (ch == CTRL_E)            /* Ctrl+E = End */
@@ -1421,23 +1442,13 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
       else if (ch == CTRL_W)           /* Ctrl+W = Kill word backward (FIXME) */
         {
           int start, k;
-          start = cursor;
-          while (start > 0 && buf[start - 1] == ' ')
-            start--;
-          while (start > 0 && buf[start - 1] != ' ')
-            start--;
+          start = word_skip(buf, cursor, 0, false);
           for (k = start; k < nch; k++)
             buf[k - (cursor - start)] = buf[k];
           nch -= (cursor - start);
           cursor = start;
           buf[nch] = '\0';
-          RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-          if (cursor < nch)
-            {
-              RL_WRITE(vtbl, buf + cursor, nch - cursor);
-              for (k = nch; k > cursor; k--)
-                RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-            }
+          redraw_tail(vtbl, buf, nch, cursor);
         }
 
 #ifdef CONFIG_READLINE_EDIT_EMACS_REVERSE_SEARCH
@@ -1507,13 +1518,7 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
               for (j = nch; j > cursor; j--) buf[j] = buf[j - 1];
               buf[cursor] = (char)ch; nch++; cursor++;
 #  ifdef CONFIG_READLINE_ECHO
-              if (cursor < nch)
-                {
-                  RL_WRITE(vtbl, g_erasetoeol, sizeof(g_erasetoeol));
-                  RL_WRITE(vtbl, buf + cursor, nch - cursor);
-                  for (j = nch; j > cursor; j--)
-                    RL_WRITE(vtbl, g_curleft, sizeof(g_curleft));
-                }
+              redraw_tail(vtbl, buf, nch, cursor);
 #  endif
             }
 #else

--- a/system/readline/readline_fd.c
+++ b/system/readline/readline_fd.c
@@ -157,7 +157,21 @@ static void readline_write(FAR struct rl_common_s *vtbl,
                            FAR const char *buffer, size_t buflen)
 {
   FAR struct readline_s *priv = (FAR struct readline_s *)vtbl;
-  DEBUGASSERT(priv && buffer && buflen > 0);
+  DEBUGASSERT(priv && buffer);
+
+  /* Several full-line-redraw paths in readline_common.c (Home, End,
+   * Ctrl+A, Ctrl+U, Ctrl+Left/Right, ...) call RL_WRITE(vtbl, buf, nch)
+   * unconditionally after repositioning the cursor, and 'nch' -- the
+   * number of characters currently in the line -- can legitimately be
+   * 0 (e.g. pressing Home on an empty prompt, or Ctrl+U clearing the
+   * line back to empty).  Writing zero bytes is a valid no-op; it must
+   * not be treated as a caller error.
+   */
+
+  if (buflen == 0)
+    {
+      return;
+    }
 
   /* If outfd is a invalid fd, return directly. */
 


### PR DESCRIPTION
## Summary

One missing feature on nsh> is the ability to command line editing. If the user makes a mistake at the beginning of the line he/she needs to erase all characters until arrive there and fix the typo.

Now the user can use the arrow keys to move until the mistake and fix it.

This feature adds less than 700 bytes to the firmware (only Line Edit is enabled by default)

```
original stm32f103-minimum:nsh without line edit, emacs, TAB and History support:
alan@dev:~/nuttxspace/nuttx$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
  51192	    472	   2952	  54616	   d558	nuttx

With: Line Edit, Without Emacs, TAB, History:
$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
  51844	    472	   2956	  55272	   d7e8	nuttx

With: Line Edit and Emacs, Without TAB, History:

$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
  52220	    472	   2956	  55648	   d960	nuttx

With: Line Edit, Emacs and TAB, Without History
$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
  52756	    472	   2960	  56188	   db7c	nuttx

With: Line Edit, Emacs, TAB and History, Without: Reverse Search
$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
  53060	    472	   3228	  56760	   ddb8	nuttx

With: Line Edit, Emacs, TAB, History and Reverse Search
$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
  53896	    472	   3228	  57596	   e0fc	nuttx
```

## Impact

User will be able to use the nsh> more efficiently

## Testing

Line editing:

<img width="902" height="192" alt="image" src="https://github.com/user-attachments/assets/a9566729-5f07-461f-857f-4b051ebbe103" />
