### PR TITLE
netutils/telnetd: fix silent listen-socket loss and per-connection daemon death

### DIFF
--- a/netutils/telnetd/telnetd_daemon.c
+++ b/netutils/telnetd/telnetd_daemon.c
@@ -126,12 +126,11 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
     }
 
   /* If the daemon was started without standard streams (e.g. spawned by
-   * nsh_telnetstart() before a USB console device exists), socket() may
-   * have returned a descriptor in 0..2.  The "go silent"
-   * close(0)..close(2) at the top of the accept loop below would then
-   * destroy the listen socket: every subsequent accept4() fails and the
-   * daemon serves nothing.  Move the descriptor above the
-   * standard-stream range.
+   * nsh_telnetstart() before a USB console exists), socket() may have
+   * returned a descriptor in 0..2.  The "go silent" close(0)..close(2)
+   * at the top of the accept loop below would then destroy the listen
+   * socket: every subsequent accept4() fails and the daemon serves
+   * nothing.  Move the descriptor above the standard-stream range.
    */
 
   if (listensd <= 2)
@@ -224,17 +223,33 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       acceptsd = accept4(listensd, &addr.generic, &addrlen, SOCK_CLOEXEC);
       if (acceptsd < 0)
         {
-          /* Just continue if a signal was received */
+          int err = errno;
 
-          if (errno == EINTR)
+          /* A bad listen socket can never recover - exiting loudly beats
+           * spinning forever while serving nothing.
+           */
+
+          if (err == EBADF || err == ENOTSOCK || err == EINVAL ||
+              err == EOPNOTSUPP)
             {
-              continue;
-            }
-          else
-            {
-              nerr("ERROR: accept failed: %d\n", errno);
+              nerr("ERROR: accept failed fatally: %d\n", err);
               goto errout_with_socket;
             }
+
+          /* Everything else is transient: a peer that reset before the
+           * accept completed (a port scan, nc -z, ECONNABORTED), a
+           * signal, or the interface bouncing.  None of those may take
+           * the daemon down; the pause keeps a persistent transient
+           * (interface down) from busy-spinning.
+           */
+
+          nerr("ERROR: accept failed: %d\n", err);
+          if (err != EINTR)
+            {
+              usleep(100 * 1000);
+            }
+
+          continue;
         }
 
 #ifdef CONFIG_NET_SOLINGER
@@ -247,8 +262,14 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       if (setsockopt(acceptsd, SOL_SOCKET, SO_LINGER,
                      &ling, sizeof(struct linger)) < 0)
         {
+          /* Per-connection failure (e.g. the peer already reset the
+           * connection - a port scan does this).  Drop the connection and
+           * keep accepting; exiting here lets any probe kill the daemon.
+           */
+
           nerr("ERROR: setsockopt failed: %d\n", errno);
-          goto errout_with_acceptsd;
+          close(acceptsd);
+          continue;
         }
 #endif
 
@@ -258,7 +279,8 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       if (drvrfd < 0)
         {
           nerr("ERROR: open(/dev/telnet) failed: %d\n", errno);
-          goto errout_with_acceptsd;
+          close(acceptsd);
+          continue;
         }
 
       /* Create a character device to "wrap" the accepted socket descriptor */
@@ -271,9 +293,10 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       if (ioctl(drvrfd, SIOCTELNET,
                 (unsigned long)((uintptr_t)&session)) < 0)
         {
-          nerr("ERROR: open(/dev/telnet) failed: %d\n", errno);
+          nerr("ERROR: SIOCTELNET failed: %d\n", errno);
           close(drvrfd);
-          goto errout_with_acceptsd;
+          close(acceptsd);
+          continue;
         }
 
       close(drvrfd);
@@ -284,8 +307,12 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       drvrfd = open(session.ts_devpath, O_RDWR);
       if (drvrfd < 0)
         {
+          /* The socket now belongs to the telnet driver instance; just
+           * keep accepting.
+           */
+
           nerr("ERROR: Failed to open %s: %d\n", session.ts_devpath, errno);
-          goto errout_with_socket;
+          continue;
         }
 
       /* Use this driver as stdin, stdout, and stderror */
@@ -341,15 +368,11 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
           if (ret > 0)
             {
               nerr("ERROR: Failed start the telnet session: %d\n", ret);
-              errno = ret;
-              goto errout_with_socket;
+              continue;
             }
         }
 #endif
     }
-
-errout_with_acceptsd:
-  close(acceptsd);
 
 errout_with_socket:
   close(listensd);

--- a/netutils/telnetd/telnetd_daemon.c
+++ b/netutils/telnetd/telnetd_daemon.c
@@ -125,6 +125,28 @@ int telnetd_daemon(FAR const struct telnetd_config_s *config)
       goto errout;
     }
 
+  /* If the daemon was started without standard streams (e.g. spawned by
+   * nsh_telnetstart() before a USB console device exists), socket() may
+   * have returned a descriptor in 0..2.  The "go silent"
+   * close(0)..close(2) at the top of the accept loop below would then
+   * destroy the listen socket: every subsequent accept4() fails and the
+   * daemon serves nothing.  Move the descriptor above the
+   * standard-stream range.
+   */
+
+  if (listensd <= 2)
+    {
+      int highsd = fcntl(listensd, F_DUPFD_CLOEXEC, 3);
+      if (highsd < 0)
+        {
+          nerr("ERROR: F_DUPFD_CLOEXEC failed: %d\n", errno);
+          goto errout_with_socket;
+        }
+
+      close(listensd);
+      listensd = highsd;
+    }
+
 #ifdef CONFIG_NET_SOCKOPTS
   /* Set socket to reuse address */
 


### PR DESCRIPTION
## Summary

Two robustness fixes for the telnet daemon (`netutils/telnetd/telnetd_daemon.c`). As it stands, the standard NuttX telnet console can be disabled by a single aborted connection, and on some configurations it silently serves nothing from boot.

**1. Keep the listen socket out of the standard-stream range.**
When the daemon starts without open standard streams — exactly what happens when `nsh_telnetstart()` spawns `telnetd &` before the console device exists (e.g. `CONFIG_NSH_USBCONSOLE` boards, where `nsh_initialize()` runs before the USB console is connected) — `socket()` returns a descriptor in 0..2. The accept loop's own "go silent" `close(0)..close(2)` then destroys the listen socket on the first iteration; every subsequent `accept4()` fails and the daemon serves nothing, while appearing alive in the task list. Fix: `F_DUPFD_CLOEXEC` the descriptor above 2 before use.

**2. Survive transient connection errors instead of exiting.**
Previously any single failed connection killed the whole daemon:
- a peer resetting before the accept completes (a port scanner, or a plain `nc -z` probe) surfaces as an `accept4()` error such as `ECONNABORTED` and took the errout path;
- the per-connection error paths after a successful accept (setsockopt, `/dev/telnet` open, `SIOCTELNET`, session-device open, session spawn) likewise exited the daemon.

One bad or aborted connection and the telnet console is dead until reboot — a trivial remote way to take out the console of any reachable NuttX device. Fix: treat these as per-connection failures (drop the connection, keep accepting). Genuinely unrecoverable `accept4()` errors (`EBADF`/`ENOTSOCK`/`EINVAL`/`EOPNOTSUPP`) still exit loudly, and a short pause on repeated transient failures avoids busy-spinning while an interface is down. Daemon setup errors (socket/bind/listen) exit as before.

## Impact

Any board using `netutils/telnetd` (directly or via `CONFIG_NSH_TELNET`). Bug 1 affects configurations where the daemon can start before its standard streams exist (USB-console boards being the common case). Bug 2 affects everyone: a subnet `nmap` sweep kills every reachable NuttX telnet console.

## Testing

Reproduced and verified on hardware: Raspberry Pi Pico 2 W (RP2350), composite USB CDC-ACM console + CDC-NCM network, `CONFIG_NSH_USBCONSOLE`, telnetd auto-started via `nsh_telnetstart()`.

- Before (bug 1): daemon task alive but port 23 refused all connections from boot; the RTOS-aware debugger thread list showed it looping on the failed accept with the listen socket closed by its own `close(0)`.
- Before (bug 2): a single `nc -zv <addr> 23` probe permanently killed a manually started, correctly listening daemon.
- After: daemon listens from boot (within 5 s of enumeration), survives repeated `nc -z` probe barrages, and interactive nsh telnet sessions work.

`tools/nxstyle.c` passes on the modified file.

## Note

These changes were developed with the assistance of an AI agent (Claude) and have been human-reviewed and tested on real hardware as described above.
