### PR TITLE
audioutils/lame: Add CMake vector sources.

### DIFF
--- a/audioutils/lame/CMakeLists.txt
+++ b/audioutils/lame/CMakeLists.txt
@@ -75,7 +75,6 @@ if(CONFIG_AUDIOUTILS_LAME)
       "${SRC_PATH}/libmp3lame/newmdct.c"
       "${SRC_PATH}/libmp3lame/psymodel.c"
       "${SRC_PATH}/libmp3lame/quantize.c"
-      "${SRC_PATH}/libmp3lame/vector/xmm_quantize_sub.c"
       "${SRC_PATH}/libmp3lame/quantize_pvt.c"
       "${SRC_PATH}/libmp3lame/set_get.c"
       "${SRC_PATH}/libmp3lame/vbrquantize.c"
@@ -86,6 +85,18 @@ if(CONFIG_AUDIOUTILS_LAME)
       "${SRC_PATH}/libmp3lame/VbrTag.c"
       "${SRC_PATH}/libmp3lame/version.c"
       "${SRC_PATH}/libmp3lame/presets.c")
+
+  if(CONFIG_HOST_X86 OR CONFIG_HOST_X86_64)
+    list(
+      APPEND
+      CSRCS
+      "${SRC_PATH}/libmp3lame/vector/xmm_quantize_sub.c"
+      "${SRC_PATH}/libmp3lame/vector/xmm_choose_table.c"
+      "${SRC_PATH}/libmp3lame/vector/xmm_quantize_lines.c"
+      "${SRC_PATH}/libmp3lame/vector/xmm_calc_sfb_noise.c"
+      "${SRC_PATH}/libmp3lame/vector/avx2_choose_table.c"
+      "${SRC_PATH}/libmp3lame/vector/avx2_quantize_lines.c")
+  endif()
 
   # Add custom target to generate config_h
   set(CONFIG_H_FILE "${CMAKE_CURRENT_SOURCE_DIR}/lame/configure")


### PR DESCRIPTION
## Summary

Fix the CMake build of the bundled LAME encoder for x86 simulator hosts.

LAME's generated configuration enables SSE2 and AVX2 runtime-dispatch paths when the host compiler supports their per-function target attributes. The CMake `libmp3lame` target omitted the corresponding vector translation units, which left `sim:alsa` with unresolved symbols at link time. This change adds the complete vector source group only for `CONFIG_HOST_X86` and `CONFIG_HOST_X86_64`; non-x86 simulator hosts retain LAME's scalar implementation.

Companion NuttX PR: https://github.com/apache/nuttx/pull/19541. It supplies the bundled codec header include paths required to compile `sim_offload.c`.

## Impact

- New feature: **No**.
- User adaptation: **No**.
- Build impact: **Yes**. Fixes linking of CMake `sim:alsa` builds on x86 hosts when LAME enables its vector dispatch.
- Hardware impact: **No**. This is host-simulator build integration; x86 vector routines continue to be selected only by LAME's runtime CPU dispatch.
- Documentation impact: **No**.
- Security impact: **No**.
- Compatibility impact: **No**. Non-x86 hosts continue to compile and use the scalar LAME path.
- Dependency: must be merged with the companion NuttX codec-header PR for a complete `sim:alsa` CMake fix.

## Testing

Verified locally with the companion NuttX branch.

- Build host: Fedora Linux 44, x86_64, GCC 16.1.1.
- Target: `sim:alsa`, CMake/Ninja, `CONFIG_SIM_M32=y`.

Before this change, after resolving the missing codec headers, the final link failed with unresolved LAME vector symbols:

```text
undefined reference to `quantize_lines_xrpow_avx2'
undefined reference to `count_bit_esc_sse2'
```

After this change:

```sh
cmake -B build -DBOARD_CONFIG=sim:alsa -DNXTMPDIR=OFF -GNinja
cmake --build build -j4
```

completed successfully and produced `nuttx.tgz`.

Additional verification:

```sh
cmake-format --check audioutils/lame/CMakeLists.txt
git diff --check
```

Both completed successfully.

No hardware runtime test applies to this host simulator build.

## PR verification self-check

- [x] This PR introduces one focused functional change.
- [x] All required PR description fields are completed.
- [x] The commit has a descriptive topic/body, `Signed-off-by`, and `Assisted-by` trailer.
- [x] The modified CMake file passes `cmake-format` and `git diff --check`.
- [x] This PR is ready for review.
