### PR TITLE
build: Omit default priority ELF symbol.

### DIFF
--- a/Application.mk
+++ b/Application.mk
@@ -146,10 +146,9 @@ ifneq ($(strip $(PROGNAME)),)
   # CONFIG_SCHED_USER_IDENTITY) so the binary loader can recover them.
   # Per-target so each PROGLIST entry picks up its own STACKSIZE_/PRIORITY_.
 
-  $(PROGLIST): SYM_PRIORITY = $(if $(filter SCHED_PRIORITY_DEFAULT,$(PRIORITY_$@)),0,$(PRIORITY_$@))
   $(PROGLIST): MODLDFLAGS += \
     $(if $(STACKSIZE_$@),--defsym nx_stacksize=$(STACKSIZE_$@)) \
-    $(if $(PRIORITY_$@),--defsym nx_priority=$(SYM_PRIORITY))
+    $(if $(filter-out SCHED_PRIORITY_DEFAULT,$(PRIORITY_$@)),--defsym nx_priority=$(PRIORITY_$@))
 ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
   $(PROGLIST): MODLDFLAGS += \
     $(if $(UID_$@),--defsym nx_uid=$(UID_$@)) \
@@ -159,7 +158,7 @@ endif
 
   # Keep the attribute symbols through --strip-unneeded so the binary loader
   # can still read them from the stripped runtime image in bin/.
-  $(PROGLIST): NX_KEEP = $(if $(STACKSIZE_$@),-K nx_stacksize) $(if $(PRIORITY_$@),-K nx_priority) $(if $(UID_$@),-K nx_uid) $(if $(GID_$@),-K nx_gid) $(if $(MODE_$@),-K nx_mode)
+  $(PROGLIST): NX_KEEP = $(if $(STACKSIZE_$@),-K nx_stacksize) $(if $(filter-out SCHED_PRIORITY_DEFAULT,$(PRIORITY_$@)),-K nx_priority) $(if $(UID_$@),-K nx_uid) $(if $(GID_$@),-K nx_gid) $(if $(MODE_$@),-K nx_mode)
 endif
 
 # Condition flags


### PR DESCRIPTION
## Summary

Follow up on the review from @xiaoxiang781216 in apache/nuttx#19537.

Application.mk previously encoded PRIORITY = SCHED_PRIORITY_DEFAULT as an absolute nx_priority symbol with value zero. A zero priority is invalid for a runnable application task. Do not emit nx_priority for this symbolic default instead: when the symbol is absent, the ELF loader keeps its scheduler default. Explicit numeric priorities continue to be emitted and retained in stripped module ELFs.

## Impact

This is a focused Apps build-system correction for kernel-build module ELFs. Applications using SCHED_PRIORITY_DEFAULT no longer receive an invalid priority-zero ELF attribute. Applications with explicit numeric priorities are unchanged. There is no API, ABI, configuration, documentation, or hardware-interface change.

Related review: apache/nuttx#19537.

## Testing

Host: workspace environment with GNU Make.

- ./tools/checkpatch.sh -f ../apps/Application.mk (from the companion NuttX checkout): passed.
- Focused GNU Make expansion test:

  default=
  numeric=--defsym nx_priority=50

This confirms the default case emits no linker symbol while an explicit numeric priority is still emitted.

No NuttX ELF-capable hardware target, cross-compiler, or QEMU runtime is available in this workspace. This PR is therefore a draft pending the required build and runtime validation on an ELF kernel-build target.