### PR TITLE
nshlib: add relative image path support in boot command

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -405,6 +405,7 @@ int cmd_switchboot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   struct boardioc_boot_info_s info;
+  FAR char *fullpath = NULL;
 
   memset(&info, 0, sizeof(info));
 
@@ -421,7 +422,8 @@ int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         /* Go through */
 
       case 1:
-        info.path = argv[1];
+        fullpath = nsh_getfullpath(vtbl, argv[1]);
+        info.path = fullpath;
 
         /* Go through */
 
@@ -439,6 +441,7 @@ int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
    */
 
   nsh_error(vtbl, g_fmtcmdfailed, argv[0], "boardctl", NSH_ERRNO);
+  nsh_freefullpath(fullpath);
   return ERROR;
 }
 #endif


### PR DESCRIPTION

## Summary

cmd_boot passed the image path straight to boardctl(), which resolves it in a context that does not inherit the NSH shell cwd, so relative paths failed, and only absolute paths worked. Use nsh_getfullpath() to resolve relative paths against the cwd before calling boardctl().

## Impact

- **Users**: `boot <relative-path>` now resolves against the NSH cwd;
  absolute-path behavior is unchanged.
- **Build**: None -- uses the existing `nsh_getfullpath`/`nsh_freefullpath`
  helpers, no new dependency.
- **Hardware**: None -- NSH command logic only, no board-specific code.
- **Documentation**: None.
- **Security & Compatibility**: None -- behavior extension; absolute
  paths behave exactly as before.

## Testing

Local build on Cortex-M55 (enables CONFIG_BOARDCTL_BOOT_IMAGE); the boot ELF builds and the `boot` NSH command succeeds.

And the change follows the established `nsh_getfullpath()`/`nsh_freefullpath()` convention already used by the other NSH file-path commands. Representative upstream examples (the same pattern is also used by `mv`, `ls`, `ln`, `mkdir`, and every other NSH file-path command):

- cp (src)  -- https://github.com/apache/nuttx-apps/blob/master/nshlib/nsh_fscmds.c#L1106
- cp (dest) -- https://github.com/apache/nuttx-apps/blob/master/nshlib/nsh_fscmds.c#L1113
- cat       -- https://github.com/apache/nuttx-apps/blob/master/nshlib/nsh_fscmds.c#L854
- rm        -- https://github.com/apache/nuttx-apps/blob/master/nshlib/nsh_fscmds.c#L2667