### PR TITLE
testing/sched: fix invalid timerjitter results

### DIFF
--- a/testing/sched/timerjitter/timerjitter.c
+++ b/testing/sched/timerjitter/timerjitter.c
@@ -24,11 +24,12 @@
  * Included Files
  ****************************************************************************/
 
+#include <inttypes.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <signal.h>
 #include <time.h>
 
 /****************************************************************************
@@ -36,8 +37,8 @@
  ****************************************************************************/
 
 #define DEFAULT_CLOCKID   CLOCK_REALTIME
-#define DEFAULT_INTERVAL  (1000 * USEC_PER_TICK)
-#define DEFAULT_ITERATION (USEC_PER_SEC / DEFAULT_INTERVAL)
+#define DEFAULT_INTERVAL  (USEC_PER_TICK > 1000 ? USEC_PER_TICK : 1000)
+#define DEFAULT_ITERATION ((USEC_PER_SEC - 1) / DEFAULT_INTERVAL + 1)
 
 /* Fix compilation error for Non-NuttX OS */
 #ifndef FAR
@@ -63,8 +64,8 @@ struct timerjitter_param_s
   unsigned long max_cnt;
   unsigned long cur_cnt;
   double        avg;
-  unsigned long max;
-  unsigned long min;
+  int64_t       max;
+  int64_t       min;
   int           print;
   unsigned int  missed;
 };
@@ -193,7 +194,7 @@ static FAR void *timerjitter(FAR void *arg)
 
   param->avg = 0;
   param->max = 0;
-  param->min = (unsigned long)-1;
+  param->min = 0;
 
   while (param->cur_cnt < param->max_cnt)
     {
@@ -220,12 +221,12 @@ static FAR void *timerjitter(FAR void *arg)
                   (intmax_t)now.tv_sec, now.tv_nsec);
         }
 
-      if (diff > param->max)
+      if (param->cur_cnt == 1 || diff > param->max)
         {
           param->max = diff;
         }
 
-      if (diff < param->min)
+      if (param->cur_cnt == 1 || diff < param->min)
         {
           param->min = diff;
         }
@@ -241,7 +242,7 @@ static FAR void *timerjitter(FAR void *arg)
       while (ts_greater(&now, &next))
         {
           calc_next(&next, &intv);
-          printf("time frame missed %u\n", ++param->missed);
+          param->missed++;
         }
     }
 
@@ -330,11 +331,22 @@ int main(int argc, FAR char *argv[])
       if (argc > 1)
         {
           param.interval = get_num(argv[1]);
+          if (param.interval < USEC_PER_TICK)
+            {
+              printf("interval must be at least %lu us\n",
+                     (unsigned long)USEC_PER_TICK);
+              return EXIT_FAILURE;
+            }
         }
 
       if (argc > 2)
         {
           param.max_cnt = get_num(argv[2]);
+          if (param.max_cnt == 0)
+            {
+              printf("iteration must be greater than 0\n");
+              return EXIT_FAILURE;
+            }
         }
     }
 
@@ -358,8 +370,13 @@ int main(int argc, FAR char *argv[])
       printf("pthread_attr_destroy failed %d\n", ret);
     }
 
+  if (param.missed > 0)
+    {
+      printf("time frames missed: %u\n", param.missed);
+    }
+
   printf("timer jitter in %lu run:\n", param.max_cnt);
-  printf("(latency/us) min: %lu, avg: %.0lf, max %lu\n",
+  printf("(latency/us) min: %" PRId64 ", avg: %.0lf, max %" PRId64 "\n",
          param.min, param.avg, param.max);
 
   return 0;


### PR DESCRIPTION
## Summary

- preserve the original 1 ms default interval when possible, while raising it to `USEC_PER_TICK` on lower-resolution systems
- round up the default iteration count so the default run always collects at least one sample
- reject intervals below the system tick and reject zero iterations
- keep minimum and maximum jitter values signed
- aggregate missed-frame reporting after the measurement instead of printing inside the catch-up loop

Fixes #3634

## Root cause

The default interval was changed from 1000 us to `1000 * USEC_PER_TICK`. With a 10 ms system tick this becomes 10 seconds, so `USEC_PER_SEC / DEFAULT_INTERVAL` evaluates to zero. The test then reports an uninitialized minimum and divides the accumulated latency by zero.

A requested interval below `USEC_PER_TICK` cannot be represented by the tick-based POSIX timer. The timer expires at tick resolution while timerjitter advances its expected timestamp by the smaller requested interval. This produces many missed frames. Printing every missed frame from the catch-up loop adds serial I/O latency and can create still more missed frames.

The measured difference is an `int64_t`, but the minimum and maximum fields were `unsigned long`. Assigning a negative difference to these fields wrapped it to a large positive value.

## Hardware validation

The change was validated on real hardware with the following environment:

- MCU: STM32F407ZG (Arm Cortex-M4F)
- NuttX board configuration: `stm32f407zg-p1`
- NuttX runtime: 13.0.0
- Toolchain: `arm-none-eabi-gcc 9.2.1 20191025`
- `CONFIG_USEC_PER_TICK=10000`
- `CONFIG_TESTING_TIMERJITTER=y`
- `CONFIG_LIBC_FLOATINGPOINT=y`

### Before

The captured log reached 27 consecutive missed-frame messages:

```text
NuttShell (NSH) NuttX-13.0.0
nsh> timerjitter
timer jitter in 0 run:
(latency/us) min: 4294967295, avg: nan, max 0
nsh> timerjitter 10000 10
timer jitter in 10 run:
(latency/us) min: 10000, avg: 10000, max 10000
nsh> timerjitter 100 5
time frame missed 1
time frame missed 2
time frame missed 3
time frame missed 4
time frame missed 5
time frame missed 6
time frame missed 7
time frame missed 8
time frame missed 9
time frame missed 10
time frame missed 11
time frame missed 12
time frame missed 13
time frame missed 14
time frame missed 15
time frame missed 16
time frame missed 17
time frame missed 18
time frame missed 19
time frame missed 20
time frame missed 21
time frame missed 22
time frame missed 23
time frame missed 24
time frame missed 25
time frame missed 26
time frame missed 27
```

### After

```text
NuttShell (NSH) NuttX-13.0.0
nsh> timerjitter
timer jitter in 100 run:
(latency/us) min: 10000, avg: 10000, max 10000
nsh> timerjitter -m 10000 10
timer jitter in 10 run:
(latency/us) min: 10000, avg: 10000, max 10000
nsh> timerjitter 100 5
interval must be at least 10000 us
nsh> timerjitter 10000 0
iteration must be greater than 0
nsh>
```

The 10000 us values are the expected tick-resolution behavior of this configuration; this change fixes invalid statistics and runaway reporting, not the target timer resolution.

## Additional checks

- `nxstyle testing/sched/timerjitter/timerjitter.c`
- strict host compilation with `-Wall -Wextra -Werror`
- complete STM32F407ZG NuttX build
