### PR TITLE
testing/ostest: build the perf test only where it can link

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -161,7 +161,10 @@ if(CONFIG_TESTING_OSTEST)
     list(APPEND SRCS nxevent.c)
   endif()
 
-  if(CONFIG_ARCH_HAVE_PERF_EVENTS)
+  # perf_gettime() and perf_getfreq() live in the kernel and are not system
+  # calls, so only a flat build can reach them from here.
+
+  if(CONFIG_ARCH_HAVE_PERF_EVENTS AND CONFIG_BUILD_FLAT)
     list(APPEND SRCS perf_gettime.c)
   endif()
 

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -164,8 +164,13 @@ CSRCS += nxevent.c
 endif
 endif
 
+# perf_gettime() and perf_getfreq() live in the kernel and are not system
+# calls, so only a flat build can reach them from here.
+
 ifeq ($(CONFIG_ARCH_HAVE_PERF_EVENTS),y)
+ifeq ($(CONFIG_BUILD_FLAT),y)
 CSRCS += perf_gettime.c
+endif
 endif
 
 ifeq ($(CONFIG_BUILD_FLAT),y)

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -304,7 +304,7 @@ void spinlock_test(void);
 
 /* perf_gettime.c ***********************************************************/
 
-#ifdef CONFIG_ARCH_HAVE_PERF_EVENTS
+#if defined(CONFIG_ARCH_HAVE_PERF_EVENTS) && defined(CONFIG_BUILD_FLAT)
 void perf_gettime_test(void);
 #endif
 

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -656,7 +656,8 @@ static int user_main(int argc, char *argv[])
       check_test_memory_usage();
 #endif
 
-#if defined(CONFIG_ARCH_PERF_EVENTS) && !defined(CONFIG_ARCH_PERF_EVENTS_USER_ACCESS)
+#if defined(CONFIG_ARCH_PERF_EVENTS) && \
+    !defined(CONFIG_ARCH_PERF_EVENTS_USER_ACCESS) && defined(CONFIG_BUILD_FLAT)
       /* Verify performance event time counter */
 
       printf("\nuser_main: performance event time counter test\n");


### PR DESCRIPTION
## Summary

`testing/ostest` cannot link in a protected or kernel build whenever
`CONFIG_ARCH_PERF_EVENTS` is set.

`perf_gettime()` and `perf_getfreq()` are kernel functions, defined in
`sched/clock/clock_perf.c`. Neither appears in `syscall.csv`, and
`libs/libc/sched/clock_perf.c` supplies only `perf_gettime()`, gated on
`CONFIG_ARCH_HAVE_PERF_EVENTS_USER_ACCESS`. So user space has no way to reach
either symbol unless the build is flat.

The pieces disagree about when to use them:

* `testing/ostest/Makefile` / `CMakeLists.txt` compile `perf_gettime.c` when
  `CONFIG_ARCH_HAVE_PERF_EVENTS` is set.
* `ostest_main.c` calls `perf_gettime_test()` when `CONFIG_ARCH_PERF_EVENTS`
  is set and `CONFIG_ARCH_PERF_EVENTS_USER_ACCESS` is not — which is exactly
  the case where the symbols are kernel-only.

So any protected/kernel configuration with `ARCH_PERF_EVENTS=y` fails to link:

```
ostest/perf_gettime.c:91:  undefined reference to `perf_gettime'
ostest/perf_gettime.c:184: undefined reference to `perf_getfreq'
make[1]: *** [nuttx_user.elf] Error 1
```

`mps3-an547:knsh` is one, because its defconfig sets `CONFIG_SCHED_IRQMONITOR`,
which makes `ARCH_PERF_EVENTS` default `y`. `mps2-an521:knsh` and
`mps2-an500:knsh` escape only because they set neither `SCHED_IRQMONITOR` nor
`SCHED_CRITMONITOR`, so `ARCH_PERF_EVENTS` is off, the call compiles out and
the archive member is never pulled in.

This adds `CONFIG_BUILD_FLAT` to all four sites, which is where ostest links
against the kernel's own copy of these functions.

## Impact

No configuration that runs this test today stops running it — flat builds are
untouched. Protected and kernel builds that previously could not link ostest
at all now build, and skip the one test they could never have executed.

Users affected: anyone enabling `TESTING_OSTEST` on a `BUILD_PROTECTED` or
`BUILD_KERNEL` target with `SCHED_IRQMONITOR`, `SCHED_CRITMONITOR`,
`RPMSG_PING` or `SEGGER_SYSVIEW` enabled (the four that make
`ARCH_PERF_EVENTS` default `y`).

No API, Kconfig or documentation change.

## Testing

Host: macOS 15.5 (Darwin 25.5.0), Apple Silicon; `arm-none-eabi-gcc` 14.2.Rel1;
QEMU 11.0.3.

Target: `mps3-an547:knsh` — Armv8-M, Cortex-M55, `BUILD_PROTECTED`, the
configuration that exposed this.

**Before** — link fails:

```
arm-none-eabi-ld: apps/testing/ostest/perf_gettime.c:91:(.text.perf_gettime_test+0x12):
    undefined reference to `perf_gettime'
arm-none-eabi-ld: apps/testing/ostest/perf_gettime.c:184:(.text.perf_gettime_test+0x1bc):
    undefined reference to `perf_getfreq'
make[1]: *** [nuttx_user.elf] Error 1
make: *** [nuttx] Error 2
```

**After** — both blobs link:

```
   text	   data	    bss	    dec	    hex	filename
 256663	   1020	  10160	 267843	  41643	nuttx
 176857	    640	   3088	 180585	  2c169	nuttx_user.elf
```

and the image boots to NSH and runs `ostest` under
`qemu-system-arm -M mps3-an547`.

The flat path is unchanged by construction — the patch only ever *adds* a
condition, so no build that compiled `perf_gettime.c` before and still
satisfies `CONFIG_BUILD_FLAT` is affected.
