### PR TITLE
testing/ostest: extend multiuser identity and permission tests

### DIFF
--- a/nshlib/nsh_identity.c
+++ b/nshlib/nsh_identity.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <errno.h>
+#include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -381,28 +382,228 @@ int cmd_su(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 }
 #endif
 
+#ifndef CONFIG_NSH_DISABLE_ID
+
+/****************************************************************************
+ * Name: nsh_id_format_uid
+ *
+ * Description:
+ *   Format a UID token in Linux id(1) style, e.g. "uid=0(root)".
+ *
+ ****************************************************************************/
+
+static void nsh_id_format_uid(FAR char *buf, size_t buflen,
+                              FAR const char *tag, uid_t uid)
+{
+#ifdef CONFIG_LIBC_PASSWD_FILE
+  FAR struct passwd *pwd = getpwuid(uid);
+
+  if (pwd != NULL && pwd->pw_name != NULL)
+    {
+      snprintf(buf, buflen, "%s=%d(%s)", tag, uid, pwd->pw_name);
+      return;
+    }
+#endif
+
+  if (uid == 0)
+    {
+      snprintf(buf, buflen, "%s=%d(root)", tag, uid);
+    }
+  else
+    {
+      snprintf(buf, buflen, "%s=%d", tag, uid);
+    }
+}
+
+/****************************************************************************
+ * Name: nsh_id_format_gid
+ *
+ * Description:
+ *   Format a GID token in Linux id(1) style, e.g. "gid=0(root)".
+ *
+ ****************************************************************************/
+
+static void nsh_id_format_gid(FAR char *buf, size_t buflen,
+                              FAR const char *tag, gid_t gid)
+{
+#ifdef CONFIG_LIBC_GROUP_FILE
+  FAR struct group *grp = getgrgid(gid);
+
+  if (grp != NULL && grp->gr_name != NULL)
+    {
+      snprintf(buf, buflen, "%s=%d(%s)", tag, gid, grp->gr_name);
+      return;
+    }
+#endif
+
+  if (gid == 0)
+    {
+      snprintf(buf, buflen, "%s=%d(root)", tag, gid);
+    }
+  else
+    {
+      snprintf(buf, buflen, "%s=%d", tag, gid);
+    }
+}
+
+static void nsh_id_append(FAR char *line, size_t linelen,
+                          FAR const char *token)
+{
+  size_t len = strlen(line);
+
+  if (len > 0)
+    {
+      strlcat(line, " ", linelen);
+    }
+
+  strlcat(line, token, linelen);
+}
+
+#ifdef CONFIG_LIBC_PASSWD_FILE
+/****************************************************************************
+ * Name: nsh_id_format_group_value
+ *
+ * Description:
+ *   Format a bare group value for a groups= list, e.g. "0(root)".
+ *
+ ****************************************************************************/
+
+static void nsh_id_format_group_value(FAR char *buf, size_t buflen,
+                                      gid_t gid)
+{
+#ifdef CONFIG_LIBC_GROUP_FILE
+  FAR struct group *grp = getgrgid(gid);
+
+  if (grp != NULL && grp->gr_name != NULL)
+    {
+      snprintf(buf, buflen, "%d(%s)", gid, grp->gr_name);
+      return;
+    }
+#endif
+
+  if (gid == 0)
+    {
+      snprintf(buf, buflen, "0(root)");
+    }
+  else
+    {
+      snprintf(buf, buflen, "%d", gid);
+    }
+}
+
+/****************************************************************************
+ * Name: nsh_id_append_groups
+ *
+ * Description:
+ *   Append a Linux-style groups= list to the id output line.
+ *
+ ****************************************************************************/
+
+static void nsh_id_append_groups(FAR char *line, size_t linelen)
+{
+  gid_t grouplist[8];
+  char token[48];
+  int ngroups;
+  int i;
+
+  ngroups = getgroups(sizeof(grouplist) / sizeof(grouplist[0]), grouplist);
+  if (ngroups <= 0)
+    {
+      return;
+    }
+
+  strlcat(line, " groups=", linelen);
+
+  for (i = 0; i < ngroups; i++)
+    {
+      if (i > 0)
+        {
+          strlcat(line, ",", linelen);
+        }
+
+      nsh_id_format_group_value(token, sizeof(token), grouplist[i]);
+      strlcat(line, token, linelen);
+    }
+}
+#endif /* CONFIG_LIBC_PASSWD_FILE */
+
 /****************************************************************************
  * Name: cmd_id
  *
  * Description:
- *   Print real and effective UID/GID for the current session.
+ *   Print real, effective, and saved-set UID/GID for the current session in
+ *   Linux id(1) style with optional user and group names.
  *
  ****************************************************************************/
 
-#ifndef CONFIG_NSH_DISABLE_ID
 int cmd_id(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
+  uid_t ruid;
+  uid_t euid;
+  uid_t suid;
+  gid_t rgid;
+  gid_t egid;
+  gid_t sgid;
+  char line[256];
+  char token[48];
+
   if (argc != 1)
     {
       nsh_error(vtbl, g_fmtarginvalid, argv[0]);
       return ERROR;
     }
 
-  nsh_output(vtbl, "uid=%d euid=%d gid=%d egid=%d\n",
-             getuid(), geteuid(), getgid(), getegid());
+  if (getresuid(&ruid, &euid, &suid) != 0)
+    {
+      nsh_error(vtbl, "id: getresuid() failed: %d\n", errno);
+      return ERROR;
+    }
+
+  if (getresgid(&rgid, &egid, &sgid) != 0)
+    {
+      nsh_error(vtbl, "id: getresgid() failed: %d\n", errno);
+      return ERROR;
+    }
+
+  line[0] = '\0';
+
+  nsh_id_format_uid(token, sizeof(token), "uid", ruid);
+  nsh_id_append(line, sizeof(line), token);
+
+  if (euid != ruid)
+    {
+      nsh_id_format_uid(token, sizeof(token), "euid", euid);
+      nsh_id_append(line, sizeof(line), token);
+    }
+
+  if (suid != ruid && suid != euid)
+    {
+      nsh_id_format_uid(token, sizeof(token), "suid", suid);
+      nsh_id_append(line, sizeof(line), token);
+    }
+
+  nsh_id_format_gid(token, sizeof(token), "gid", rgid);
+  nsh_id_append(line, sizeof(line), token);
+
+  if (egid != rgid)
+    {
+      nsh_id_format_gid(token, sizeof(token), "egid", egid);
+      nsh_id_append(line, sizeof(line), token);
+    }
+
+  if (sgid != rgid && sgid != egid)
+    {
+      nsh_id_format_gid(token, sizeof(token), "sgid", sgid);
+      nsh_id_append(line, sizeof(line), token);
+    }
+
+#ifdef CONFIG_LIBC_PASSWD_FILE
+  nsh_id_append_groups(line, sizeof(line));
+#endif
+  nsh_output(vtbl, "%s\n", line);
   return OK;
 }
-#endif
+#endif /* CONFIG_NSH_DISABLE_ID */
 
 /****************************************************************************
  * Name: cmd_whoami
@@ -442,7 +643,7 @@ int cmd_whoami(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     }
   else
     {
-      nsh_output(vtbl, "%d\n", (int)euid);
+      nsh_output(vtbl, "%d\n", euid);
     }
 
   return OK;

--- a/testing/ostest/Kconfig
+++ b/testing/ostest/Kconfig
@@ -124,11 +124,16 @@ config TESTING_OSTEST_MULTIUSER
 	bool "Multi-user identity and permission tests"
 	default n
 	depends on SCHED_USER_IDENTITY
+	depends on LIBC_PASSWD_FILE
 	---help---
 		Enable regression tests for UID/GID identity switching and file
 		permission enforcement.  Individual sub-tests run only when the
 		corresponding kernel options are enabled (for example pseudoFS
 		permission checks require FS_PERMISSION and PSEUDOFS_FILE).
+
+		The passwd lookup sub-test creates a temporary passwd file at
+		CONFIG_LIBC_PASSWD_FILEPATH (default /tmp/ostest_passwd when this
+		option is enabled).
 
 config TEST_LOOP_SCALE
 	int "Loop scale of spinlock test (N x 10,000)"

--- a/testing/ostest/multiuser.c
+++ b/testing/ostest/multiuser.c
@@ -37,6 +37,18 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#if !defined(CONFIG_DISABLE_MQUEUE)
+#  include <mqueue.h>
+#endif
+
+#if defined(CONFIG_FS_NAMED_SEMAPHORES)
+#  include <semaphore.h>
+#endif
+
+#if defined(CONFIG_FS_SHMFS)
+#  include <sys/mman.h>
+#endif
+
 #include "ostest.h"
 
 /****************************************************************************
@@ -239,6 +251,26 @@ static int mu_verify_owner(FAR struct mu_ctx_s *ctx, FAR const char *path,
   return 0;
 }
 
+static void mu_verify_mode(FAR struct mu_ctx_s *ctx, FAR const char *path,
+                           mode_t mode)
+{
+  struct stat st;
+
+  if (stat(path, &st) != 0)
+    {
+      mu_fail(ctx, "stat(%s) after create errno=%d", path, errno);
+    }
+  else if ((st.st_mode & 0777) != mode)
+    {
+      mu_fail(ctx, "%s mode expected %04o got %04o", path,
+              (unsigned int)mode, (unsigned int)(st.st_mode & 0777));
+    }
+  else
+    {
+      mu_pass("%s mode %04o", path, (unsigned int)mode);
+    }
+}
+
 #if defined(CONFIG_SCHED_USER_IDENTITY)
 
 static int multiuser_effective_test(FAR struct mu_ctx_s *ctx)
@@ -291,7 +323,179 @@ static int multiuser_effective_test(FAR struct mu_ctx_s *ctx)
   return ctx->failures;
 }
 
+static int multiuser_resuid_test(FAR struct mu_ctx_s *ctx)
+{
+  uid_t ruid;
+  uid_t euid;
+  uid_t suid;
+  gid_t rgid;
+  gid_t egid;
+  gid_t sgid;
+  int ret;
+
+  printf("multiuser: getresuid/getresgid and setreuid/setregid\n");
+
+  ret = getresuid(&ruid, &euid, &suid);
+  if (mu_expect_ok(ctx, "getresuid(initial)", ret) != 0)
+    {
+      return ctx->failures;
+    }
+
+  mu_check_eq(ctx, "initial real uid", ruid, 0);
+  mu_check_eq(ctx, "initial eff uid", euid, 0);
+  mu_check_eq(ctx, "initial saved uid", suid, 0);
+
+  ret = getresgid(&rgid, &egid, &sgid);
+  if (mu_expect_ok(ctx, "getresgid(initial)", ret) != 0)
+    {
+      return ctx->failures;
+    }
+
+  mu_check_eq(ctx, "initial real gid", rgid, 0);
+  mu_check_eq(ctx, "initial eff gid", egid, 0);
+  mu_check_eq(ctx, "initial saved gid", sgid, 0);
+
+  ret = setreuid((uid_t)-1, MU_UID1);
+  if (mu_expect_ok(ctx, "root setreuid(-1,1000)", ret) != 0)
+    {
+      mu_restore_root(ctx);
+      return ctx->failures;
+    }
+
+  ret = getresuid(&ruid, &euid, &suid);
+  mu_check_eq(ctx, "real uid after setreuid(-1,1000)", ruid, 0);
+  mu_check_eq(ctx, "eff uid after setreuid(-1,1000)", euid, MU_UID1);
+  mu_check_eq(ctx, "saved uid after setreuid(-1,1000)", suid, MU_UID1);
+
+  ret = setreuid(MU_UID2, (uid_t)-1);
+  mu_expect_denied(ctx, "non-root setreuid(2000,-1)", ret);
+
+  ret = setreuid((uid_t)-1, 0);
+  if (mu_expect_ok(ctx, "setreuid(-1,0) drop effective", ret) != 0)
+    {
+      mu_restore_root(ctx);
+      return ctx->failures;
+    }
+
+  ret = setreuid(0, (uid_t)-1);
+  if (mu_expect_ok(ctx, "root setreuid(0,-1) restore", ret) != 0)
+    {
+      mu_restore_root(ctx);
+      return ctx->failures;
+    }
+
+  ret = getresuid(&ruid, &euid, &suid);
+  mu_check_eq(ctx, "real uid restored", ruid, 0);
+  mu_check_eq(ctx, "eff uid restored", euid, 0);
+  mu_check_eq(ctx, "saved uid restored", suid, 0);
+
+  ret = setregid((gid_t)-1, MU_GID1);
+  if (mu_expect_ok(ctx, "root setregid(-1,1000)", ret) != 0)
+    {
+      mu_restore_root(ctx);
+      return ctx->failures;
+    }
+
+  ret = getresgid(&rgid, &egid, &sgid);
+  mu_check_eq(ctx, "real gid after setregid(-1,1000)", rgid, 0);
+  mu_check_eq(ctx, "eff gid after setregid(-1,1000)", egid, MU_GID1);
+  mu_check_eq(ctx, "saved gid after setregid(-1,1000)", sgid, MU_GID1);
+
+  ret = setregid(MU_GID2, (gid_t)-1);
+  mu_expect_denied(ctx, "non-root setregid(2000,-1)", ret);
+
+  ret = setregid((gid_t)-1, 0);
+  if (mu_expect_ok(ctx, "setregid(-1,0) drop effective", ret) != 0)
+    {
+      mu_restore_root(ctx);
+      return ctx->failures;
+    }
+
+  ret = setregid(0, (gid_t)-1);
+  mu_expect_ok(ctx, "root setregid(0,-1) restore", ret);
+
+  mu_restore_root(ctx);
+  return ctx->failures;
+}
+
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_BUILD_KERNEL)
+
+static int mu_run_child(FAR struct mu_ctx_s *ctx, FAR const char *name,
+                        main_t entry)
+{
+  pid_t pid;
+  int status;
+
+  pid = task_create(name, MU_CHILD_PRIORITY, STACKSIZE, entry, NULL);
+  if (pid < 0)
+    {
+      mu_fail(ctx, "task_create(%s) failed", name);
+      return ctx->failures;
+    }
+
+  if (waitpid(pid, &status, 0) != pid)
+    {
+      mu_fail(ctx, "waitpid(%s) failed errno=%d", name, errno);
+      return ctx->failures;
+    }
+
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS)
+    {
+      mu_fail(ctx, "%s child exited with status=%d", name, status);
+    }
+  else
+    {
+      mu_pass("%s child completed successfully", name);
+    }
+
+  return ctx->failures;
+}
+
+static int multiuser_resuid_child(int argc, FAR char *argv[])
+{
+  struct mu_ctx_s ctx =
+  {
+    0
+  };
+
+  uid_t ruid;
+  uid_t euid;
+  uid_t suid;
+  int ret;
+
+  (void)argc;
+  (void)argv;
+
+  ret = setreuid(MU_UID1, MU_UID1);
+  if (mu_expect_ok(&ctx, "root setreuid(1000,1000)", ret) != 0)
+    {
+      return EXIT_FAILURE;
+    }
+
+  ret = getresuid(&ruid, &euid, &suid);
+  if (mu_expect_ok(&ctx, "getresuid(after setreuid)", ret) != 0)
+    {
+      return EXIT_FAILURE;
+    }
+
+  mu_check_eq(&ctx, "real uid after setreuid", ruid, MU_UID1);
+  mu_check_eq(&ctx, "eff uid after setreuid", euid, MU_UID1);
+  mu_check_eq(&ctx, "saved uid after setreuid", suid, MU_UID1);
+
+  printf("multiuser_resuid_child: %d failure(s)\n", ctx.failures);
+  return ctx.failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+static int multiuser_resuid_child_test(FAR struct mu_ctx_s *ctx)
+{
+  printf("multiuser: setreuid(1000,1000) full assignment (child task)\n");
+
+  mu_run_child(ctx, "mu_resuid", multiuser_resuid_child);
+  mu_check_eq(ctx, "parent euid after resuid child", geteuid(), 0);
+  mu_check_eq(ctx, "parent egid after resuid child", getegid(), 0);
+
+  return ctx->failures;
+}
 
 static int multiuser_suid_child(int argc, FAR char *argv[])
 {
@@ -347,34 +551,9 @@ static int multiuser_suid_child(int argc, FAR char *argv[])
 
 static int multiuser_suid_test(FAR struct mu_ctx_s *ctx)
 {
-  pid_t pid;
-  int status;
-
   printf("multiuser: saved set-UID/GID semantics (child task)\n");
 
-  pid = task_create("mu_suid", MU_CHILD_PRIORITY, STACKSIZE,
-                    multiuser_suid_child, NULL);
-  if (pid < 0)
-    {
-      mu_fail(ctx, "task_create(mu_suid) failed");
-      return ctx->failures;
-    }
-
-  if (waitpid(pid, &status, 0) != pid)
-    {
-      mu_fail(ctx, "waitpid(mu_suid) failed errno=%d", errno);
-      return ctx->failures;
-    }
-
-  if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS)
-    {
-      mu_fail(ctx, "mu_suid child exited with status=%d", status);
-    }
-  else
-    {
-      mu_pass("mu_suid child completed successfully");
-    }
-
+  mu_run_child(ctx, "mu_suid", multiuser_suid_child);
   mu_check_eq(ctx, "parent euid after child", geteuid(), 0);
   mu_check_eq(ctx, "parent egid after child", getegid(), 0);
 
@@ -383,8 +562,7 @@ static int multiuser_suid_test(FAR struct mu_ctx_s *ctx)
 
 #endif /* CONFIG_SCHED_WAITPID && !CONFIG_BUILD_KERNEL */
 
-#if defined(CONFIG_FS_PERMISSION) && defined(CONFIG_PSEUDOFS_ATTRIBUTES) && \
-    defined(CONFIG_PSEUDOFS_FILE)
+#if defined(CONFIG_FS_PERMISSION)
 
 static int multiuser_open_secret(FAR struct mu_ctx_s *ctx,
                                  FAR const char *path, int expect_ok)
@@ -422,6 +600,11 @@ static int multiuser_open_secret(FAR struct mu_ctx_s *ctx,
   mu_pass("open(%s) denied with EACCES", path);
   return 0;
 }
+
+#endif /* CONFIG_FS_PERMISSION */
+
+#if defined(CONFIG_FS_PERMISSION) && defined(CONFIG_PSEUDOFS_ATTRIBUTES) && \
+    defined(CONFIG_PSEUDOFS_FILE)
 
 static int multiuser_pseudofs_test(FAR struct mu_ctx_s *ctx)
 {
@@ -581,6 +764,286 @@ out:
 
 #endif /* CONFIG_FS_PERMISSION && CONFIG_FS_TMPFS */
 
+#if defined(CONFIG_FS_PERMISSION) && defined(CONFIG_PSEUDOFS_ATTRIBUTES)
+
+#if !defined(CONFIG_DISABLE_MQUEUE)
+#  define MU_MQ_NAME   "ostest_mu_mq"
+#  define MU_MQ_PATH   CONFIG_FS_MQUEUE_VFS_PATH "/" MU_MQ_NAME
+#endif
+
+#if defined(CONFIG_FS_NAMED_SEMAPHORES)
+#  define MU_SEM_NAME  "ostest_mu_sem"
+#  define MU_SEM_PATH  CONFIG_FS_NAMED_SEMAPHORES_VFS_PATH "/" MU_SEM_NAME
+#endif
+
+#if defined(CONFIG_FS_SHMFS)
+#  define MU_SHM_NAME  "ostest_mu_shm"
+#  define MU_SHM_PATH  CONFIG_FS_SHMFS_VFS_PATH "/" MU_SHM_NAME
+#endif
+
+#if defined(CONFIG_PIPES)
+#  define MU_FIFO_PATH "/ostest_mu_fifo"
+#endif
+
+#if !defined(CONFIG_DISABLE_MQUEUE)
+
+static int multiuser_mqueue_test(FAR struct mu_ctx_s *ctx)
+{
+  mqd_t mq;
+  struct mq_attr attr;
+
+  printf("multiuser: message queue ownership and permissions\n");
+
+  mu_restore_root(ctx);
+  mq_unlink(MU_MQ_NAME);
+
+  memset(&attr, 0, sizeof(attr));
+  attr.mq_maxmsg  = 4;
+  attr.mq_msgsize = 64;
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  mq = mq_open(MU_MQ_NAME, O_CREAT | O_RDWR | O_EXCL, 0600, &attr);
+  if (mq == (mqd_t)-1)
+    {
+      mu_fail(ctx, "mq_open(create) errno=%d", errno);
+      goto out;
+    }
+
+  mq_close(mq);
+  mu_verify_owner(ctx, MU_MQ_PATH, MU_UID1, MU_GID1);
+  mu_verify_mode(ctx, MU_MQ_PATH, 0600);
+
+  if (mu_set_effective(ctx, MU_UID2, MU_GID2) != 0)
+    {
+      goto out;
+    }
+
+  mq = mq_open(MU_MQ_NAME, O_RDWR);
+  mu_expect_denied(ctx, "mq_open(other user)", mq == (mqd_t)-1 ? -1 : 0);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  mq = mq_open(MU_MQ_NAME, O_RDWR);
+  if (mq == (mqd_t)-1)
+    {
+      mu_fail(ctx, "mq_open(owner) errno=%d", errno);
+    }
+  else
+    {
+      mu_pass("mq_open(owner)");
+      mq_close(mq);
+    }
+
+out:
+  mu_restore_root(ctx);
+  mq_unlink(MU_MQ_NAME);
+  return ctx->failures;
+}
+
+#endif /* !CONFIG_DISABLE_MQUEUE */
+
+#if defined(CONFIG_FS_NAMED_SEMAPHORES)
+
+static int multiuser_sem_test(FAR struct mu_ctx_s *ctx)
+{
+  sem_t *sem;
+
+  printf("multiuser: named semaphore ownership and permissions\n");
+
+  mu_restore_root(ctx);
+  sem_unlink(MU_SEM_NAME);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  sem = sem_open(MU_SEM_NAME, O_CREAT | O_EXCL, 0600, 1);
+  if (sem == SEM_FAILED)
+    {
+      mu_fail(ctx, "sem_open(create) errno=%d", errno);
+      goto out;
+    }
+
+  sem_close(sem);
+  mu_verify_owner(ctx, MU_SEM_PATH, MU_UID1, MU_GID1);
+
+  if (mu_set_effective(ctx, MU_UID2, MU_GID2) != 0)
+    {
+      goto out;
+    }
+
+  sem = sem_open(MU_SEM_NAME, 0);
+  mu_expect_denied(ctx, "sem_open(other user)", sem == SEM_FAILED ? -1 : 0);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  sem = sem_open(MU_SEM_NAME, 0);
+  if (sem == SEM_FAILED)
+    {
+      mu_fail(ctx, "sem_open(owner) errno=%d", errno);
+    }
+  else
+    {
+      mu_pass("sem_open(owner)");
+      sem_close(sem);
+    }
+
+out:
+  mu_restore_root(ctx);
+  sem_unlink(MU_SEM_NAME);
+  return ctx->failures;
+}
+
+#endif /* CONFIG_FS_NAMED_SEMAPHORES */
+
+#if defined(CONFIG_FS_SHMFS)
+
+static int multiuser_shm_test(FAR struct mu_ctx_s *ctx)
+{
+  int fd;
+
+  printf("multiuser: shared memory ownership and permissions\n");
+
+  mu_restore_root(ctx);
+  shm_unlink(MU_SHM_NAME);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  fd = shm_open(MU_SHM_NAME, O_CREAT | O_EXCL | O_RDWR, 0600);
+  if (fd < 0)
+    {
+      mu_fail(ctx, "shm_open(create) errno=%d", errno);
+      goto out;
+    }
+
+  close(fd);
+  mu_verify_owner(ctx, MU_SHM_PATH, MU_UID1, MU_GID1);
+
+  if (mu_set_effective(ctx, MU_UID2, MU_GID2) != 0)
+    {
+      goto out;
+    }
+
+  fd = shm_open(MU_SHM_NAME, O_RDWR, 0);
+  mu_expect_denied(ctx, "shm_open(other user)", fd < 0 ? -1 : 0);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  fd = shm_open(MU_SHM_NAME, O_RDWR, 0);
+  if (fd < 0)
+    {
+      mu_fail(ctx, "shm_open(owner) errno=%d", errno);
+    }
+  else
+    {
+      mu_pass("shm_open(owner)");
+      close(fd);
+    }
+
+out:
+  mu_restore_root(ctx);
+  shm_unlink(MU_SHM_NAME);
+  return ctx->failures;
+}
+
+#endif /* CONFIG_FS_SHMFS */
+
+#if defined(CONFIG_PIPES)
+
+static int multiuser_fifo_test(FAR struct mu_ctx_s *ctx)
+{
+  int fd;
+
+  printf("multiuser: FIFO ownership and permissions\n");
+
+  mu_restore_root(ctx);
+  unlink(MU_FIFO_PATH);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  if (mkfifo(MU_FIFO_PATH, 0600) != 0)
+    {
+      mu_fail(ctx, "mkfifo errno=%d", errno);
+      goto out;
+    }
+
+  mu_verify_owner(ctx, MU_FIFO_PATH, MU_UID1, MU_GID1);
+
+  if (mu_set_effective(ctx, MU_UID2, MU_GID2) != 0)
+    {
+      goto out;
+    }
+
+  fd = open(MU_FIFO_PATH, O_RDONLY | O_NONBLOCK);
+  mu_expect_denied(ctx, "open fifo (other user)", fd < 0 ? -1 : 0);
+
+  if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
+    {
+      goto out;
+    }
+
+  fd = open(MU_FIFO_PATH, O_RDONLY | O_NONBLOCK);
+  if (fd < 0)
+    {
+      mu_fail(ctx, "open fifo (owner) errno=%d", errno);
+    }
+  else
+    {
+      mu_pass("open fifo (owner)");
+      close(fd);
+    }
+
+out:
+  mu_restore_root(ctx);
+  unlink(MU_FIFO_PATH);
+  return ctx->failures;
+}
+
+#endif /* CONFIG_PIPES */
+
+static int multiuser_ipc_test(FAR struct mu_ctx_s *ctx)
+{
+#if !defined(CONFIG_DISABLE_MQUEUE)
+  multiuser_mqueue_test(ctx);
+#endif
+
+#if defined(CONFIG_FS_NAMED_SEMAPHORES)
+  multiuser_sem_test(ctx);
+#endif
+
+#if defined(CONFIG_FS_SHMFS)
+  multiuser_shm_test(ctx);
+#endif
+
+#if defined(CONFIG_PIPES)
+  multiuser_fifo_test(ctx);
+#endif
+
+  return ctx->failures;
+}
+
+#endif /* CONFIG_FS_PERMISSION && CONFIG_PSEUDOFS_ATTRIBUTES */
+
 #if defined(CONFIG_LIBC_PASSWD_FILE)
 
 static int multiuser_passwd_test(FAR struct mu_ctx_s *ctx)
@@ -644,8 +1107,10 @@ int multiuser_test(void)
   printf("multiuser_test: start\n");
 
   multiuser_effective_test(&ctx);
+  multiuser_resuid_test(&ctx);
 
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_BUILD_KERNEL)
+  multiuser_resuid_child_test(&ctx);
   multiuser_suid_test(&ctx);
 #else
   printf("multiuser: skipping saved set-UID/GID child test "
@@ -665,6 +1130,13 @@ int multiuser_test(void)
 #else
   printf("multiuser: skipping tmpfs permission tests "
          "(need FS_PERMISSION and FS_TMPFS)\n");
+#endif
+
+#if defined(CONFIG_FS_PERMISSION) && defined(CONFIG_PSEUDOFS_ATTRIBUTES)
+  multiuser_ipc_test(&ctx);
+#else
+  printf("multiuser: skipping IPC/FIFO permission tests "
+         "(need FS_PERMISSION and PSEUDOFS_ATTRIBUTES)\n");
 #endif
 
 #if defined(CONFIG_LIBC_PASSWD_FILE)

--- a/testing/ostest/multiuser.c
+++ b/testing/ostest/multiuser.c
@@ -170,17 +170,17 @@ static int mu_set_effective(FAR struct mu_ctx_s *ctx, uid_t uid, gid_t gid)
 
   if (seteuid(uid) != 0)
     {
-      mu_fail(ctx, "seteuid(%u) errno=%d", (unsigned int)uid, errno);
+      mu_fail(ctx, "seteuid(%u) errno=%d", uid, errno);
       return -1;
     }
 
   if (setegid(gid) != 0)
     {
-      mu_fail(ctx, "setegid(%u) errno=%d", (unsigned int)gid, errno);
+      mu_fail(ctx, "setegid(%u) errno=%d", gid, errno);
       return -1;
     }
 
-  if (geteuid() != (int)uid || getegid() != (int)gid)
+  if (geteuid() != uid || getegid() != gid)
     {
       mu_fail(ctx, "effective credential switch failed "
               "(have euid=%d egid=%d)", geteuid(), getegid());
@@ -242,12 +242,11 @@ static int mu_verify_owner(FAR struct mu_ctx_s *ctx, FAR const char *path,
   if (st.st_uid != uid || st.st_gid != gid)
     {
       mu_fail(ctx, "%s owner expected %u:%u got %u:%u",
-              path, (unsigned int)uid, (unsigned int)gid,
-              (unsigned int)st.st_uid, (unsigned int)st.st_gid);
+              path, uid, gid, st.st_uid, st.st_gid);
       return -1;
     }
 
-  mu_pass("%s owner %u:%u", path, (unsigned int)uid, (unsigned int)gid);
+  mu_pass("%s owner %u:%u", path, uid, gid);
   return 0;
 }
 
@@ -263,11 +262,11 @@ static void mu_verify_mode(FAR struct mu_ctx_s *ctx, FAR const char *path,
   else if ((st.st_mode & 0777) != mode)
     {
       mu_fail(ctx, "%s mode expected %04o got %04o", path,
-              (unsigned int)mode, (unsigned int)(st.st_mode & 0777));
+              mode, st.st_mode & 0777);
     }
   else
     {
-      mu_pass("%s mode %04o", path, (unsigned int)mode);
+      mu_pass("%s mode %04o", path, mode);
     }
 }
 
@@ -1044,7 +1043,40 @@ static int multiuser_ipc_test(FAR struct mu_ctx_s *ctx)
 
 #endif /* CONFIG_FS_PERMISSION && CONFIG_PSEUDOFS_ATTRIBUTES */
 
-#if defined(CONFIG_LIBC_PASSWD_FILE)
+#if defined(CONFIG_LIBC_PASSWD_FILE) && defined(CONFIG_TESTING_OSTEST_MULTIUSER)
+
+static int multiuser_passwd_install(FAR struct mu_ctx_s *ctx)
+{
+  int fd;
+  ssize_t nwritten;
+  static const char content[] =
+    "root:x:0:0:/\n"
+    "testuser:x:1000:1000:/home/testuser\n";
+
+  fd = open(CONFIG_LIBC_PASSWD_FILEPATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (fd < 0)
+    {
+      mu_fail(ctx, "create %s errno=%d", CONFIG_LIBC_PASSWD_FILEPATH, errno);
+      return -1;
+    }
+
+  nwritten = write(fd, content, sizeof(content) - 1);
+  close(fd);
+  if (nwritten != (ssize_t)(sizeof(content) - 1))
+    {
+      mu_fail(ctx, "write %s errno=%d", CONFIG_LIBC_PASSWD_FILEPATH, errno);
+      unlink(CONFIG_LIBC_PASSWD_FILEPATH);
+      return -1;
+    }
+
+  mu_pass("installed %s", CONFIG_LIBC_PASSWD_FILEPATH);
+  return 0;
+}
+
+static void multiuser_passwd_remove(void)
+{
+  unlink(CONFIG_LIBC_PASSWD_FILEPATH);
+}
 
 static int multiuser_passwd_test(FAR struct mu_ctx_s *ctx)
 {
@@ -1052,8 +1084,14 @@ static int multiuser_passwd_test(FAR struct mu_ctx_s *ctx)
 
   printf("multiuser: passwd lookup after credential drop\n");
 
+  if (multiuser_passwd_install(ctx) != 0)
+    {
+      return ctx->failures;
+    }
+
   if (mu_set_effective(ctx, MU_UID1, MU_GID1) != 0)
     {
+      multiuser_passwd_remove();
       return ctx->failures;
     }
 
@@ -1065,7 +1103,7 @@ static int multiuser_passwd_test(FAR struct mu_ctx_s *ctx)
     }
   else
     {
-      mu_pass("getpwnam(root) uid=%u", (unsigned int)pwd->pw_uid);
+      mu_pass("getpwnam(root) uid=%u", pwd->pw_uid);
     }
 
   pwd = getpwnam("testuser");
@@ -1076,18 +1114,19 @@ static int multiuser_passwd_test(FAR struct mu_ctx_s *ctx)
   else if (pwd->pw_uid != MU_UID1)
     {
       mu_fail(ctx, "getpwnam(testuser) uid=%u (expected %u)",
-              (unsigned int)pwd->pw_uid, (unsigned int)MU_UID1);
+              pwd->pw_uid, MU_UID1);
     }
   else
     {
-      mu_pass("getpwnam(testuser) uid=%u", (unsigned int)pwd->pw_uid);
+      mu_pass("getpwnam(testuser) uid=%u", pwd->pw_uid);
     }
 
   mu_restore_root(ctx);
+  multiuser_passwd_remove();
   return ctx->failures;
 }
 
-#endif /* CONFIG_LIBC_PASSWD_FILE */
+#endif /* CONFIG_LIBC_PASSWD_FILE && CONFIG_TESTING_OSTEST_MULTIUSER */
 
 #endif /* CONFIG_SCHED_USER_IDENTITY */
 
@@ -1139,11 +1178,11 @@ int multiuser_test(void)
          "(need FS_PERMISSION and PSEUDOFS_ATTRIBUTES)\n");
 #endif
 
-#if defined(CONFIG_LIBC_PASSWD_FILE)
+#if defined(CONFIG_LIBC_PASSWD_FILE) && defined(CONFIG_TESTING_OSTEST_MULTIUSER)
   multiuser_passwd_test(&ctx);
 #else
   printf("multiuser: skipping passwd lookup test "
-         "(need LIBC_PASSWD_FILE)\n");
+         "(need LIBC_PASSWD_FILE and TESTING_OSTEST_MULTIUSER)\n");
 #endif
 
   mu_restore_root(&ctx);


### PR DESCRIPTION
## Summary

Extends testing/ostest/multiuser.c with regression tests for POSIX credential switching (getresuid/setreuid, saved set-UID/GID) and file/IPC permission enforcement. Enhances NSH id to print real, effective, and saved UID/GID in Linux-style format. Creates a temporary passwd file at build-configured path before getpwnam() checks, so sim:ostest multiuser tests do not need a pre-built /etc/passwd.

## Impact

Enables automated validation of multi-user identity and permission behavior when CONFIG_TESTING_OSTEST_MULTIUSER and CONFIG_SCHED_USER_IDENTITY are enabled. The id command output is richer but backward-compatible (same command, more detail). No effect on builds that do not enable multiuser ostest options.

## Testing

```
user_main: multi-user test
multiuser_test: start
multiuser: effective UID/GID switching
  PASS: initial uid == 0
  PASS: initial euid == 0
  PASS: initial gid == 0
  PASS: initial egid == 0
  PASS: root seteuid(1000)
  PASS: euid after seteuid(1000) == 1000
  PASS: root seteuid(0) restore
  PASS: euid restored to 0 == 0
  PASS: root setegid(2000)
  PASS: egid after setegid(2000) == 2000
  PASS: root setegid(0) restore
  PASS: egid restored to 0 == 0
multiuser: getresuid/getresgid and setreuid/setregid
  PASS: getresuid(initial)
  PASS: initial real uid == 0
  PASS: initial eff uid == 0
  PASS: initial saved uid == 0
  PASS: getresgid(initial)
  PASS: initial real gid == 0
  PASS: initial eff gid == 0
  PASS: initial saved gid == 0
  PASS: root setreuid(-1,1000)
  PASS: real uid after setreuid(-1,1000) == 0
  PASS: eff uid after setreuid(-1,1000) == 1000
  PASS: saved uid after setreuid(-1,1000) == 1000
  PASS: non-root setreuid(2000,-1) denied errno=1
  PASS: setreuid(-1,0) drop effective
  PASS: root setreuid(0,-1) restore
  PASS: real uid restored == 0
  PASS: eff uid restored == 0
  PASS: saved uid restored == 0
  PASS: root setregid(-1,1000)
  PASS: real gid after setregid(-1,1000) == 0
  PASS: eff gid after setregid(-1,1000) == 1000
  PASS: saved gid after setregid(-1,1000) == 1000
  PASS: non-root setregid(2000,-1) denied errno=1
  PASS: setregid(-1,0) drop effective
  PASS: root setregid(0,-1) restore
multiuser: setreuid(1000,1000) full assignment (child task)
  PASS: root setreuid(1000,1000)
  PASS: getresuid(after setreuid)
  PASS: real uid after setreuid == 1000
  PASS: eff uid after setreuid == 1000
  PASS: saved uid after setreuid == 1000
multiuser_resuid_child: 0 failure(s)
  PASS: mu_resuid child completed successfully
  PASS: parent euid after resuid child == 0
  PASS: parent egid after resuid child == 0
multiuser: saved set-UID/GID semantics (child task)
multiuser_suid_child: saved set-UID/GID semantics
  PASS: setuid(1000) as root
  PASS: uid after setuid(1000) == 1000
  PASS: euid after setuid(1000) == 1000
  PASS: non-root seteuid(0) denied errno=1
  PASS: euid unchanged after denied seteuid(0) == 1000
  PASS: non-root seteuid(1000)
  PASS: root-group setegid(2000)
  PASS: egid after setegid(2000) == 2000
  PASS: root-group setegid(0) restore
  PASS: setgid(3000)
  PASS: gid after setgid(3000) == 3000
  PASS: egid after setgid(3000) == 3000
  PASS: non-root setegid(0) denied errno=1
  PASS: egid unchanged after denied setegid(0) == 3000
multiuser_suid_child: 0 failure(s)
  PASS: mu_suid child completed successfully
  PASS: parent euid after child == 0
  PASS: parent egid after child == 0
multiuser: pseudoFS chmod/chown/open permissions
  PASS: /ostest_mu_perm owner 0:0
  PASS: root chmod(0600)
  PASS: non-owner chmod(0777) denied errno=1
  PASS: non-root chown(0,0) denied errno=1
  PASS: root chown to 1000:1000
  PASS: /ostest_mu_perm owner 1000:1000
  PASS: owner chmod(0777)
  PASS: /ostest_mu_secret owner 0:0
  PASS: open(/ostest_mu_secret) denied with EACCES
  PASS: open(/ostest_mu_secret) allowed
  PASS: /ostest_mu_user owner 1000:1000
  PASS: open(/ostest_mu_user) allowed
multiuser: tmpfs open permission enforcement
  PASS: /tmp/ostest_mu_secret owner 0:0
  PASS: open(/tmp/ostest_mu_secret) denied with EACCES
  PASS: open(/tmp/ostest_mu_secret) allowed
multiuser: message queue ownership and permissions
  PASS: /var/mqueue/ostest_mu_mq owner 1000:1000
  PASS: /var/mqueue/ostest_mu_mq mode 0600
  PASS: mq_open(other user) denied errno=13
  PASS: mq_open(owner)
multiuser: named semaphore ownership and permissions
  PASS: /var/sem/ostest_mu_sem owner 1000:1000
  PASS: sem_open(other user) denied errno=13
  PASS: sem_open(owner)
multiuser: shared memory ownership and permissions
  PASS: /var/shm/ostest_mu_shm owner 1000:1000
  PASS: shm_open(other user) denied errno=13
  PASS: shm_open(owner)
multiuser: FIFO ownership and permissions
  PASS: /ostest_mu_fifo owner 1000:1000
  PASS: open fifo (other user) denied errno=13
  PASS: open fifo (owner)
multiuser: passwd lookup after credential drop
  PASS: installed /tmp/ostest_passwd
  PASS: getpwnam(root) uid=0
  PASS: getpwnam(testuser) uid=1000
multiuser_test: 0 failure(s)