### PR TITLE
Add microwindows

### DIFF
--- a/graphics/microwindows/Makefile
+++ b/graphics/microwindows/Makefile
@@ -108,6 +108,8 @@ else ifeq ($(CONFIG_MICROWINDOWS_MOUSE_CUSTOM),y)
 MOUSE = CUSTOM
 endif
 
+HAVE_FNT_SUPPORT = Y
+
 -include microwindows/src/engine/Objects.rules
 -include microwindows/src/drivers/Objects.rules
 -include microwindows/src/fonts/Objects.rules


### PR DESCRIPTION
## Summary

I accidentally removed `HAVE_FNT_SUPPORT = Y` from `Make.defs` while refactoring config items into `Makefile`.  Although
`mwconfig.nuttx` provides `#define HAVE_FNT_SUPPORT 1` at the C preprocessor level, the Make variable is still needed by `Objects.rules` to include `font_fnt.o` in the build.  Without it, linking fails with:

```
undefined reference to `fnt_createfont'
```

This restores the variable in `Makefile`, which is the correct location since it is only needed when building the Microwindows library itself, not by external applications.

## Impact

- Fixes link failure for `sim:mw` and `qemu-intel64:mw` using Microwindows.
- No impact on existing behavior otherwise.

## Testing

- Build tested on `sim:mw` with `make -j$(nproc)` before and after the fix.
  Before: link fails.  After: link succeeds.
- Host: Linux x86_64, GCC.