### PR TITLE
nshlib,fsutils: add Kconfig deps for NSH console login with PBKDF2

### DIFF
--- a/fsutils/passwd/Kconfig
+++ b/fsutils/passwd/Kconfig
@@ -7,14 +7,17 @@ config FSUTILS_PASSWD
 	bool "Password file support"
 	default n
 	depends on CRYPTO_CRYPTODEV
+	depends on CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO || CRYPTO_CRYPTODEV_HARDWARE
 	depends on NETUTILS_CODECS
 	depends on CODECS_BASE64
 	---help---
 		Enables support for /etc/passwd file access routines.
 
 		Requires CONFIG_CRYPTO=y, CRYPTO_CRYPTODEV (and
-		ALLOW_BSD_COMPONENTS), plus NETUTILS_CODECS/CODECS_BASE64 for
-		base64url hash encoding.
+		ALLOW_BSD_COMPONENTS), a cryptodev backend
+		(CONFIG_CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO or
+		CONFIG_CRYPTO_CRYPTODEV_HARDWARE), plus NETUTILS_CODECS/CODECS_BASE64
+		for base64url hash encoding.
 
 		NOTE: Password hashes use PBKDF2-HMAC-SHA256 (modular crypt format).
 		Existing TEA-encrypted /etc/passwd entries are NOT compatible and

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -1235,23 +1235,35 @@ config NSH_CONSOLE_LOGIN
 	bool "Console Login"
 	default n
 	depends on FSUTILS_PASSWD
+	depends on !ETC_ROMFS || BOARD_ETC_ROMFS_PASSWD_ENABLE
 	select NSH_LOGIN
 	---help---
 		If defined, then the console user will be required to provide a
 		username and password to start the NSH shell.  Requires
-		CONFIG_FSUTILS_PASSWD so credentials are verified against the
-		encrypted password file (for example ROMFS /etc/passwd).
+		CONFIG_FSUTILS_PASSWD (PBKDF2-HMAC-SHA256) so credentials are
+		verified against the encrypted password file.
+
+		When CONFIG_ETC_ROMFS is enabled, also enable
+		CONFIG_BOARD_ETC_ROMFS_PASSWD_ENABLE so /etc/passwd is generated
+		at build time (or provide the passwd file by other means and leave
+		ETC_ROMFS disabled).
 
 config NSH_TELNET_LOGIN
 	bool "Telnet Login"
 	default n
 	depends on NSH_TELNET && FSUTILS_PASSWD
+	depends on !ETC_ROMFS || BOARD_ETC_ROMFS_PASSWD_ENABLE
 	select NSH_LOGIN
 	---help---
 		If defined, then the Telnet user will be required to provide a
 		username and password to start the NSH shell.  Requires
-		CONFIG_FSUTILS_PASSWD so credentials are verified against the
-		encrypted password file (for example ROMFS /etc/passwd).
+		CONFIG_FSUTILS_PASSWD (PBKDF2-HMAC-SHA256) so credentials are
+		verified against the encrypted password file.
+
+		When CONFIG_ETC_ROMFS is enabled, also enable
+		CONFIG_BOARD_ETC_ROMFS_PASSWD_ENABLE so /etc/passwd is generated
+		at build time (or provide the passwd file by other means and leave
+		ETC_ROMFS disabled).
 
 if NSH_LOGIN
 


### PR DESCRIPTION
## Summary

Requires a cryptodev backend for `FSUTILS_PASSWD`, which also ties `NSH_CONSOLE_LOGIN` and `NSH_TELNET_LOGIN` to ROMFS passwd generation when `ETC_ROMFS` is enabled.

## Impact

Fixes https://github.com/apache/nuttx/issues/19573

## Testing

```
abhishek@Lethallaptop:~/nuttx$ ./tools/configure.sh sim:rust
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/abhishek/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/abhishek/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/abhishek/nuttx-apps/platform/dummy
LN: include/arch to arch/sim/include
LN: include/arch/board to /home/abhishek/nuttx/boards/sim/sim/sim/include
LN: drivers/platform to /home/abhishek/nuttx/drivers/dummy
LN: include/arch/chip to /home/abhishek/nuttx/arch/sim/include/sim
LN: arch/sim/src/chip to /home/abhishek/nuttx/arch/sim/src/sim
LN: arch/sim/src/board to /home/abhishek/nuttx/boards/sim/sim/sim/src
mkkconfig in /home/abhishek/nuttx-apps/audioutils
mkkconfig in /home/abhishek/nuttx-apps/benchmarks
mkkconfig in /home/abhishek/nuttx-apps/boot
mkkconfig in /home/abhishek/nuttx-apps/canutils
mkkconfig in /home/abhishek/nuttx-apps/crypto
mkkconfig in /home/abhishek/nuttx-apps/database
mkkconfig in /home/abhishek/nuttx-apps/examples/elf/tests
mkkconfig in /home/abhishek/nuttx-apps/examples/elf
mkkconfig in /home/abhishek/nuttx-apps/examples/mcuboot
mkkconfig in /home/abhishek/nuttx-apps/examples/module
mkkconfig in /home/abhishek/nuttx-apps/examples/rust
mkkconfig in /home/abhishek/nuttx-apps/examples/sotest
mkkconfig in /home/abhishek/nuttx-apps/examples
mkkconfig in /home/abhishek/nuttx-apps/fsutils
mkkconfig in /home/abhishek/nuttx-apps/games
mkkconfig in /home/abhishek/nuttx-apps/graphics
mkkconfig in /home/abhishek/nuttx-apps/industry/modbus
mkkconfig in /home/abhishek/nuttx-apps/industry
mkkconfig in /home/abhishek/nuttx-apps/inertial
mkkconfig in /home/abhishek/nuttx-apps/interpreters/luamodules
mkkconfig in /home/abhishek/nuttx-apps/interpreters
mkkconfig in /home/abhishek/nuttx-apps/logging
mkkconfig in /home/abhishek/nuttx-apps/lte
mkkconfig in /home/abhishek/nuttx-apps/math
mkkconfig in /home/abhishek/nuttx-apps/mlearning
mkkconfig in /home/abhishek/nuttx-apps/netutils
mkkconfig in /home/abhishek/nuttx-apps/sdr
mkkconfig in /home/abhishek/nuttx-apps/system
mkkconfig in /home/abhishek/nuttx-apps/tee
mkkconfig in /home/abhishek/nuttx-apps/testing/arch
mkkconfig in /home/abhishek/nuttx-apps/testing/cxx
mkkconfig in /home/abhishek/nuttx-apps/testing/drivers
mkkconfig in /home/abhishek/nuttx-apps/testing/fs
mkkconfig in /home/abhishek/nuttx-apps/testing/libc
mkkconfig in /home/abhishek/nuttx-apps/testing/mm
mkkconfig in /home/abhishek/nuttx-apps/testing/sched
mkkconfig in /home/abhishek/nuttx-apps/testing
mkkconfig in /home/abhishek/nuttx-apps/videoutils
mkkconfig in /home/abhishek/nuttx-apps/wireless/bluetooth
mkkconfig in /home/abhishek/nuttx-apps/wireless/ieee802154
mkkconfig in /home/abhishek/nuttx-apps/wireless
mkkconfig in /home/abhishek/nuttx-apps
Loaded configuration '.config'
Configuration saved to '.config'
abhishek@Lethallaptop:~/nuttx$ make
Create version.h
LN: platform/board to /home/abhishek/nuttx-apps/platform/dummy
Register: gpio
Register: hello_rust
Register: dd
Register: nsh
Register: sh
CP:  /home/abhishek/nuttx/include/nuttx/config.h
CP:  /home/abhishek/nuttx/include/nuttx/fs/hostfs.h
ROMFS root password (min 8 characters): 
Confirm password: 
LD:  nuttx
Pac SIM with dynamic libs..
'/lib/x86_64-linux-gnu/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/lib/x86_64-linux-gnu/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
SIM elf with dynamic libs archive in nuttx.tgz
abhishek@Lethallaptop:~/nuttx$ ./nuttx
login: root
password: 
User Logged-in!
nsh>
```

