### PR TITLE
fsutils/flashtool: Fix compile error due to missing statement after default label

### DIFF
--- a/fsutils/flashtool/flashtool_main.c
+++ b/fsutils/flashtool/flashtool_main.c
@@ -365,6 +365,7 @@ int main(int argc, FAR char *argv[])
         ret = check_bad_block(fd, &geo);
         break;
       default:
+        break;
     }
 
 oops:


### PR DESCRIPTION
In flashtool_main.c, the 'default:' label in a switch statement was
followed directly by '}', which is invalid in C and causes a compile
error.

This commit adds a 'break;' statement after the default label to
resolve the error.

Impact:
- Build: Fixes compilation of flashtool utility
- Runtime: No functional change
- Area: fsutils/flashtool

Tested:
- Build Host: Ubuntu 22.04, arm-none-eabi-gcc 15.10.3
- Target: sim:nsh (compilation test)