### PR TITLE
audioutils/lame: pin the checkout and build its AVX-512 sources

### DIFF
--- a/audioutils/lame/CMakeLists.txt
+++ b/audioutils/lame/CMakeLists.txt
@@ -36,11 +36,20 @@ if(CONFIG_AUDIOUTILS_LAME)
     list(APPEND CFG_CMDS "--cross-prefix=${CROSSDEV}")
   endif()
 
+  # The revision to check out.  See the comment in Makefile: an unpinned
+  # checkout stops linking on the day lame's trunk grows its next vector tier.
+  # Raise this deliberately, together with the vector source list below.
+
+  if(NOT DEFINED LAME_VERSION)
+    set(LAME_VERSION 6720)
+  endif()
+
   # # Download lame if no lame/configure found
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lame/configure")
     execute_process(
-      COMMAND "svn" "checkout" "https://svn.code.sf.net/p/lame/svn/trunk/lame"
-              "lame" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+      COMMAND "svn" "checkout" "-r" "${LAME_VERSION}"
+              "https://svn.code.sf.net/p/lame/svn/trunk/lame" "lame"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 
   # Set source path
@@ -95,7 +104,10 @@ if(CONFIG_AUDIOUTILS_LAME)
       "${SRC_PATH}/libmp3lame/vector/xmm_quantize_lines.c"
       "${SRC_PATH}/libmp3lame/vector/xmm_calc_sfb_noise.c"
       "${SRC_PATH}/libmp3lame/vector/avx2_choose_table.c"
-      "${SRC_PATH}/libmp3lame/vector/avx2_quantize_lines.c")
+      "${SRC_PATH}/libmp3lame/vector/avx2_quantize_lines.c"
+      "${SRC_PATH}/libmp3lame/vector/avx512_choose_table.c"
+      "${SRC_PATH}/libmp3lame/vector/avx512_quantize_lines.c"
+      "${SRC_PATH}/libmp3lame/vector/avx512_calc_sfb_noise.c")
   endif()
 
   # Add custom target to generate config_h

--- a/audioutils/lame/Makefile
+++ b/audioutils/lame/Makefile
@@ -20,10 +20,19 @@
 #
 ############################################################################
 
+# The revision to check out.  lame's trunk grows vector tiers over time --
+# SSE2, then AVX2, then AVX-512 -- and each one adds sources that this file
+# and CMakeLists.txt have to name, so an unpinned checkout stops linking on
+# the day upstream adds the next one.  Raise this deliberately, together with
+# the vector source list below.
+
+LAME_VERSION ?= 6720
+
 # Download lame if no lame/configure found
 lame-svn:
 	$(Q) echo "svn checkout lame ..."
-	$(Q) svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame lame
+	$(Q) svn checkout -r $(LAME_VERSION) \
+		https://svn.code.sf.net/p/lame/svn/trunk/lame lame
 
 ifeq ($(wildcard lame/configure),)
 context:: lame-svn
@@ -72,7 +81,6 @@ CSRCS += $(SRC_PATH)/libmp3lame/bitstream.c \
          $(SRC_PATH)/libmp3lame/newmdct.c \
          $(SRC_PATH)/libmp3lame/psymodel.c \
          $(SRC_PATH)/libmp3lame/quantize.c \
-         $(SRC_PATH)/libmp3lame/vector/xmm_quantize_sub.c \
          $(SRC_PATH)/libmp3lame/quantize_pvt.c \
          $(SRC_PATH)/libmp3lame/set_get.c \
          $(SRC_PATH)/libmp3lame/vbrquantize.c \
@@ -83,6 +91,23 @@ CSRCS += $(SRC_PATH)/libmp3lame/bitstream.c \
          $(SRC_PATH)/libmp3lame/VbrTag.c \
          $(SRC_PATH)/libmp3lame/version.c \
          $(SRC_PATH)/libmp3lame/presets.c
+
+# lame's configure enables the SSE2, AVX2 and AVX-512 dispatch paths whenever
+# the host compiler accepts their per-function target attributes, and the
+# scalar code then calls into them, so the whole group has to be built on an
+# x86 host.  Other hosts keep lame's scalar implementation.
+
+ifneq ($(CONFIG_HOST_X86)$(CONFIG_HOST_X86_64),)
+CSRCS += $(SRC_PATH)/libmp3lame/vector/xmm_quantize_sub.c \
+         $(SRC_PATH)/libmp3lame/vector/xmm_choose_table.c \
+         $(SRC_PATH)/libmp3lame/vector/xmm_quantize_lines.c \
+         $(SRC_PATH)/libmp3lame/vector/xmm_calc_sfb_noise.c \
+         $(SRC_PATH)/libmp3lame/vector/avx2_choose_table.c \
+         $(SRC_PATH)/libmp3lame/vector/avx2_quantize_lines.c \
+         $(SRC_PATH)/libmp3lame/vector/avx512_choose_table.c \
+         $(SRC_PATH)/libmp3lame/vector/avx512_quantize_lines.c \
+         $(SRC_PATH)/libmp3lame/vector/avx512_calc_sfb_noise.c
+endif
 
 LAME_CONFIG_SCRIPT := $(CURDIR)$(DELIM)lame$(DELIM)configure
 


### PR DESCRIPTION
## Summary

The bundled LAME encoder is checked out from `trunk` with no revision, so every build takes whatever `trunk` happens to be at that moment. LAME's trunk grows vector tiers over time and each one adds sources that the two build files have to name, so an unpinned checkout stops linking the day upstream adds the next one. That has now happened twice in six days:

* [r6655](https://sourceforge.net/p/lame/svn/6655/) (2026-07-25) — "Detect AVX2 and offer it to the vector routines"
* [r6718](https://sourceforge.net/p/lame/svn/6718/) (2026-07-30) — "Add an AVX-512 tier for the constant-bitrate vector routines"
* [r6720](https://sourceforge.net/p/lame/svn/6720/) (2026-07-30) — "Bring back the AVX-512 band-noise routine, behind a second switch"

The AVX-512 sources were never listed, so `sim:alsa` stopped linking on x86 hosts ([CI job](https://github.com/apache/nuttx/actions/runs/30580951557/job/91001313430)):

```text
takehiro.c:332:    undefined reference to `quantize_lines_xrpow_avx512'
takehiro.c:533:    undefined reference to `ix_max_avx512'
takehiro.c:569:    undefined reference to `count_bit_esc_avx512'
vbrquantize.c:261: undefined reference to `calc_sfb_noise_x34_avx512'
```

The first three come from r6718, the fourth from r6720. r6718 is also what starts defining `HAVE_AVX512_INTRINSICS` in `config.h`, which is why the call sites and the definitions appeared together upstream — only this repository's source list was left behind.

This change:

1. **Pins the checkout to r6720** through a `LAME_VERSION` variable in both build files, matching how the rest of `apps/` handles third-party sources. The pin is what keeps the two in step: the source list is maintained by hand, so it can only be correct for a known revision. Raising it is now a deliberate act, taken together with the source list.
2. **Adds the three AVX-512 sources** that r6720 provides — `avx512_choose_table.c`, `avx512_quantize_lines.c`, `avx512_calc_sfb_noise.c`.
3. **Fixes the same gap in `Makefile`**, which named only `vector/xmm_quantize_sub.c` and none of the other vector sources. A Make build on an x86 host fails the same way with a longer symbol list, from SSE2 upwards. CI builds `sim:alsa` through CMake only, so that half was latent rather than visible. Both files now list the same nine sources under the same host condition.

Worth noting for reviewers: the checkout is only performed when `lame/configure` is absent and is never updated afterwards. Before this change a tree was therefore frozen at whatever `trunk` was on the day it was first built — anyone who checked out before 2026-07-30 still links and cannot reproduce the failure, which is why this surfaced only in CI.

## Impact

- New feature: **No**.
- User adaptation: **No**. Existing trees with a `lame/` checkout are untouched; the pin applies to fresh checkouts. Delete `apps/audioutils/lame/lame` to move an existing tree to r6720.
**- Build impact: Yes. Fixes the `sim:alsa` link failure on x86 hosts and makes the LAME source revision reproducible.**
- Hardware impact: **No**. Host-simulator build integration; the x86 vector routines are still selected only by LAME's runtime CPU dispatch.
- Documentation impact: **No**.
- Security impact: **No**.
- Compatibility impact: **No**. Non-x86 hosts continue to compile and use LAME's scalar path.
- Dependency: none.

## Testing

Verified:

* `cmake-format --check audioutils/lame/CMakeLists.txt` — clean.
* `git diff --check` — clean.
* `tools/checkpatch.sh -c -u -m -g <base>..HEAD` — ✔️ All checks pass.
* The new `ifneq ($(CONFIG_HOST_X86)$(CONFIG_HOST_X86_64),)` condition evaluated with GNU make for all three cases — neither symbol set, `CONFIG_HOST_X86=y`, and `CONFIG_HOST_X86_64=y` — selecting the vector group in the latter two only.
* The nine source names checked against [the `libmp3lame/vector` listing at r6720](https://sourceforge.net/p/lame/svn/6720/tree/trunk/lame/libmp3lame/vector/), and the four missing symbols traced to their defining files (`ix_max_avx512` and `count_bit_esc_avx512` in `avx512_choose_table.c`, `quantize_lines_xrpow_avx512` in `avx512_quantize_lines.c`, `calc_sfb_noise_x34_avx512` in `avx512_calc_sfb_noise.c`).

**Not verified by me:** I have no x86 host, so I have not linked `sim:alsa` with this change — my only machines are arm64. The source list and the pin are verified by inspection against r6720 as described above, and CI covers the actual link. If a maintainer with an x86 box can confirm the build before merge, that would close the gap.

One thing this change does **not** address: `neon_choose_table.c` exists at r6720 and is not listed for any host. If LAME's configure enables NEON dispatch on an arm64 simulator host, that host would fail the same way. I have not confirmed whether it does, and did not want to add an untested condition here.

## PR verification self-check

- [x] This PR introduces one focused functional change.
- [x] All required PR description fields are completed.
- [x] The commit has a descriptive topic/body, `Signed-off-by`, and `Assisted-by` trailer.
- [x] The modified CMake file passes `cmake-format` and `git diff --check`.
- [x] This PR is ready for review.
