### PR TITLE
Fix/uorb listener fetch only sensors

### DIFF
--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -16,7 +16,11 @@ config UORB_PRIORITY
 
 config UORB_STACKSIZE
 	int "stack size"
+	default 4096 if UORB_FORMAT
 	default DEFAULT_TASK_STACKSIZE
+	---help---
+		UORB_FORMAT needs around 2.2KB of stack for the listener, which
+		does not fit in a DEFAULT_TASK_STACKSIZE of 2048.
 
 config UORB_FORMAT
 	bool

--- a/system/uorb/Kconfig
+++ b/system/uorb/Kconfig
@@ -20,6 +20,7 @@ config UORB_STACKSIZE
 
 config UORB_FORMAT
 	bool
+	select LIBC_PRINT_EXTENSION
 	default n
 
 config UORB_LISTENER

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -913,6 +913,8 @@ static void listener_monitor(FAR struct listen_list_s *objlist,
 
   while ((!nb_msgs || nb_recv_msgs < nb_msgs) && !g_should_exit)
     {
+      orb_abstime start = orb_absolute_time();
+
       if (poll(&fds[0], nb_objects, timeout * 1000) > 0)
         {
           i = 0;
@@ -954,6 +956,16 @@ static void listener_monitor(FAR struct listen_list_s *objlist,
           uorbinfo_raw("Waited for %d seconds without a message. "
                        "Giving up. err:%d", timeout, errno);
           break;
+        }
+
+      if (interval != 0)
+        {
+          orb_abstime elapsed = orb_absolute_time() - start;
+
+          if (elapsed < (orb_abstime)interval)
+            {
+              usleep((unsigned)((orb_abstime)interval - elapsed));
+            }
         }
     }
 

--- a/system/uorb/listener.c
+++ b/system/uorb/listener.c
@@ -200,15 +200,31 @@ static int listener_create_dir(FAR char *dir, size_t size)
 static int listener_subscribe(FAR struct listen_object_s *tmp,
                               bool nonwakeup)
 {
+  int flags;
+  int fd;
+
   if (nonwakeup)
     {
-      return orb_subscribe_multi_nonwakeup(tmp->object.meta,
-                                           tmp->object.instance);
+      fd = orb_subscribe_multi_nonwakeup(tmp->object.meta,
+                                         tmp->object.instance);
     }
   else
     {
-      return orb_subscribe_multi(tmp->object.meta, tmp->object.instance);
+      fd = orb_subscribe_multi(tmp->object.meta, tmp->object.instance);
     }
+
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  flags = fcntl(fd, F_GETFL, 0);
+  if (flags >= 0)
+    {
+      fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    }
+
+  return fd;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

`uorb_listener` never showed data for a sensor whose lower half only
implements `fetch()` (the usual case for an I2C part with no interrupt
line wired, e.g. the MPU6050): `orb_subscribe_multi()` opens the
descriptor blocking, and a fetch()-only sensor never pushes a sample
into the circular buffer, so `sensor_poll()`/`sensor_read()` wait
forever. The 5-second timeout was silent and indistinguishable from a
sensor that genuinely has nothing to report.

Four fixes, one per commit:

* Set `O_NONBLOCK` on the descriptor after subscribing — the core fix,
  makes fetch()-only sensors visible to the listener at all.
* Honor the requested rate (`-r`) for fetch()-only sensors — the upper
  half only applies `SNIOC_SET_INTERVAL` to pushed samples, so without
  this the loop read as fast as it could run.
* Select `LIBC_PRINT_EXTENSION` from `UORB_FORMAT` — without it,
  `orb_info()`'s `"%pB"` extension printed the raw buffer address
  instead of the decoded data.
* Raise the default `UORB_STACKSIZE` to 4096 when `UORB_FORMAT` is
  enabled — the nested `"%pB"` formatting pass peaked at ~2.2KB
  (measured with `STACK_COLORATION`), overflowing the 2048 byte
  default and corrupting memory outside the task rather than failing
  cleanly.

## Impact

Affects any board using `uorb_listener` on a uORB sensor whose lower
half only implements `fetch()`. Push-based sensors are unaffected:
neither `sensor_poll()` nor `sensor_read()` consults `O_NONBLOCK` on
that path. `UORB_STACKSIZE` default only changes for configs that
already select `UORB_FORMAT` (i.e. already use the listener).

## Testing

Target: ESP32-S3-DevKitC (N16R8) with a GY-521 (MPU6050) on I2C0 (SDA
GPIO5 / SCL GPIO4), `esp32s3-devkit:mpu6050` defconfig
(`EXAMPLES_SENSOR_FUSION` disabled just for this test, since it needs
a separate unmerged fix and is unrelated to this bug).

Before (apps master, `5f286fc92`, without this fix):

```
    nsh> uorb_listener -n 5 sensor_accel0
    Monitor objects num:1
    object_name:sensor_accel, object_instance:0
    Waited for 5 seconds without a message. Giving up. err:0
    Object name:sensor_accel0, received:0
    Total number of received Message:0/5
```

The sensor was confirmed alive and publishing via `sensortest` at the
same time.

After (this branch, `6fe80c8ad`):

```
    nsh> uorb_listener -n 5 sensor_accel0
    Monitor objects num:1
    object_name:sensor_accel, object_instance:0
    sensor_accel(now:10940000):timestamp:10940000,x:0.045489,y:-0.435745,z:10.307038,temperature:26.365292
    sensor_accel(now:10940000):timestamp:10940000,x:-0.043095,y:-0.426168,z:10.268731,temperature:26.506470
    sensor_accel(now:10950000):timestamp:10950000,x:0.019153,y:-0.418985,z:10.127473,temperature:26.412352
    sensor_accel(now:10960000):timestamp:10960000,x:-0.014365,y:-0.462081,z:10.129868,temperature:26.412352
    sensor_accel(now:10970000):timestamp:10970000,x:-0.004788,y:-0.416591,z:10.165780,temperature:26.506470
    Object name:sensor_accel0, received:5
    Total number of received Message:5/5

    nsh> uorb_listener -n 3 -r 10 sensor_accel0,sensor_gyro0
    Monitor objects num:2
    object_name:sensor_gyro, object_instance:0
    object_name:sensor_accel, object_instance:0
    sensor_gyro(now:28020000):timestamp:28020000,x:-0.010791,y:0.031042,z:0.693735,temperature:26.318233
    sensor_accel(now:28020000):timestamp:28020000,x:-0.043095,y:-0.440533,z:10.170568,temperature:25.847645
    sensor_gyro(now:28130000):timestamp:28130000,x:-0.015987,y:0.027978,z:-0.013989,temperature:26.035881
    Object name:sensor_gyro0, received:2
    Object name:sensor_accel0, received:1
    Total number of received Message:3/3
```

Accelerometer Z reads gravity with the board resting flat, gyroscope
reads near zero, both topics interleave correctly, and the 10 Hz rate
requested with `-r` is honored (~110ms between samples).
