### PR TITLE
testing/ostest: add strto base tests

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 if(CONFIG_TESTING_OSTEST)
 
-  set(SRCS getopt.c libc_memmem.c restart.c sighelper.c)
+  set(SRCS getopt.c libc_memmem.c libc_strto.c restart.c sighelper.c)
 
   if(CONFIG_ENABLE_ALL_SIGNALS)
     list(APPEND SRCS sighand.c signest.c)

--- a/testing/ostest/Makefile
+++ b/testing/ostest/Makefile
@@ -31,7 +31,7 @@ MODULE = $(CONFIG_TESTING_OSTEST)
 
 # NuttX OS Test
 
-CSRCS  = getopt.c libc_memmem.c restart.c sighelper.c
+CSRCS  = getopt.c libc_memmem.c libc_strto.c restart.c sighelper.c
 
 ifeq ($(CONFIG_ENABLE_ALL_SIGNALS),y)
 CSRCS += sighand.c signest.c

--- a/testing/ostest/libc_strto.c
+++ b/testing/ostest/libc_strto.c
@@ -1,0 +1,122 @@
+/****************************************************************************
+ * apps/testing/ostest/libc_strto.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include "ostest.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int strto_test(void)
+{
+  unsigned long value;
+  char input[3];
+  char *endptr;
+  int base;
+
+  /* Verify the largest lower- and upper-case digit and a positional value
+   * in every supported explicit base.
+   */
+
+  input[1] = '!';
+  input[2] = '\0';
+  for (base = 2; base <= 36; base++)
+    {
+      input[0] = base <= 10 ? '0' + base - 1 : 'a' + base - 11;
+      errno = 0;
+      value = strtoul(input, &endptr, base);
+      ASSERT(value == (unsigned long)base - 1);
+      ASSERT(endptr == input + 1);
+      ASSERT(errno == 0);
+
+      if (base > 10)
+        {
+          input[0] = 'A' + base - 11;
+          errno = 0;
+          value = strtoul(input, &endptr, base);
+          ASSERT(value == (unsigned long)base - 1);
+          ASSERT(endptr == input + 1);
+          ASSERT(errno == 0);
+        }
+
+      errno = 0;
+      value = strtoul("10!", &endptr, base);
+      ASSERT(value == (unsigned long)base);
+      ASSERT(*endptr == '!');
+      ASSERT(errno == 0);
+    }
+
+  /* All public integer conversion interfaces share this base validation. */
+
+  errno = 0;
+  ASSERT(strtol("z!", &endptr, 36) == 35);
+  ASSERT(*endptr == '!');
+  ASSERT(errno == 0);
+
+  errno = 0;
+  ASSERT(strtoul("z!", &endptr, 36) == 35);
+  ASSERT(*endptr == '!');
+  ASSERT(errno == 0);
+
+  errno = 0;
+  ASSERT(strtoll("z!", &endptr, 36) == 35);
+  ASSERT(*endptr == '!');
+  ASSERT(errno == 0);
+
+  errno = 0;
+  ASSERT(strtoull("z!", &endptr, 36) == 35);
+  ASSERT(*endptr == '!');
+  ASSERT(errno == 0);
+
+  errno = 0;
+  ASSERT(strtoimax("z!", &endptr, 36) == 35);
+  ASSERT(*endptr == '!');
+  ASSERT(errno == 0);
+
+  errno = 0;
+  ASSERT(strtoumax("z!", &endptr, 36) == 35);
+  ASSERT(*endptr == '!');
+  ASSERT(errno == 0);
+
+  /* Bases outside the supported range remain invalid. */
+
+  errno = 0;
+  ASSERT(strtoul("10", &endptr, 1) == 0);
+  ASSERT(errno == EINVAL);
+
+  errno = 0;
+  ASSERT(strtoul("10", &endptr, 37) == 0);
+  ASSERT(errno == EINVAL);
+
+  return OK;
+}

--- a/testing/ostest/ostest.h
+++ b/testing/ostest/ostest.h
@@ -97,6 +97,10 @@ int getopt_test(void);
 
 int memmem_test(void);
 
+/* libc_strto.c *************************************************************/
+
+int strto_test(void);
+
 /* setvbuf.c ****************************************************************/
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING

--- a/testing/ostest/ostest_main.c
+++ b/testing/ostest/ostest_main.c
@@ -266,6 +266,7 @@ static int user_main(int argc, char *argv[])
 
   printf("\nuser_main: libc tests\n");
   memmem_test();
+  strto_test();
   check_test_memory_usage();
 
   /* If retention of child status is enable, then suppress it for this task.


### PR DESCRIPTION
## Summary

Add regression coverage to `ostest` for the explicit-base handling fixed by apache/nuttx#19594.

The new test:

- exhaustively checks bases 2 through 36 with lower- and upper-case digits
- verifies positional values and end pointers
- exercises `strtol()`, `strtoul()`, `strtoll()`, `strtoull()`, `strtoimax()`, and `strtoumax()`
- verifies that bases 1 and 37 still fail with `EINVAL`
- is included by both the Make and CMake builds

## Impact

This only extends `ostest`; application behavior is unchanged.

## Testing

Built `sim:ostest` with GNU Make against apache/nuttx#19594.

Without the libc fix, the new regression test fails at the first base-27 assertion:

```text
user_main: libc tests
dump_assert_info: Assertion failed : at file: libc_strto.c:58 task: ostest process: ostest
ostest_main: Exiting with status 256
```

With the libc fix, the libc test section completes and ostest proceeds to the following tests:

```text
user_main: libc tests

End of test memory usage:
...
user_main: setvbuf test
```

Commit-level style checks also pass:

```text
$ tools/checkpatch.sh -g HEAD~1..HEAD
✔️ All checks pass.
```

