### PR TITLE
examples/sotest: Check that a library can be opened twice

### DIFF
--- a/examples/sotest/main/sotest_main.c
+++ b/examples/sotest/main/sotest_main.c
@@ -130,6 +130,7 @@ int main(int argc, FAR char *argv[])
   FAR void *handle1;
 #endif
   FAR void *handle2;
+  FAR void *handle3;
   CODE void (*testfunc)(FAR const char *msg);
   FAR const char *msg;
   int ret;
@@ -323,6 +324,42 @@ int main(int argc, FAR char *argv[])
     }
 
   /* Execute testfunc3 */
+
+  testfunc(msg);
+
+  /* Open the same library again.  dlopen() must return the object that is
+   * already loaded, and closing one of the two handles must leave the
+   * other usable.
+   */
+
+  handle3 = dlopen(sotest_path, RTLD_NOW | RTLD_LOCAL);
+  if (handle3 == NULL)
+    {
+      fprintf(stderr, "ERROR: dlopen(%s) failed on an already loaded "
+                      "library\n", sotest_path);
+      exit(EXIT_FAILURE);
+    }
+
+  if (handle3 != handle2)
+    {
+      fprintf(stderr, "ERROR: dlopen() returned %p for a library already "
+                      "loaded at %p\n", handle3, handle2);
+      exit(EXIT_FAILURE);
+    }
+
+  ret = dlclose(handle3);
+  if (ret != 0)
+    {
+      fprintf(stderr, "ERROR: dlclose(handle3) failed: %d\n", ret);
+      exit(EXIT_FAILURE);
+    }
+
+  testfunc = (CODE void (*)(FAR const char *))dlsym(handle2, "testfunc1");
+  if (testfunc == NULL)
+    {
+      fprintf(stderr, "ERROR: closing one handle unloaded the library\n");
+      exit(EXIT_FAILURE);
+    }
 
   testfunc(msg);
 


### PR DESCRIPTION
Depends-on: https://github.com/apache/nuttx/pull/19639

## Summary

`dlopen()` of an already loaded library used to fail, so nothing exercised what happens when two callers hold the same object.

This opens the library a second time, checks the same handle comes back, closes one of the two handles and checks the library is still usable through the other.

## Testing

Without apache/nuttx#19639 the second `dlopen()` returns `NULL` and this test reports it.

Run on `lm3s6965-ek` under QEMU with `CONFIG_EXAMPLES_SOTEST`, `CONFIG_ELF`, `CONFIG_LIBC_ELF` and `CONFIG_LIBC_DLFCN`.

Without apache/nuttx#19639:

```
ERROR: dlopen(/mnt/sotest/romfs/sotest) failed on an already loaded library
```

With it:

```
testfunc3: Let's talk again very soon
   caller: Yes, don't be a stranger!
testfunc1: Hello, everyone!
   caller: Yes, don't be a stranger!
module_uninitialize
```

The repeated `testfunc1` is the library still working after one of the two handles was closed, and `module_uninitialize` is it unloading once the last one went.

