### PR TITLE
games/NXDoom: drop the assignments left over from dehacked

### DIFF
--- a/games/NXDoom/src/doom/f_finale.c
+++ b/games/NXDoom/src/doom/f_finale.c
@@ -634,8 +634,6 @@ static void f_art_screen_drawer(void)
           return;
         }
 
-      lumpname = (lumpname);
-
       v_draw_patch(0, 0, w_cache_lump_name(lumpname, PU_CACHE));
     }
 }
@@ -687,11 +685,6 @@ void f_start_finale(void)
           finaleflat = screen->background;
         }
     }
-
-  /* Do dehacked substitutions of strings */
-
-  finaletext = (finaletext);
-  finaleflat = (finaleflat);
 
   finalestage = F_STAGE_TEXT;
   finalecount = 0;

--- a/games/NXDoom/src/doom/g_game.c
+++ b/games/NXDoom/src/doom/g_game.c
@@ -442,8 +442,6 @@ static void g_do_load_level(void)
           skytexturename = "SKY3";
         }
 
-      skytexturename = (skytexturename);
-
       skytexture = r_texture_num_for_name(skytexturename);
     }
 
@@ -2285,7 +2283,6 @@ void g_init_new(skill_t skill, int episode, int map)
           break;
         }
 
-      skytexturename = (skytexturename);
       skytexture = r_texture_num_for_name(skytexturename);
     }
 

--- a/games/NXDoom/src/doom/hu_stuff.c
+++ b/games/NXDoom/src/doom/hu_stuff.c
@@ -381,9 +381,6 @@ void hu_start(void)
       s = HU_TITLE_CHEX;
     }
 
-  /* dehacked substitution to get modified level name */
-
-  s = (s);
   while (*s)
     {
       hu_lib_add_char_to_text_line(&w_title, *(s++));


### PR DESCRIPTION

## Summary

Six statements in the NXDoom sources assign a variable to itself, which clang
rejects:

```
src/doom/f_finale.c:637:16: error: explicitly assigning value of variable of
type 'const char *' to itself [-Werror,-Wself-assign]
  637 |       lumpname = (lumpname);
      |       ~~~~~~~~ ^  ~~~~~~~~
```

Chocolate DOOM wraps those strings in `DEH_String()` so that a dehacked patch
can substitute them. The port has no dehacked support and the macro went away
with it, leaving the bare parentheses behind. This removes the six leftover
assignments, plus two comments that only described the substitution:

- `games/NXDoom/src/doom/f_finale.c`: `lumpname`, `finaletext`, `finaleflat`
- `games/NXDoom/src/doom/g_game.c`: `skytexturename` (two sites)
- `games/NXDoom/src/doom/hu_stuff.c`: `s`

## Impact

Build only, and only for configurations compiled with clang. GCC does not warn
about self-assignment, so the configurations built so far never noticed it;
clang does, and the build fails because the CI passes `-Werror`
(`tools/ci/cibuild.sh`: `-e "-Wno-cpp -Werror"`). The nxdoom configurations are
`sim:nxdoom`, `linum-stm32h753bi:nxdoom` and `raspberrypi-4b:nxdoom`.

No functional change: the removed statements are no-ops. They were not entirely
free, though -- the nxdoom configurations build with `CONFIG_DEBUG_NOOPT=y`, so
the redundant stores were actually emitted, and the image loses 16 bytes of
text (see the sizes below). No change to the API, configuration, build system
or documentation.

## Testing

Host: Ubuntu 24.04.4 LTS, x86_64, Linux 7.0.0-28-generic
  - clang 18.1.3, LLVM binutils 18 (`CONFIG_ARM_TOOLCHAIN_CLANG=y`)
  - arm-none-eabi-gcc 13.2.1 (Arm GNU Toolchain 13.2.rel1)

Target: arm, `linum-stm32h753bi:nxdoom`

Both builds use the same warning flags the CI uses:
`make EXTRAFLAGS="-Wno-cpp -Werror"`.

### Before, clang

```
$ make -k -j EXTRAFLAGS="-Wno-cpp -Werror"
src/doom/f_finale.c:637:16: error: explicitly assigning value of variable of type 'const char *' to itself [-Werror,-Wself-assign]
  637 |       lumpname = (lumpname);
      |       ~~~~~~~~ ^  ~~~~~~~~
src/doom/f_finale.c:693:14: error: explicitly assigning value of variable of type 'const char *' to itself [-Werror,-Wself-assign]
  693 |   finaletext = (finaletext);
      |   ~~~~~~~~~~ ^  ~~~~~~~~~~
src/doom/f_finale.c:694:14: error: explicitly assigning value of variable of type 'const char *' to itself [-Werror,-Wself-assign]
  694 |   finaleflat = (finaleflat);
      |   ~~~~~~~~~~ ^  ~~~~~~~~~~
src/doom/hu_stuff.c:386:5: error: explicitly assigning value of variable of type 'const char *' to itself [-Werror,-Wself-assign]
src/doom/g_game.c:445:22: error: explicitly assigning value of variable of type 'const char *' to itself [-Werror,-Wself-assign]
src/doom/g_game.c:2288:22: error: explicitly assigning value of variable of type 'const char *' to itself [-Werror,-Wself-assign]
make[2]: *** [apps/Application.mk:264: src/doom/f_finale.c...o] Error 1
```

### After, clang

Compiles with no warnings and no errors.

### After, arm-none-eabi-gcc 13.2.1

```
$ make -j EXTRAFLAGS="-Wno-cpp -Werror"
$ arm-none-eabi-size nuttx
   text	   data	    bss	    dec	    hex	filename
 616070	  42876	 262656	 921602	  e1002	nuttx
```

Same configuration before the change, for comparison:

```
   text	   data	    bss	    dec	    hex	filename
 616086	  42876	 262656	 921618	  e1012	nuttx
```

`data` and `bss` are unchanged; `text` drops the 16 bytes of the redundant
stores.

### Runtime

The resulting image was flashed on a LINUM-STM32H753BI over ST-LINK-V3 and
nxdoom was run from the NSH prompt: the game starts and plays exactly as it did
before the change, as expected for statements that had no effect.
