### PR TITLE
{bp-3679} nshlib,fsutils: add Kconfig deps for NSH console login with PBKDF2

### DIFF
--- a/fsutils/passwd/Kconfig
+++ b/fsutils/passwd/Kconfig
@@ -7,14 +7,17 @@ config FSUTILS_PASSWD
 	bool "Password file support"
 	default n
 	depends on CRYPTO_CRYPTODEV
+	depends on CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO || CRYPTO_CRYPTODEV_HARDWARE
 	depends on NETUTILS_CODECS
 	depends on CODECS_BASE64
 	---help---
 		Enables support for /etc/passwd file access routines.
 
 		Requires CONFIG_CRYPTO=y, CRYPTO_CRYPTODEV (and
-		ALLOW_BSD_COMPONENTS), plus NETUTILS_CODECS/CODECS_BASE64 for
-		base64url hash encoding.
+		ALLOW_BSD_COMPONENTS), a cryptodev backend
+		(CONFIG_CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO or
+		CONFIG_CRYPTO_CRYPTODEV_HARDWARE), plus NETUTILS_CODECS/CODECS_BASE64
+		for base64url hash encoding.
 
 		NOTE: Password hashes use PBKDF2-HMAC-SHA256 (modular crypt format).
 		Existing TEA-encrypted /etc/passwd entries are NOT compatible and

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -1231,23 +1231,35 @@ config NSH_CONSOLE_LOGIN
 	bool "Console Login"
 	default n
 	depends on FSUTILS_PASSWD
+	depends on !ETC_ROMFS || BOARD_ETC_ROMFS_PASSWD_ENABLE
 	select NSH_LOGIN
 	---help---
 		If defined, then the console user will be required to provide a
 		username and password to start the NSH shell.  Requires
-		CONFIG_FSUTILS_PASSWD so credentials are verified against the
-		encrypted password file (for example ROMFS /etc/passwd).
+		CONFIG_FSUTILS_PASSWD (PBKDF2-HMAC-SHA256) so credentials are
+		verified against the encrypted password file.
+
+		When CONFIG_ETC_ROMFS is enabled, also enable
+		CONFIG_BOARD_ETC_ROMFS_PASSWD_ENABLE so /etc/passwd is generated
+		at build time (or provide the passwd file by other means and leave
+		ETC_ROMFS disabled).
 
 config NSH_TELNET_LOGIN
 	bool "Telnet Login"
 	default n
 	depends on NSH_TELNET && FSUTILS_PASSWD
+	depends on !ETC_ROMFS || BOARD_ETC_ROMFS_PASSWD_ENABLE
 	select NSH_LOGIN
 	---help---
 		If defined, then the Telnet user will be required to provide a
 		username and password to start the NSH shell.  Requires
-		CONFIG_FSUTILS_PASSWD so credentials are verified against the
-		encrypted password file (for example ROMFS /etc/passwd).
+		CONFIG_FSUTILS_PASSWD (PBKDF2-HMAC-SHA256) so credentials are
+		verified against the encrypted password file.
+
+		When CONFIG_ETC_ROMFS is enabled, also enable
+		CONFIG_BOARD_ETC_ROMFS_PASSWD_ENABLE so /etc/passwd is generated
+		at build time (or provide the passwd file by other means and leave
+		ETC_ROMFS disabled).
 
 if NSH_LOGIN
 


### PR DESCRIPTION
## Summary

Require a cryptodev backend for FSUTILS_PASSWD and tie NSH console/telnet login to ROMFS passwd generation when ETC_ROMFS is enabled.

Fixes #19573

## Impact

RELEASE

## Testing

CI