### PR TITLE
{bp-3565} nsh/echo: Fix echo previous behavior, single write with '\n'

### DIFF
--- a/nshlib/nsh_envcmds.c
+++ b/nshlib/nsh_envcmds.c
@@ -390,19 +390,18 @@ do_echo:
           str_escape(argv[0]);
         }
 
-      nsh_output(vtbl, "%s", argv[0]);
+      if (argc > 1)
+        {
+          nsh_output(vtbl, "%s ", argv[0]);
+        }
+      else
+        {
+          nsh_output(vtbl, newline ? "%s\n" : "%s", argv[0]);
+          break;
+        }
 
       --argc;
       ++argv;
-      if (argc > 0)
-        {
-          nsh_output(vtbl, " ");
-        }
-    }
-
-  if (newline)
-    {
-      nsh_output(vtbl, "\n");
     }
 
   return OK;


### PR DESCRIPTION
## Summary

This commit fixes the previous behavior where an echo with a single string and its default new line is send as single write().

This issue came from:  https://github.com/apache/nuttx-apps/pull/1559

## Impact

RELEASE

## Testing

CI