### PR TITLE
nxplayer: share the setup path between play and playraw, add tone command

### DIFF
--- a/include/system/nxplayer.h
+++ b/include/system/nxplayer.h
@@ -48,6 +48,14 @@ struct nxplayer_dec_ops_s
   CODE int (*fill_data)(int fd, FAR struct ap_buffer_s *apb);
 };
 
+struct nxplayer_tone_s
+{
+  uint32_t cur_samps;    /* The number of samples currently */
+  uint32_t total_samps;  /* Total number of samples */
+  uint32_t sample_rate;  /* Sampling rate */
+  uint32_t pitch_freq;   /* Pitch frequency */
+};
+
 /* This structure describes the internal state of the NxPlayer */
 
 struct nxplayer_s
@@ -83,6 +91,7 @@ struct nxplayer_s
 #endif
 
   FAR const struct nxplayer_dec_ops_s *ops;
+  struct nxplayer_tone_s tone;
 };
 
 typedef int (*nxplayer_func)(FAR struct nxplayer_s *pplayer, char *pargs);
@@ -215,10 +224,14 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
  * Input Parameters:
  *   pplayer   - Pointer to the context to initialize
  *   filename  - Pointer to pathname of the file to play
- *   nchannels  channel num
- *   bpsampe    bit width
- *   samprate   sample rate
- *   chmap      channel map
+ *   filefmt   - Format of audio in filename if known, AUDIO_FMT_UNDEF
+ *               to let nxplayer_playraw() determine automatically.
+ *   subfmt    - Sub-Format of audio in filename if known, AUDIO_FMT_UNDEF
+ *               to let nxplayer_playraw() determine automatically.
+ *   nchannels - channel num
+ *   bpsampe   - bit width
+ *   samprate  - sample rate
+ *   chmap     - channel map
  *
  * Returned Value:
  *   OK if file found, device found, and playback started.
@@ -226,8 +239,32 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
  ****************************************************************************/
 
 int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
-                     FAR const char *filename, uint8_t nchannels,
+                     FAR const char *filename,
+                     int filefmt, int subfmt, uint8_t nchannels,
                      uint8_t bpsamp, uint32_t samprate, uint8_t chmap);
+
+/****************************************************************************
+ * Name: nxplayer_playtone
+ *
+ *   Plays the generated tone data using the Audio system.
+ *   If a preferred device has been set, that device will be used for
+ *   the playback, otherwise the first suitable device found in
+ *   the /dev/audio directory will be used.
+ *
+ * Input Parameters:
+ *   pplayer   - Pointer to the context to initialize
+ *   samprate  - sample rate
+ *   pitchfreq - pitch frequency‌
+ *   duration  - duration of the generated tone
+ *
+ *
+ * Returned Value:
+ *   OK if device found, and playback started.
+ *
+ ****************************************************************************/
+
+int nxplayer_playtone(FAR struct nxplayer_s *pplayer, uint32_t samprate,
+                      uint32_t pitchfreq, uint32_t duration);
 
 /****************************************************************************
  * Name: nxplayer_stop

--- a/system/nxplayer/nxplayer.c
+++ b/system/nxplayer/nxplayer.c
@@ -31,6 +31,8 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
+#include <math.h>
 #include <sched.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -652,6 +654,49 @@ static int nxplayer_mediasearch(FAR struct nxplayer_s *pplayer,
 #endif
 
 /****************************************************************************
+ * Name: nxplayer_filltone
+ *
+ *  Fill the generated tone data into the specified
+ *  buffer.
+ *
+ ****************************************************************************/
+
+static int nxplayer_filltone(FAR struct nxplayer_tone_s *tone,
+                             FAR struct ap_buffer_s *apb)
+{
+  FAR uint16_t *samples;
+  float value;
+  size_t i;
+
+  apb->nbytes = 0;
+  apb->curbyte = 0;
+  samples = (FAR uint16_t *)apb->samp;
+
+  if (tone->cur_samps >= tone->total_samps)
+    {
+      return -ENODATA;
+    }
+
+  for (i = 0; i < apb->nmaxbytes / 4; i++)
+    {
+      value = sinf(2 * M_PI * tone->pitch_freq *
+                   tone->cur_samps / tone->sample_rate);
+      samples[i * 2 + 1] = samples[i * 2] = (uint16_t)(value * 10000);
+
+      tone->cur_samps++;
+      apb->nbytes += 4;
+
+      if (tone->cur_samps >= tone->total_samps)
+        {
+          apb->flags |= AUDIO_APB_FINAL;
+          break;
+        }
+    }
+
+  return 0;
+}
+
+/****************************************************************************
  * Name: nxplayer_readbuffer
  *
  *  Read the next block of data from the media file into the specified
@@ -853,7 +898,19 @@ static FAR void *nxplayer_playthread(pthread_addr_t pvarg)
     {
       /* Read the next buffer of data */
 
-      ret = nxplayer_readbuffer(pplayer, buffers[x]);
+      if (pplayer->tone.sample_rate)
+        {
+          /* Fill the generated tone data into apb  */
+
+          ret = nxplayer_filltone(&pplayer->tone, buffers[x]);
+        }
+      else
+        {
+          /* Fill the audio data of the file into apb */
+
+          ret = nxplayer_readbuffer(pplayer, buffers[x]);
+        }
+
       if (ret != OK)
         {
           /* nxplayer_readbuffer will return an error if there is no further
@@ -1031,7 +1088,19 @@ static FAR void *nxplayer_playthread(pthread_addr_t pvarg)
               {
                 /* Read the next buffer of data */
 
-                ret = nxplayer_readbuffer(pplayer, msg.u.ptr);
+                if (pplayer->tone.sample_rate)
+                  {
+                    /* Fill the generated tone data into apb  */
+
+                    ret = nxplayer_filltone(&pplayer->tone, msg.u.ptr);
+                  }
+                else
+                  {
+                    /* Fill the audio data of the file into apb */
+
+                    ret = nxplayer_readbuffer(pplayer, msg.u.ptr);
+                  }
+
                 if (ret != OK)
                   {
                     /* Out of data.  Stay in the loop until the device sends
@@ -1176,6 +1245,10 @@ err_out:
   mq_unlink(pplayer->mqname);             /* Unlink the message queue */
   pplayer->ops   = NULL;                  /* Clear offload parser */
   pplayer->state = NXPLAYER_STATE_IDLE;   /* Go to IDLE */
+
+  /* Clear the tone field */
+
+  memset(&pplayer->tone, 0, sizeof(pplayer->tone));
 
   pthread_mutex_unlock(&pplayer->mutex);
 
@@ -1756,8 +1829,9 @@ int nxplayer_stop(FAR struct nxplayer_s *pplayer)
  *
  * Input:
  *   pplayer    Pointer to the initialized MPlayer context
- *   pfilename  Pointer to the filename to play
  *   filefmt    Format of the file or AUD_FMT_UNDEF if unknown / to be
+ *              determined by nxplayer_playfile()
+ *   subfmt     Sub-Format of the file or AUD_FMT_UNDEF if unknown / to be
  *              determined by nxplayer_playfile()
  *   nchannels  channels num (raw data playback needed)
  *   bpsamp     bits pre sample (raw data playback needed)
@@ -1775,10 +1849,9 @@ int nxplayer_stop(FAR struct nxplayer_s *pplayer)
  ****************************************************************************/
 
 static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
-                                 FAR const char *pfilename, int filefmt,
-                                 int subfmt, uint8_t nchannels,
-                                 uint8_t bpsamp, uint32_t samprate,
-                                 uint8_t chmap)
+                                 int filefmt, int subfmt,
+                                 uint8_t nchannels, uint8_t bpsamp,
+                                 uint32_t samprate, uint8_t chmap)
 {
   struct mq_attr      attr;
   struct sched_param  sparam;
@@ -1787,97 +1860,7 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
   struct ap_buffer_info_s  buf_info;
   struct audio_caps_s      caps;
   int                      min_channels;
-#ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
-  char                path[PATH_MAX];
-#endif
-  int                 tmpsubfmt = AUDIO_FMT_UNDEF;
   int                 ret;
-  int                 c;
-
-  DEBUGASSERT(pplayer != NULL);
-  DEBUGASSERT(pfilename != NULL);
-
-  if (pplayer->state != NXPLAYER_STATE_IDLE)
-    {
-      return -EBUSY;
-    }
-
-  audinfo("==============================\n");
-  audinfo("Playing file %s\n", pfilename);
-  audinfo("==============================\n");
-
-  /* Test that the specified file exists */
-
-#ifdef CONFIG_NXPLAYER_HTTP_STREAMING_SUPPORT
-  if ((pplayer->fd = _open_with_http(pfilename)) == -1)
-#else
-  if ((pplayer->fd = open(pfilename, O_RDONLY)) == -1)
-#endif
-    {
-      /* File not found.  Test if its in the mediadir */
-
-#ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
-      snprintf(path, sizeof(path), "%s/%s", pplayer->mediadir, pfilename);
-
-      if ((pplayer->fd = open(path, O_RDONLY)) == -1)
-        {
-#ifdef CONFIG_NXPLAYER_MEDIA_SEARCH
-          /* File not found in the media dir.  Do a search */
-
-          if (nxplayer_mediasearch(pplayer, pfilename, path,
-                                   sizeof(path)) != OK)
-            {
-              auderr("ERROR: Could not find file\n");
-              return -ENOENT;
-            }
-#else
-          auderr("ERROR: Could not open %s or %s\n", pfilename, path);
-          return -ENOENT;
-#endif /* CONFIG_NXPLAYER_MEDIA_SEARCH */
-        }
-
-#else   /* CONFIG_NXPLAYER_INCLUDE_MEDIADIR */
-
-      auderr("ERROR: Could not open %s\n", pfilename);
-      return -ENOENT;
-#endif /* CONFIG_NXPLAYER_INCLUDE_MEDIADIR */
-    }
-
-#ifdef CONFIG_NXPLAYER_FMT_FROM_EXT
-  /* Try to determine the format of audio file based on the extension */
-
-  if (filefmt == AUDIO_FMT_UNDEF)
-    {
-      filefmt = nxplayer_fmtfromextension(pplayer, pfilename, &tmpsubfmt);
-    }
-#endif
-
-#ifdef CONFIG_NXPLAYER_FMT_FROM_HEADER
-  /* If type not identified, then test for known header types */
-
-  if (filefmt == AUDIO_FMT_UNDEF)
-    {
-      filefmt = nxplayer_fmtfromheader(pplayer, &subfmt, &tmpsubfmt);
-    }
-#endif
-
-  /* Test if we determined the file format */
-
-  if (filefmt == AUDIO_FMT_UNDEF)
-    {
-      /* Hmmm, it's some unknown / unsupported type */
-
-      auderr("ERROR: Unsupported format: %d\n", filefmt);
-      ret = -ENOSYS;
-      goto err_out_nodev;
-    }
-
-  /* Test if we have a sub format assignment from above */
-
-  if (subfmt == AUDIO_FMT_UNDEF)
-    {
-      subfmt = tmpsubfmt;
-    }
 
   /* Try to open the device */
 
@@ -1887,27 +1870,7 @@ static int nxplayer_playinternal(FAR struct nxplayer_s *pplayer,
       /* Error opening the device */
 
       auderr("ERROR: nxplayer_opendevice failed: %d\n", ret);
-      goto err_out_nodev;
-    }
-
-  for (c = 0; c < nitems(g_dec_ops); c++)
-    {
-      if (g_dec_ops[c].format == filefmt)
-        {
-          pplayer->ops = &g_dec_ops[c];
-          break;
-        }
-    }
-
-  if (!pplayer->ops)
-    {
-      goto err_out;
-    }
-
-  if (pplayer->ops->pre_parse)
-    {
-      ret = pplayer->ops->pre_parse(pplayer->fd, &samprate,
-                                    &nchannels, &bpsamp);
+      return ret;
     }
 
   /* Try to reserve the device */
@@ -2033,13 +1996,6 @@ err_out:
   close(pplayer->dev_fd);
   pplayer->dev_fd = -1;
 
-err_out_nodev:
-  if (0 < pplayer->fd)
-    {
-      close(pplayer->fd);
-      pplayer->fd = -1;
-    }
-
   return ret;
 }
 
@@ -2056,6 +2012,8 @@ err_out_nodev:
  *   pfilename  Pointer to the filename to play
  *   filefmt    Format of the file or AUD_FMT_UNDEF if unknown / to be
  *              determined by nxplayer_playfile()
+ *   subfmt     Sub-Format of audio in filename if known, AUDIO_FMT_UNDEF
+ *              to let nxplayer_playfile() determine automatically
  *
  * Returns:
  *   OK         File is being played
@@ -2069,14 +2027,14 @@ err_out_nodev:
 int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
                       FAR const char *pfilename, int filefmt, int subfmt)
 {
-  return nxplayer_playinternal(pplayer, pfilename, filefmt,
-                               subfmt, 0, 0, 0, 0);
+  return nxplayer_playraw(pplayer, pfilename, filefmt,
+                          subfmt, 0, 0, 0, 0);
 }
 
 /****************************************************************************
  * Name: nxplayer_playraw
  *
- *   nxplayer_playraw() tries to play the raw data file using the Audio
+ *   nxplayer_playraw() tries to play the audio file using the Audio
  *   system.  If a preferred device is specified, it will try to use that
  *   device otherwise it will perform a search of the Audio device files
  *   to find a suitable device.
@@ -2084,6 +2042,10 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
  * Input:
  *   pplayer    Pointer to the initialized MPlayer context
  *   pfilename  Pointer to the filename to play
+ *   filefmt   - Format of audio in filename if known, AUDIO_FMT_UNDEF
+ *               to let nxplayer_playraw() determine automatically.
+ *   subfmt    - Sub-Format of audio in filename if known, AUDIO_FMT_UNDEF
+ *               to let nxplayer_playraw() determine automatically.
  *   nchannels  channel num
  *   bpsampe    bit width
  *   samprate   sample rate
@@ -2099,9 +2061,127 @@ int nxplayer_playfile(FAR struct nxplayer_s *pplayer,
  ****************************************************************************/
 
 int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
-                     FAR const char *pfilename, uint8_t nchannels,
+                     FAR const char *pfilename,
+                     int filefmt, int subfmt, uint8_t nchannels,
                      uint8_t bpsamp, uint32_t samprate, uint8_t chmap)
 {
+#ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
+  char path[PATH_MAX];
+#endif
+  int  tmpsubfmt = AUDIO_FMT_UNDEF;
+  int  ret;
+  int  c;
+
+  DEBUGASSERT(pplayer != NULL);
+  DEBUGASSERT(pfilename != NULL);
+
+  if (pplayer->state != NXPLAYER_STATE_IDLE)
+    {
+      return -EBUSY;
+    }
+
+  audinfo("==============================\n");
+  audinfo("Playing file %s\n", pfilename);
+  audinfo("==============================\n");
+
+  /* Test that the specified file exists */
+
+#ifdef CONFIG_NXPLAYER_HTTP_STREAMING_SUPPORT
+  if ((pplayer->fd = _open_with_http(pfilename)) == -1)
+#else
+  if ((pplayer->fd = open(pfilename, O_RDONLY)) == -1)
+#endif
+    {
+      /* File not found.  Test if its in the mediadir */
+
+#ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
+      snprintf(path, sizeof(path), "%s/%s", pplayer->mediadir, pfilename);
+
+      if ((pplayer->fd = open(path, O_RDONLY)) == -1)
+        {
+#ifdef CONFIG_NXPLAYER_MEDIA_SEARCH
+          /* File not found in the media dir.  Do a search */
+
+          if (nxplayer_mediasearch(pplayer, pfilename, path,
+                                   sizeof(path)) != OK)
+            {
+              auderr("ERROR: Could not find file\n");
+              return -ENOENT;
+            }
+#else
+          auderr("ERROR: Could not open %s or %s\n", pfilename, path);
+          return -ENOENT;
+#endif /* CONFIG_NXPLAYER_MEDIA_SEARCH */
+        }
+
+#else   /* CONFIG_NXPLAYER_INCLUDE_MEDIADIR */
+
+      auderr("ERROR: Could not open %s\n", pfilename);
+      return -ENOENT;
+#endif /* CONFIG_NXPLAYER_INCLUDE_MEDIADIR */
+    }
+
+#ifdef CONFIG_NXPLAYER_FMT_FROM_EXT
+  /* Try to determine the format of audio file based on the extension */
+
+  if (filefmt == AUDIO_FMT_UNDEF)
+    {
+      filefmt = nxplayer_fmtfromextension(pplayer, pfilename, &tmpsubfmt);
+    }
+#endif
+
+#ifdef CONFIG_NXPLAYER_FMT_FROM_HEADER
+  /* If type not identified, then test for known header types */
+
+  if (filefmt == AUDIO_FMT_UNDEF)
+    {
+      filefmt = nxplayer_fmtfromheader(pplayer, &subfmt, &tmpsubfmt);
+    }
+#endif
+
+  /* Test if we determined the file format */
+
+  if (filefmt == AUDIO_FMT_UNDEF)
+    {
+      /* Hmmm, it's some unknown / unsupported type */
+
+      auderr("ERROR: Unsupported format: %d\n", filefmt);
+      ret = -ENOSYS;
+      goto err_out;
+    }
+
+  /* Test if we have a sub format assignment from above */
+
+  if (subfmt == AUDIO_FMT_UNDEF)
+    {
+      subfmt = tmpsubfmt;
+    }
+
+  for (c = 0; c < nitems(g_dec_ops); c++)
+    {
+      if (g_dec_ops[c].format == filefmt)
+        {
+          pplayer->ops = &g_dec_ops[c];
+          break;
+        }
+    }
+
+  if (!pplayer->ops)
+    {
+      ret = -ENOSYS;
+      goto err_out;
+    }
+
+  if (pplayer->ops->pre_parse)
+    {
+      ret = pplayer->ops->pre_parse(pplayer->fd, &samprate,
+                                    &nchannels, &bpsamp);
+      if (ret < 0)
+        {
+          goto err_out;
+        }
+    }
+
   if (nchannels == 0)
     {
       nchannels = 2;
@@ -2117,8 +2197,66 @@ int nxplayer_playraw(FAR struct nxplayer_s *pplayer,
       samprate = 48000;
     }
 
-  return nxplayer_playinternal(pplayer, pfilename, AUDIO_FMT_PCM, 0,
-                               nchannels, bpsamp, samprate, chmap);
+  ret = nxplayer_playinternal(pplayer, filefmt, subfmt,
+                              nchannels, bpsamp, samprate, chmap);
+  if (ret < 0)
+    {
+      goto err_out;
+    }
+
+  return OK;
+
+err_out:
+  close(pplayer->fd);
+  pplayer->fd = -1;
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: nxplayer_playtone
+ *
+ *   Plays the generated tone data using the Audio system.
+ *   If a preferred device has been set, that device will be used for
+ *   the playback, otherwise the first suitable device found in
+ *   the /dev/audio directory will be used.
+ *
+ * Input Parameters:
+ *   pplayer   - Pointer to the context to initialize
+ *   samprate  - sample rate
+ *   pitchfreq - pitch frequency‌
+ *   duration  - duration of the generated tone
+ *
+ *
+ * Returned Value:
+ *   OK if device found, and playback started.
+ *
+ ****************************************************************************/
+
+int nxplayer_playtone(FAR struct nxplayer_s *pplayer, uint32_t samprate,
+                      uint32_t pitchfreq, uint32_t duration)
+{
+  DEBUGASSERT(pplayer != NULL);
+
+  if (pplayer->state != NXPLAYER_STATE_IDLE)
+    {
+      return -EBUSY;
+    }
+
+  pplayer->tone.sample_rate = samprate ? samprate : 48000;
+  pplayer->tone.pitch_freq  = pitchfreq ? pitchfreq : 440;
+  pplayer->tone.total_samps = (duration ? duration : 10) *
+                               pplayer->tone.sample_rate;
+
+  audinfo("==============================\n");
+  audinfo("Playing tone : samprate:%" PRIu32 " HZ pitchfreq:%" PRIu32 " HZ \
+          duration:%" PRIu32 " s\n",
+          pplayer->tone.sample_rate, pplayer->tone.pitch_freq,
+          pplayer->tone.total_samps / pplayer->tone.sample_rate);
+  audinfo("==============================\n");
+
+  return nxplayer_playinternal(pplayer, AUDIO_FMT_PCM, AUDIO_FMT_UNDEF,
+                               2, 16, pplayer->tone.sample_rate, 0);
 }
 
 /****************************************************************************
@@ -2191,6 +2329,8 @@ FAR struct nxplayer_s *nxplayer_create(void)
 #ifdef CONFIG_AUDIO_MULTI_SESSION
   pplayer->session = NULL;
 #endif
+
+  memset(&pplayer->tone, 0, sizeof(pplayer->tone));
 
 #ifdef CONFIG_NXPLAYER_INCLUDE_MEDIADIR
   strlcpy(pplayer->mediadir, CONFIG_NXPLAYER_DEFAULT_MEDIADIR,

--- a/system/nxplayer/nxplayer_main.c
+++ b/system/nxplayer/nxplayer_main.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 #include <nuttx/audio/audio.h>
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -69,6 +70,7 @@ struct mp_cmd_s
 static int nxplayer_cmd_quit(FAR struct nxplayer_s *pplayer, char *parg);
 static int nxplayer_cmd_play(FAR struct nxplayer_s *pplayer, char *parg);
 static int nxplayer_cmd_playraw(FAR struct nxplayer_s *pplayer, char *parg);
+static int nxplayer_cmd_tone(FAR struct nxplayer_s *pplayer, char *parg);
 
 #ifdef CONFIG_NXPLAYER_INCLUDE_SYSTEM_RESET
 static int nxplayer_cmd_reset(FAR struct nxplayer_s *pplayer, char *parg);
@@ -207,8 +209,8 @@ static struct mp_cmd_s g_nxplayer_cmds[] =
 #endif
   {
     "tone",
-    "freq secs",
-    NULL,
+    "samplerate duration pitchfreq",
+    nxplayer_cmd_tone,
     NXPLAYER_HELP_TEXT("Produce a pure tone")
   },
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
@@ -335,10 +337,10 @@ static int nxplayer_cmd_playraw(FAR struct nxplayer_s *pplayer, char *parg)
 
   /* Try to play the file specified */
 
-  ret = nxplayer_playraw(pplayer, filename, channels,
-                         bpsamp, samprate, chmap);
+  ret = nxplayer_playraw(pplayer, filename, AUDIO_FMT_PCM, 0,
+                         channels, bpsamp, samprate, chmap);
 
-  /* nxplayer_playfile returned values:
+  /* nxplayer_playraw returned values:
    *
    *   OK         File is being played
    *   -EBUSY     The media device is busy
@@ -370,6 +372,56 @@ static int nxplayer_cmd_playraw(FAR struct nxplayer_s *pplayer, char *parg)
 
       default:
         printf("Error playing file: %d\n", -ret);
+        break;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: nxplayer_cmd_tone
+ *
+ *   nxplayer_cmd_tone() plays the tone using the nxplayer
+ *   context.
+ *
+ ****************************************************************************/
+
+static int nxplayer_cmd_tone(FAR struct nxplayer_s *pplayer, char *parg)
+{
+  int ret;
+  uint32_t samprate  = 0;
+  uint32_t pitchfreq = 0;
+  uint32_t duration  = 0;
+
+  sscanf(parg, "%" PRIu32 " %" PRIu32 " %" PRIu32 "",
+         &samprate, &duration, &pitchfreq);
+
+  /* Try to play tone */
+
+  ret = nxplayer_playtone(pplayer, samprate, pitchfreq, duration);
+
+  /* nxplayer_playtone returned values:
+   *
+   *   OK         Tone is being played
+   *   -EBUSY     The media device is busy
+   *   -ENODEV    No audio device suitable to play the media type
+   */
+
+  switch (-ret)
+    {
+      case OK:
+        break;
+
+      case ENODEV:
+        printf("No suitable Audio Device found\n");
+        break;
+
+      case EBUSY:
+        printf("Audio device busy\n");
+        break;
+
+      default:
+        printf("Error playing tone: %d\n", -ret);
         break;
     }
 


### PR DESCRIPTION
## Summary

This PR contains one commit doing two related things: it reworks the
nxplayer setup path so that `play` and `playraw` share it, which fixes a
playback regression, and it adds a `tone` command on top of the reworked
path.

### 1. Fix: `play` never issues AUDIOIOC_CONFIGURE

Playback is silent on a Raspberry Pi Pico 2 with the
`raspberrypi-pico-2:spisd` configuration. Reported and bisected to two
commits from apache/nuttx#18348 on the dev mailing list:
https://www.mail-archive.com/dev@nuttx.apache.org/msg14859.html
This PR fixes the `nuttx-apps` side; the `nuttx` side is apache/nuttx#19686.

`nxplayer_playfile()` calls `nxplayer_playinternal()` directly with zeroed
`nchannels`/`bpsamp`/`samprate`, while the fallback defaults added by
09a3bc44b4 ("Add playraw command") live in `nxplayer_playraw()`. As a
result `play` never issues `AUDIOIOC_CONFIGURE` for any format whose
parameters the application cannot determine on its own.

That used to be harmless, because the audio upper half only tracked a
`started` flag and `AUDIOIOC_START` worked either way. It now requires
`AUDIO_STATE_PREPARED`, which only `audio_configure()` sets:

```
  before:  OPEN ---------------------> RUNNING     (configure optional)
  after:   OPEN --configure--> PREPARED --> RUNNING
```

Formats whose header the application parses itself are unaffected, since
`pre_parse` fills in the three values and the defaults are never needed.
WAV is the one case left where the parsing lives in the kernel:
`pcm_decode` reads the RIFF header from the first enqueued buffer and
configures the lower half directly, which does not pass through the upper
half. So the device stays in `AUDIO_STATE_OPEN` and `AUDIOIOC_START` is
rejected even though the hardware is already programmed correctly.

Move the file open, format detection and `pre_parse` call from
`nxplayer_playinternal()` into `nxplayer_playraw()`, ahead of the default
fill, and let `nxplayer_playfile()` go through it. Both entry points now
share one path, so `play` picks up the defaults that `playraw` already had.
The `pre_parse` return value is checked as well; it was previously ignored,
and a header that fails to parse left the three out-parameters at zero and
produced the same failure.

### 2. New `tone` command

With the setup path no longer tied to a file, the same machinery can drive
a generated stream, so this adds a `tone` command:

```
    nxplayer> device pcm0p
    nxplayer> tone 48000 20
```

Arguments are `samplerate duration pitchfreq`, all optional, defaulting to
48000 Hz, 10 s and 440 Hz respectively.

`nxplayer_playtone()` stores the tone parameters in the player context and
enters the same `nxplayer_playinternal()` flow used for files, declaring the
format as 2 channels / 16 bits / the requested sample rate. In the play
thread, `nxplayer_filltone()` takes the place of the file read and
synthesises a 16-bit stereo sine wave with `sinf()` directly into each audio
pipeline buffer, marking the last one with `AUDIO_APB_FINAL` when the
requested duration is reached.

This is useful for bring-up and for narrowing down playback problems, since
it exercises the audio device without involving a filesystem or any format
decoding: if a tone plays but a file does not, the problem is above the
driver.

depends-on: apache/nuttx/pull/19686

## Impact

- `play` now issues `AUDIOIOC_CONFIGURE` in all cases. The values may be
  defaults rather than the real ones, which is harmless: a lower half that
  derives the format itself overrides them before the stream starts.
- `nxplayer_playraw()` gains `filefmt` and `subfmt` parameters, so its
  prototype in `include/system/nxplayer.h` changes and out-of-tree callers
  need updating. In-tree callers are updated in the same commit.
- `nxplayer_playinternal()` no longer takes a filename.
- New public function `nxplayer_playtone()`, new `struct nxplayer_tone_s`
  member in `struct nxplayer_s`, and a new `tone` command. `nxplayer_filltone()`
  uses `sinf()`, so a toolchain with libm is required for that path.
- A `pre_parse` failure is now reported instead of silently proceeding with
  zeroed format parameters.

## Testing

Runtime verification was kindly done by the reporter on
`raspberrypi-pico-2:spisd`, together with the companion nuttx change:
https://www.mail-archive.com/dev@nuttx.apache.org/msg14859.html

Before:

```
nsh> nxplayer
nxplayer> play /mnt/sd0/test.wav
```

Nothing happens - no I2S clock or data on the pins.

After: playback runs.

Local checks on Ubuntu 22.04.5 LTS x86_64:

- `tools/checkpatch.sh` - clean