### PR TITLE
testing/ostest: set STACKSIZE for the standalone ELF build

### DIFF
--- a/testing/ostest/CMakeLists.txt
+++ b/testing/ostest/CMakeLists.txt
@@ -176,6 +176,7 @@ if(CONFIG_TESTING_OSTEST)
   endif()
 
   set(OSTEST_SRCS ostest_main.c ${SRCS})
-  nuttx_add_application(NAME ostest SRCS ${OSTEST_SRCS})
+  nuttx_add_application(NAME ostest SRCS ${OSTEST_SRCS} STACKSIZE
+                        ${CONFIG_DEFAULT_TASK_STACKSIZE})
 
 endif()


### PR DESCRIPTION
## Summary

The CMake build passed no STACKSIZE, so kernel-mode ELF loading fell back to CONFIG_ELF_STACKSIZE, which may exceed the initial user heap. Use CONFIG_DEFAULT_TASK_STACKSIZE as the Makefile does.

## Impact

align cmake with make

## Testing

qemu-intel64 with cmake in kernel build

