### PR TITLE
system/readline: Fix escape sequence returning to user console

### DIFF
--- a/system/readline/readline_common.c
+++ b/system/readline/readline_common.c
@@ -1598,7 +1598,10 @@ ssize_t readline_common(FAR struct rl_common_s *vtbl, FAR char *buf,
 
               buf[cursor] = (char)ch; nch++; cursor++;
 #  ifdef CONFIG_READLINE_ECHO
-              redraw_tail(vtbl, buf, nch, cursor);
+              if (cursor < nch)
+                {
+                  redraw_tail(vtbl, buf, nch, cursor);
+                }
 #  endif
             }
 #else


### PR DESCRIPTION
## Summary

This commit fixes the issue:
https://github.com/apache/nuttx-apps/issues/3680

## Impact

Fixes nsh output garbage.

## Testing

Tested locally and confirmed by Filipe:
https://github.com/apache/nuttx-apps/issues/3680

