### PR TITLE
nshlib: guard nsh_getfullpath against NULL argv[1] in boot command

### DIFF
--- a/nshlib/nsh_syscmds.c
+++ b/nshlib/nsh_syscmds.c
@@ -422,7 +422,7 @@ int cmd_boot(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
         /* Go through */
 
       case 1:
-        fullpath = nsh_getfullpath(vtbl, argv[1]);
+        fullpath = argv[1] ? nsh_getfullpath(vtbl, argv[1]) : NULL;
         info.path = fullpath;
 
         /* Go through */


### PR DESCRIPTION
## Summary

A bare `boot` (no argument, argc == 1) passes `argv[1] == NULL`. nsh_getfullpath(NULL) returns `strdup(g_home) == "/"` https://github.com/apache/nuttx-apps/blob/6e61ce7cb7cce474572e32f3f837361ec18f1f62/nshlib/nsh_envcmds.c#L191-L203  instead of `NULL`, which turned the default-boot path (NULL -> board default image) into `"/"`.  `board_boot_image("/")` then failed with -`EINVAL (-22)`, preventing the board from booting.

Guard the `nsh_getfullpath()` call so NULL passes through unchanged, restoring the original default-boot behavior while still resolving relative paths when an argument is given.

This fixes the regression introduced by the relative-path support
```bash
commit fabafbc3615b3d22636bbf33f932578f491bef23 (origin/master, origin/HEAD)
Author: Junbo Zheng <zhengjunbo1@xiaomi.com>
Date:   Fri Jul 24 23:47:44 2026 +0800

    nshlib: add relative image path support in boot command

    cmd_boot passed the image path straight to boardctl(), which resolves
    it in a context that does not inherit the NSH shell cwd, so relative
    paths failed and only absolute paths worked. Use nsh_getfullpath() to
    resolve relative paths against the cwd before calling boardctl().

    Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>
```

## Impact

- Users: Fixes a regression where bare boot (no image argument) stopped working after the relative-path support boot now works again
- Build: None -- one-line source change, no con change.
- Hardware: None -- no board-specific logic touched; affects all boards using NSH boot.
- Documentation: None.
- Security & Compatibility: None

## Testing

Passed internal CT tests by running boot with no argument

- before, it returned `-EINVAL` and no boot occurred
- after, the default boot path proceeds

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>