### PR TITLE
testing/libc/arch_libc: Add a throughput benchmark.

### DIFF
--- a/testing/libc/arch_libc/CMakeLists.txt
+++ b/testing/libc/arch_libc/CMakeLists.txt
@@ -21,6 +21,10 @@
 # ##############################################################################
 
 if(CONFIG_TESTING_ARCH_LIBC)
+  if(CONFIG_TESTING_ARCH_LIBC_BENCH)
+    set(bench_srcs arch_libc_bench.c)
+  endif()
+
   nuttx_add_application(
     NAME
     ${CONFIG_TESTING_ARCH_LIBC_PROGNAME}
@@ -31,5 +35,6 @@ if(CONFIG_TESTING_ARCH_LIBC)
     MODULE
     ${CONFIG_TESTING_ARCH_LIBC}
     SRCS
-    arch_libc_test_main.c)
+    arch_libc_test_main.c
+    ${bench_srcs})
 endif()

--- a/testing/libc/arch_libc/CMakeLists.txt
+++ b/testing/libc/arch_libc/CMakeLists.txt
@@ -31,5 +31,6 @@ if(CONFIG_TESTING_ARCH_LIBC)
     MODULE
     ${CONFIG_TESTING_ARCH_LIBC}
     SRCS
-    arch_libc_test_main.c)
+    arch_libc_test_main.c
+    arch_libc_string.c)
 endif()

--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -43,6 +43,10 @@ config TESTING_ARCH_LIBC_STRCPY
 	bool "test strcpy"
 	default y
 
+config TESTING_ARCH_LIBC_STRLCPY
+	bool "test strlcpy"
+	default y
+
 config TESTING_ARCH_LIBC_STRLEN
 	bool "test strlen"
 	default y

--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -16,6 +16,22 @@ config TESTING_ARCH_LIBC_STRCPY
 	bool "test strcpy"
 	default y
 
+config TESTING_ARCH_LIBC_STRING
+	bool "string and memory function suite"
+	default y
+	---help---
+		Correctness across alignments, sizes, overlaps and terminator
+		placement for the string and memory functions a machine
+		directory may override, plus a speed report for each.
+
+config TESTING_ARCH_LIBC_STRING_BUFSIZE
+	int "string suite buffer size"
+	default 262144
+	depends on TESTING_ARCH_LIBC_STRING
+	---help---
+		Each of the two test buffers, in bytes.  The large-block
+		speed scenarios use a quarter of this.
+
 config TESTING_ARCH_LIBC_PROGNAME
 	string "Program name"
 	default "arch_libctest"

--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -75,6 +75,32 @@ config TESTING_ARCH_LIBC_STRCHRNUL
 	bool "test strchrnul"
 	default y
 
+config TESTING_ARCH_LIBC_BENCH
+	bool "throughput benchmark"
+	default n
+	---help---
+		Measure each function across a size sweep and every source and
+		destination alignment pair, reporting MB/s and cycles per byte.
+		An implementation usually takes its wide path only when the
+		pointers meet some alignment condition, so an aligned measurement
+		alone does not show what the rest of the input space costs.
+
+if TESTING_ARCH_LIBC_BENCH
+
+config TESTING_ARCH_LIBC_BENCH_BUFSIZE
+	int "benchmark buffer size"
+	default 262144
+	---help---
+		Size of each of the two buffers the benchmark allocates.
+
+config TESTING_ARCH_LIBC_BENCH_MINMS
+	int "minimum milliseconds per measurement"
+	default 250
+	---help---
+		Each measurement repeats until it has run for at least this long.
+
+endif
+
 config TESTING_ARCH_LIBC_PROGNAME
 	string "Program name"
 	default "arch_libctest"

--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -43,6 +43,14 @@ config TESTING_ARCH_LIBC_STRCPY
 	bool "test strcpy"
 	default y
 
+config TESTING_ARCH_LIBC_MEMCCPY
+	bool "test memccpy"
+	default y
+
+config TESTING_ARCH_LIBC_STPNCPY
+	bool "test stpncpy"
+	default y
+
 config TESTING_ARCH_LIBC_STRLCPY
 	bool "test strlcpy"
 	default y

--- a/testing/libc/arch_libc/Makefile
+++ b/testing/libc/arch_libc/Makefile
@@ -31,6 +31,10 @@ MODULE = $(CONFIG_TESTING_ARCH_LIBC)
 
 # arch libc test
 
+ifneq ($(CONFIG_TESTING_ARCH_LIBC_BENCH),)
+CSRCS += arch_libc_bench.c
+endif
+
 MAINSRC = arch_libc_test_main.c
 
 include $(APPDIR)/Application.mk

--- a/testing/libc/arch_libc/Makefile
+++ b/testing/libc/arch_libc/Makefile
@@ -33,4 +33,8 @@ MODULE = $(CONFIG_TESTING_ARCH_LIBC)
 
 MAINSRC = arch_libc_test_main.c
 
+ifeq ($(CONFIG_TESTING_ARCH_LIBC_STRING),y)
+CSRCS += arch_libc_string.c
+endif
+
 include $(APPDIR)/Application.mk

--- a/testing/libc/arch_libc/arch_libc_bench.c
+++ b/testing/libc/arch_libc/arch_libc_bench.c
@@ -92,6 +92,8 @@
 #define OP_STPCPY    14
 #define OP_STRNCPY   15
 #define OP_STRCAT    16
+#define OP_MEMCCPY   17
+#define OP_STPNCPY   18
 
 /****************************************************************************
  * Private Types
@@ -134,6 +136,8 @@ static const struct bench_op_s g_ops[] =
   {"stpcpy",  OP_STPCPY,  true,  true},
   {"strncpy", OP_STRNCPY, true,  true},
   {"strcat",  OP_STRCAT,  true,  true},
+  {"memccpy", OP_MEMCCPY, true,  false},
+  {"stpncpy", OP_STPNCPY, true,  true},
 };
 
 static const size_t g_sizes[] =
@@ -323,6 +327,12 @@ static void bench_one(FAR const struct bench_op_s *o, size_t n,
                 break;
               case OP_STRNCPY:
                 strncpy(d, s, n);
+                break;
+              case OP_MEMCCPY:
+                g_sink += (uintptr_t)memccpy(d, s, '~', n);
+                break;
+              case OP_STPNCPY:
+                g_sink += (uintptr_t)stpncpy(d, s, n);
                 break;
               case OP_STRCAT:
 

--- a/testing/libc/arch_libc/arch_libc_bench.c
+++ b/testing/libc/arch_libc/arch_libc_bench.c
@@ -116,6 +116,7 @@ struct bench_op_s
 static FAR char *g_src;
 static FAR char *g_dst;
 static volatile unsigned long g_sink;
+static clockid_t g_clock = CLOCK_MONOTONIC;
 
 static const struct bench_op_s g_ops[] =
 {
@@ -182,8 +183,55 @@ static double bench_now(void)
 {
   struct timespec t;
 
-  clock_gettime(CLOCK_MONOTONIC, &t);
+  clock_gettime(g_clock, &t);
   return t.tv_sec + t.tv_nsec / 1e9;
+}
+
+/****************************************************************************
+ * Name: bench_pick_clock
+ *
+ * Description:
+ *   Settle on a clock that runs.  Every measurement below repeats until a
+ *   stated interval has passed, so a clock that reads the same value twice
+ *   would spin forever rather than report anything.  CLOCK_MONOTONIC is
+ *   preferred and does not advance on every target.
+ *
+ ****************************************************************************/
+
+static bool bench_pick_clock(void)
+{
+  static const clockid_t tries[] =
+  {
+    CLOCK_MONOTONIC, CLOCK_REALTIME
+  };
+
+  struct timespec a;
+  struct timespec b;
+  volatile int i;
+  size_t k;
+
+  for (k = 0; k < sizeof(tries) / sizeof(tries[0]); k++)
+    {
+      if (clock_gettime(tries[k], &a) < 0)
+        {
+          continue;
+        }
+
+      for (i = 0; i < 1000000; i++);
+
+      if (clock_gettime(tries[k], &b) < 0)
+        {
+          continue;
+        }
+
+      if (b.tv_sec != a.tv_sec || b.tv_nsec != a.tv_nsec)
+        {
+          g_clock = tries[k];
+          return true;
+        }
+    }
+
+  return false;
 }
 
 /****************************************************************************
@@ -384,6 +432,12 @@ int arch_libc_bench(void)
   size_t oi;
   size_t si;
   size_t ai;
+
+  if (!bench_pick_clock())
+    {
+      printf("arch_libc bench: no clock advances, cannot time anything\n");
+      return 1;
+    }
 
   g_src = malloc(BENCH_BUF);
   g_dst = malloc(BENCH_BUF);

--- a/testing/libc/arch_libc/arch_libc_bench.c
+++ b/testing/libc/arch_libc/arch_libc_bench.c
@@ -1,0 +1,420 @@
+/****************************************************************************
+ * apps/testing/libc/arch_libc/arch_libc_bench.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Throughput for the string and memory functions a machine directory may
+ * override, across a size sweep and every source/destination alignment
+ * pair.  A machine implementation usually takes its wide path only when
+ * the pointers satisfy some alignment condition, so a single aligned size
+ * reports the best case and hides what the rest of the input space costs.
+ *
+ * Each measurement reports MB/s, which compares across machines, and
+ * cycles per byte from perf_gettime(), which does not depend on the
+ * timebase being calibrated.  Both come from one timed loop.
+ *
+ * Two ways a benchmark of these functions measures nothing are defeated
+ * here: the compiler treating a pure call with unchanged arguments as loop
+ * invariant, countered by laundering the pointers through an asm that
+ * claims to change them, and comparison inputs an earlier measurement
+ * scribbled on, countered by preparing the buffers before each timed loop.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BENCH_BUF    (CONFIG_TESTING_ARCH_LIBC_BENCH_BUFSIZE)
+#define BENCH_MINMS  (CONFIG_TESTING_ARCH_LIBC_BENCH_MINMS)
+#define BENCH_GUARD  64
+#define BENCH_BATCH  16
+
+/* perf_gettime() reaches an application only where the C library builds
+ * its own copy, or where the application and the kernel are one image.
+ * Elsewhere the cycle count is left out and the throughput stands alone.
+ */
+
+#if defined(CONFIG_ARCH_HAVE_PERF_EVENTS_USER_ACCESS) || \
+    defined(CONFIG_BUILD_FLAT)
+#  define BENCH_CYCLES 1
+#endif
+
+/* Operations.  A writer stores through the destination pointer, so its
+ * destination offset is worth sweeping; a reader only takes one.
+ */
+
+#define OP_MEMCPY    0
+#define OP_MEMMOVE   1
+#define OP_MEMSET    2
+#define OP_MEMCMP    3
+#define OP_MEMCHR    4
+#define OP_STRLEN    5
+#define OP_STRCMP    6
+#define OP_STRNCMP   7
+#define OP_STRCPY    8
+#define OP_STRLCPY   9
+#define OP_STRCHR    10
+#define OP_STRRCHR   11
+#define OP_STRCHRNUL 12
+#define OP_STRNLEN   13
+#define OP_STPCPY    14
+#define OP_STRNCPY   15
+#define OP_STRCAT    16
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct bench_op_s
+{
+  FAR const char *name;
+  uint8_t         op;
+  bool            dst;       /* Touches the destination pointer, so its
+                              * offset is worth sweeping too */
+  bool            str;       /* Operand is a string, so it needs a
+                              * terminator at the measured length */
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static FAR char *g_src;
+static FAR char *g_dst;
+static volatile unsigned long g_sink;
+
+static const struct bench_op_s g_ops[] =
+{
+  {"memcpy",  OP_MEMCPY,  true,  false},
+  {"memmove", OP_MEMMOVE, true,  false},
+  {"memset",  OP_MEMSET,  true,  false},
+  {"memcmp",  OP_MEMCMP,  true,  false},
+  {"memchr",  OP_MEMCHR,  false, false},
+  {"strlen",  OP_STRLEN,  false, true},
+  {"strcmp",  OP_STRCMP,  true,  true},
+  {"strncmp", OP_STRNCMP, true,  true},
+  {"strcpy",  OP_STRCPY,  true,  true},
+  {"strlcpy", OP_STRLCPY, true,  true},
+  {"strchr",  OP_STRCHR,  false, true},
+  {"strrchr", OP_STRRCHR, false, true},
+  {"strchrnul", OP_STRCHRNUL, false, true},
+  {"strnlen", OP_STRNLEN, false, true},
+  {"stpcpy",  OP_STPCPY,  true,  true},
+  {"strncpy", OP_STRNCPY, true,  true},
+  {"strcat",  OP_STRCAT,  true,  true},
+};
+
+static const size_t g_sizes[] =
+{
+  64, 512, 4096, 32768
+};
+
+/* Source and destination offsets within a register.  Aligned, equally
+ * misaligned, misaligned by different amounts, and a source shift against
+ * an aligned destination.
+ */
+
+static const uint8_t g_aligns[][2] =
+{
+  {
+    0, 0
+  },
+  {
+    1, 1
+  },
+  {
+    1, 2
+  },
+  {
+    3, 0
+  }
+};
+
+#define NOPS    (sizeof(g_ops) / sizeof(g_ops[0]))
+#define NSIZES  (sizeof(g_sizes) / sizeof(g_sizes[0]))
+#define NALIGNS (sizeof(g_aligns) / sizeof(g_aligns[0]))
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bench_now
+ ****************************************************************************/
+
+static double bench_now(void)
+{
+  struct timespec t;
+
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return t.tv_sec + t.tv_nsec / 1e9;
+}
+
+/****************************************************************************
+ * Name: bench_seen_src
+ *
+ * Description:
+ *   Whether an earlier alignment pair already used this source offset.
+ *
+ ****************************************************************************/
+
+static bool bench_seen_src(size_t ai)
+{
+  size_t i;
+
+  for (i = 0; i < ai; i++)
+    {
+      if (g_aligns[i][0] == g_aligns[ai][0])
+        {
+          return true;
+        }
+    }
+
+  return false;
+}
+
+/****************************************************************************
+ * Name: bench_prepare
+ *
+ * Description:
+ *   Content for one measurement.  The compares need the two operands equal
+ *   for the whole length, or they stop early and time nothing, and the
+ *   absent-character scans need a byte that never appears.
+ *
+ ****************************************************************************/
+
+static void bench_prepare(FAR const struct bench_op_s *o, size_t n,
+                          int so, int dofs)
+{
+  FAR char *s = g_src + BENCH_GUARD + so;
+  FAR char *d = g_dst + BENCH_GUARD + dofs;
+  size_t i;
+
+  for (i = 0; i < n + BENCH_GUARD; i++)
+    {
+      s[i] = 'a' + (i % 23);
+    }
+
+  memcpy(d, s, n + BENCH_GUARD);
+
+  if (o->str)
+    {
+      s[n] = '\0';
+      d[n] = '\0';
+    }
+}
+
+/****************************************************************************
+ * Name: bench_one
+ *
+ * Description:
+ *   One operation at one size and one alignment pair, timed until it has
+ *   run for at least the configured interval.
+ *
+ ****************************************************************************/
+
+static void bench_one(FAR const struct bench_op_s *o, size_t n,
+                      int so, int dofs)
+{
+#ifdef BENCH_CYCLES
+  clock_t c0;
+  clock_t c1;
+#endif
+  double  t0;
+  double  el;
+  double  mbs;
+  unsigned long reps = 0;
+  int i;
+
+  bench_prepare(o, n, so, dofs);
+
+  t0 = bench_now();
+#ifdef BENCH_CYCLES
+  c0 = perf_gettime();
+#endif
+
+  do
+    {
+      for (i = 0; i < BENCH_BATCH; i++)
+        {
+          FAR char *s = g_src + BENCH_GUARD + so;
+          FAR char *d = g_dst + BENCH_GUARD + dofs;
+
+          __asm__ volatile("" : "+r"(s), "+r"(d));
+
+          switch (o->op)
+            {
+              case OP_MEMCPY:
+                memcpy(d, s, n);
+                break;
+              case OP_MEMMOVE:
+                memmove(d + 8, d, n);
+                break;
+              case OP_MEMSET:
+                memset(d, i, n);
+                break;
+              case OP_MEMCMP:
+                g_sink += memcmp(s, d, n);
+                break;
+              case OP_MEMCHR:
+                g_sink += (uintptr_t)memchr(s, '~', n);
+                break;
+              case OP_STRLEN:
+                g_sink += strlen(s);
+                break;
+              case OP_STRCMP:
+                g_sink += strcmp(s, d);
+                break;
+              case OP_STRNCMP:
+                g_sink += strncmp(s, d, n);
+                break;
+              case OP_STRCPY:
+                strcpy(d, s);
+                break;
+              case OP_STRLCPY:
+                g_sink += strlcpy(d, s, n + 1);
+                break;
+              case OP_STRCHR:
+                g_sink += (uintptr_t)strchr(s, '~');
+                break;
+              case OP_STRRCHR:
+                g_sink += (uintptr_t)strrchr(s, '~');
+                break;
+              case OP_STRCHRNUL:
+                g_sink += (uintptr_t)strchrnul(s, '~');
+                break;
+              case OP_STRNLEN:
+                g_sink += strnlen(s, n);
+                break;
+              case OP_STPCPY:
+                g_sink += (uintptr_t)stpcpy(d, s);
+                break;
+              case OP_STRNCPY:
+                strncpy(d, s, n);
+                break;
+              case OP_STRCAT:
+
+                /* Appending to what the last turn appended would grow the
+                 * destination without bound, so it starts empty each time.
+                 * The store is inside the measurement.
+                 */
+
+                d[0] = '\0';
+                strcat(d, s);
+                break;
+            }
+
+          g_sink += (unsigned char)d[0];
+        }
+
+      reps += BENCH_BATCH;
+      el    = bench_now() - t0;
+    }
+  while (el * 1000.0 < BENCH_MINMS);
+
+  mbs = (double)reps * n / el / 1048576.0;
+
+#ifdef BENCH_CYCLES
+  c1 = perf_gettime();
+  printf("  %-8s %6zu B  s+%d/d+%d  %9.1f MB/s  %8.3f cyc/B\n",
+         o->name, n, so, dofs, mbs,
+         (double)(uintmax_t)(c1 - c0) / ((double)reps * n));
+#else
+  printf("  %-8s %6zu B  s+%d/d+%d  %9.1f MB/s\n",
+         o->name, n, so, dofs, mbs);
+#endif
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arch_libc_bench
+ *
+ * Description:
+ *   Run every operation over the size sweep and the alignment matrix.
+ *
+ ****************************************************************************/
+
+int arch_libc_bench(void)
+{
+  size_t oi;
+  size_t si;
+  size_t ai;
+
+  g_src = malloc(BENCH_BUF);
+  g_dst = malloc(BENCH_BUF);
+  if (g_src == NULL || g_dst == NULL)
+    {
+      printf("arch_libc bench: cannot allocate 2 x %d\n", BENCH_BUF);
+      free(g_src);
+      free(g_dst);
+      return 1;
+    }
+
+  printf("== throughput ==\n");
+
+  for (oi = 0; oi < NOPS; oi++)
+    {
+      for (si = 0; si < NSIZES; si++)
+        {
+          if (g_sizes[si] + 2 * BENCH_GUARD + 8 > BENCH_BUF)
+            {
+              continue;
+            }
+
+          for (ai = 0; ai < NALIGNS; ai++)
+            {
+              /* An operation that never touches the destination is decided
+               * by the source offset alone, so a pair repeating one already
+               * measured would report the same number twice.
+               */
+
+              if (!g_ops[oi].dst && bench_seen_src(ai))
+                {
+                  continue;
+                }
+
+              bench_one(&g_ops[oi], g_sizes[si],
+                        g_aligns[ai][0], g_aligns[ai][1]);
+            }
+        }
+    }
+
+  free(g_src);
+  free(g_dst);
+  return 0;
+}

--- a/testing/libc/arch_libc/arch_libc_string.c
+++ b/testing/libc/arch_libc/arch_libc_string.c
@@ -1,0 +1,808 @@
+/****************************************************************************
+ * apps/testing/libc/arch_libc/arch_libc_string.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Correctness and speed for the string and memory functions a machine
+ * directory may override, aimed at the mistakes such overrides actually
+ * make: alignment cases (every combination of source and destination
+ * offset within a register), sizes straddling every internal boundary
+ * (word, block, and the small-size cutoff), overlap in both directions
+ * for memmove, the interaction of terminators with length caps, and
+ * writes past either end, which guard bytes around every destination
+ * catch.
+ *
+ * The speed half measures through CLOCK_MONOTONIC.  Two things would
+ * otherwise make it measure nothing: the compiler hoisting a pure call
+ * whose arguments never change, countered by laundering the pointers
+ * through an asm that claims to change them, and comparison buffers an
+ * earlier benchmark scribbled on, countered by checking equality before
+ * timing.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRING
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define STR_BUF     (CONFIG_TESTING_ARCH_LIBC_STRING_BUFSIZE)
+#define STR_GUARD   64
+#define STR_MINMS   250
+#define STR_BIG     (STR_BUF / 4)
+#define STR_STRLEN  4096
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static FAR char *g_src;
+static FAR char *g_dst;
+static volatile unsigned long g_sink;
+static int g_fails;
+
+static const int g_sizes[] =
+{
+  0, 1, 2, 3, 7, 8, 9, 15, 16, 17, 31, 32, 63, 64, 65, 127, 128, 129,
+  255, 256, 1000
+};
+
+#define NSIZES ((int)(sizeof(g_sizes) / sizeof(g_sizes[0])))
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void str_note(FAR const char *fn, int bad)
+{
+  printf("  %-10s correctness: %s (%d bad)\n", fn,
+         bad ? "FAIL" : "ok", bad);
+  g_fails += bad;
+}
+
+static double str_now(void)
+{
+  struct timespec t;
+
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return t.tv_sec + t.tv_nsec / 1e9;
+}
+
+/****************************************************************************
+ * Name: str_ck_copy
+ *
+ * Description:
+ *   memcpy and memmove against distinct buffers: every alignment pair,
+ *   every boundary size, result pointer, content, and the guard bytes.
+ *
+ ****************************************************************************/
+
+static void str_ck_copy(int move)
+{
+  int k;
+  int so;
+  int dofs;
+  int i;
+  int bad = 0;
+
+  for (k = 0; k < NSIZES; k++)
+    {
+      for (so = 0; so < 8; so++)
+        {
+          for (dofs = 0; dofs < 8; dofs++)
+            {
+              int n = g_sizes[k];
+              FAR char *s = g_src + STR_GUARD + so;
+              FAR char *d = g_dst + STR_GUARD + dofs;
+              FAR void *r;
+
+              for (i = 0; i < n; i++)
+                {
+                  s[i] = (char)(i * 7 + so + k + 1);
+                }
+
+              memset(g_dst, 0x5a, 2 * STR_GUARD + 1100);
+              r = move ? memmove(d, s, n) : memcpy(d, s, n);
+
+              if (r != d)
+                {
+                  bad++;
+                  continue;
+                }
+
+              for (i = 0; i < n; i++)
+                {
+                  if (d[i] != (char)(i * 7 + so + k + 1))
+                    {
+                      bad++;
+                      break;
+                    }
+                }
+
+              if ((unsigned char)d[-1] != 0x5a ||
+                  (unsigned char)d[n] != 0x5a)
+                {
+                  bad++;
+                }
+            }
+        }
+    }
+
+  str_note(move ? "memmove" : "memcpy", bad);
+}
+
+/****************************************************************************
+ * Name: str_ck_overlap
+ *
+ * Description:
+ *   memmove where the regions overlap, forward and backward, at every
+ *   distance up to a register width either side, at every size.
+ *
+ ****************************************************************************/
+
+static void str_ck_overlap(void)
+{
+  int k;
+  int ofs;
+  int i;
+  int bad = 0;
+
+  for (k = 0; k < NSIZES; k++)
+    {
+      for (ofs = -8; ofs <= 8; ofs++)
+        {
+          int n = g_sizes[k];
+          FAR char *base = g_dst + STR_GUARD + 16;
+          FAR char *d = base + ofs;
+
+          if (n == 0)
+            {
+              continue;
+            }
+
+          for (i = -8; i < n + 8; i++)
+            {
+              base[i] = (char)(i * 5 + k + 3);
+            }
+
+          memmove(d, base, n);
+
+          for (i = 0; i < n; i++)
+            {
+              if (d[i] != (char)(i * 5 + k + 3))
+                {
+                  bad++;
+                  break;
+                }
+            }
+        }
+    }
+
+  str_note("mv-overlap", bad);
+}
+
+/****************************************************************************
+ * Name: str_ck_memset
+ ****************************************************************************/
+
+static void str_ck_memset(void)
+{
+  int k;
+  int dofs;
+  int i;
+  int bad = 0;
+
+  for (k = 0; k < NSIZES; k++)
+    {
+      for (dofs = 0; dofs < 8; dofs++)
+        {
+          int n = g_sizes[k];
+          FAR char *d = g_dst + STR_GUARD + dofs;
+
+          memset(g_dst, 0x5a, 2 * STR_GUARD + 1100);
+          if (memset(d, 0xc3, n) != d)
+            {
+              bad++;
+              continue;
+            }
+
+          for (i = 0; i < n; i++)
+            {
+              if ((unsigned char)d[i] != 0xc3)
+                {
+                  bad++;
+                  break;
+                }
+            }
+
+          if ((unsigned char)d[-1] != 0x5a ||
+              (unsigned char)d[n] != 0x5a)
+            {
+              bad++;
+            }
+        }
+    }
+
+  str_note("memset", bad);
+}
+
+/****************************************************************************
+ * Name: str_ck_memcmp
+ *
+ * Description:
+ *   Equal buffers, then a single difference planted at the start, the
+ *   middle and the end: the sign both ways, and that a length cap short
+ *   of the difference hides it.  Values stay below 0x80 so the planted
+ *   difference cannot wrap.
+ *
+ ****************************************************************************/
+
+static void str_ck_memcmp(void)
+{
+  int k;
+  int so;
+  int dofs;
+  int at;
+  int bad = 0;
+
+  for (k = 0; k < NSIZES; k++)
+    {
+      for (so = 0; so < 4; so++)
+        {
+          for (dofs = 0; dofs < 4; dofs++)
+            {
+              int n = g_sizes[k];
+              FAR char *a = g_src + STR_GUARD + so;
+              FAR char *b = g_dst + STR_GUARD + dofs;
+              int i;
+
+              for (i = 0; i < n; i++)
+                {
+                  a[i] = b[i] = (char)((i * 3 + 40) & 0x7f);
+                }
+
+              if (memcmp(a, b, n) != 0)
+                {
+                  bad++;
+                  continue;
+                }
+
+              for (at = 0; at < n; at += (n > 8 ? n / 3 : 1))
+                {
+                  b[at] = (char)(a[at] + 13);
+                  if (memcmp(a, b, n) >= 0)
+                    {
+                      bad++;
+                    }
+
+                  if (memcmp(b, a, n) <= 0)
+                    {
+                      bad++;
+                    }
+
+                  if (memcmp(a, b, at) != 0)
+                    {
+                      bad++;
+                    }
+
+                  b[at] = a[at];
+                }
+            }
+        }
+    }
+
+  str_note("memcmp", bad);
+}
+
+/****************************************************************************
+ * Name: str_ck_scan
+ *
+ * Description:
+ *   strlen, strnlen, memchr and the strchr family: every alignment,
+ *   lengths crossing the word size, the probe at every position, a
+ *   probe that is absent, and the terminator probed for by name.  A
+ *   tripwire byte sits just past every terminator.
+ *
+ ****************************************************************************/
+
+static void str_ck_scan(void)
+{
+  int so;
+  int len;
+  int at;
+  int i;
+  int bad = 0;
+
+  for (so = 0; so < 8; so++)
+    {
+      for (len = 0; len < 40; len++)
+        {
+          FAR char *s = g_src + STR_GUARD + so;
+
+          for (i = 0; i < len; i++)
+            {
+              s[i] = 'a' + (i % 23);
+            }
+
+          s[len] = '\0';
+          s[len + 1] = 'Z';
+
+          if ((int)strlen(s) != len)
+            {
+              bad++;
+            }
+
+          if ((int)strnlen(s, 1000) != len)
+            {
+              bad++;
+            }
+
+          if ((int)strnlen(s, len) != len)
+            {
+              bad++;
+            }
+
+          if (len > 0 && (int)strnlen(s, len - 1) != len - 1)
+            {
+              bad++;
+            }
+
+          if ((int)strnlen(s, 0) != 0)
+            {
+              bad++;
+            }
+
+          for (at = 0; at < len; at += (len > 6 ? len / 3 : 1))
+            {
+              char c = s[at];
+              FAR char *want = NULL;
+
+              for (i = 0; i <= len; i++)
+                {
+                  if (s[i] == c)
+                    {
+                      want = s + i;
+                      break;
+                    }
+                }
+
+              if (strchr(s, c) != want)
+                {
+                  bad++;
+                }
+
+              if (strchrnul(s, c) != want)
+                {
+                  bad++;
+                }
+
+              want = NULL;
+              for (i = len; i >= 0; i--)
+                {
+                  if (s[i] == c)
+                    {
+                      want = s + i;
+                      break;
+                    }
+                }
+
+              if (strrchr(s, c) != want)
+                {
+                  bad++;
+                }
+            }
+
+          if (strchr(s, '~') != NULL)
+            {
+              bad++;
+            }
+
+          if (strchrnul(s, '~') != s + len)
+            {
+              bad++;
+            }
+
+          if (strrchr(s, '~') != NULL)
+            {
+              bad++;
+            }
+
+          if (strchr(s, '\0') != s + len)
+            {
+              bad++;
+            }
+
+          if (strrchr(s, '\0') != s + len)
+            {
+              bad++;
+            }
+
+          if (len > 2)
+            {
+              if (memchr(s, s[len - 1], len) == NULL)
+                {
+                  bad++;
+                }
+
+              if (memchr(s, '~', len) != NULL)
+                {
+                  bad++;
+                }
+            }
+        }
+    }
+
+  str_note("str-scan", bad);
+}
+
+/****************************************************************************
+ * Name: str_ck_cmpcpy
+ *
+ * Description:
+ *   strcmp, strncmp and strcpy: a planted difference at every position,
+ *   the n cap before, at and past it, and the copy checked round trip
+ *   with a tripwire past the terminator.
+ *
+ ****************************************************************************/
+
+static void str_ck_cmpcpy(void)
+{
+  int ao;
+  int bo;
+  int at;
+  int i;
+  int bad = 0;
+
+  for (ao = 0; ao < 8; ao++)
+    {
+      for (bo = 0; bo < 8; bo++)
+        {
+          for (at = 0; at < 24; at++)
+            {
+              FAR char *a = g_src + STR_GUARD + ao;
+              FAR char *b = g_dst + STR_GUARD + bo;
+              int exp;
+
+              for (i = 0; i < 24; i++)
+                {
+                  a[i] = b[i] = 'A' + (i % 20);
+                }
+
+              a[23] = b[23] = '\0';
+              if (at < 23)
+                {
+                  b[at] = a[at] + 1;
+                }
+
+              exp = (at < 23) ? -1 : 0;
+              i = strcmp(a, b);
+              i = (i < 0) ? -1 : ((i > 0) ? 1 : 0);
+              if (i != exp)
+                {
+                  bad++;
+                }
+
+              if (strncmp(a, b, at) != 0)
+                {
+                  bad++;
+                }
+
+              i = strncmp(a, b, 24);
+              i = (i < 0) ? -1 : ((i > 0) ? 1 : 0);
+              if (i != exp)
+                {
+                  bad++;
+                }
+
+              if (strncmp(a, b, 0) != 0)
+                {
+                  bad++;
+                }
+
+              {
+                FAR char *d = g_dst + STR_GUARD + 40 + bo;
+
+                d[24] = 0x33;
+                if (strcpy(d, a) != d)
+                  {
+                    bad++;
+                  }
+
+                if (strcmp(d, a) != 0)
+                  {
+                    bad++;
+                  }
+
+                if (d[24] != 0x33)
+                  {
+                    bad++;
+                  }
+              }
+            }
+        }
+    }
+
+  str_note("strcmp-fam", bad);
+}
+
+/****************************************************************************
+ * Name: str_ck_strlcpy
+ *
+ * Description:
+ *   strlcpy: the return is always the source length, the result is
+ *   always terminated when the cap is nonzero, at most cap-1 bytes are
+ *   copied, and a cap of zero writes nothing at all.
+ *
+ ****************************************************************************/
+
+static void str_ck_strlcpy(void)
+{
+  int so;
+  int dofs;
+  int len;
+  size_t cap;
+  int i;
+  int bad = 0;
+
+  for (so = 0; so < 8; so++)
+    {
+      for (dofs = 0; dofs < 8; dofs++)
+        {
+          for (len = 0; len < 24; len++)
+            {
+              FAR char *a = g_src + STR_GUARD + so;
+
+              for (i = 0; i < len; i++)
+                {
+                  a[i] = 'a' + (i % 23);
+                }
+
+              a[len] = '\0';
+
+              for (cap = 0; cap <= (size_t)len + 2; cap++)
+                {
+                  FAR char *d = g_dst + STR_GUARD + dofs;
+
+                  memset(g_dst, 0x5a, 2 * STR_GUARD + 64);
+                  if (strlcpy(d, a, cap) != (size_t)len)
+                    {
+                      bad++;
+                    }
+
+                  if (cap > 0)
+                    {
+                      size_t want = ((size_t)len < cap - 1) ?
+                                    (size_t)len : cap - 1;
+
+                      if (d[want] != '\0')
+                        {
+                          bad++;
+                        }
+
+                      for (i = 0; i < (int)want; i++)
+                        {
+                          if (d[i] != a[i])
+                            {
+                              bad++;
+                              break;
+                            }
+                        }
+
+                      if ((unsigned char)d[want + 1] != 0x5a &&
+                          want == cap - 1)
+                        {
+                          bad++;
+                        }
+                    }
+                  else if ((unsigned char)d[0] != 0x5a)
+                    {
+                      bad++;
+                    }
+                }
+            }
+        }
+    }
+
+  str_note("strlcpy", bad);
+}
+
+/****************************************************************************
+ * Name: str_bench
+ *
+ * Description:
+ *   Time one scenario and print a rate.  The asm around the pointers
+ *   stops the compiler treating a pure call with unchanged arguments as
+ *   loop invariant, without disturbing the alignment under test.
+ *
+ ****************************************************************************/
+
+static void str_bench(FAR const char *name, int op, int so, int dofs, int n)
+{
+  double t0;
+  double el;
+  long reps = 0;
+  int i;
+
+  t0 = str_now();
+  do
+    {
+      for (i = 0; i < 16; i++)
+        {
+          FAR char *s = g_src + STR_GUARD + so;
+          FAR char *d = g_dst + STR_GUARD + dofs;
+
+          __asm__ volatile("" : "+r"(s), "+r"(d));
+
+          switch (op)
+            {
+              case 0:
+                memcpy(d, s, n);
+                g_sink += (unsigned char)d[0];
+                break;
+              case 1:
+                memmove(d + 8, d, n);
+                g_sink += (unsigned char)d[8];
+                break;
+              case 2:
+                g_sink += memcmp(s, d, n);
+                break;
+              case 3:
+                g_sink += strlen(s);
+                break;
+              case 4:
+                g_sink += strncmp(s, d, n);
+                break;
+              case 5:
+                g_sink += (uintptr_t)memchr(s, '~', n);
+                break;
+              case 6:
+                g_sink += (uintptr_t)strchr(s, '~');
+                break;
+              case 7:
+                strcpy(d, s);
+                g_sink += (unsigned char)d[0];
+                break;
+              case 8:
+                g_sink += (uintptr_t)strrchr(s, 'q');
+                break;
+              case 9:
+                memset(d, i, n);
+                g_sink += (unsigned char)d[0];
+                break;
+              case 10:
+                g_sink += strlcpy(d, s, n);
+                break;
+            }
+        }
+
+      reps += 16;
+      el = str_now() - t0;
+    }
+  while (el * 1000.0 < STR_MINMS);
+
+  printf("  %-26s %9.1f MB/s\n", name,
+         (double)reps * n / el / 1048576.0);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arch_libc_test_string
+ ****************************************************************************/
+
+int arch_libc_test_string(void)
+{
+  int i;
+
+  g_src = malloc(STR_BUF);
+  g_dst = malloc(STR_BUF);
+  if (g_src == NULL || g_dst == NULL)
+    {
+      printf("arch_libc string: cannot allocate 2 x %d\n", STR_BUF);
+      free(g_src);
+      free(g_dst);
+      return 1;
+    }
+
+  printf("== string correctness ==\n");
+  str_ck_copy(0);
+  str_ck_copy(1);
+  str_ck_overlap();
+  str_ck_memset();
+  str_ck_memcmp();
+  str_ck_scan();
+  str_ck_cmpcpy();
+  str_ck_strlcpy();
+
+  /* Speed.  Equal content in both buffers, strings terminated at the
+   * probe lengths, and no '~' anywhere, so the absent-probe scans walk
+   * the whole string.
+   */
+
+  for (i = 0; i < STR_BUF; i++)
+    {
+      g_src[i] = 'a' + (i % 23);
+    }
+
+  memcpy(g_dst, g_src, STR_BUF);
+  g_src[STR_GUARD + STR_BIG] = '\0';
+  g_dst[STR_GUARD + STR_BIG] = '\0';
+  g_src[STR_GUARD + STR_STRLEN] = '\0';
+  g_dst[STR_GUARD + STR_STRLEN] = '\0';
+
+  printf("== string speed ==\n");
+
+  /* Readers first: the writers below scribble on the destination
+   * buffer, and the compares depend on the two staying equal.
+   */
+
+  if (memcmp(g_src + STR_GUARD, g_dst + STR_GUARD, STR_BIG) != 0)
+    {
+      printf("  compare buffers differ, speed numbers void\n");
+      g_fails++;
+    }
+
+  str_bench("memcmp big aligned",     2, 0, 0, STR_BIG);
+  str_bench("memcmp big s+1/d+1",     2, 1, 1, STR_BIG);
+  str_bench("strncmp 4K aligned",     4, 0, 0, STR_STRLEN);
+  str_bench("strncmp 4K both+2",      4, 2, 2, STR_STRLEN);
+  str_bench("strlen 4K aligned",      3, 0, 0, STR_STRLEN);
+  str_bench("strlen 4K +3",           3, 3, 0, STR_STRLEN);
+  str_bench("memchr 4K aligned",      5, 0, 0, STR_STRLEN);
+  str_bench("strchr 4K absent",       6, 0, 0, STR_STRLEN);
+  str_bench("strchr 4K absent +5",    6, 5, 0, STR_STRLEN);
+  str_bench("strrchr 4K",             8, 0, 0, STR_STRLEN);
+
+  /* Mismatched-offset compare wants equal content at shifted positions,
+   * and preparing that scribbles, so it comes after every clean reader.
+   */
+
+  memcpy(g_dst + STR_GUARD + 2, g_src + STR_GUARD + 1, STR_BIG + 8);
+  str_bench("memcmp big s+1/d+2",     2, 1, 2, STR_BIG);
+
+  str_bench("memcpy big aligned",     0, 0, 0, STR_BIG);
+  str_bench("memcpy big src+1",       0, 1, 0, STR_BIG);
+  str_bench("memmove-bk big",         1, 0, 0, STR_BIG);
+  str_bench("memset big aligned",     9, 0, 0, STR_BIG);
+  str_bench("strcpy 4K aligned",      7, 0, 0, STR_STRLEN);
+  str_bench("strcpy 4K both+1",       7, 1, 1, STR_STRLEN);
+  str_bench("strlcpy 4K aligned",    10, 0, 0, STR_STRLEN);
+
+  printf("== string fails: %d ==\n", g_fails);
+  free(g_src);
+  free(g_dst);
+  return g_fails != 0;
+}
+
+#endif /* CONFIG_TESTING_ARCH_LIBC_STRING */

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -793,6 +793,183 @@ static void speed_strlcpy(void)
 #endif
 
 /****************************************************************************
+ * Name: test_memccpy
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCCPY
+static int test_memccpy(void)
+{
+  int size;
+  int fail = 0;
+  int ai;
+  int i;
+
+  printf("Testing memccpy...\n");
+
+  for (ai = 0; ai < 64; ai++)
+    {
+      int da = ai / 8;
+      int sa = ai % 8;
+
+      for (size = 1; size <= 64; size++)
+        {
+          FAR char *p;
+          int at = size / 2;
+
+          fill_pattern(g_buf1 + sa, size);
+          g_buf1[sa + at] = '#';
+          memset(g_buf2, 0x5a, sizeof(g_buf2));
+
+          /* The character is present, so the copy stops just past it */
+
+          p = memccpy(g_buf2 + da, g_buf1 + sa, '#', size);
+          if (p != g_buf2 + da + at + 1 ||
+              memcmp(g_buf2 + da, g_buf1 + sa, at + 1) != 0 ||
+              (unsigned char)g_buf2[da + at + 1] != 0x5a)
+            {
+              printf("  FAIL found: sa=%d da=%d size=%d\n", sa, da, size);
+              fail++;
+            }
+
+          /* The character is absent, so the whole length is copied */
+
+          for (i = 0; i < size; i++)
+            {
+              g_buf1[sa + i] = 'A' + (i % 26);
+            }
+
+          memset(g_buf2, 0x5a, sizeof(g_buf2));
+          p = memccpy(g_buf2 + da, g_buf1 + sa, '#', size);
+          if (p != NULL || memcmp(g_buf2 + da, g_buf1 + sa, size) != 0 ||
+              (unsigned char)g_buf2[da + size] != 0x5a)
+            {
+              printf("  FAIL absent: sa=%d da=%d size=%d\n", sa, da, size);
+              fail++;
+            }
+        }
+    }
+
+  printf("memccpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+#ifdef ARCH_LIBC_HAVE_PERF
+static void speed_memccpy(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)memccpy(g_buf2, g_buf1, '#', 128);
+    }
+
+  end = perf_gettime();
+  printf("memccpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+#endif
+
+/****************************************************************************
+ * Name: test_stpncpy
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STPNCPY
+static int test_stpncpy(void)
+{
+  int size;
+  int fail = 0;
+  int ai;
+  int cap;
+  int i;
+
+  printf("Testing stpncpy...\n");
+
+  for (ai = 0; ai < 64; ai++)
+    {
+      int da = ai / 8;
+      int sa = ai % 8;
+
+      for (size = 1; size <= 48; size++)
+        {
+          fill_pattern(g_buf1 + sa, size);
+          g_buf1[sa + size] = '\0';
+
+          for (cap = 0; cap <= size + 4; cap++)
+            {
+              FAR char *p;
+              FAR char *want;
+
+              memset(g_buf2, 0x5a, sizeof(g_buf2));
+              p = stpncpy(g_buf2 + da, g_buf1 + sa, cap);
+
+              /* Up to the terminator is copied, the rest is padded, and
+               * the result points at the terminator or one past the end.
+               */
+
+              want = size < cap ? g_buf2 + da + size : g_buf2 + da + cap;
+              if (p != want)
+                {
+                  printf("  FAIL ret: sa=%d da=%d size=%d cap=%d\n",
+                         sa, da, size, cap);
+                  fail++;
+                  continue;
+                }
+
+              for (i = 0; i < cap; i++)
+                {
+                  char expect = i < size ? g_buf1[sa + i] : '\0';
+
+                  if (g_buf2[da + i] != expect)
+                    {
+                      printf("  FAIL content: sa=%d da=%d size=%d cap=%d\n",
+                             sa, da, size, cap);
+                      fail++;
+                      break;
+                    }
+                }
+
+              if ((unsigned char)g_buf2[da + cap] != 0x5a)
+                {
+                  printf("  FAIL overrun: sa=%d da=%d size=%d cap=%d\n",
+                         sa, da, size, cap);
+                  fail++;
+                }
+            }
+        }
+    }
+
+  printf("stpncpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+#ifdef ARCH_LIBC_HAVE_PERF
+static void speed_stpncpy(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)stpncpy(g_buf2, g_buf1, 128);
+    }
+
+  end = perf_gettime();
+  printf("stpncpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+#endif
+
+/****************************************************************************
  * Name: test_strchr
  ****************************************************************************/
 
@@ -1544,6 +1721,18 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
   fail += test_strcpy();
   speed_strcpy();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCCPY
+  fail += test_memccpy();
+#  ifdef ARCH_LIBC_HAVE_PERF
+  speed_memccpy();
+#  endif
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STPNCPY
+  fail += test_stpncpy();
+#  ifdef ARCH_LIBC_HAVE_PERF
+  speed_stpncpy();
+#  endif
 #endif
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRLCPY
   fail += test_strlcpy();

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -45,6 +45,14 @@
 #define MAX_ALIGN      16
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_BENCH
+int arch_libc_bench(void);
+#endif
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -1457,6 +1465,9 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCHRNUL
   fail += test_strchrnul();
   speed_strchrnul();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_BENCH
+  fail += arch_libc_bench();
 #endif
 
   printf("arch_libc_test %s\n", fail ? "Failed" : "Passed");

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -233,6 +233,14 @@ int arch_libc_strcpy_speed(void)
 #endif
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRING
+int arch_libc_test_string(void);
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -242,11 +250,17 @@ int arch_libc_strcpy_speed(void)
 
 int main(int argc, FAR char *argv[])
 {
+  int ret = 0;
+
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
   arch_libc_test_strcpy();
   arch_libc_strcpy_speed();
 #endif
 
-  return 0;
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRING
+  ret = arch_libc_test_string();
+#endif
+
+  return ret;
 }
 

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -682,6 +682,117 @@ static void speed_strcpy(void)
 #endif
 
 /****************************************************************************
+ * Name: test_strlcpy
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRLCPY
+static int test_strlcpy(void)
+{
+  int size;
+  int fail = 0;
+  int ai;
+  size_t cap;
+  size_t ret;
+  size_t want;
+
+  printf("Testing strlcpy...\n");
+
+  /* sa != da is the case that matters.  An implementation that walks only
+   * one of the two pointers to a boundary and then copies a register at a
+   * time still passes every sa == da case.
+   */
+
+  for (ai = 0; ai < 64; ai++)
+    {
+      int da = ai / 8;
+      int sa = ai % 8;
+
+      for (size = 1; size <= 64; size++)
+        {
+          fill_pattern(g_buf1 + sa, size);
+          g_buf1[sa + size] = '\0';
+
+          for (cap = 0; cap <= (size_t)size + 1; cap++)
+            {
+              memset(g_buf2, 0x5a, sizeof(g_buf2));
+              ret = strlcpy(g_buf2 + da, g_buf1 + sa, cap);
+
+              if (ret != (size_t)size)
+                {
+                  printf("  FAIL ret: sa=%d da=%d size=%d cap=%zu got=%zu\n",
+                         sa, da, size, cap, ret);
+                  fail++;
+                  continue;
+                }
+
+              if (cap == 0)
+                {
+                  /* Nothing may be written when there is no room */
+
+                  if ((unsigned char)g_buf2[da] != 0x5a)
+                    {
+                      printf("  FAIL cap0 wrote: sa=%d da=%d\n", sa, da);
+                      fail++;
+                    }
+
+                  continue;
+                }
+
+              want = (size_t)size < cap - 1 ? (size_t)size : cap - 1;
+
+              if (strlen(g_buf2 + da) != want ||
+                  memcmp(g_buf2 + da, g_buf1 + sa, want) != 0)
+                {
+                  printf("  FAIL content: sa=%d da=%d size=%d cap=%zu\n",
+                         sa, da, size, cap);
+                  fail++;
+                }
+              else if ((unsigned char)g_buf2[da + want + 1] != 0x5a)
+                {
+                  printf("  FAIL overrun: sa=%d da=%d size=%d cap=%zu\n",
+                         sa, da, size, cap);
+                  fail++;
+                }
+            }
+        }
+    }
+
+  printf("strlcpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+/* perf_gettime() reaches an application only where the C library builds its
+ * own copy, or where the application and the kernel are one image.
+ */
+
+#if defined(CONFIG_ARCH_HAVE_PERF_EVENTS_USER_ACCESS) || \
+    defined(CONFIG_BUILD_FLAT)
+#  define ARCH_LIBC_HAVE_PERF 1
+#endif
+
+#ifdef ARCH_LIBC_HAVE_PERF
+static void speed_strlcpy(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = strlcpy(g_buf2, g_buf1, sizeof(g_buf2));
+    }
+
+  end = perf_gettime();
+  printf("strlcpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+#endif
+
+/****************************************************************************
  * Name: test_strchr
  ****************************************************************************/
 
@@ -1433,6 +1544,12 @@ int main(int argc, FAR char *argv[])
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
   fail += test_strcpy();
   speed_strcpy();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRLCPY
+  fail += test_strlcpy();
+#  ifdef ARCH_LIBC_HAVE_PERF
+  speed_strlcpy();
+#  endif
 #endif
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCHR
   fail += test_strchr();


### PR DESCRIPTION
## Summary

Rebased onto #3712 as requested, and reduced to the part #3712 does not already
cover.

The correctness suite is gone. #3712 tests all sixteen functions this PR used to
test, plus `stpcpy`, `strcat` and `strncpy` that it did not, so there is nothing
left for it to add.

What remains is the throughput measurement. #3712 times one call per function at
one size, 128 bytes, with both operands aligned. This sweeps four sizes and four
source/destination alignment pairs across seventeen functions, which is #3712's
sixteen plus `strlcpy`.

It sits behind `TESTING_ARCH_LIBC_BENCH`, default n. Nothing changes when it is
off.

## Why the alignment matrix

A machine implementation usually takes its wide path only when the pointers meet
some alignment condition, so a single aligned measurement reports the best case
and says nothing about the rest of the input space. On rv64:

```
  strcpy    32768 B  s+0/d+0     2938.0 MB/s
  strcpy    32768 B  s+1/d+1     2942.0 MB/s
  strcpy    32768 B  s+1/d+2      626.0 MB/s
```

Two pointers misaligned by the same amount run at the aligned rate. Misaligned by
different amounts they fall to a fifth of it. Neither number is visible from an
aligned measurement alone.

A function with no machine implementation reports the same rate at every
alignment, so the sweep also shows which functions a machine directory actually
covers.

In passing this caught a `strlcpy` regression in 931d5f50d4, where the misaligned
case runs 55x slower than the generic C it replaced. I will open a separate PR
for that.

## What it reports

Each measurement gives MB/s, which compares across machines, and cycles per byte
where `perf_gettime()` is reachable from an application, both from one timed
loop.

## Testing

EIC7700X (rv64, 1.4 GHz), `CONFIG_BUILD_KERNEL`, 248 measurements per run, in two
configurations: the generic C library, and the RISC-V assembly currently on
master. Both pass.

## Note for kernel builds

`perf_gettime()` is not in `syscall.csv`, so an application cannot reach it
unless the C library builds its own copy
(`CONFIG_ARCH_HAVE_PERF_EVENTS_USER_ACCESS`) or the build is flat. This
benchmark guards for that and reports MB/s alone where the counter is out of
reach.
