### PR TITLE
import: Link libnx for graphics applications in a kernel build.

### DIFF
--- a/import/Make.defs
+++ b/import/Make.defs
@@ -68,6 +68,14 @@ LDLIBPATH = $(addprefix -L,$(call CONVERT_PATH,$(TOPDIR)$(DELIM)libs))
 # Link with user libraries
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
+  # Before libc, since the graphics library calls into it.  Without it
+  # every graphics application in a kernel build fails to find the font
+  # and geometry routines.
+
+  ifeq ($(CONFIG_NX),y)
+    LDLIBS += -lnx
+  endif
+
   LDLIBS += -lmm -lc -lproxies
   ifeq ($(CONFIG_HAVE_CXX),y)
     LDLIBS += -lxx


### PR DESCRIPTION
## Summary

  * In a kernel build, every application built on NX or NXFONTS fails to
    link. The nx examples and fbcon alike come out with undefined references
    to the font and geometry routines.
  * The link line for applications in a kernel build is `-lmm -lc -lproxies`.
    libnx is never named, even though the export has been shipping
    `libnx.a` all along, so nothing ever resolves against it.
  * `import/Make.defs` now names it, ahead of `-lc` since libnx calls into
    libc, and only when `CONFIG_NX` is set so that configurations without
    graphics are unaffected.
  * This is the build-system half of getting a graphics application running
    in a kernel build. fbcon needs one further, unrelated fix, which is a
    separate PR against this repo; I will link it here once it is open.
  * No related issue filed.

## Impact

  * Is new feature added? Is existing feature changed? **NO.** Build fix.
  * Impact on user? **YES, positive.** NX and NXFONTS applications become
    linkable in kernel builds. Nothing to adapt to.
  * Impact on build? **YES**, that is the change: one more library on the
    application link line, and only when `CONFIG_NX=y`. Configurations
    without graphics see a byte-identical link line.
  * Impact on hardware? **NO.**
  * Impact on documentation? **NO.**
  * Impact on security? **NO.**
  * Impact on compatibility? **NO.** Additive; no existing link succeeds
    differently.
  * Build-mode dependence? **YES, `CONFIG_BUILD_KERNEL` only.** The block
    edited is already inside `ifeq ($(CONFIG_BUILD_KERNEL),y)`. Flat and
    protected builds do not use this link line and are untouched.

## Testing

  I confirm that changes are verified on local setup and works as intended:

  * Build Host: macOS 26.5.1, arm64 (Apple Silicon), xPack riscv-none-elf-gcc
    15.2.0
  * Target: RISC-V, ESWIN EIC7700X EVB (downstream board port, not yet
    upstream), kernel build, `CONFIG_NX=y`, `CONFIG_NXFONTS=y`

  Testing logs before change, linking `examples/fbcon`:

  ```
  /Users/fish/github/apps/examples/fbcon/fbcon_main.c:1142:(.text.fbcon_getglyph+0x20): undefined reference to `nxf_getbitmap'
  /Users/fish/github/apps/examples/fbcon/fbcon_main.c:1062:(.text.fbcon_getglyph+0x164): undefined reference to `nxf_convert_32bpp'
  /Users/fish/github/apps/examples/fbcon/fbcon_main.c:1536:(.text.fbcon_fillchar+0x46): undefined reference to `nxgl_rectintersect'
  riscv-none-elf-ld: /Users/fish/github/apps/examples/fbcon/fbcon_main.c:1547:(.text.fbcon_fillchar+0x50): undefined reference to `nxgl_nullrect'
  ```

  Every one of those symbols lives in `libnx.a`, which the export had already
  installed.

  Testing logs after change: the `nxf_*` and `nxgl_*` references resolve, the
  application links, and it runs on the target:

  ```
  [CPU0] display: /dev/fb0 1080p60
  ##### CMD 1: fbcon &
  fbcon [0:100]
  ##### END 1 (ok, 1.57s)
  ```

  Worth being precise about what this change does and does not fix: with only
  this patch applied, fbcon's link gets past libnx and then fails on
  `g_builtin_count` and `g_builtins` instead. That is a separate defect in
  fbcon itself, fixed by the companion PR mentioned above. The run shown here
  has both applied. Any other NX application, which does not consult the
  builtin registry, links and runs with this patch alone.

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.

---

*Claude (claude-opus-5) assisted with diagnosing this and with authoring the
code comment and this PR description. The commit carries an `Assisted-by:` tag
per [CONTRIBUTING.md](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) §1.5.*
