### PR TITLE
examples/fbcon: Do not require a builtin registry to spawn the shell.

### DIFF
--- a/examples/fbcon/fbcon_main.c
+++ b/examples/fbcon/fbcon_main.c
@@ -2379,7 +2379,9 @@ int main(int argc, FAR char *argv[])
   pid_t                       pid;
   posix_spawn_file_actions_t  actions;
   posix_spawnattr_t           attr;
+#ifdef CONFIG_BUILTIN
   FAR const struct builtin_s *builtin;
+#endif
   int                         exitcode = FBCON_EXIT_SUCCESS;
   FAR const char             *fbdev   = CONFIG_EXAMPLES_FBCON_DEF_FB;
 
@@ -2583,6 +2585,7 @@ int main(int argc, FAR char *argv[])
 
 #endif /* CONFIG_EXAMPLES_FBCON_PIPE_STDIN */
 
+#ifdef CONFIG_BUILTIN
   index = builtin_isavail(SPAWN_TASK);
   if (index < 0)
     {
@@ -2600,6 +2603,7 @@ int main(int argc, FAR char *argv[])
       exitcode = FBCON_EXIT_APP_INDEX_UNAVAILABLE;
       goto errout;
     }
+#endif
 
   /* Set up for app/task spawn */
 
@@ -2612,8 +2616,19 @@ int main(int argc, FAR char *argv[])
       goto errout;
     }
 
+#ifdef CONFIG_BUILTIN
   attr.stacksize = builtin->stacksize;
   attr.priority  = builtin->priority;
+#else
+  /* No registry of built-in applications to ask: a kernel build spawns
+   * programs from the filesystem, and posix_spawn() below finds this one
+   * on PATH.  Its stack and priority come from this example's own
+   * configuration instead.
+   */
+
+  attr.stacksize = CONFIG_EXAMPLES_FBCON_STACKSIZE;
+  attr.priority  = CONFIG_EXAMPLES_FBCON_PRIORITY;
+#endif
 
   /* Spawn required application                                             */
 


### PR DESCRIPTION
## Summary

  * `examples/fbcon` does not build in a kernel build. It asks the registry
    of built-in applications for the stack size and priority to spawn its
    shell with, and a kernel build has no such registry, so the reference
    does not resolve.
  * A kernel build's programs are ELF files in a filesystem, which is
    exactly what the `posix_spawn()` below already handles, PATH search and
    all. There is nothing for the registry to tell it.
  * fbcon now consults the registry only where there is one, and takes the
    stack size and priority from this example's own configuration otherwise.
  * Companion to apache/nuttx-apps#3707, which puts libnx on the kernel-build
    link line. Both are needed for fbcon specifically; this one is fbcon's
    own defect, that one affects every NX application. Neither depends on the
    other to be correct, but fbcon needs both to link.
  * No related issue filed.

## Impact

  * Is new feature added? Is existing feature changed? **NO.** Build fix.
  * Impact on user? **YES, positive**, and confined to this example. Where a
    builtin registry exists the behaviour is byte-for-byte what it was; the
    new path is reached only where the registry does not exist, which is
    where fbcon previously did not compile.
  * Impact on build? **NO** beyond fbcon compiling where it did not.
  * Impact on hardware? **NO.**
  * Impact on documentation? **NO.**
  * Impact on security? **NO.**
  * Impact on compatibility? **NO.**
  * Build-mode dependence? **YES, `CONFIG_BUILD_KERNEL` only**, in the sense
    that the guarded path is reached only where `CONFIG_BUILTIN` is unset,
    which is the kernel-build case. Flat and protected builds keep the
    registry lookup unchanged.

## Testing

  I confirm that changes are verified on local setup and works as intended:

  * Build Host: macOS 26.5.1, arm64 (Apple Silicon), xPack riscv-none-elf-gcc
    15.2.0
  * Target: RISC-V, ESWIN EIC7700X EVB (downstream board port, not yet
    upstream), kernel build, HDMI framebuffer at 1080p60

  Testing logs before change, linking `examples/fbcon` with
  apache/nuttx-apps#3707 already applied so that libnx is no longer the
  obstacle:

  ```
  /Users/fish/github/nuttx/libs/libc/builtin/lib_builtin_forindex.c:56:(.text.builtin_for_index+0x0): undefined reference to `g_builtin_count'
  riscv-none-elf-ld: /Users/fish/github/nuttx/libs/libc/builtin/lib_builtin_forindex.c:58:(.text.builtin_for_index+0x12): undefined reference to `g_builtins'
  make[3]: *** [/Users/fish/github/apps/bin/fbcon] Error 1
  ```

  Testing logs after change: fbcon builds, starts, and renders its console on
  the framebuffer, spawning a shell whose prompt appears on the monitor:

  ```
  [CPU0] display: /dev/fb0 1080p60
  ##### CMD 1: fbcon &
  fbcon [0:100]
  ##### END 1 (ok, 1.57s)
  ```

  With glyph rendering traced, showing it drawing to the framebuffer:

  ```
  ##### CMD 1: fbcon
  [CPU2] fbcon_renderglyph: ch=H [48]
  [CPU2] fbcon_renderglyph: ch=e [65]
  [CPU2] fbcon_renderglyph: ch=l [6c]
  [CPU2] fbcon_renderglyph: ch=o [6f]
  ```

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.

---

*Claude (claude-opus-5) assisted with diagnosing this and with authoring the
code comment and this PR description. The commit carries an `Assisted-by:` tag
per [CONTRIBUTING.md](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) §1.5.*
