### PR TITLE
examples/lvglterm: Let the shell be named something other than nsh.

### DIFF
--- a/examples/lvglterm/Kconfig
+++ b/examples/lvglterm/Kconfig
@@ -75,3 +75,13 @@ config EXAMPLES_LVGLTERM_STACKSIZE
 	default 16384
 
 endif # EXAMPLES_LVGLTERM
+
+config EXAMPLES_LVGLTERM_SHELL
+	string "Shell to run in the terminal"
+	default "nsh"
+	depends on EXAMPLES_LVGLTERM
+	---help---
+		The program the terminal spawns.  A bare name is looked up on
+		PATH; a path is taken as given, which is what a configuration
+		installing NSH under another name needs -- "/system/bin/init",
+		for instance, where NSH is the system's init.

--- a/examples/lvglterm/lvglterm.c
+++ b/examples/lvglterm/lvglterm.c
@@ -93,7 +93,16 @@
 
 /* NSH Task to be started */
 
-#define NSH_TASK "nsh"
+/* The shell to run.  A name is looked up on PATH, a path is taken as
+ * given, which matters where the shell is installed under another name,
+ * as it is when NSH is built as the system's init.
+ */
+
+#ifdef CONFIG_EXAMPLES_LVGLTERM_SHELL
+#  define NSH_TASK CONFIG_EXAMPLES_LVGLTERM_SHELL
+#else
+#  define NSH_TASK "nsh"
+#endif
 
 /****************************************************************************
  * Private Function Prototypes


### PR DESCRIPTION
## Summary

  * `examples/lvglterm` spawned `"nsh"` by a name compiled in. On a system
    that installs NSH under a different name it finds nothing: the terminal
    comes up, takes keystrokes, and has no shell behind it.
  * A kernel build where NSH is the system's init is exactly that case. The
    program is `/system/bin/init` and no `nsh` exists at all.
  * The name is now `CONFIG_EXAMPLES_LVGLTERM_SHELL`, defaulting to `"nsh"`,
    so existing configurations are unchanged. A bare name is looked up on
    PATH as before, and a path is taken as given.
  * No related issue filed.

## Impact

  * Is new feature added? Is existing feature changed? **CHANGED**,
    additively. One new Kconfig string with the previous hardcoded value as
    its default.
  * Impact on user? **NO** unless they want the new behaviour. The default
    reproduces the old string exactly.
  * Impact on build? **NO.**
  * Impact on hardware? **NO.**
  * Impact on documentation? **NO**, beyond the Kconfig help text included.
  * Impact on security? **NO.** The name comes from build-time configuration,
    not from input, and is passed to the same `posix_spawn()` as before.
  * Impact on compatibility? **NO.** Default-identical.
  * Build-mode dependence? **NO.** The defect is reachable in any build where
    NSH is installed under another name; a kernel build with NSH as init is
    simply the common way to arrive there.

## Testing

  I confirm that changes are verified on local setup and works as intended:

  * Build Host: macOS 26.5.1, arm64 (Apple Silicon), xPack riscv-none-elf-gcc
    15.2.0
  * Target: RISC-V, ESWIN EIC7700X EVB (downstream board port, not yet
    upstream), kernel build with NSH as init at `/system/bin/init`, LVGL on
    an HDMI framebuffer with a USB keyboard

  Testing logs before change: the terminal starts and accepts keystrokes, but
  the spawn finds no such program:

  ```
  [CPU2] romfs_open: ERROR: Failed to find directory directory entry for 'nsh': -2
  ```

  After the change, with `CONFIG_EXAMPLES_LVGLTERM_SHELL` set to
  `"/system/bin/init"`, the shell spawns and its prompt appears in the
  terminal widget.

  Being straight about the evidence on that last point: the terminal renders
  into the framebuffer rather than to the serial console, so the result was
  confirmed visually on the monitor and there is no console capture to paste.
  The board it was confirmed on also carried two local fixes to LVGL's NuttX
  driver glue for kernel builds, which are third-party files fetched at build
  time and are not part of this PR. Neither is needed for the change here to
  be correct: it replaces one compiled-in string with a configurable one whose
  default is that same string.

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.

---

*Claude (claude-opus-5) assisted with diagnosing this and with authoring the
code comment and this PR description. The commit carries an `Assisted-by:` tag
per [CONTRIBUTING.md](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) §1.5.*
