### PR TITLE
cmake: Use NUTTX(_DIR/_BIN_DIR) instead of CMAKE(_SOURCE_DIR/BIN_DIR)

### DIFF
--- a/benchmarks/coremark-pro/CMakeLists.txt
+++ b/benchmarks/coremark-pro/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CONFIG_BENCHMARK_COREMARK_PRO)
       coremark_fetch
       URL https://github.com/eembc/coremark-pro/archive/refs/heads/main.zip
           SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/coremark-pro BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/coremark/coremark-pro
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/coremark/coremark-pro
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/benchmarks/coremark/CMakeLists.txt
+++ b/benchmarks/coremark/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CONFIG_BENCHMARK_COREMARK)
       coremark_fetch
       URL https://github.com/eembc/coremark/archive/main.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/coremark BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/coremark/coremark
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/coremark/coremark
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/benchmarks/dhrystone/CMakeLists.txt
+++ b/benchmarks/dhrystone/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_BENCHMARK_DHRYSTONE)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/dhrystone
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/coremark/dhrystone
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/coremark/dhrystone
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-dry2.2-Fix-malloc-type-mismatch.patch &&

--- a/benchmarks/fio/CMakeLists.txt
+++ b/benchmarks/fio/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CONFIG_BENCHMARK_FIO)
       fio_fetch
       URL https://github.com/ldorau/fio/archive/refs/heads/master.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/fio BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/fio/fio
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/fio/fio
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30
       PATCH_COMMAND

--- a/benchmarks/superpi/CMakeLists.txt
+++ b/benchmarks/superpi/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_BENCHMARK_SUPERPI)
     FetchContent_Declare(
       superpi_fetch
       URL ${SUPERPI_URL}/${SUPERPI_ZIP} SOURCE_DIR ${SUPERPI_UNPACK} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/superpi/superpi
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/superpi/superpi
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/benchmarks/tacle-bench/CMakeLists.txt
+++ b/benchmarks/tacle-bench/CMakeLists.txt
@@ -1,24 +1,24 @@
-############################################################################
+# ##############################################################################
 # apps/benchmarks/tacle-bench/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_BENCHMARK_TACLEBENCH)
 
@@ -33,7 +33,7 @@ if(CONFIG_BENCHMARK_TACLEBENCH)
     FetchContent_Declare(
       taclebench_fetch
       URL ${TACLEBENCH_URL}/${TACLEBENCH_ZIP} SOURCE_DIR ${TACLEBENCH_UNPACK}
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/benchmarks/tacle-bench/tacle-bench
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/benchmarks/tacle-bench/tacle-bench
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-tacle-bench-add-makefile-and-all-in-one-main-file.patch

--- a/benchmarks/test-tlb/CMakeLists.txt
+++ b/benchmarks/test-tlb/CMakeLists.txt
@@ -1,24 +1,24 @@
-############################################################################
+# ##############################################################################
 # apps/benchmarks/test-tlb/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 if(CONFIG_BENCHMARK_TESTTLB)
 
   set(SRCS test-tlb/test-tlb.c)
@@ -32,7 +32,7 @@ if(CONFIG_BENCHMARK_TESTTLB)
     FetchContent_Declare(
       testtlb_fetch
       URL ${TESTTLB_URL}/${TESTTLB_ZIP} SOURCE_DIR ${TESTTLB_UNPACK} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/test-tlb/test-tlb
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/test-tlb/test-tlb
       PATCH_COMMAND patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
                     ${CMAKE_CURRENT_LIST_DIR}/0001-test-tlb-port-for-NuttX.patch
       DOWNLOAD_NO_PROGRESS true

--- a/benchmarks/tinymembench/CMakeLists.txt
+++ b/benchmarks/tinymembench/CMakeLists.txt
@@ -1,24 +1,24 @@
-############################################################################
+# ##############################################################################
 # apps/benchmarks/tinymembench/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_BENCHMARK_TINY_MEMBENCH)
 
@@ -31,7 +31,7 @@ if(CONFIG_BENCHMARK_TINY_MEMBENCH)
     FetchContent_Declare(
       tinymb_fetch
       URL ${TINYMB_URL}/${TINYMB_ZIP} SOURCE_DIR ${TINYMB_UNPACK} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/benchmarks/tinymembench/tinymembench
+          ${NUTTX_BINARY_DIR}/apps/benchmarks/tinymembench/tinymembench
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-tinymembench-fix-compiling-error-for-NuttX.patch

--- a/boot/mcuboot/CMakeLists.txt
+++ b/boot/mcuboot/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CONFIG_BOOT_MCUBOOT)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/mcuboot
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/boot/mcuboot/mcuboot
+          ${NUTTX_BINARY_DIR}/apps/boot/mcuboot/mcuboot
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/canutils/lely-canopen/CMakeLists.txt
+++ b/canutils/lely-canopen/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CONFIG_CANUTILS_LELYCANOPEN)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/lely-core
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/canutils/lely-canopen/lely-core
+          ${NUTTX_BINARY_DIR}/apps/canutils/lely-canopen/lely-core
       PATCH_COMMAND
         patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/lely-core <
         ${CMAKE_CURRENT_LIST_DIR}/0001-tools-eliminate-multiple-definitions-of-poll-compile.patch

--- a/canutils/libdronecan/CMakeLists.txt
+++ b/canutils/libdronecan/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CONFIG_CANUTILS_LIBDRONECAN)
       libdronecan_fetch
       URL ${CONFIG_LIBDRONECAN_URL}/${CONFIG_LIBDRONECAN_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/libcanard BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/canutils/libdronecan/libcanard
+          ${NUTTX_BINARY_DIR}/apps/canutils/libdronecan/libcanard
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/canutils/libopencyphal/CMakeLists.txt
+++ b/canutils/libopencyphal/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CONFIG_CANUTILS_LIBOPENCYPHAL)
       libcanard_fetch
       URL ${CONFIG_LIBOPENCYPHAL_URL}/${CONFIG_LIBOPENCYPHAL_VERSION}.zip
           SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/libcanard BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/canutils/libopencyphal/libcanard
+          ${NUTTX_BINARY_DIR}/apps/canutils/libopencyphal/libcanard
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
     FetchContent_GetProperties(libcanard_fetch)
@@ -47,7 +47,7 @@ if(CONFIG_CANUTILS_LIBOPENCYPHAL)
       o1heap_fetch
       URL ${CONFIG_O1HEAP_URL}/${CONFIG_O1HEAP_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/o1heap BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/canutils/libopencyphal/o1heap
+          ${NUTTX_BINARY_DIR}/apps/canutils/libopencyphal/o1heap
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
     FetchContent_GetProperties(o1heap_fetch)

--- a/cmake/nuttx_add_luamod.cmake
+++ b/cmake/nuttx_add_luamod.cmake
@@ -20,7 +20,7 @@
 #
 # ##############################################################################
 
-set(LUAMOD_DIR ${CMAKE_BINARY_DIR}/luamod)
+set(LUAMOD_DIR ${NUTTX_BINARY_DIR}/luamod)
 
 if(NOT EXISTS {LUAMOD_DIR})
   file(MAKE_DIRECTORY ${LUAMOD_DIR})

--- a/cmake/nuttx_add_rust.cmake
+++ b/cmake/nuttx_add_rust.cmake
@@ -202,7 +202,7 @@ function(nuttx_add_rust)
     OUTPUT ${RUST_LIB_PATH}
     COMMAND
       ${CMAKE_COMMAND} -E env
-      NUTTX_INCLUDE_DIR=${PROJECT_SOURCE_DIR}/include:${CMAKE_BINARY_DIR}/include:${CMAKE_BINARY_DIR}/include/arch
+      NUTTX_INCLUDE_DIR=${PROJECT_SOURCE_DIR}/include:${NUTTX_BINARY_DIR}/include:${NUTTX_BINARY_DIR}/include/arch
       RUSTFLAGS=${RUST_PANIC_FLAGS} cargo build ${RUST_PROFILE_FLAG}
       -Zbuild-std=std,panic_abort -Zjson-target-spec --manifest-path
       ${CRATE_PATH}/Cargo.toml --target ${RUST_TARGET} --target-dir

--- a/cmake/nuttx_add_wamrmod.cmake
+++ b/cmake/nuttx_add_wamrmod.cmake
@@ -20,7 +20,7 @@
 #
 # ##############################################################################
 
-set(WAMR_MODULE_DIR ${CMAKE_BINARY_DIR}/wamrmod)
+set(WAMR_MODULE_DIR ${NUTTX_BINARY_DIR}/wamrmod)
 
 if(NOT EXISTS {WAMR_MODULE_DIR})
   file(MAKE_DIRECTORY ${WAMR_MODULE_DIR})

--- a/cmake/nuttx_wasm_interface.cmake
+++ b/cmake/nuttx_wasm_interface.cmake
@@ -38,13 +38,13 @@ function(wasm_add_application)
 
   if(APP_INSTALL_NAME)
     add_custom_command(
-      OUTPUT ${CMAKE_BINARY_DIR}/wasm/${APP_INSTALL_NAME}
+      OUTPUT ${NUTTX_BINARY_DIR}/wasm/${APP_INSTALL_NAME}
       COMMAND ${CMAKE_COMMAND} -E touch_nocreate
-              ${CMAKE_BINARY_DIR}/wasm/${APP_INSTALL_NAME}
+              ${NUTTX_BINARY_DIR}/wasm/${APP_INSTALL_NAME}
       DEPENDS apps)
     add_custom_target(wasm_gen_${APP_NAME}
-                      DEPENDS ${CMAKE_BINARY_DIR}/wasm/${APP_INSTALL_NAME})
-    add_dynamic_rcraws(RAWS ${CMAKE_BINARY_DIR}/wasm/${APP_INSTALL_NAME}
+                      DEPENDS ${NUTTX_BINARY_DIR}/wasm/${APP_INSTALL_NAME})
+    add_dynamic_rcraws(RAWS ${NUTTX_BINARY_DIR}/wasm/${APP_INSTALL_NAME}
                        DEPENDS wasm_gen_${APP_NAME})
   endif()
 

--- a/crypto/controlse/CMakeLists.txt
+++ b/crypto/controlse/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 if(CONFIG_CRYPTO_CONTROLSE)
 
-  set(MBEDTLS_DIR ${CMAKE_BINARY_DIR}/apps/include/mbedtls)
+  set(MBEDTLS_DIR ${NUTTX_BINARY_DIR}/apps/include/mbedtls)
 
   nuttx_add_application(
     NAME

--- a/crypto/libsodium/CMakeLists.txt
+++ b/crypto/libsodium/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_LIBSODIUM)
       libsodium_fetch
       URL ${LIBSODIUM_URL}/${CONFIG_LIBSODIUM_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/libsodium BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/crypto/libsodium/libsodium
+          ${NUTTX_BINARY_DIR}/apps/crypto/libsodium/libsodium
       PATCH_COMMAND
         patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libsodium <
         ${CMAKE_CURRENT_LIST_DIR}/0001-fix-multiple-definition-bug-in-libsodium-test.patch

--- a/crypto/libtomcrypt/CMakeLists.txt
+++ b/crypto/libtomcrypt/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_CRYPTO_LIBTOMCRYPT)
       libtomcrypt_fetch
       URL ${CONFIG_LIBTOMCRYPT_URL}/v${CONFIG_LIBTOMCRYPT_VERSION}.zip
           SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/libtomcrypt BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/crypto/libtomcrypt/libtomcrypt
+          ${NUTTX_BINARY_DIR}/apps/crypto/libtomcrypt/libtomcrypt
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/digit-bit.patch && patch -p0 -d

--- a/crypto/mbedtls/CMakeLists.txt
+++ b/crypto/mbedtls/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_CRYPTO_MBEDTLS)
       mbedtls_fetch
       URL ${MBEDTLS_URL}/v${CONFIG_MBEDTLS_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/mbedtls BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/crypto/mbedtls/mbedtls
+          ${NUTTX_BINARY_DIR}/apps/crypto/mbedtls/mbedtls
       PATCH_COMMAND
         patch -p1 -d ${MBEDTLS_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-mbedtls-entropy_poll-use-getrandom-to-get-the-system.patch

--- a/crypto/tinycrypt/CMakeLists.txt
+++ b/crypto/tinycrypt/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CONFIG_TINYCRYPT)
     FetchContent_Declare(
       tinycrypt_fetch
       URL ${TINYCRYPT_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/tinycrypt
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/crypto/tinycrypt/tinycrypt
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/crypto/tinycrypt/tinycrypt
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/tinycrypt <
         ${CMAKE_CURRENT_LIST_DIR}/0001-TinyCrypt-test-resolve-compile-error.patch

--- a/crypto/tinydtls/CMakeLists.txt
+++ b/crypto/tinydtls/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_CRYPTO_TINYDTLS)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/tinydtls
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/crypto/tinydtls/tinydtls
+          ${NUTTX_BINARY_DIR}/apps/crypto/tinydtls/tinydtls
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/examples/elf/main/CMakeLists.txt
+++ b/examples/elf/main/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CONFIG_EXAMPLES_ELF)
   set(ELF_BINARY_FILES)
   set(ELF_BINARY_TARGETS)
   foreach(ELFNAME IN LISTS ELFNAME_BASE)
-    list(APPEND ELF_BINARY_FILES ${CMAKE_BINARY_DIR}/bin/${ELFNAME})
+    list(APPEND ELF_BINARY_FILES ${NUTTX_BINARY_DIR}/bin/${ELFNAME})
 
     if(CMAKE_C_ELF_COMPILER)
       list(APPEND ELF_BINARY_TARGETS ${ELFNAME})
@@ -52,11 +52,11 @@ if(CONFIG_EXAMPLES_ELF)
     set(ELF_ROMFS_DEPS ${ELF_BINARY_TARGETS})
 
     if(CONFIG_SYSTEM_NXPKG)
-      set(ELF_INDEX_JSON ${CMAKE_BINARY_DIR}/bin/index.json)
-      set(ELF_BAD_INDEX_JSON ${CMAKE_BINARY_DIR}/bin/bad-index.json)
-      set(ELF_PKGTEST ${CMAKE_BINARY_DIR}/bin/pkgtest.nsh)
-      set(ELF_PKGFAIL ${CMAKE_BINARY_DIR}/bin/pkgfail.nsh)
-      set(ELF_HELLO_BIN ${CMAKE_BINARY_DIR}/bin/hello)
+      set(ELF_INDEX_JSON ${NUTTX_BINARY_DIR}/bin/index.json)
+      set(ELF_BAD_INDEX_JSON ${NUTTX_BINARY_DIR}/bin/bad-index.json)
+      set(ELF_PKGTEST ${NUTTX_BINARY_DIR}/bin/pkgtest.nsh)
+      set(ELF_PKGFAIL ${NUTTX_BINARY_DIR}/bin/pkgfail.nsh)
+      set(ELF_HELLO_BIN ${NUTTX_BINARY_DIR}/bin/hello)
       set(ELF_FIXTURE_HOST_DIR ${CMAKE_CURRENT_BINARY_DIR}/host)
       set(ELF_FIXTURE_HOST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/host/CMakeLists.txt)
       set(ELF_FIXTURE_TOOL
@@ -99,7 +99,7 @@ if(CONFIG_EXAMPLES_ELF)
 
     add_custom_command(
       OUTPUT ${ELF_ROMFS_IMG}
-      COMMAND genromfs -f ${ELF_ROMFS_IMG} -d ${CMAKE_BINARY_DIR}/bin
+      COMMAND genromfs -f ${ELF_ROMFS_IMG} -d ${NUTTX_BINARY_DIR}/bin
       DEPENDS ${ELF_ROMFS_DEPS}
       VERBATIM)
 

--- a/examples/nettest/CMakeLists.txt
+++ b/examples/nettest/CMakeLists.txt
@@ -49,7 +49,7 @@ if(CONFIG_EXAMPLES_NETTEST)
     SRCS
     nettest_target1.c
     INCLUDE_DIRECTORIES
-    ${CMAKE_BINARY_DIR}/include/nuttx
+    ${NUTTX_BINARY_DIR}/include/nuttx
     STACKSIZE
     ${CONFIG_EXAMPLES_NETTEST_STACKSIZE1}
     PRIORITY
@@ -73,7 +73,7 @@ if(CONFIG_EXAMPLES_NETTEST)
       SRCS
       nettest_target2.c
       INCLUDE_DIRECTORIES
-      ${CMAKE_BINARY_DIR}/include/nuttx
+      ${NUTTX_BINARY_DIR}/include/nuttx
       STACKSIZE
       ${CONFIG_EXAMPLES_NETTEST_STACKSIZE2}
       PRIORITY
@@ -81,7 +81,7 @@ if(CONFIG_EXAMPLES_NETTEST)
 
   endif()
 
-  target_include_directories(apps PRIVATE ${CMAKE_BINARY_DIR}/include/nuttx)
+  target_include_directories(apps PRIVATE ${NUTTX_BINARY_DIR}/include/nuttx)
   target_sources(apps PRIVATE ${SRCS})
 
   # Host
@@ -91,10 +91,10 @@ if(CONFIG_EXAMPLES_NETTEST)
     ExternalProject_Add(
       nettest
       SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/host
-      INSTALL_DIR ${CMAKE_BINARY_DIR}/apps/examples/nettest/host
+      INSTALL_DIR ${NUTTX_BINARY_DIR}/apps/examples/nettest/host
       CMAKE_ARGS
-        -DNUTTX_DIR=${NUTTX_DIR} -DNUTTX_BINARY_DIR=${CMAKE_BINARY_DIR}
-        -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/apps/examples/nettest/host
+        -DNUTTX_DIR=${NUTTX_DIR} -DNUTTX_BINARY_DIR=${NUTTX_BINARY_DIR}
+        -DCMAKE_INSTALL_PREFIX=${NUTTX_BINARY_DIR}/apps/examples/nettest/host
       USES_TERMINAL_CONFIGURE true
       USES_TERMINAL_BUILD true
       USES_TERMINAL_INSTALL true)

--- a/examples/sotest/main/CMakeLists.txt
+++ b/examples/sotest/main/CMakeLists.txt
@@ -24,8 +24,8 @@ if(CONFIG_EXAMPLES_SOTEST)
   set(SOTEST_SYMTAB ${CMAKE_CURRENT_BINARY_DIR}/sotest_symtab.c)
   set(SOTEST_ROMFS_IMG ${CMAKE_CURRENT_BINARY_DIR}/sotest_romfs.img)
   set(SOTEST_ROMFS_SRC ${CMAKE_CURRENT_BINARY_DIR}/sotest_romfs.c)
-  set(SOTEST_MODPRINT_ELF ${CMAKE_BINARY_DIR}/bin/modprint)
-  set(SOTEST_SHARED_ELF ${CMAKE_BINARY_DIR}/bin/sotest)
+  set(SOTEST_MODPRINT_ELF ${NUTTX_BINARY_DIR}/bin/modprint)
+  set(SOTEST_SHARED_ELF ${NUTTX_BINARY_DIR}/bin/sotest)
 
   # Dynamic applications are wrapped in ELF_* helper targets when the build uses
   # the non-ELF-capable compiler path.
@@ -52,8 +52,8 @@ if(CONFIG_EXAMPLES_SOTEST)
     set(SOTEST_ROMFS_DEPS ${SOTEST_MODPRINT_TARGET} ${SOTEST_SHARED_TARGET})
 
     if(CONFIG_SYSTEM_NXPKG)
-      set(SOTEST_SHARED_INDEX ${CMAKE_BINARY_DIR}/bin/shared-index.json)
-      set(SOTEST_SHARED_SCRIPT ${CMAKE_BINARY_DIR}/bin/pkgsotest.nsh)
+      set(SOTEST_SHARED_INDEX ${NUTTX_BINARY_DIR}/bin/shared-index.json)
+      set(SOTEST_SHARED_SCRIPT ${NUTTX_BINARY_DIR}/bin/pkgsotest.nsh)
       set(SOTEST_FIXTURE_HOST_DIR ${CMAKE_CURRENT_BINARY_DIR}/host)
       set(SOTEST_FIXTURE_HOST_SRC
           ${CMAKE_CURRENT_SOURCE_DIR}/host/CMakeLists.txt)
@@ -93,7 +93,7 @@ if(CONFIG_EXAMPLES_SOTEST)
 
     add_custom_command(
       OUTPUT ${SOTEST_ROMFS_IMG}
-      COMMAND genromfs -f ${SOTEST_ROMFS_IMG} -d ${CMAKE_BINARY_DIR}/bin
+      COMMAND genromfs -f ${SOTEST_ROMFS_IMG} -d ${NUTTX_BINARY_DIR}/bin
       DEPENDS ${SOTEST_ROMFS_DEPS}
       VERBATIM)
 

--- a/examples/tcpblaster/CMakeLists.txt
+++ b/examples/tcpblaster/CMakeLists.txt
@@ -55,7 +55,7 @@ if(CONFIG_EXAMPLES_TCPBLASTER)
     MODULE
     ${CONFIG_EXAMPLES_TCPBLASTER}
     INCLUDE_DIRECTORIES
-    ${CMAKE_BINARY_DIR}/include/nuttx
+    ${NUTTX_BINARY_DIR}/include/nuttx
     SRCS
     tcpblaster_target1.c
     ${CSRCS})
@@ -78,7 +78,7 @@ if(CONFIG_EXAMPLES_TCPBLASTER)
       MODULE
       ${CONFIG_EXAMPLES_TCPBLASTER}
       INCLUDE_DIRECTORIES
-      ${CMAKE_BINARY_DIR}/include/nuttx
+      ${NUTTX_BINARY_DIR}/include/nuttx
       SRCS
       tcpblaster_target2.c
       ${CSRCS})

--- a/examples/tcpblaster/tcpblaster_host.cmake
+++ b/examples/tcpblaster/tcpblaster_host.cmake
@@ -31,7 +31,7 @@ endif()
 
 message(STATUS "NuttX apps examples tcpblaster host")
 
-include_directories(${CMAKE_BINARY_DIR}/include/nuttx)
+include_directories(${NUTTX_BINARY_DIR}/include/nuttx)
 
 add_compile_definitions(TCPBLASTER_HOST=1)
 

--- a/examples/udp/CMakeLists.txt
+++ b/examples/udp/CMakeLists.txt
@@ -48,7 +48,7 @@ if(CONFIG_EXAMPLES_UDP)
     MODULE
     ${CONFIG_EXAMPLES_UDP}
     INCLUDE_DIRECTORIES
-    ${CMAKE_BINARY_DIR}/include/nuttx
+    ${NUTTX_BINARY_DIR}/include/nuttx
     SRCS
     udp_target1.c
     ${CSRCS})
@@ -72,7 +72,7 @@ if(CONFIG_EXAMPLES_UDP)
       MODULE
       ${CONFIG_EXAMPLES_UDP}
       INCLUDE_DIRECTORIES
-      ${CMAKE_BINARY_DIR}/include/nuttx
+      ${NUTTX_BINARY_DIR}/include/nuttx
       SRCS
       udp_target2.c
       ${CSRCS})

--- a/examples/udpblaster/udpblaster_host.cmake
+++ b/examples/udpblaster/udpblaster_host.cmake
@@ -31,7 +31,7 @@ endif()
 
 message(STATUS "NuttX apps examples udpblaster host")
 
-include_directories(${CMAKE_BINARY_DIR}/include/nuttx)
+include_directories(${NUTTX_BINARY_DIR}/include/nuttx)
 
 add_compile_definitions(UDPBLASTER_HOST=1)
 add_library(udpblaster)

--- a/fsutils/inih/CMakeLists.txt
+++ b/fsutils/inih/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CONFIG_FSUTILS_INIH)
     FetchContent_Declare(
       inih_fetch
       URL ${INIH_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/inih-r42 BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/fsutils/inih/inih-r42
+          ${NUTTX_BINARY_DIR}/apps/fsutils/inih/inih-r42
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/graphics/libyuv/CMakeLists.txt
+++ b/graphics/libyuv/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_LIBYUV)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/libyuv
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/graphics/libyuv/libyuv
+          ${NUTTX_BINARY_DIR}/apps/graphics/libyuv/libyuv
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-include-libyuv-fix-strict-prototype-warning.patch

--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CONFIG_GRAPHICS_LVGL)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/lvgl
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/graphics/lvgl/lvgl
+          ${NUTTX_BINARY_DIR}/apps/graphics/lvgl/lvgl
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 120)
 

--- a/inertial/madgwick/CMakeLists.txt
+++ b/inertial/madgwick/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CONFIG_LIB_MADGWICK)
           SOURCE_DIR
           ${MADGWICK_DIR}
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/inertial/madgwick/fusion
+          ${NUTTX_BINARY_DIR}/apps/inertial/madgwick/fusion
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/interpreters/berry/CMakeLists.txt
+++ b/interpreters/berry/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_INTERPRETERS_BERRY)
       berry_fetch
       URL ${BERRY_URL_BASE}/${BERRY_COMMIT_ID}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/berry BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/interpreters/berry/berry
+          ${NUTTX_BINARY_DIR}/apps/interpreters/berry/berry
       PATCH_COMMAND
         patch -l -p1 -d ${CMAKE_CURRENT_LIST_DIR}/berry -i
         ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-Berry-default-port-for-NuttX.patch

--- a/interpreters/jimtcl/CMakeLists.txt
+++ b/interpreters/jimtcl/CMakeLists.txt
@@ -43,7 +43,7 @@ if(CONFIG_INTERPRETERS_JIMTCL)
                   "/^void Jim_SetEnviron/,/^/{s/\$/ *\\//}" jim.c
     CONFIGURE_COMMAND
       ./configure --host=${CMAKE_C_COMPILER_TARGET}
-      "CFLAGS=$<JOIN:$<TARGET_PROPERTY:apps_jimsh,COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:apps_jimsh,COMPILE_DEFINITIONS>, -D> -I$<JOIN:$<TARGET_PROPERTY:apps_jimsh,INCLUDE_DIRECTORIES>, -I> -isystem ${CMAKE_SOURCE_DIR}/include -isystem ${CMAKE_BINARY_DIR}/include"
+      "CFLAGS=$<JOIN:$<TARGET_PROPERTY:apps_jimsh,COMPILE_OPTIONS>, > -D$<JOIN:$<TARGET_PROPERTY:apps_jimsh,COMPILE_DEFINITIONS>, -D> -I$<JOIN:$<TARGET_PROPERTY:apps_jimsh,INCLUDE_DIRECTORIES>, -I> -isystem ${NUTTX_DIR}/include -isystem ${NUTTX_BINARY_DIR}/include"
     BUILD_COMMAND make libjim.a initjimsh.o
     INSTALL_COMMAND ""
     BUILD_IN_SOURCE TRUE

--- a/interpreters/lua/CMakeLists.txt
+++ b/interpreters/lua/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_INTERPRETERS_LUA)
       lua_fetch
       URL ${LUA_URL}/v${CONFIG_INTERPRETERS_LUA_VERSION}.tar.gz SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/lua BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/interpreters/lua/lua
+          ${NUTTX_BINARY_DIR}/apps/interpreters/lua/lua
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/interpreters/quickjs/CMakeLists.txt
+++ b/interpreters/quickjs/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CONFIG_INTERPRETERS_QUICKJS)
       quickjs_fetch
       URL ${QUICKJS_URL_BASE}/6e2e68fd0896957f92eb6c242a2e048c1ef3cae0.zip
           SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/quickjs BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/interpreters/quickjs/quickjs
+          ${NUTTX_BINARY_DIR}/apps/interpreters/quickjs/quickjs
       PATCH_COMMAND
         patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/quickjs <
         ${CMAKE_CURRENT_LIST_DIR}/0001-Disabled-unsupported-feature-on-NuttX.patch

--- a/interpreters/wamr/CMakeLists.txt
+++ b/interpreters/wamr/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CONFIG_INTERPRETERS_WAMR)
       wamr_fetch
       URL ${WAMR_URL_BASE}/${CONFIG_INTERPRETERS_WAMR_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/wamr BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/interpreters/wamr/wamr
+          ${NUTTX_BINARY_DIR}/apps/interpreters/wamr/wamr
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -87,9 +87,9 @@ if(CONFIG_INTERPRETERS_WAMR)
     target_sources(wamr PRIVATE wamr_custom_init.c)
   endif()
 
-  # Add ${CMAKE_BINARY_DIR}/wamrmod to the include directories
+  # Add ${NUTTX_BINARY_DIR}/wamrmod to the include directories
   if(CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY)
-    target_include_directories(wamr PRIVATE ${CMAKE_BINARY_DIR}/wamrmod)
+    target_include_directories(wamr PRIVATE ${NUTTX_BINARY_DIR}/wamrmod)
   endif()
 
 endif()

--- a/math/gemmlowp/CMakeLists.txt
+++ b/math/gemmlowp/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CONFIG_MATH_GEMMLOWP)
     FetchContent_Declare(
       gemmlowp_fetch
       URL ${GEMMLOWP_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/gemmlowp
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/math/gemmlowp/gemmlowp
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/math/gemmlowp/gemmlowp
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/math/kissfft/CMakeLists.txt
+++ b/math/kissfft/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_MATH_KISSFFT)
     FetchContent_Declare(
       kissfft_fetch
       URL ${KISSFFT_URL} SOURCE_DIR ${KISSFFT_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/math/kissfft/kissfft
+          ${NUTTX_BINARY_DIR}/apps/math/kissfft/kissfft
       PATCH_COMMAND patch -d ${KISSFFT_DIR} -p1 <
                     ${CMAKE_CURRENT_LIST_DIR}/kissfft.patch
       DOWNLOAD_NO_PROGRESS true

--- a/math/libtommath/CMakeLists.txt
+++ b/math/libtommath/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_MATH_LIBTOMMATH)
       libtommath_fetch
       URL ${CONFIG_LIBTOMMATH_URL}/v${CONFIG_LIBTOMMATH_VERSION}.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/libtommath BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/math/libtommath/libtommath
+          ${NUTTX_BINARY_DIR}/apps/math/libtommath/libtommath
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/math/ruy/CMakeLists.txt
+++ b/math/ruy/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CONFIG_MATH_RUY)
     FetchContent_Declare(
       ruy_fetch
       URL ${RUY_URL} SOURCE_DIR ${RUY_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/math/ruy/ruy
+          ${NUTTX_BINARY_DIR}/apps/math/ruy/ruy
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/mlearning/cmsis-nn/CMakeLists.txt
+++ b/mlearning/cmsis-nn/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CONFIG_MLEARNING_CMSIS_NN)
     FetchContent_Declare(
       cmsis_nn_fetch
       URL ${CMSIS_NN_URL} SOURCE_DIR ${CMSIS_NN_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/mlearning/cmsis-nn/cmsis-nn
+          ${NUTTX_BINARY_DIR}/apps/mlearning/cmsis-nn/cmsis-nn
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/mlearning/tflite-micro/CMakeLists.txt
+++ b/mlearning/tflite-micro/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CONFIG_TFLITEMICRO)
     FetchContent_Declare(
       tflite_micro_fetch
       URL ${TFLITE_MICRO_URL} SOURCE_DIR ${TFLITE_MICRO_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro
+          ${NUTTX_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro
       PATCH_COMMAND
         patch -d ${TFLITE_MICRO_DIR} -p1 <
         ${CMAKE_CURRENT_LIST_DIR}/tflite-micro.patch && patch -d
@@ -182,7 +182,7 @@ if(CONFIG_TFLITEMICRO)
 
   function(tflite_generate_data in out declare)
     set(tflm_data_out
-        ${CMAKE_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro/${out})
+        ${NUTTX_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro/${out})
     if(NOT EXISTS ${tflm_data_out})
       get_filename_component(TFLM_OUT ${tflm_data_out} DIRECTORY)
       if(NOT EXISTS ${TFLM_OUT})
@@ -244,7 +244,7 @@ if(CONFIG_TFLITEMICRO)
       ${TFLITE_MICRO_DIR}/tensorflow/lite/micro/examples/hello_world/hello_world_test.cc
       INCLUDE_DIRECTORIES
       ${INCDIR}
-      ${CMAKE_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro
+      ${NUTTX_BINARY_DIR}/apps/mlearning/tflite-micro/tflite-micro
       COMPILE_FLAGS
       ${COMMON_FLAGS})
   endif()

--- a/netutils/connectedhomeip/CMakeLists.txt
+++ b/netutils/connectedhomeip/CMakeLists.txt
@@ -78,7 +78,7 @@ if(CONFIG_MATTER)
     SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/connectedhomeip
     BINARY_DIR
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip
     TIMEOUT
     90
     PATCH_LIST
@@ -92,7 +92,7 @@ if(CONFIG_MATTER)
     SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/pigweed
     BINARY_DIR
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip
     TIMEOUT
     90)
 
@@ -104,7 +104,7 @@ if(CONFIG_MATTER)
     SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/nlio
     BINARY_DIR
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip
     TIMEOUT
     30)
 
@@ -116,7 +116,7 @@ if(CONFIG_MATTER)
     SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/nlassert
     BINARY_DIR
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip
     TIMEOUT
     30)
 
@@ -128,7 +128,7 @@ if(CONFIG_MATTER)
     SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/nlunit-test
     BINARY_DIR
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip
     TIMEOUT
     30)
 
@@ -140,7 +140,7 @@ if(CONFIG_MATTER)
     SOURCE_DIR
     ${CMAKE_CURRENT_LIST_DIR}/inipp
     BINARY_DIR
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip
     TIMEOUT
     30)
 
@@ -158,12 +158,12 @@ if(CONFIG_MATTER)
     list(APPEND nuttx_include_dirs ${include_dirs})
   endif()
   list(APPEND nuttx_include_dirs ${NUTTX_DIR}/include
-       ${CMAKE_BINARY_DIR}/include)
+       ${NUTTX_BINARY_DIR}/include)
   list(APPEND nuttx_include_dirs ${NUTTX_APPS_BINDIR}/include/mbedtls)
 
   set(MATTER_INCDIR
       ${nuttx_include_dirs}
-      ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/gen/include
+      ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip/gen/include
       ${NUTTX_APPS_DIR}/include
       ${NUTTX_APPS_DIR}/netutils/jsoncpp/jsoncpp/include
       inipp
@@ -353,15 +353,15 @@ if(CONFIG_MATTER)
     100)
 
   add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a
+    OUTPUT ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a
     COMMAND echo generate libchipnuttx.a)
   add_custom_target(
     libchipnuttx ALL
-    DEPENDS ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a
+    DEPENDS ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a
   )
   add_dependencies(libchipnuttx chip-gn)
 
   nuttx_add_extra_library(
-    ${CMAKE_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a)
+    ${NUTTX_BINARY_DIR}/apps/netutils/connectedhomeip/lib/libchipnuttx.a)
 
 endif()

--- a/netutils/jsoncpp/CMakeLists.txt
+++ b/netutils/jsoncpp/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CONFIG_NETUTILS_JSONCPP)
     FetchContent_Declare(
       jsoncpp_fetch
       URL ${JSONCPP_URL}/${JSONCPP_VERSION}.zip SOURCE_DIR ${JSONCPP_DIR}
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/netutils/jsoncpp
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/netutils/jsoncpp
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/libcoap/CMakeLists.txt
+++ b/netutils/libcoap/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CONFIG_NETUTILS_LIBCOAP)
     FetchContent_Declare(
       libcoap_fetch
       URL ${LIBCOAP_URL}/v${LIBCOAP_VERSION} SOURCE_DIR ${LIBCOAP_DIR}
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/netutils/libcoap
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/netutils/libcoap
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/libwebsockets/CMakeLists.txt
+++ b/netutils/libwebsockets/CMakeLists.txt
@@ -39,7 +39,7 @@ if(CONFIG_NETUTILS_LIBWEBSOCKETS)
       libwebsockets_fetch
       URL ${LIBWEBSOCKETS_URL}/v${LWS_VERSION}.zip SOURCE_DIR
           ${LIBWEBSOCKETS_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/netutils/libwebsockets/libwebsockets
+          ${NUTTX_BINARY_DIR}/apps/netutils/libwebsockets/libwebsockets
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/nng/CMakeLists.txt
+++ b/netutils/nng/CMakeLists.txt
@@ -1,24 +1,24 @@
-############################################################################
+# ##############################################################################
 # apps/netutils/nng/CMakeLists.txt
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# License for the specific language governing permissions and limitations under
+# the License.
 #
-############################################################################
+# ##############################################################################
 
 if(CONFIG_NETUTILS_NNG)
 
@@ -33,7 +33,7 @@ if(CONFIG_NETUTILS_NNG)
     FetchContent_Declare(
       nng_fetch
       URL ${NNG_URL}/v${CONFIG_NETUTILS_NNG_VERSION}.tar.gz SOURCE_DIR
-          ${NNG_DIR} BINARY_DIR ${CMAKE_BINARY_DIR}/apps/netutils/nng/nng
+          ${NNG_DIR} BINARY_DIR ${NUTTX_BINARY_DIR}/apps/netutils/nng/nng
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/paho_mqtt/CMakeLists.txt
+++ b/netutils/paho_mqtt/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CONFIG_LIB_MQTT5)
     FetchContent_Declare(
       paho_mqtt_fetch
       URL ${PAHO_MQTT_URL}/v${PAHO_MQTT_VERSION}.zip SOURCE_DIR ${PAHO_MQTT_DIR}
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/netutils/paho_mqtt/paho_mqtt
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/netutils/paho_mqtt/paho_mqtt
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/rtptools/CMakeLists.txt
+++ b/netutils/rtptools/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_NETUTILS_RTPTOOLS)
       rtptools_fetch
       URL ${RTPTOOLS_URL}/${CONFIG_NETUTILS_RTPTOOLS_VERSION}.tar.gz SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/rtptools BINARY_DIR
-          ${CMAKE_BINARY_DIR}/netutils/rtptools/rtptools
+          ${NUTTX_BINARY_DIR}/netutils/rtptools/rtptools
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/netutils/wakaama/CMakeLists.txt
+++ b/netutils/wakaama/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_NETUTILS_WAKAAMA)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/wakaama
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/netutils/wakaama/wakaama
+          ${NUTTX_BINARY_DIR}/apps/netutils/wakaama/wakaama
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/system/adb/CMakeLists.txt
+++ b/system/adb/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CONFIG_SYSTEM_ADBD)
       microADB
       URL "${ADBD_URL}/${ADBD_VERSION}.zip" SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/microADB BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/system/microADB/microADB
+          ${NUTTX_BINARY_DIR}/apps/system/microADB/microADB
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/system/argtable3/CMakeLists.txt
+++ b/system/argtable3/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CONFIG_SYSTEM_ARGTABLE3)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/argtable3
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/system/argtable3/argtable3
+          ${NUTTX_BINARY_DIR}/apps/system/argtable3/argtable3
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/system/flatbuffers/CMakeLists.txt
+++ b/system/flatbuffers/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_SYSTEM_FLATBUFFERS)
     FetchContent_Declare(
       flatbuffers_fetch
       URL ${FLATBUFFERS_URL} SOURCE_DIR ${FLATBUFFERS_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/math/flatbuffers/flatbuffers
+          ${NUTTX_BINARY_DIR}/apps/math/flatbuffers/flatbuffers
       PATCH_COMMAND patch -d ${FLATBUFFERS_DIR} -p1 <
                     ${CMAKE_CURRENT_LIST_DIR}/flatbuffers.patch
       DOWNLOAD_NO_PROGRESS true

--- a/system/libuv/CMakeLists.txt
+++ b/system/libuv/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CONFIG_LIBUV)
     FetchContent_Declare(
       libuv_fetch
       URL ${LIBUV_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/libuv BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/system/libuv/libuv
+          ${NUTTX_BINARY_DIR}/apps/system/libuv/libuv
       PATCH_COMMAND patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libuv <
                     ${CMAKE_CURRENT_LIST_DIR}/0001-libuv-port-for-nuttx.patch
       DOWNLOAD_NO_PROGRESS true

--- a/system/nxdiag/CMakeLists.txt
+++ b/system/nxdiag/CMakeLists.txt
@@ -73,7 +73,7 @@ if(CONFIG_SYSTEM_NXDIAG)
   add_custom_command(
     OUTPUT ${NXDIAG_SYSINFO}
     COMMAND ${PYTHON3} ${NXDIAG_PY_FLAGS} ${NXDIAG_TOOLSDIR}/host_info_dump.py
-            ${NXDIAG_FLAGS} -b ${CMAKE_BINARY_DIR} > ${NXDIAG_SYSINFO}
+            ${NXDIAG_FLAGS} -b ${NUTTX_BINARY_DIR} > ${NXDIAG_SYSINFO}
     DEPENDS ${NXDIAG_TOOLSDIR}/host_info_dump.py
     COMMENT "Generating nxdiag sysinfo.h"
     VERBATIM)
@@ -95,7 +95,7 @@ if(CONFIG_SYSTEM_NXDIAG)
     nxdiag_sysinfo_gen)
 
   set_property(
-    DIRECTORY ${CMAKE_SOURCE_DIR}
+    DIRECTORY ${NUTTX_DIR}
     APPEND
     PROPERTY ADDITIONAL_CLEAN_FILES ${NXDIAG_SYSINFO})
 

--- a/system/zlib/CMakeLists.txt
+++ b/system/zlib/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_LIB_ZLIB)
     FetchContent_Declare(
       zlib_fetch
       URL ${ZLIB_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/zlib BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/system/zlib/zlib
+          ${NUTTX_BINARY_DIR}/apps/system/zlib/zlib
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/tee/optee_client/CMakeLists.txt
+++ b/tee/optee_client/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_LIBTEEC)
       optee_client_fetch
       URL ${OPTEE_CLIENT_URL}/${OPTEE_CLIENT_VER}.zip SOURCE_DIR
           ${OPTEE_CLIENT_DIR} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/tee/optee_client/optee_client
+          ${NUTTX_BINARY_DIR}/tee/optee_client/optee_client
       PATCH_COMMAND
         patch -p1 -d ${OPTEE_CLIENT_DIR} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-libteec-NuttX.patch && patch -p1 -d

--- a/testing/cmocka/CMakeLists.txt
+++ b/testing/cmocka/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_TESTING_CMOCKA)
       cmocka_fetch
       URL ${CONFIG_CMOCKA_URL}/1.1.5.zip SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/cmocka BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/testing/cmocka/cmocka
+          ${NUTTX_BINARY_DIR}/apps/testing/cmocka/cmocka
       PATCH_COMMAND
         patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/cmocka <
         ${CMAKE_CURRENT_LIST_DIR}/0001-cmocka.c-Reduce-the-call-stack-consumption-of-printf.patch

--- a/testing/drivers/rng/nist-sts/CMakeLists.txt
+++ b/testing/drivers/rng/nist-sts/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CONFIG_TESTING_NIST_STS)
       nist-sts_fetch
       URL ${CONFIG_NIST_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/nist-sts
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/testing/drivers/rng/nist-sts/nist-sts
+          ${NUTTX_BINARY_DIR}/apps/testing/drivers/rng/nist-sts/nist-sts
       PATCH_COMMAND
         patch -p0 -d ${CMAKE_CURRENT_LIST_DIR}/nist-sts <
         ${CMAKE_CURRENT_LIST_DIR}/0001-Solve-the-memory-out-of-bounds-problem-in-sts.patch

--- a/testing/fff/CMakeLists.txt
+++ b/testing/fff/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CONFIG_TESTING_FFF)
     FetchContent_Declare(
       fff_fetch
       URL ${FFF_URL} SOURCE_DIR ${FFF_UNPACK} BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/testing/fff/fff
+          ${NUTTX_BINARY_DIR}/apps/testing/fff/fff
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/testing/ltp/CMakeLists.txt
+++ b/testing/ltp/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CONFIG_TESTING_LTP)
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
       URL "${LTP_DOWNLOAD_URL}${LTPS_VERSION}.zip" SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/ltp BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/testing/ltp/ltp
+          ${NUTTX_BINARY_DIR}/apps/testing/ltp/ltp
       PATCH_COMMAND
         patch -p1 -d ${LTP_UNPACK} <
         ${CMAKE_CURRENT_LIST_DIR}/0001-pthread_rwlock_unlock-follow-linux.patch

--- a/testing/mm/memtester/CMakeLists.txt
+++ b/testing/mm/memtester/CMakeLists.txt
@@ -31,7 +31,7 @@ if(CONFIG_UTILS_MEMTESTER)
     FetchContent_Declare(
       memtester_fetch
       URL ${CONFIG_MEMTESTER_URL} SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/memtester
-          BINARY_DIR ${CMAKE_BINARY_DIR}/apps/testing/memtester/memtester
+          BINARY_DIR ${NUTTX_BINARY_DIR}/apps/testing/memtester/memtester
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/testing/mm/stressapptest/CMakeLists.txt
+++ b/testing/mm/stressapptest/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CONFIG_TESTING_STRESSAPPTEST)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/stressapptest
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/stressapptest
+          ${NUTTX_BINARY_DIR}/stressapptest
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/testing/unity/CMakeLists.txt
+++ b/testing/unity/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CONFIG_TESTING_UNITY)
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
       URL "${CONFIG_TESTING_UNITY_URL}/v${CONFIG_TESTING_UNITY_VERSION}.tar.gz"
           SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/Unity BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/testing/unity/unity
+          ${NUTTX_BINARY_DIR}/apps/testing/unity/unity
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 
@@ -50,7 +50,7 @@ if(CONFIG_TESTING_UNITY)
   # allow use of <testing/unity.h> like for make build
   file(COPY ${CMAKE_CURRENT_LIST_DIR}/Unity/src/unity.h
             ${CMAKE_CURRENT_LIST_DIR}/Unity/src/unity_internals.h
-       DESTINATION ${CMAKE_BINARY_DIR}/include/testing/)
+       DESTINATION ${NUTTX_BINARY_DIR}/include/testing/)
 
   target_sources(unity PRIVATE ${SRCS})
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -25,11 +25,11 @@ if(CONFIG_TOOLS_WASM_BUILD OR CONFIG_INTERPRETERS_WAMR_BUILD_MODULES_FOR_NUTTX)
   include(ExternalProject)
 
   set(TOPDIR
-      ${CMAKE_SOURCE_DIR}
+      ${NUTTX_DIR}
       CACHE INTERNAL "")
 
   set(KCONFIG_FILE_PATH
-      ${CMAKE_BINARY_DIR}/.config
+      ${NUTTX_BINARY_DIR}/.config
       CACHE INTERNAL "")
 
   # Get parent dir of CMAKE_CURRENT_SOURCE_DIR
@@ -47,13 +47,13 @@ if(CONFIG_TOOLS_WASM_BUILD OR CONFIG_INTERPRETERS_WAMR_BUILD_MODULES_FOR_NUTTX)
   add_custom_target(
     configure_wasm_build
     COMMAND
-      ${CMAKE_COMMAND} -B${CMAKE_BINARY_DIR}/Wasm
+      ${CMAKE_COMMAND} -B${NUTTX_BINARY_DIR}/Wasm
       ${CMAKE_CURRENT_SOURCE_DIR}/Wasm -DAPPDIR=${APPDIR} -DTOPDIR=${TOPDIR}
-      -DTOPBINDIR=${CMAKE_BINARY_DIR} -DKCONFIG_FILE_PATH=${KCONFIG_FILE_PATH}
+      -DTOPBINDIR=${NUTTX_BINARY_DIR} -DKCONFIG_FILE_PATH=${KCONFIG_FILE_PATH}
       -DWASI_SDK_PATH=$ENV{WASI_SDK_PATH} -DWASM_DIRS="${WASM_DIRS}")
 
   add_custom_target(wasm_build COMMAND ${CMAKE_COMMAND} --build
-                                       ${CMAKE_BINARY_DIR}/Wasm)
+                                       ${NUTTX_BINARY_DIR}/Wasm)
 
   add_dependencies(wasm_build configure_wasm_build)
 

--- a/wireless/bluetooth/nimble/CMakeLists.txt
+++ b/wireless/bluetooth/nimble/CMakeLists.txt
@@ -32,7 +32,7 @@ if(CONFIG_NIMBLE)
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/mynewt-nimble
           BINARY_DIR
-          ${CMAKE_BINARY_DIR}/apps/wireless/bluetooth/nimble/mynewt-nimble
+          ${NUTTX_BINARY_DIR}/apps/wireless/bluetooth/nimble/mynewt-nimble
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 


### PR DESCRIPTION
## Summary

This companion change updates the nuttx-apps CMake build to use NuttX’s NUTTX_DIR and NUTTX_BINARY_DIR instead of CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR, which incorrectly refer to the outermost project when NuttX is embedded via add_subdirectory(). Since apps/ is itself included from NuttX’s top-level CMakeLists.txt, these variables were effectively being used as references to NuttX’s root and inherited the same bug fixed in the matching NuttX change for #19697. All self-referencing uses are replaced while intentionally preserving standalone projects and unrelated custom variables or hardcoded paths. The change affects only the CMake build system, preserves normal standalone behavior, and was tested with sim:nsh both standalone and embedded, with apps such as hello and ostest successfully built and available in NSH.

## Impact

Fixes https://github.com/apache/nuttx/issues/19697

## Testing

```
alan@dev:~/nuttxspace/parent$ cmake -B build -DBOARD_CONFIG=sim:nsh
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
  Select HOST_LINUX=y
  Select HOST_X86_64=y
Loaded configuration '/home/alan/nuttxspace/parent/build/nuttx_build/.config.compressed'
Minimal configuration saved to '/home/alan/nuttxspace/parent/build/nuttx_build/defconfig.tmp'
--   CMake:  3.28.3
--   Board:  sim
--   Config: nsh
--   Appdir: /home/alan/nuttxspace/apps
-- The C compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Linux
-- CMake host system processor: x86_64
   TOOLS_DIR path is "/home/alan/nuttxspace/nuttx"
   HOST = Linux
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/alan/nuttxspace/parent/build/nuttx_build/bin_host
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (3.3s)
-- Generating done (0.4s)
-- Build files have been written to: /home/alan/nuttxspace/parent/build
alan@dev:~/nuttxspace/parent$ cmake --build build -j$(nproc)
[  0%] Built target nuttx_context
[  0%] Built target always_rebuild_lib_utsname
[  0%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o
[  0%] Built target apps_context
[  0%] Building C object nuttx_build/CMakeFiles/sim_head.dir/arch/sim/src/sim/sim_head.c.o
[  0%] Generating nuttx-names.dat
[  0%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_globals.c.o
[  0%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_register.c.o
[  0%] Building C object nuttx_build/CMakeFiles/sim_head.dir/arch/sim/src/sim/sim_doirq.c.o
[  0%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_unregister.c.o
[  0%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_loadmodule.c.o
[  0%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchlib_setup.c.o
[  1%] Generating etc/init.d/rcS
[  1%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/kasan/hook.c.o
[  1%] Generating etc/init.d/rc.sysinit
[  1%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_initialize.c.o
[  1%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/fs_initialize.c.o
[  1%] Built target sim_redefine_symbols
[  2%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock.c.o
[  2%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/binfs/fs_binfs.c.o
[  2%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/fs_heap.c.o
[  2%] Built target target-romfs
[  2%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_registerdriver.c.o
[  2%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchlib_teardown.c.o
[  2%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/map/mm_map.c.o
[  2%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_initialize.c.o
[  2%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/assert/lib_assert.c.o
[  2%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mempool/mempool.c.o
[  2%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_registerpipedriver.c.o
[  3%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_unregisterdriver.c.o
[  4%] Built target sim_head
[  4%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchlib_read.c.o
[  5%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mempool/mempool_multiple.c.o
[  5%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_unloadmodule.c.o
[  5%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_idle.c.o
[  5%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_doirq.c.o
[  5%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mempool/mempool_procfs.c.o
[  6%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_cpuinfo.c.o
[  6%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_initialstate.c.o
[  6%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/assert/lib_stackchk.c.o
[  7%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/builtin/lib_builtin_getname.c.o
[  7%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_createstack.c.o
[  7%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchlib_write.c.o
[  7%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_unregisterpipedriver.c.o
[  7%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_notifier.c.o
[  7%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_usestack.c.o
[  7%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_execmodule.c.o
[  7%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_getres.c.o
[  7%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_registerblockdriver.c.o
[  7%] Generating romfs_etc.c
[  7%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/builtin/lib_builtin_isavail.c.o
[  7%] Building C object nuttx_build/apps/builtin/CMakeFiles/apps_builtin.dir/builtin_list.c.o
[  7%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_unregisterblockdriver.c.o
[  7%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchlib_cache.c.o
[  8%] Building C object nuttx_build/apps/system/dd/CMakeFiles/apps_dd.dir/dd_main.c.o
[  8%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/dummy.c.o
[  8%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_initialize.c.o
[  8%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/builtin/lib_builtin_forindex.c.o
[  8%] Building C object nuttx_build/apps/builtin/CMakeFiles/apps_builtin.dir/exec_builtin.c.o
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchdev_register.c.o
[  8%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isalnum.c.o
[  8%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/fsutils/mkfatfs/mkfatfs.c.o
[  8%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_releasestack.c.o
[  8%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/fsutils/mkfatfs/configfat.c.o
[  8%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_finddriver.c.o
[  8%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_settime.c.o
[  8%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_findblockdriver.c.o
[  8%] Building C object nuttx_build/boards/exclude_board/src/CMakeFiles/romfs_etc.dir/romfs_etc.c.o
[  8%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_exec.c.o
[  8%] Building C object nuttx_build/apps/system/dumpstack/CMakeFiles/apps_dumpstack.dir/dumpstack.c.o
[  8%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_gettime.c.o
[  8%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isalpha.c.o
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchdev_unregister.c.o
[  8%] Building C object nuttx_build/apps/system/gcov/CMakeFiles/apps_gcov.dir/gcov.c.o
[  8%] Built target romfs_etc
[  8%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_stackframe.c.o
[  8%] Linking C static library libapps_builtin.a
[  8%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_openblockdriver.c.o
[  8%] Linking C static library libapps_dd.a
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/ioexpander/ioe_dummy.c.o
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/bch/bchdev_driver.c.o
[  8%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_lock.c.o
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/ioexpander/gpio.c.o
[  8%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_copyargv.c.o
[  8%] Linking C static library libapps_dumpstack.a
[  8%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_closeblockdriver.c.o
[  8%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isascii.c.o
[  8%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/fsutils/mkfatfs/writefat.c.o
[  8%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_realtime2absticks.c.o
[  8%] Built target apps_builtin
[  8%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_init.c.o
[  8%] Built target apps_dd
[  8%] Linking C static library libapps_gcov.a
[  8%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isblank.c.o
[  8%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_exit.c.o
[  8%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_switchcontext.c.o
[  8%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_ummheap.c.o
[  8%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_blockpartition.c.o
[  8%] Built target apps_dumpstack
[  8%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_uart.c.o
[  8%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_systime_ticks.c.o
[  8%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_copyactions.c.o
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/ioexpander/gpio_lower_half.c.o
[  8%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/loop/losetup.c.o
[  8%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_iscntrl.c.o
[  9%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_dumpmodule.c.o
[  9%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_malloc_size.c.o
[  9%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_findmtddriver.c.o
[  9%] Built target apps_gcov
[  9%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_parse.c.o
[  9%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_systime_timespec.c.o
[  9%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/loop/loop.c.o
[  9%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_copyfullstate.c.o
[  9%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/misc/dev_null.c.o
[  9%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isdigit.c.o
[  9%] Building C object nuttx_build/apps/system/nsh/CMakeFiles/apps_nsh.dir/nsh_main.c.o
[  9%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_sched_ticks.c.o
[  9%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_shrinkchunk.c.o
[  9%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_console.c.o
[  9%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/binfmt_execsymtab.c.o
[ 10%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_registerdump.c.o
[ 10%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_blockmerge.c.o
[ 10%] Building C object nuttx_build/apps/system/nsh/CMakeFiles/apps_sh.dir/sh_main.c.o
[ 10%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isgraph.c.o
[ 10%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_brkaddr.c.o
[ 10%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_calloc.c.o
[ 11%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/misc/dev_zero.c.o
[ 11%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_saveusercontext.c.o
[ 11%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_extend.c.o
[ 11%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_script.c.o
[ 11%] Linking C static library libapps_nsh.a
[ 11%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/clock/clock_perf.c.o
[ 11%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_islower.c.o
[ 11%] Linking C static library libapps_sh.a
[ 11%] Building C object nuttx_build/binfmt/CMakeFiles/binfmt.dir/builtin.c.o
[ 12%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_ispunct.c.o
[ 12%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isprint.c.o
[ 13%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_closemtddriver.c.o
[ 13%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_system.c.o
[ 13%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_command.c.o
[ 13%] Built target apps_nsh
[ 13%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/misc/ramdisk.c.o
[ 13%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/ostest_main.c.o
[ 13%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_free.c.o
[ 13%] Built target apps_sh
[ 13%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_tcbinfo.c.o
[ 13%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_getenvironptr.c.o
[ 13%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isspace.c.o
[ 14%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/getopt.c.o
[ 14%] Building C object nuttx_build/apps/examples/gpio/CMakeFiles/apps_gpio.dir/gpio_main.c.o
[ 15%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_dup.c.o
[ 15%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isupper.c.o
[ 15%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/libc_memmem.c.o
[ 15%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_mallinfo.c.o
[ 15%] Linking C static library libbinfmt.a
[ 15%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_isxdigit.c.o
[ 15%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_sectionheap.c.o
[ 15%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_release.c.o
[ 15%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_findvar.c.o
[ 15%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/driver/fs_blockproxy.c.o
[ 15%] Building C object nuttx_build/apps/examples/hello/CMakeFiles/apps_hello.dir/hello_main.c.o
[ 15%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/misc/mkrd.c.o
[ 15%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/pipes/pipe.c.o
[ 15%] Built target binfmt
[ 15%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_toupper.c.o
[ 15%] Linking C static library libapps_gpio.a
[ 15%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_fscmds.c.o
[ 15%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_tolower.c.o
[ 15%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/restart.c.o
[ 16%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_malloc.c.o
[ 16%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_foreach.c.o
[ 16%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_checkhostfstypes.c.o
[ 16%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/ctype/lib_ctype.c.o
[ 16%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_removevar.c.o
[ 16%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_sigdeliver.c.o
[ 16%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_schedulesigaction.c.o
[ 16%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/fat/fs_fat32.c.o
[ 16%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_clearenv.c.o
[ 16%] Linking C static library libapps_hello.a
[ 16%] Building C object nuttx_build/boards/CMakeFiles/board.dir/__/dummy.c.o
[ 16%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_getenv.c.o
[ 16%] Built target apps_gpio
[ 16%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/pipes/fifo.c.o
[ 16%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_readdirr.c.o
[ 16%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_putenv.c.o
[ 16%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_proccmds.c.o
[ 16%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/sighelper.c.o
[ 16%] Building C object nuttx_build/boards/CMakeFiles/board.dir/boardctl.c.o
[ 16%] Built target apps_hello
[ 16%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/sighand.c.o
[ 16%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_telldir.c.o
[ 16%] Building C object nuttx_build/boards/CMakeFiles/board.dir/sim/sim/sim/src/sim_boot.c.o
[ 16%] Building ASM object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_fork_x86_64.S.o
[ 16%] Building C object nuttx_build/boards/CMakeFiles/board.dir/sim/sim/sim/src/sim_bringup.c.o
[ 17%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_mmcmds.c.o
[ 17%] Building C object nuttx_build/boards/CMakeFiles/board.dir/sim/sim/sim/src/sim_ioexpander.c.o
[ 17%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/pipes/pipe_common.c.o
[ 17%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_memalign.c.o
[ 17%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_backtrace.c.o
[ 17%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_setenv.c.o
[ 17%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_realloc.c.o
[ 17%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_alphasort.c.o
[ 17%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_unsetenv.c.o
[ 17%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/serial/serial.c.o
[ 17%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/fat/fs_fat32dirent.c.o
[ 17%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/signest.c.o
[ 17%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_fork.c.o
[ 17%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/sigprocmask.c.o
[ 17%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_scandir.c.o
[ 17%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_ftw.c.o
[ 17%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_timcmds.c.o
[ 17%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/dev_null.c.o
[ 17%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_foreach.c.o
[ 17%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/setvbuf.c.o
[ 17%] Linking C static library libboard.a
[ 17%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_nftw.c.o
[ 17%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_zalloc.c.o
[ 17%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_heapmember.c.o
[ 17%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_oneshot.c.o
[ 17%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/mm_heap/mm_memdump.c.o
[ 17%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/waitpid.c.o
[ 17%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_envcmds.c.o
[ 17%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/serial/serial_io.c.o
[ 17%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_globals.c.o
[ 17%] Built target board
[ 17%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/serial/serial_dma.c.o
[ 17%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/environ/env_secureexec.c.o
[ 17%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_init.c.o
[ 17%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_rtc.c.o
[ 17%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/cancel.c.o
[ 18%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_blockdevice.c.o
[ 18%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_initialize.c.o
[ 19%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_opendir.c.o
[ 19%] Building C object nuttx_build/arch/CMakeFiles/arch.dir/sim/src/sim/sim_deviceimage.c.o
[ 19%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/fat/fs_fat32attrib.c.o
[ 19%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_prompt.c.o
[ 19%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_syscmds.c.o
[ 19%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_fdopendir.c.o
[ 19%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_post.c.o
[ 20%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_reset.c.o
[ 20%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/fat/fs_fat32util.c.o
[ 20%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_addregion.c.o
[ 20%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_malloc_size.c.o
[ 20%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/hostfs/hostfs.c.o
[ 20%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/syslog/vsyslog.c.o
[ 20%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/syslog/syslog_early.c.o
[ 20%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_brkaddr.c.o
[ 20%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/syslog/syslog_channel.c.o
[ 20%] Linking C static library libarch.a
[ 20%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_destroy.c.o
[ 20%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/cond.c.o
[ 21%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/mutex.c.o
[ 21%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_closedir.c.o
[ 21%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/timedmutex.c.o
[ 21%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_readdir.c.o
[ 21%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_dbgcmds.c.o
[ 21%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_calloc.c.o
[ 21%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/syslog/syslog_write.c.o
[ 21%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_session.c.o
[ 21%] Built target arch
[ 22%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/syslog/syslog_flush.c.o
[ 22%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_wait.c.o
[ 22%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/sem.c.o
[ 22%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/semtimed.c.o
[ 22%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_rewinddir.c.o
[ 22%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/barrier.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_extend.c.o
[ 23%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_files.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_seekdir.c.o
[ 23%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_fsutils.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_free.c.o
[ 23%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_clear.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_malloc.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_mallinfo.c.o
[ 23%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_foreachinode.c.o
[ 23%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/syslog/syslog_initialize.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_dirfd.c.o
[ 23%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/pthread_rwlock.c.o
[ 23%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/timedwait.c.o
[ 23%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/timers/arch_alarm.c.o
[ 23%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/timers/oneshot.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_memalign.c.o
[ 23%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/timers/arch_rtc.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dirent/lib_versionsort.c.o
[ 23%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/timers/rtc.c.o
[ 23%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_getmask.c.o
[ 23%] Building C object nuttx_build/drivers/CMakeFiles/drivers.dir/drivers_initialize.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_realloc.c.o
[ 23%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_fileapps.c.o
[ 23%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_builtin.c.o
[ 23%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inode.c.o
[ 23%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodeaddref.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/dlfcn/lib_dlfind_object.c.o
[ 23%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/pthread_rwlock_cancel.c.o
[ 23%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodebasename.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/errno/lib_errno.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/fixedmath/lib_b16sin.c.o
[ 23%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/event/event_waitirq.c.o
[ 23%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_zalloc.c.o
[ 23%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/schedlock.c.o
[ 23%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_mntcmds.c.o
[ 23%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_create.c.o
[ 23%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/fixedmath/lib_b16cos.c.o
[ 24%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/fixedmath/lib_b16atan2.c.o
[ 24%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/pthread_exit.c.o
[ 24%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_consolemain.c.o
[ 24%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_heapmember.c.o
[ 24%] Building C object nuttx_build/mm/CMakeFiles/mm.dir/umm_heap/umm_memdump.c.o
[ 24%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/fixedmath/lib_ubsqrt.c.o
[ 24%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodefind.c.o
[ 24%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_join.c.o
[ 25%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_printf.c.o
[ 25%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/robust.c.o
[ 25%] Linking C static library libdrivers.a
[ 25%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_leave.c.o
[ 25%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_setupidlefiles.c.o
[ 25%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_setuptaskfiles.c.o
[ 25%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrgid.c.o
[ 25%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_test.c.o
[ 26%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_foreachchild.c.o
[ 26%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodefree.c.o
[ 26%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodegetpath.c.o
[ 26%] Linking C static library libmm.a
[ 26%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrgidr.c.o
[ 26%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/wqueue.c.o
[ 27%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/timedmqueue.c.o
[ 27%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_wait.c.o
[ 27%] Built target drivers
[ 27%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/mqueue.c.o
[ 27%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/nshlib/nsh_alias.c.o
[ 27%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/posixtimer.c.o
[ 27%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrnam.c.o
[ 27%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrnamr.c.o
[ 27%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_signal.c.o
[ 28%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/group/group_killchildren.c.o
[ 28%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_initgroups.c.o
[ 28%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/system/readline/readline.c.o
[ 28%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrouplist.c.o
[ 28%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrbuf.c.o
[ 28%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inoderelease.c.o
[ 28%] Built target mm
[ 28%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/vfork.c.o
[ 28%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/init/nx_bringup.c.o
[ 28%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/init/nx_start.c.o
[ 28%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/setjmp.c.o
[ 28%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/grp/lib_getgrbufr.c.o
[ 28%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/system/readline/readline_fd.c.o
[ 28%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/inttypes/lib_imaxabs.c.o
[ 28%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inoderemove.c.o
[ 28%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/system/readline/readline_stream.c.o
[ 28%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/inttypes/lib_imaxdiv.c.o
[ 28%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/instrument/instrument.c.o
[ 29%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/inttypes/lib_strtoimax.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodereserve.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/irq/irq_initialize.c.o
[ 29%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/nxevent.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/inode/fs_inodesearch.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/irq/irq_attach.c.o
[ 29%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/wdog.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mmap/fs_mmap.c.o
[ 29%] Building C object nuttx_build/apps/testing/ostest/CMakeFiles/apps_ostest.dir/spinlock.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/irq/irq_attach_wqueue.c.o
[ 29%] Building C object nuttx_build/apps/CMakeFiles/apps.dir/system/readline/readline_common.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/irq/irq_attach_thread.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mmap/fs_munmap.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mmap/fs_mmisc.c.o
[ 29%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/inttypes/lib_strtoumax.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mmap/fs_msync.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/irq/irq_dispatch.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/irq/irq_unexpectedisr.c.o
[ 29%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/libgen/lib_basename.c.o
[ 29%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/misc/assert.c.o
[ 29%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mmap/fs_rammap.c.o
[ 29%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/libgen/lib_dirname.c.o
[ 30%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/misc/reboot_notifier.c.o
[ 30%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mmap/fs_anonmap.c.o
[ 30%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/misc/panic_notifier.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mount/fs_mount.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mount/fs_umount2.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mount/fs_foreachmountpoint.c.o
[ 31%] Linking C static library libapps_ostest.a
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_initialize.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mount/fs_procfs_mount.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mount/fs_gettype.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_duplocale.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_freelocale.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_localeconv.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_newlocale.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mqueue/mq_open.c.o
[ 31%] Linking C static library libapps.a
[ 31%] Built target apps_ostest
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_setlocale.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mqueue/mq_close.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/mqueue/mq_unlink.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_waitirq.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_send.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_recover.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfs.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_uselocale.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/partition/fs_partition.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_receive.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_sndinternal.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_rcvinternal.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_msgfree.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_catalog.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_msgqalloc.c.o
[ 31%] Built target apps
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfscpuinfo.c.o
[ 31%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_gettext.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_msgqfree.c.o
[ 31%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfscpuload.c.o
[ 31%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_setattr.c.o
[ 32%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_notify.c.o
[ 32%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_langinfo.c.o
[ 32%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/mq_getattr.c.o
[ 32%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/msgctl.c.o
[ 33%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfscritmon.c.o
[ 33%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/msgget.c.o
[ 33%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsfdt.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsiobinfo.c.o
[ 34%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_iconv.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/msginternal.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsmeminfo.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfstcbinfo.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsproc.c.o
[ 34%] Building ASM object nuttx_build/libs/libc/CMakeFiles/c.dir/machine/sim/arch_setjmp_x86_64.S.o
[ 34%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/locale/lib_maxlocale.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsuptime.c.o
[ 34%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/machine/arch_atomic.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/msgrcv.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/mqueue/msgsnd.c.o
[ 34%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_bitmap.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsutil.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_create.c.o
[ 34%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/procfs/fs_procfsversion.c.o
[ 34%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_circbuf.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_exit.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_join.c.o
[ 34%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_creat.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_getschedparam.c.o
[ 34%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_detach.c.o
[ 35%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_setschedparam.c.o
[ 35%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_mknod.c.o
[ 35%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_umask.c.o
[ 35%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/romfs/fs_romfs.c.o
[ 35%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/romfs/fs_romfsutil.c.o
[ 35%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_cancel.c.o
[ 35%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_sigmask.c.o
[ 35%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_chstat.c.o
[ 36%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_close.c.o
[ 36%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_dup.c.o
[ 36%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_getrandom.c.o
[ 36%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_utsname.c.o
[ 36%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_dup2.c.o
[ 36%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_completejoin.c.o
[ 36%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_xorshift128.c.o
[ 36%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_findjoininfo.c.o
[ 36%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_dup3.c.o
[ 36%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_release.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_tea_encrypt.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_fcntl.c.o
[ 37%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/pthread/pthread_setschedprio.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_tea_decrypt.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_epoll.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_fstat.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_fchstat.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_fstatfs.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_cxx_initialize.c.o
[ 37%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_addreadytorun.c.o
[ 37%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_profil.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_idr.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_impure.c.o
[ 37%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_getfiles.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_ioctl.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_lseek.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_memfd.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_mkdir.c.o
[ 37%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_mutex.c.o
[ 37%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_open.c.o
[ 38%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_poll.c.o
[ 38%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_removereadytorun.c.o
[ 38%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_addblocked.c.o
[ 38%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_pread.c.o
[ 38%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_fchmodat.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_removeblocked.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_pwrite.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_gettcb.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_verifytcb.c.o
[ 39%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_fstatat.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_read.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_setparam.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_rename.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_rmdir.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_setpriority.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_releasetcb.c.o
[ 39%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_getfullpath.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_setscheduler.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_getparam.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_select.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_stat.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_getscheduler.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_yield.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_sendfile.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_rrgetinterval.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_statfs.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_uio.c.o
[ 39%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_unlink.c.o
[ 39%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_openat.c.o
[ 39%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_foreach.c.o
[ 39%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_mkdirat.c.o
[ 41%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_write.c.o
[ 41%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_utimensat.c.o
[ 41%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_mallopt.c.o
[ 41%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_lock.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_lockcount.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_unlock.c.o
[ 42%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_dir.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_getnprocs.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_idletask.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_self.c.o
[ 42%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_fsync.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_getcpu.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_get_stackinfo.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_get_tls.c.o
[ 42%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_syncfs.c.o
[ 42%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_truncate.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_sysinfo.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_get_stateinfo.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_tempbuffer.c.o
[ 42%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_link.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_umul32.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_switchcontext.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_umul32x64.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_umul64.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_sleep.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_uadd32x64.c.o
[ 42%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_uadd64.c.o
[ 42%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_symlink.c.o
[ 42%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_reprioritizertr.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_mergepending.c.o
[ 43%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_readlink.c.o
[ 43%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_usub64x32.c.o
[ 43%] Building C object nuttx_build/fs/CMakeFiles/fs.dir/vfs/fs_pseudofile.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_waitpid.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_waitid.c.o
[ 43%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_usub64.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_wait.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_backtrace.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/sched/sched_processtick.c.o
[ 43%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_dumpbuffer.c.o
[ 43%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_mkfifo.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_destroy.c.o
[ 43%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_wait.c.o
[ 44%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_dumpvbuffer.c.o
[ 44%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_trywait.c.o
[ 44%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_tickwait.c.o
[ 44%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_fnmatch.c.o
[ 44%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_timedwait.c.o
[ 44%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_debug.c.o
[ 44%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_clockwait.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_timeout.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_post.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_recover.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_reset.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc64.c.o
[ 45%] Linking C static library libfs.a
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_waitirq.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc64emac.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/semaphore/sem_rw.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_nanosleep.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc32.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc32h04c11db7.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc32hf4acfb13.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_clockwait.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_sleep.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc16.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_usleep.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc16ccitt.c.o
[ 45%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc16ibm.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_tgkill.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_kill.c.o
[ 45%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_procmask.c.o
[ 46%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_suspend.c.o
[ 46%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_queue.c.o
[ 46%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc16xmodem.c.o
[ 46%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_waitinfo.c.o
[ 46%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc16h8005.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc16h1021.c.o
[ 47%] Built target fs
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_timedwait.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_lowest.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc8.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_notification.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_dispatch.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc8ccitt.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc8h1d.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_pselect.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_pause.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc8h2f.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc8table.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_crc8rohc.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_ppoll.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_glob.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_cleanup.c.o
[ 47%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_initialize.c.o
[ 47%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_backtrace.c.o
[ 48%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_pending.c.o
[ 48%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_ftok.c.o
[ 48%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_releasependingsignal.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_err.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_instrument.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_removependingsignal.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_unmaskpendingsignal.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/misc/lib_envpath.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_addrconfig.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_base64.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_action.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_htons.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_htonl.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_allocpendingsigaction.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_deliver.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_htonq.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_findaction.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_inetaddr.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/signal/sig_releasependingsigaction.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_argvstr.c.o
[ 49%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_inetaton.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_create.c.o
[ 49%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_init.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_setup.c.o
[ 50%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_inetntoa.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_activate.c.o
[ 50%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_inetntop.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_start.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_delete.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_exit.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_exithook.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_getgroup.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_getpid.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_prctl.c.o
[ 50%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_inetpton.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_recover.c.o
[ 50%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_inetnetwork.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_restart.c.o
[ 50%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_spawnparms.c.o
[ 51%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_etherntoa.c.o
[ 51%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/net/lib_etheraton.c.o
[ 51%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_cancelpt.c.o
[ 51%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_init.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_gettid.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_terminate.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_join.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_alloc.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_free.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_copy.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/exit.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_make_room.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_getppid.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_blank.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_reparent.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_grow.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_finish.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_object_size.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_fork.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_spawn.c.o
[ 52%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_execve.c.o
[ 52%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_room.c.o
[ 53%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_vprintf.c.o
[ 53%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_malloc.c.o
[ 53%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/obstack/lib_obstack_printf.c.o
[ 53%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/task/task_posixspawn.c.o
[ 53%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_init.c.o
[ 53%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setschedpolicy.c.o
[ 53%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_initialize.c.o
[ 53%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_destroy.c.o
[ 53%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_create.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_delete.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_getoverrun.c.o
[ 54%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getschedpolicy.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_getitimer.c.o
[ 54%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setinheritsched.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_gettime.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_setitimer.c.o
[ 54%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getinheritsched.c.o
[ 54%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getdetachstate.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_settime.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/timer/timer_release.c.o
[ 54%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setdetachstate.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/tls/task_initinfo.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/tls/task_uninitinfo.c.o
[ 54%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setstackaddr.c.o
[ 54%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/tls/tls_initinfo.c.o
[ 55%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getstackaddr.c.o
[ 55%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setstacksize.c.o
[ 55%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getstacksize.c.o
[ 55%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/tls/tls_dupinfo.c.o
[ 55%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wdog/wd_initialize.c.o
[ 55%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wdog/wd_cancel.c.o
[ 56%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wdog/wd_start.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setstack.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getstack.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setschedparam.c.o
[ 56%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wdog/wd_gettime.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getschedparam.c.o
[ 56%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wqueue/kwork_queue.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setscope.c.o
[ 56%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wqueue/kwork_thread.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_setguardsize.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getguardsize.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_attr_getscope.c.o
[ 56%] Building C object nuttx_build/sched/CMakeFiles/sched.dir/wqueue/kwork_cancel.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierattr_init.c.o
[ 56%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierattr_destroy.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierattr_getpshared.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierattr_setpshared.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierinit.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierdestroy.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_barrierwait.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condattr_init.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condattr_destroy.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condattr_getpshared.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condattr_setclock.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condattr_setpshared.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condattr_getclock.c.o
[ 57%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condbroadcast.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condinit.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condclockwait.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_conddestroy.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condtimedwait.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condsignal.c.o
[ 58%] Linking C static library libsched.a
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_condwait.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_create.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_exit.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_setname_np.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_getname_np.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_equal.c.o
[ 58%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_get_stackaddr_np.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_get_stacksize_np.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_init.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_getpshared.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_destroy.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_setpshared.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_setprotocol.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_getprotocol.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_gettype.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_settype.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_setrobust.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_getprioceiling.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_getrobust.c.o
[ 59%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutexattr_setprioceiling.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_getprioceiling.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_destroy.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_init.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_setprioceiling.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_lock.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_timedlock.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_trylock.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_once.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_atfork.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_yield.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_unlock.c.o
[ 60%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlockattr_destroy.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlockattr_init.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlockattr_getpshared.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlockattr_setpshared.c.o
[ 61%] Built target sched
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlock_wrlock.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlock_rdlock.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_setcancelstate.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_rwlock.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_testcancel.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_getcpuclockid.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_setcanceltype.c.o
[ 61%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_self.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_gettid_np.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_concurrency.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_consistent.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_kill.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pthread/pthread_mutex_inconsistent.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwnam.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwnamr.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwuidr.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwuid.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwent.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwbuf.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getpwbufr.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_getspnam.c.o
[ 62%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/pwd/lib_pwd_globals.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/queue/queue.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/sched_getprioritymax.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/sched_getprioritymin.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/clock_getcpuclockid.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_cancelpt.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_setcancelstate.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_testcancel.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_setcanceltype.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_gettid.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_getpid.c.o
[ 63%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/sched_dumpstack.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/sched_backtrace.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/sched/task_startup.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/search/hash_func.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/search/hcreate.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/search/hcreate_r.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_init.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_setprotocol.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_getprotocol.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_getvalue.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_destroy.c.o
[ 64%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_wait.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_trywait.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_timedwait.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_clockwait.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_addset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_fillset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_delset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/semaphore/sem_post.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_emptyset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_nandset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_andset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_isemptyset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_xorset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_orset.c.o
[ 65%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_killpg.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_altstack.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_hold.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_ismember.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_raise.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_pause.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_psignal.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_relse.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_wait.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_ignore.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_set.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_interrupt.c.o
[ 66%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/signal/sig_signal.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_addaction.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_adddup2.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_addclose.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_addopen.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_destroy.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_init.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getschedparam.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getschedpolicy.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getflags.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_init.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setflags.c.o
[ 67%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setschedparam.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setschedpolicy.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getsigmask.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setsigmask.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getstacksize.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setstacksize.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setpriority.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_destroy.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_setstackaddr.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getpriority.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_getstackaddr.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psfa_dump.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/spawn/lib_psa_dump.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fileno.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_sprintf.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_snprintf.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vsprintf.c.o
[ 68%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_asprintf.c.o
[ 69%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vasprintf.c.o
[ 69%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_printf.c.o
[ 69%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vsnprintf.c.o
[ 69%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_dprintf.c.o
[ 69%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vdprintf.c.o
[ 69%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vprintf.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_getchar.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_perror.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_putchar.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_puts.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_gets.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_gets_s.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libdgets.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_sscanf.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_remove.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_tempnam.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vsscanf.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_tmpnam.c.o
[ 70%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_renameat.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fopen.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_freopen.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_putwchar.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fread.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fclose.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libfread_unlocked.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fseek.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fseeko.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_ftell.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_getdelim.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fsetpos.c.o
[ 71%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_ftello.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fgetpos.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fgetc.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_getc.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fgets.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libfgets.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libfwrite.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fwrite.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fflush.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libfflush.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libflushall.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_rdflush_unlocked.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_wrflush_unlocked.c.o
[ 72%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_putc.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fputc.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fputs.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_ungetc.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fprintf.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vfprintf.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_feof.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_ferror.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_rewind.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_scanf.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fscanf.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vscanf.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_vfscanf.c.o
[ 73%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_clearerr.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_tmpfile.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_setvbuf.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libfilelock.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_setbuf.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_setbuffer.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_libgetstreams.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fputwc.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_putwc.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fputws.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fopencookie.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fmemopen.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_open_memstream.c.o
[ 74%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_fgetwc.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_getwc.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdio/lib_ungetwc.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_abs.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_atoi.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_abort.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_atof.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_getprogname.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_atol.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_div.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_atoll.c.o
[ 75%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_ldiv.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_exit.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_lldiv.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_itoa.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_labs.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_llabs.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_rand.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_reallocarray.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_bsearch.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_realpath.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_rand48.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_qsort.c.o
[ 76%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_strtol.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_strtoll.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_srand.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_strtoul.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_strtoull.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_checkbase.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_mktemp.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_mkstemp.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_mkdtemp.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_aligned_alloc.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_posix_memalign.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_valloc.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_mblen.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_mbtowc.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_wctomb.c.o
[ 77%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_wcstombs.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_mbstowcs.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_arc4random.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_atexit.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stdlib/lib_strtold.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_meminstream.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_memoutstream.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_memsistream.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_memsostream.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_lowoutstream.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_rawinstream.c.o
[ 78%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_rawoutstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_rawsistream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_rawsostream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_zeroinstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_nullinstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_nulloutstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_mtdsostream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_mtdoutstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_libnoflush.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_syslogstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_syslograwstream.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_libsnoflush.c.o
[ 79%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_bufferedoutstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_hexdumpstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_base64outstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_fileinstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_fileoutstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_libbsprintf.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_libvsprintf.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_libvscanf.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_ultoa_invert.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_stdinstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_stdoutstream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_stdsistream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_stdsostream.c.o
[ 80%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/stream/lib_blkoutstream.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_ffs.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_ffsl.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_ffsll.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_fls.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_flsl.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_flsll.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_isbasedigit.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memmem.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_popcountl.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_popcount.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_popcountll.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_skipspace.c.o
[ 81%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcspn.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcasecmp.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strerror.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strdup.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strncasecmp.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strncat.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcasestr.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strndup.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strpbrk.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strspn.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strstr.c.o
[ 82%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strtok.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strtokr.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strsep.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strerrorr.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_explicit_bzero.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_rindex.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_index.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strsignal.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_timingsafe_bcmp.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_rawmemchr.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strverscmp.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_mempcpy.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memmove.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strlcat.c.o
[ 83%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strnlen.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strlcpy.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memcpy.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strxfrm.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcoll.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memccpy.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memcmp.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memrchr.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_stpncpy.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strchr.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcmp.c.o
[ 84%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memset.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strlen.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strncpy.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_stpcpy.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_memchr.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcat.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strchrnul.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strcpy.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strncmp.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/string/lib_strrchr.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/symtab/symtab_findbyname.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/symtab/symtab_findbyvalue.c.o
[ 85%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/symtab/symtab_sortbyname.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_cfspeed.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/syslog/lib_syslog.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/syslog/lib_setlogmask.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_cfmakeraw.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcflush.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_isatty.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcdrain.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcflow.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcgetattr.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcsetattr.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcsendbreak.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_ttynamer.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_ttyname.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcgetsid.c.o
[ 86%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcsetpgrp.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/termios/lib_tcgetpgrp.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_calendar2utc.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_daysbeforemonth.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_strftime.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_isleapyear.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_gettimeofday.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_settimeofday.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_time.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_timespec_get.c.o
[ 87%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_nanosleep.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_difftime.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_asctime.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_dayofweek.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_asctimer.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_ctimer.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_ctime.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_gethrtime.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_gmtime.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_gmtimer.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/tls/task_getinfo.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/time/lib_timegm.c.o
[ 88%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/tls/tls_getinfo.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uio/lib_preadv.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uio/lib_pwritev.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_access.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_swab.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_daemon.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_sysconf.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getcwd.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_pathconf.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getentropy.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getopt_common.c.o
[ 89%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getopt_long.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getoptvars.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getopt.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getopt_longonly.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getoptargp.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getopterrp.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getoptoptp.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_times.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_alarm.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getoptindp.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_fstatvfs.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_statvfs.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_sleep.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_nice.c.o
[ 90%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getrusage.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_utime.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_utimes.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setrlimit.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getrlimit.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setpriority.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getpriority.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_lutimes.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_futimes.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_gethostname.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_sethostname.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_fchownat.c.o
[ 91%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_linkat.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_readlinkat.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_symlinkat.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_usleep.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getpgrp.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_unlinkat.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getpgid.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getsid.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getgroups.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setpgid.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_lockf.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_flock.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getpass.c.o
[ 92%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setsid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_chdir.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_fchdir.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_confstr.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_ulimit.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setuid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setgid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getuid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getgid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setegid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_geteuid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getegid.c.o
[ 93%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_seteuid.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setreuid.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getresuid.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_setregid.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_issetugid.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_restoredir.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_execle.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_getresgid.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_execl.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_truncate.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_posix_fallocate.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_execv.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_fork.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_compare.c.o
[ 94%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_create.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/unistd/lib_pipe.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_create_nil.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_from_string.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_equal.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_hash.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_is_nil.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_to_string.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/uuid/lib_uuid_stream.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcscmp.c.o
[ 95%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcslen.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wmemchr.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wmemcmp.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wmemmove.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wmemcpy.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wmemset.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_btowc.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_mbrtowc.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wctob.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcslcpy.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsxfrm.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcrtomb.c.o
[ 96%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsftime.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstol.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcscoll.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstoull.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstoll.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstold.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstoul.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstof.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstod.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_mbsnrtowcs.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_swprintf.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsnrtombs.c.o
[ 97%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_mbsinit.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_mbsrtowcs.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_mbrlen.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsrtombs.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcscpy.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcscat.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcschr.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsncat.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsncpy.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsncmp.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcslcat.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsrchr.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsspn.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcscspn.c.o
[ 98%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcspbrk.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcsstr.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcstok.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcswcs.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcwidth.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wctype/lib_wctype.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wctype/lib_iswctype.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wchar/lib_wcswidth.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wctype/lib_towlower.c.o
[ 99%] Building C object nuttx_build/libs/libc/CMakeFiles/c.dir/wctype/lib_towupper.c.o
[ 99%] Linking C static library libc.a
[ 99%] Built target c
[ 99%] Generating nuttx.rel
[ 99%] Generating sim linker script nuttx.ld
[ 99%] Built target nuttx-rel
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hostmisc.c.o
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hostirq.c.o
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hostmemory.c.o
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hostsmp.c.o
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_errno.c.o
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hostfs.c.o
[ 99%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hostuart.c.o
[100%] Building C object nuttx_build/CMakeFiles/nuttx.dir/arch/sim/src/sim/posix/sim_hosttime.c.o
[100%] Building C object nuttx_build/CMakeFiles/nuttx.dir/empty.c.o
[100%] Linking C executable nuttx
[100%] Built target nuttx
[100%] Generating System.map
[100%] Built target systemmap
[100%] Built target nuttx_post
[100%] Pac SIM with dynamic libs in nuttx.tgz
'/lib/x86_64-linux-gnu/libz.so.1' -> 'sim-pac/libs/libz.so.1'
'/lib/x86_64-linux-gnu/libc.so.6' -> 'sim-pac/libs/libc.so.6'
'/lib64/ld-linux-x86-64.so.2' -> 'sim-pac/ld-linux-x86-64.so.2'
[100%] Built target nuttx_post_build
[100%] Built target post_build
alan@dev:~/nuttxspace/parent$

I was forgetting another important step:

alan@dev:~/nuttxspace/parent$ cd build/nuttx_build/
alan@dev:~/nuttxspace/parent/build/nuttx_build$ ./nuttx 

NuttShell (NSH) NuttX-13.0.0
nsh> uname -a
NuttX 13.0.0 5041bec5f5 Aug  8 2026 18:09:14 sim sim
nsh> 

```
