### PR TITLE
testing/libc/arch_libc: Extend coverage to all string/memory functions

### DIFF
--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -72,6 +72,10 @@ config TESTING_ARCH_LIBC_STRRCHR
 	bool "test strrchr"
 	default y
 
+config TESTING_ARCH_LIBC_STRCHRNUL
+	bool "test strchrnul"
+	default y
+
 config TESTING_ARCH_LIBC_PROGNAME
 	string "Program name"
 	default "arch_libctest"

--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -6,7 +6,6 @@
 config TESTING_ARCH_LIBC
 	tristate "arch-specific libc function test"
 	default n
-	depends on ARCH_TOOLCHAIN_GNU
 	---help---
 		Enable the arch libc test
 

--- a/testing/libc/arch_libc/Kconfig
+++ b/testing/libc/arch_libc/Kconfig
@@ -12,8 +12,64 @@ config TESTING_ARCH_LIBC
 
 if TESTING_ARCH_LIBC
 
+config TESTING_ARCH_LIBC_MEMCHR
+	bool "test memchr"
+	default y
+
+config TESTING_ARCH_LIBC_MEMCMP
+	bool "test memcmp"
+	default y
+
+config TESTING_ARCH_LIBC_MEMCPY
+	bool "test memcpy"
+	default y
+
+config TESTING_ARCH_LIBC_MEMMOVE
+	bool "test memmove"
+	default y
+
+config TESTING_ARCH_LIBC_MEMSET
+	bool "test memset"
+	default y
+
+config TESTING_ARCH_LIBC_STRCHR
+	bool "test strchr"
+	default y
+
+config TESTING_ARCH_LIBC_STRCMP
+	bool "test strcmp"
+	default y
+
 config TESTING_ARCH_LIBC_STRCPY
 	bool "test strcpy"
+	default y
+
+config TESTING_ARCH_LIBC_STRLEN
+	bool "test strlen"
+	default y
+
+config TESTING_ARCH_LIBC_STRNCMP
+	bool "test strncmp"
+	default y
+
+config TESTING_ARCH_LIBC_STRNLEN
+	bool "test strnlen"
+	default y
+
+config TESTING_ARCH_LIBC_STRNCPY
+	bool "test strncpy"
+	default y
+
+config TESTING_ARCH_LIBC_STPCPY
+	bool "test stpcpy"
+	default y
+
+config TESTING_ARCH_LIBC_STRCAT
+	bool "test strcat"
+	default y
+
+config TESTING_ARCH_LIBC_STRRCHR
+	bool "test strrchr"
 	default y
 
 config TESTING_ARCH_LIBC_PROGNAME

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -618,22 +618,32 @@ static void speed_strcmp(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
 static int test_strcpy(void)
 {
-  int align;
   int size;
   int fail = 0;
+  int ai;
 
   printf("Testing strcpy...\n");
-  for (align = 0; align < 8; align++)
+
+  /* ai encodes da*8+sa: sa==da keeps src/dst in the same 4-byte congruence
+   * (aligned word-copy path), sa!=da forces different congruence and
+   * exercises the shift-merge path; any nonzero da also hits the dst byte
+   * prologue.
+   */
+
+  for (ai = 0; ai < 64; ai++)
     {
+      int da = ai / 8;
+      int sa = ai % 8;
+
       for (size = 1; size <= 64; size++)
         {
-          fill_pattern(g_buf1 + align, size);
-          g_buf1[align + size] = '\0';
+          fill_pattern(g_buf1 + sa, size);
+          g_buf1[sa + size] = '\0';
           memset(g_buf2, 0, sizeof(g_buf2));
-          strcpy(g_buf2 + align, g_buf1 + align);
-          if (strcmp(g_buf2 + align, g_buf1 + align) != 0)
+          strcpy(g_buf2 + da, g_buf1 + sa);
+          if (strcmp(g_buf2 + da, g_buf1 + sa) != 0)
             {
-              printf("  FAIL: align=%d size=%d\n", align, size);
+              printf("  FAIL: sa=%d da=%d size=%d\n", sa, da, size);
               fail++;
             }
         }
@@ -946,26 +956,34 @@ static void speed_strnlen(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRNCPY
 static int test_strncpy(void)
 {
-  int align;
   int size;
   int i;
   int fail = 0;
+  int ai;
 
   printf("Testing strncpy...\n");
-  for (align = 0; align < 8; align++)
+
+  /* ai encodes da*8+sa so src/dst offsets vary independently: sa!=da forces
+   * different congruence and exercises the shift-merge path.
+   */
+
+  for (ai = 0; ai < 64; ai++)
     {
+      int da = ai / 8;
+      int sa = ai % 8;
+
       for (size = 1; size <= 64; size++)
         {
-          fill_pattern(g_buf1 + align, size);
-          g_buf1[align + size] = '\0';
+          fill_pattern(g_buf1 + sa, size);
+          g_buf1[sa + size] = '\0';
 
           /* n > strlen: should copy and zero-fill */
 
           memset(g_buf2, 0xaa, sizeof(g_buf2));
-          strncpy(g_buf2 + align, g_buf1 + align, size + 4);
-          if (strcmp(g_buf2 + align, g_buf1 + align) != 0)
+          strncpy(g_buf2 + da, g_buf1 + sa, size + 4);
+          if (strcmp(g_buf2 + da, g_buf1 + sa) != 0)
             {
-              printf("  FAIL copy: align=%d size=%d\n", align, size);
+              printf("  FAIL copy: sa=%d da=%d size=%d\n", sa, da, size);
               fail++;
             }
 
@@ -973,9 +991,10 @@ static int test_strncpy(void)
 
           for (i = 0; i < 4; i++)
             {
-              if (g_buf2[align + size + i] != '\0')
+              if (g_buf2[da + size + i] != '\0')
                 {
-                  printf("  FAIL zfill: align=%d size=%d\n", align, size);
+                  printf("  FAIL zfill: sa=%d da=%d size=%d\n",
+                         sa, da, size);
                   fail++;
                   break;
                 }
@@ -986,10 +1005,11 @@ static int test_strncpy(void)
           if (size > 1)
             {
               memset(g_buf2, 0xaa, sizeof(g_buf2));
-              strncpy(g_buf2 + align, g_buf1 + align, size - 1);
-              if (memcmp(g_buf2 + align, g_buf1 + align, size - 1) != 0)
+              strncpy(g_buf2 + da, g_buf1 + sa, size - 1);
+              if (memcmp(g_buf2 + da, g_buf1 + sa, size - 1) != 0)
                 {
-                  printf("  FAIL trunc: align=%d size=%d\n", align, size);
+                  printf("  FAIL trunc: sa=%d da=%d size=%d\n",
+                         sa, da, size);
                   fail++;
                 }
             }
@@ -1027,40 +1047,48 @@ static void speed_strncpy(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STPCPY
 static int test_stpcpy(void)
 {
-  int align;
   int size;
   int fail = 0;
+  int ai;
   FAR char *p;
 
   printf("Testing stpcpy...\n");
-  for (align = 0; align < 8; align++)
+
+  /* ai encodes da*8+sa so src/dst offsets vary independently: sa!=da forces
+   * different congruence and exercises the shift-merge path.
+   */
+
+  for (ai = 0; ai < 64; ai++)
     {
+      int da = ai / 8;
+      int sa = ai % 8;
+
       for (size = 1; size <= 64; size++)
         {
-          fill_pattern(g_buf1 + align, size);
-          g_buf1[align + size] = '\0';
+          fill_pattern(g_buf1 + sa, size);
+          g_buf1[sa + size] = '\0';
           memset(g_buf2, 0, sizeof(g_buf2));
-          p = stpcpy(g_buf2 + align, g_buf1 + align);
+          p = stpcpy(g_buf2 + da, g_buf1 + sa);
 
           /* Check content */
 
-          if (strcmp(g_buf2 + align, g_buf1 + align) != 0)
+          if (strcmp(g_buf2 + da, g_buf1 + sa) != 0)
             {
-              printf("  FAIL copy: align=%d size=%d\n", align, size);
+              printf("  FAIL copy: sa=%d da=%d size=%d\n", sa, da, size);
               fail++;
             }
 
           /* Check return value points to NUL */
 
-          if (p != g_buf2 + align + size)
+          if (p != g_buf2 + da + size)
             {
-              printf("  FAIL retval: align=%d size=%d\n", align, size);
+              printf("  FAIL retval: sa=%d da=%d size=%d\n", sa, da, size);
               fail++;
             }
 
           if (*p != '\0')
             {
-              printf("  FAIL nul: align=%d size=%d\n", align, size);
+              printf("  FAIL nul: sa=%d da=%d size=%d\n", sa, da, size);
               fail++;
             }
         }

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -34,12 +34,13 @@
 #include <errno.h>
 #include <nuttx/debug.h>
 #include <assert.h>
+#include <sys/param.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define TEST_BUF_SIZE  256
+#define TEST_BUF_SIZE  512
 #define TEST_REPEAT    100
 #define MAX_ALIGN      16
 
@@ -50,6 +51,18 @@
 static char g_buf1[TEST_BUF_SIZE + MAX_ALIGN];
 static char g_buf2[TEST_BUF_SIZE + MAX_ALIGN];
 static volatile uintptr_t g_sink;
+
+/* Boundary sizes that exercise 8-byte and 16-byte chunk edges and sub-word
+ * tails, so that vectorized (NEON/MVE) and word-at-a-time paths are stressed
+ * at their alignment and size boundaries.  Unused if every test that sweeps
+ * these sizes is disabled.
+ */
+
+static const int unused_data g_boundary_sizes[] =
+{
+  0, 1, 7, 8, 9, 15, 16, 17, 31, 32, 33,
+  63, 64, 65, 127, 128, 129, 255, 256, 257
+};
 
 /****************************************************************************
  * Private Functions
@@ -121,36 +134,77 @@ static void speed_memcpy(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_MEMMOVE
 static int test_memmove(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
 
   printf("Testing memmove...\n");
 
-  /* Test overlapping forward */
+  /* Sweep alignment 0..7 and boundary sizes, across four overlap layouts:
+   *  forward  : dst = src + 8        (dst > src, backward copy internally)
+   *  backward : dst = src - 8        (dst < src, forward copy internally)
+   *  contained: dst = src + size/2   (full overlap region)
+   *  adjacent : dst = src + size     (no overlap, tail-to-tail)
+   */
 
-  for (size = 1; size <= 64; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size + 16);
-      memcpy(g_buf2, g_buf1, size + 16);
-      memmove(g_buf1 + 8, g_buf1, size);
-      if (memcmp(g_buf1 + 8, g_buf2, size) != 0)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL forward: size=%d\n", size);
-          fail++;
-        }
-    }
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
 
-  /* Test overlapping backward */
+          /* Forward overlap: dst = src + 8 */
 
-  for (size = 1; size <= 64; size++)
-    {
-      fill_pattern(g_buf1 + 8, size);
-      memcpy(g_buf2, g_buf1 + 8, size);
-      memmove(g_buf1, g_buf1 + 8, size);
-      if (memcmp(g_buf1, g_buf2, size) != 0)
-        {
-          printf("  FAIL backward: size=%d\n", size);
-          fail++;
+          fill_pattern(g_buf1 + align + 8, size);
+          memcpy(g_buf2 + align + 8, g_buf1 + align + 8, size);
+          memmove(g_buf1 + align + 16, g_buf1 + align + 8, size);
+          if (memcmp(g_buf1 + align + 16, g_buf2 + align + 8, size) != 0)
+            {
+              printf("  FAIL forward: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Backward overlap: dst = src - 8 */
+
+          fill_pattern(g_buf1 + align + 16, size);
+          memcpy(g_buf2 + align + 16, g_buf1 + align + 16, size);
+          memmove(g_buf1 + align + 8, g_buf1 + align + 16, size);
+          if (memcmp(g_buf1 + align + 8, g_buf2 + align + 16, size) != 0)
+            {
+              printf("  FAIL backward: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Contained overlap: dst = src + size/2 */
+
+          fill_pattern(g_buf1 + align + 32, size);
+          memcpy(g_buf2 + align + 32, g_buf1 + align + 32, size);
+          memmove(g_buf1 + align + 32 + size / 2,
+                  g_buf1 + align + 32, size);
+          if (memcmp(g_buf1 + align + 32 + size / 2,
+                     g_buf2 + align + 32, size) != 0)
+            {
+              printf("  FAIL contained: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Adjacent (no overlap): dst = src + size */
+
+          fill_pattern(g_buf1 + align + 64, size);
+          memcpy(g_buf2 + align + 64, g_buf1 + align + 64, size);
+          memmove(g_buf1 + align + 64 + size,
+                  g_buf1 + align + 64, size);
+          if (memcmp(g_buf1 + align + 64 + size,
+                     g_buf2 + align + 64, size) != 0)
+            {
+              printf("  FAIL adjacent: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -238,32 +292,59 @@ static void speed_memset(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_MEMCMP
 static int test_memcmp(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
 
   printf("Testing memcmp...\n");
-  for (size = 1; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      fill_pattern(g_buf2, size);
-      if (memcmp(g_buf1, g_buf2, size) != 0)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL equal: size=%d\n", size);
-          fail++;
-        }
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
 
-      g_buf2[size - 1] = '~';
-      if (memcmp(g_buf1, g_buf2, size) >= 0)
-        {
-          printf("  FAIL less: size=%d\n", size);
-          fail++;
-        }
+          fill_pattern(g_buf1 + align, size);
+          fill_pattern(g_buf2 + align, size);
 
-      g_buf2[size - 1] = 0;
-      if (memcmp(g_buf1, g_buf2, size) <= 0)
-        {
-          printf("  FAIL greater: size=%d\n", size);
-          fail++;
+          /* Equal */
+
+          if (memcmp(g_buf1 + align, g_buf2 + align, size) != 0)
+            {
+              printf("  FAIL equal: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Last byte less */
+
+          g_buf2[align + size - 1] = '~';
+          if (memcmp(g_buf1 + align, g_buf2 + align, size) >= 0)
+            {
+              printf("  FAIL less: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Last byte greater */
+
+          g_buf2[align + size - 1] = 0;
+          if (memcmp(g_buf1 + align, g_buf2 + align, size) <= 0)
+            {
+              printf("  FAIL greater: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* First byte differs */
+
+          g_buf2[align] = g_buf1[align] + 1;
+          if (memcmp(g_buf1 + align, g_buf2 + align, size) >= 0)
+            {
+              printf("  FAIL first: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -298,31 +379,68 @@ static void speed_memcmp(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_MEMCHR
 static int test_memchr(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
   FAR void *p;
 
   printf("Testing memchr...\n");
-  for (size = 1; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-
-      /* Find last char */
-
-      p = memchr(g_buf1, g_buf1[size - 1], size);
-      if (p == NULL)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL found: size=%d\n", size);
-          fail++;
-        }
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
 
-      /* Not found */
+          fill_pattern(g_buf1 + align, size);
 
-      p = memchr(g_buf1, 0xff, size);
-      if (p != NULL)
-        {
-          printf("  FAIL notfound: size=%d\n", size);
-          fail++;
+          /* Find first char (pattern starts with 'A' at align) */
+
+          p = memchr(g_buf1 + align, g_buf1[align], size);
+          if (p != g_buf1 + align)
+            {
+              printf("  FAIL first: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Find a unique marker placed at the last position */
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size - 1] = 0x7e;
+          p = memchr(g_buf1 + align, 0x7e, size);
+          if (p != g_buf1 + align + size - 1)
+            {
+              printf("  FAIL last: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Find a unique marker placed in the middle */
+
+          if (size > 2)
+            {
+              fill_pattern(g_buf1 + align, size);
+              g_buf1[align + size / 2] = 0x7e;
+              p = memchr(g_buf1 + align, 0x7e, size);
+              if (p != g_buf1 + align + size / 2)
+                {
+                  printf("  FAIL mid: align=%d size=%d\n", align, size);
+                  fail++;
+                }
+            }
+
+          /* Not found (full scan) */
+
+          fill_pattern(g_buf1 + align, size);
+          p = memchr(g_buf1 + align, 0xff, size);
+          if (p != NULL)
+            {
+              printf("  FAIL notfound: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -356,18 +474,25 @@ static void speed_memchr(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRLEN
 static int test_strlen(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
 
   printf("Testing strlen...\n");
-  for (size = 0; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      g_buf1[size] = '\0';
-      if ((int)strlen(g_buf1) != size)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL: size=%d got=%d\n", size, (int)strlen(g_buf1));
-          fail++;
+          size = g_boundary_sizes[si];
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          if ((int)strlen(g_buf1 + align) != size)
+            {
+              printf("  FAIL: align=%d size=%d got=%d\n", align, size,
+                     (int)strlen(g_buf1 + align));
+              fail++;
+            }
         }
     }
 
@@ -402,28 +527,54 @@ static void speed_strlen(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCMP
 static int test_strcmp(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
 
   printf("Testing strcmp...\n");
-  for (size = 1; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      g_buf1[size] = '\0';
-      fill_pattern(g_buf2, size);
-      g_buf2[size] = '\0';
-      if (strcmp(g_buf1, g_buf2) != 0)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL equal: size=%d\n", size);
-          fail++;
-        }
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
 
-      g_buf2[size - 1] = '~';
-      g_buf2[size] = '\0';
-      if (strcmp(g_buf1, g_buf2) >= 0)
-        {
-          printf("  FAIL less: size=%d\n", size);
-          fail++;
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          fill_pattern(g_buf2 + align, size);
+          g_buf2[align + size] = '\0';
+
+          /* Equal */
+
+          if (strcmp(g_buf1 + align, g_buf2 + align) != 0)
+            {
+              printf("  FAIL equal: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Last byte less */
+
+          g_buf2[align + size - 1] = '~';
+          if (strcmp(g_buf1 + align, g_buf2 + align) >= 0)
+            {
+              printf("  FAIL less: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* First byte differs */
+
+          fill_pattern(g_buf2 + align, size);
+          g_buf2[align + size] = '\0';
+          g_buf2[align] = g_buf1[align] + 1;
+          if (strcmp(g_buf1 + align, g_buf2 + align) >= 0)
+            {
+              printf("  FAIL first: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -512,41 +663,66 @@ static void speed_strcpy(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCHR
 static int test_strchr(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
   FAR char *p;
 
   printf("Testing strchr...\n");
-  for (size = 1; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      g_buf1[size] = '\0';
-
-      /* Find first char */
-
-      p = strchr(g_buf1, g_buf1[0]);
-      if (p != g_buf1)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL first: size=%d\n", size);
-          fail++;
-        }
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
 
-      /* Find NUL */
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
 
-      p = strchr(g_buf1, '\0');
-      if (p != g_buf1 + size)
-        {
-          printf("  FAIL nul: size=%d\n", size);
-          fail++;
-        }
+          /* Find first char (pattern starts with 'A' at align) */
 
-      /* Not found */
+          p = strchr(g_buf1 + align, g_buf1[align]);
+          if (p != g_buf1 + align)
+            {
+              printf("  FAIL first: align=%d size=%d\n", align, size);
+              fail++;
+            }
 
-      p = strchr(g_buf1, 0x01);
-      if (p != NULL)
-        {
-          printf("  FAIL notfound: size=%d\n", size);
-          fail++;
+          /* Find a unique marker placed at the last position */
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          g_buf1[align + size - 1] = 0x7e;
+          p = strchr(g_buf1 + align, 0x7e);
+          if (p != g_buf1 + align + size - 1)
+            {
+              printf("  FAIL last: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Find NUL terminator */
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          p = strchr(g_buf1 + align, '\0');
+          if (p != g_buf1 + align + size)
+            {
+              printf("  FAIL nul: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Not found (full scan) */
+
+          p = strchr(g_buf1 + align, 0x01);
+          if (p != NULL)
+            {
+              printf("  FAIL notfound: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -581,51 +757,72 @@ static void speed_strchr(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRNCMP
 static int test_strncmp(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
 
   printf("Testing strncmp...\n");
-  for (size = 1; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      g_buf1[size] = '\0';
-      fill_pattern(g_buf2, size);
-      g_buf2[size] = '\0';
-
-      /* Equal within n */
-
-      if (strncmp(g_buf1, g_buf2, size) != 0)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL equal: size=%d\n", size);
-          fail++;
-        }
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
 
-      /* Differ at last position */
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          fill_pattern(g_buf2 + align, size);
+          g_buf2[align + size] = '\0';
 
-      g_buf2[size - 1] = '~';
-      if (strncmp(g_buf1, g_buf2, size) >= 0)
-        {
-          printf("  FAIL less: size=%d\n", size);
-          fail++;
-        }
+          /* Equal within n */
 
-      /* Equal when n is smaller */
+          if (strncmp(g_buf1 + align, g_buf2 + align, size) != 0)
+            {
+              printf("  FAIL equal: align=%d size=%d\n", align, size);
+              fail++;
+            }
 
-      fill_pattern(g_buf2, size);
-      g_buf2[size] = '\0';
-      g_buf2[size - 1] = '~';
-      if (size > 1 && strncmp(g_buf1, g_buf2, size - 1) != 0)
-        {
-          printf("  FAIL partial: size=%d\n", size);
-          fail++;
-        }
+          /* Differ at last position */
 
-      /* Zero count */
+          g_buf2[align + size - 1] = '~';
+          if (strncmp(g_buf1 + align, g_buf2 + align, size) >= 0)
+            {
+              printf("  FAIL less: align=%d size=%d\n", align, size);
+              fail++;
+            }
 
-      if (strncmp(g_buf1, g_buf2, 0) != 0)
-        {
-          printf("  FAIL zero: size=%d\n", size);
-          fail++;
+          /* Equal when n is smaller than the difference */
+
+          fill_pattern(g_buf2 + align, size);
+          g_buf2[align + size] = '\0';
+          g_buf2[align + size - 1] = '~';
+          if (size > 1 &&
+              strncmp(g_buf1 + align, g_buf2 + align, size - 1) != 0)
+            {
+              printf("  FAIL partial: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* n boundary: 0 and 1 (reset buf2 to match buf1 first) */
+
+          fill_pattern(g_buf2 + align, size);
+          g_buf2[align + size] = '\0';
+
+          if (strncmp(g_buf1 + align, g_buf2 + align, 0) != 0)
+            {
+              printf("  FAIL zero: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          if (strncmp(g_buf1 + align, g_buf2 + align, 1) != 0)
+            {
+              printf("  FAIL one: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -662,37 +859,52 @@ static void speed_strncmp(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRNLEN
 static int test_strnlen(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
 
   printf("Testing strnlen...\n");
-  for (size = 0; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      g_buf1[size] = '\0';
-
-      /* maxlen >= actual length */
-
-      if ((int)strnlen(g_buf1, size + 10) != size)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL full: size=%d\n", size);
-          fail++;
-        }
+          size = g_boundary_sizes[si];
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
 
-      /* maxlen < actual length */
+          /* maxlen >= actual length */
 
-      if (size > 0 && (int)strnlen(g_buf1, size - 1) != size - 1)
-        {
-          printf("  FAIL trunc: size=%d\n", size);
-          fail++;
-        }
+          if ((int)strnlen(g_buf1 + align, size + 10) != size)
+            {
+              printf("  FAIL full: align=%d size=%d\n", align, size);
+              fail++;
+            }
 
-      /* maxlen == 0 */
+          /* maxlen == actual length */
 
-      if (strnlen(g_buf1, 0) != 0)
-        {
-          printf("  FAIL zero: size=%d\n", size);
-          fail++;
+          if ((int)strnlen(g_buf1 + align, size) != size)
+            {
+              printf("  FAIL exact: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* maxlen < actual length */
+
+          if (size > 0 &&
+              (int)strnlen(g_buf1 + align, size - 1) != size - 1)
+            {
+              printf("  FAIL trunc: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* maxlen == 0 */
+
+          if (strnlen(g_buf1 + align, 0) != 0)
+            {
+              printf("  FAIL zero: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -955,53 +1167,65 @@ static void speed_strcat(void)
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRRCHR
 static int test_strrchr(void)
 {
+  int align;
+  int si;
   int size;
   int fail = 0;
   FAR char *p;
 
   printf("Testing strrchr...\n");
-  for (size = 1; size <= 128; size++)
+  for (align = 0; align < 8; align++)
     {
-      fill_pattern(g_buf1, size);
-      g_buf1[size] = '\0';
-
-      /* Find last occurrence of first char (repeats every 26) */
-
-      p = strrchr(g_buf1, 'A');
-      if (p == NULL)
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
         {
-          printf("  FAIL found: size=%d\n", size);
-          fail++;
-        }
-      else
-        {
-          /* 'A' appears at 0, 26, 52, ... — last one <= size-1 */
-
-          int expected = ((size - 1) / 26) * 26;
-          if (p != g_buf1 + expected)
+          size = g_boundary_sizes[si];
+          if (size < 1)
             {
-              printf("  FAIL pos: size=%d expected=%d got=%d\n",
-                     size, expected, (int)(p - g_buf1));
+              continue;
+            }
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+
+          /* Find last occurrence of first char (repeats every 26) */
+
+          p = strrchr(g_buf1 + align, 'A');
+          if (p == NULL)
+            {
+              printf("  FAIL found: align=%d size=%d\n", align, size);
               fail++;
             }
-        }
+          else
+            {
+              /* 'A' appears at 0, 26, 52, ... — last one <= size-1 */
 
-      /* Find NUL */
+              int expected = ((size - 1) / 26) * 26;
+              if (p != g_buf1 + align + expected)
+                {
+                  printf("  FAIL pos: align=%d size=%d expected=%d"
+                         " got=%d\n", align, size, expected,
+                         (int)(p - (g_buf1 + align)));
+                  fail++;
+                }
+            }
 
-      p = strrchr(g_buf1, '\0');
-      if (p != g_buf1 + size)
-        {
-          printf("  FAIL nul: size=%d\n", size);
-          fail++;
-        }
+          /* Find NUL */
 
-      /* Not found */
+          p = strrchr(g_buf1 + align, '\0');
+          if (p != g_buf1 + align + size)
+            {
+              printf("  FAIL nul: align=%d size=%d\n", align, size);
+              fail++;
+            }
 
-      p = strrchr(g_buf1, 0x01);
-      if (p != NULL)
-        {
-          printf("  FAIL notfound: size=%d\n", size);
-          fail++;
+          /* Not found (full scan) */
+
+          p = strrchr(g_buf1 + align, 0x01);
+          if (p != NULL)
+            {
+              printf("  FAIL notfound: align=%d size=%d\n", align, size);
+              fail++;
+            }
         }
     }
 
@@ -1025,6 +1249,100 @@ static void speed_strrchr(void)
 
   end = perf_gettime();
   printf("strrchr(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strchrnul
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCHRNUL
+static int test_strchrnul(void)
+{
+  int align;
+  int si;
+  int size;
+  int fail = 0;
+  FAR char *p;
+
+  printf("Testing strchrnul...\n");
+  for (align = 0; align < 8; align++)
+    {
+      for (si = 0; si < nitems(g_boundary_sizes); si++)
+        {
+          size = g_boundary_sizes[si];
+          if (size < 1)
+            {
+              continue;
+            }
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+
+          /* Find first char (pattern starts with 'A' at align) */
+
+          p = strchrnul(g_buf1 + align, g_buf1[align]);
+          if (p != g_buf1 + align)
+            {
+              printf("  FAIL first: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Find a unique marker placed at the last position */
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          g_buf1[align + size - 1] = 0x7e;
+          p = strchrnul(g_buf1 + align, 0x7e);
+          if (p != g_buf1 + align + size - 1)
+            {
+              printf("  FAIL last: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Find NUL terminator (always succeeds) */
+
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          p = strchrnul(g_buf1 + align, '\0');
+          if (p != g_buf1 + align + size)
+            {
+              printf("  FAIL nul: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Not found: must return pointer to the NUL terminator */
+
+          p = strchrnul(g_buf1 + align, 0x01);
+          if (p != g_buf1 + align + size)
+            {
+              printf("  FAIL notfound: align=%d size=%d\n", align, size);
+              fail++;
+            }
+        }
+    }
+
+  printf("strchrnul: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strchrnul(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)strchrnul(g_buf1, g_buf1[127]);
+    }
+
+  end = perf_gettime();
+  printf("strchrnul(128) avg cycles: %ju\n",
          (uintmax_t)(end - start) / TEST_REPEAT);
 }
 #endif
@@ -1101,8 +1419,11 @@ int main(int argc, FAR char *argv[])
   fail += test_strrchr();
   speed_strrchr();
 #endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCHRNUL
+  fail += test_strchrnul();
+  speed_strchrnul();
+#endif
 
   printf("arch_libc_test %s\n", fail ? "Failed" : "Passed");
   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
 }
-

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -39,197 +39,994 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Configuration ************************************************************/
-
-#ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
-#  define TEST_MAX_STRING_LEN    128
-#  define TEST_SHORT_SRC_LEN     50
-#  define TEST_LONG_SRC_LEN      128
-#endif
+#define TEST_BUF_SIZE  256
+#define TEST_REPEAT    100
+#define MAX_ALIGN      16
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
-#ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
-static char g_test_src_str[TEST_MAX_STRING_LEN];
-static char g_test_dst_str[TEST_MAX_STRING_LEN];
-#endif
+static char g_buf1[TEST_BUF_SIZE + MAX_ALIGN];
+static char g_buf2[TEST_BUF_SIZE + MAX_ALIGN];
+static volatile uintptr_t g_sink;
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
-
-/****************************************************************************
- * Name: arch_libc_test_strcpy
- ****************************************************************************/
-
-void init_short_test_str(int dst_offset, int src_offset)
+static void fill_pattern(FAR char *buf, int len)
 {
-  int off;
-
-  memset(g_test_src_str, '\0', sizeof(g_test_src_str));
-  memset(g_test_dst_str, '\0', sizeof(g_test_dst_str));
-
-  for (off = 0; off < TEST_SHORT_SRC_LEN; off++)
+  int i;
+  for (i = 0; i < len; i++)
     {
-      g_test_src_str[off + src_offset] = '0' + off % 10;
+      buf[i] = 'A' + (i % 26);
     }
 }
 
 /****************************************************************************
- * Name: arch_libc_test_strcpy_offset
+ * Name: test_memcpy
  ****************************************************************************/
 
-int arch_libc_test_strcpy_offset(int dst_offset, int src_offset)
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCPY
+static int test_memcpy(void)
 {
-  int off;
-  FAR char *dest;
-  FAR char *src;
-  FAR char *result_str;
-  bool pass = true;
+  int align;
+  int size;
+  int fail = 0;
 
-  init_short_test_str(dst_offset, src_offset);
-  dest = g_test_dst_str + dst_offset;
-  src = g_test_src_str + src_offset;
-  result_str = strcpy(dest, src);
-
-  /* check strcpy data */
-
-  for (off = 0; off < TEST_SHORT_SRC_LEN; off++)
+  printf("Testing memcpy...\n");
+  for (align = 0; align < 8; align++)
     {
-      if (result_str[off] != '0' + off % 10)
+      for (size = 1; size <= 128; size++)
         {
-          pass = false;
-          printf("dest copied data error, index %d\n", off);
-        }
-
-      if (src[off] != '0' + off % 10)
-        {
-          pass = false;
-          printf("src data error, index %d\n", off);
-        }
-    }
-
-  for (off = TEST_SHORT_SRC_LEN; off < TEST_MAX_STRING_LEN - dst_offset;
-       off++)
-    {
-      if (result_str[off] != '\0')
-        {
-          pass = false;
-          printf("dest tailing zero error, index %d\n", off);
-        }
-    }
-
-  for (off = TEST_SHORT_SRC_LEN; off < TEST_MAX_STRING_LEN - src_offset;
-       off++)
-    {
-      if (src[off] != '\0')
-        {
-          pass = false;
-          printf("src tailing zero error, index %d\n", off);
-        }
-    }
-
-  /* strcpy shouldn't change arch_libc_test_strcpy's local variable */
-
-  if (dest != (g_test_dst_str + dst_offset) ||
-      src != (g_test_src_str + src_offset))
-    {
-      pass = false;
-      printf("local var changed after calling strcpy\n");
-    }
-
-  if (!pass)
-    {
-      printf("Test Failed at dst/src offset [%d, %d]\n", dst_offset,
-             src_offset);
-      return -1;
-    }
-
-  return 0;
-}
-
-/****************************************************************************
- * Name: arch_libc_test_strcpy
- ****************************************************************************/
-
-int arch_libc_test_strcpy(void)
-{
-  int dest_off;
-  int src_off;
-  int ret = 0;
-
-  for (dest_off = 0; dest_off <= 4; dest_off++)
-    {
-      for (src_off = 0; src_off <= 4; src_off++)
-        {
-          if (arch_libc_test_strcpy_offset(dest_off, src_off) != 0)
+          fill_pattern(g_buf1 + align, size);
+          memset(g_buf2, 0, sizeof(g_buf2));
+          memcpy(g_buf2 + align, g_buf1 + align, size);
+          if (memcmp(g_buf2 + align, g_buf1 + align, size) != 0)
             {
-              ret = -1;
+              printf("  FAIL: align=%d size=%d\n", align, size);
+              fail++;
             }
         }
     }
 
-  if (ret != 0)
-    {
-      printf("arch_libc_test_strcpy Test Failed\n");
-    }
-  else
-    {
-      printf("arch_libc_test_strcpy Test Passed\n");
-    }
-
-  return ret;
+  printf("memcpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
 }
 
-/****************************************************************************
- * Name: arch_libc_strcpy_speed_offset
- ****************************************************************************/
-
-clock_t arch_libc_strcpy_speed_offset(int dst_offset, int src_offset)
+static void speed_memcpy(void)
 {
-  FAR char *dest;
-  FAR char *src;
   clock_t start;
   clock_t end;
+  int i;
 
-  init_short_test_str(dst_offset, src_offset);
-  dest = g_test_dst_str + dst_offset;
-  src = g_test_src_str + src_offset;
+  fill_pattern(g_buf1, 128);
   start = perf_gettime();
-  strcpy(dest, src);
-  end = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)memcpy(g_buf2, g_buf1, 128);
+    }
 
-  return end - start;
+  end = perf_gettime();
+  printf("memcpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
 }
+#endif
 
 /****************************************************************************
- * Name: arch_libc_strcpy_speed
+ * Name: test_memmove
  ****************************************************************************/
 
-int arch_libc_strcpy_speed(void)
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMMOVE
+static int test_memmove(void)
 {
-  int dest_off;
-  int src_off;
-  clock_t cycles = 0;
+  int size;
+  int fail = 0;
 
-  for (dest_off = 0; dest_off <= 4; dest_off++)
+  printf("Testing memmove...\n");
+
+  /* Test overlapping forward */
+
+  for (size = 1; size <= 64; size++)
     {
-      for (src_off = 0; src_off <= 4; src_off++)
+      fill_pattern(g_buf1, size + 16);
+      memcpy(g_buf2, g_buf1, size + 16);
+      memmove(g_buf1 + 8, g_buf1, size);
+      if (memcmp(g_buf1 + 8, g_buf2, size) != 0)
         {
-          cycles += arch_libc_strcpy_speed_offset(dest_off, src_off);
+          printf("  FAIL forward: size=%d\n", size);
+          fail++;
         }
     }
 
-  printf("strcpy total(run 25 times) cpu cycles %"PRIu64"\n", cycles);
-  printf("strcpy average cpu cycles %"PRIu64"\n", cycles / 25);
+  /* Test overlapping backward */
 
-  return 0;
+  for (size = 1; size <= 64; size++)
+    {
+      fill_pattern(g_buf1 + 8, size);
+      memcpy(g_buf2, g_buf1 + 8, size);
+      memmove(g_buf1, g_buf1 + 8, size);
+      if (memcmp(g_buf1, g_buf2, size) != 0)
+        {
+          printf("  FAIL backward: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("memmove: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
 }
 
+static void speed_memmove(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)memmove(g_buf2, g_buf1, 128);
+    }
+
+  end = perf_gettime();
+  printf("memmove(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_memset
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMSET
+static int test_memset(void)
+{
+  int align;
+  int size;
+  int i;
+  int fail = 0;
+
+  printf("Testing memset...\n");
+  for (align = 0; align < 8; align++)
+    {
+      for (size = 1; size <= 128; size++)
+        {
+          memset(g_buf1, 0, sizeof(g_buf1));
+          memset(g_buf1 + align, 0xaa, size);
+          for (i = 0; i < size; i++)
+            {
+              if ((unsigned char)g_buf1[align + i] != 0xaa)
+                {
+                  printf("  FAIL: align=%d size=%d idx=%d\n",
+                         align, size, i);
+                  fail++;
+                  break;
+                }
+            }
+        }
+    }
+
+  printf("memset: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_memset(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)memset(g_buf1, 0x55, 128);
+    }
+
+  end = perf_gettime();
+  printf("memset(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_memcmp
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCMP
+static int test_memcmp(void)
+{
+  int size;
+  int fail = 0;
+
+  printf("Testing memcmp...\n");
+  for (size = 1; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      fill_pattern(g_buf2, size);
+      if (memcmp(g_buf1, g_buf2, size) != 0)
+        {
+          printf("  FAIL equal: size=%d\n", size);
+          fail++;
+        }
+
+      g_buf2[size - 1] = '~';
+      if (memcmp(g_buf1, g_buf2, size) >= 0)
+        {
+          printf("  FAIL less: size=%d\n", size);
+          fail++;
+        }
+
+      g_buf2[size - 1] = 0;
+      if (memcmp(g_buf1, g_buf2, size) <= 0)
+        {
+          printf("  FAIL greater: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("memcmp: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_memcmp(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  fill_pattern(g_buf2, 128);
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)memcmp(g_buf1, g_buf2, 128);
+    }
+
+  end = perf_gettime();
+  printf("memcmp(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_memchr
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCHR
+static int test_memchr(void)
+{
+  int size;
+  int fail = 0;
+  FAR void *p;
+
+  printf("Testing memchr...\n");
+  for (size = 1; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+
+      /* Find last char */
+
+      p = memchr(g_buf1, g_buf1[size - 1], size);
+      if (p == NULL)
+        {
+          printf("  FAIL found: size=%d\n", size);
+          fail++;
+        }
+
+      /* Not found */
+
+      p = memchr(g_buf1, 0xff, size);
+      if (p != NULL)
+        {
+          printf("  FAIL notfound: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("memchr: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_memchr(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)memchr(g_buf1, g_buf1[127], 128);
+    }
+
+  end = perf_gettime();
+  printf("memchr(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strlen
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRLEN
+static int test_strlen(void)
+{
+  int size;
+  int fail = 0;
+
+  printf("Testing strlen...\n");
+  for (size = 0; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+      if ((int)strlen(g_buf1) != size)
+        {
+          printf("  FAIL: size=%d got=%d\n", size, (int)strlen(g_buf1));
+          fail++;
+        }
+    }
+
+  printf("strlen: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strlen(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = strlen(g_buf1);
+    }
+
+  end = perf_gettime();
+  printf("strlen(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strcmp
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCMP
+static int test_strcmp(void)
+{
+  int size;
+  int fail = 0;
+
+  printf("Testing strcmp...\n");
+  for (size = 1; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+      fill_pattern(g_buf2, size);
+      g_buf2[size] = '\0';
+      if (strcmp(g_buf1, g_buf2) != 0)
+        {
+          printf("  FAIL equal: size=%d\n", size);
+          fail++;
+        }
+
+      g_buf2[size - 1] = '~';
+      g_buf2[size] = '\0';
+      if (strcmp(g_buf1, g_buf2) >= 0)
+        {
+          printf("  FAIL less: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("strcmp: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strcmp(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  fill_pattern(g_buf2, 128);
+  g_buf2[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = strcmp(g_buf1, g_buf2);
+    }
+
+  end = perf_gettime();
+  printf("strcmp(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strcpy
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
+static int test_strcpy(void)
+{
+  int align;
+  int size;
+  int fail = 0;
+
+  printf("Testing strcpy...\n");
+  for (align = 0; align < 8; align++)
+    {
+      for (size = 1; size <= 64; size++)
+        {
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          memset(g_buf2, 0, sizeof(g_buf2));
+          strcpy(g_buf2 + align, g_buf1 + align);
+          if (strcmp(g_buf2 + align, g_buf1 + align) != 0)
+            {
+              printf("  FAIL: align=%d size=%d\n", align, size);
+              fail++;
+            }
+        }
+    }
+
+  printf("strcpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strcpy(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)strcpy(g_buf2, g_buf1);
+    }
+
+  end = perf_gettime();
+  printf("strcpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strchr
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCHR
+static int test_strchr(void)
+{
+  int size;
+  int fail = 0;
+  FAR char *p;
+
+  printf("Testing strchr...\n");
+  for (size = 1; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+
+      /* Find first char */
+
+      p = strchr(g_buf1, g_buf1[0]);
+      if (p != g_buf1)
+        {
+          printf("  FAIL first: size=%d\n", size);
+          fail++;
+        }
+
+      /* Find NUL */
+
+      p = strchr(g_buf1, '\0');
+      if (p != g_buf1 + size)
+        {
+          printf("  FAIL nul: size=%d\n", size);
+          fail++;
+        }
+
+      /* Not found */
+
+      p = strchr(g_buf1, 0x01);
+      if (p != NULL)
+        {
+          printf("  FAIL notfound: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("strchr: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strchr(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)strchr(g_buf1, g_buf1[127]);
+    }
+
+  end = perf_gettime();
+  printf("strchr(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strncmp
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRNCMP
+static int test_strncmp(void)
+{
+  int size;
+  int fail = 0;
+
+  printf("Testing strncmp...\n");
+  for (size = 1; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+      fill_pattern(g_buf2, size);
+      g_buf2[size] = '\0';
+
+      /* Equal within n */
+
+      if (strncmp(g_buf1, g_buf2, size) != 0)
+        {
+          printf("  FAIL equal: size=%d\n", size);
+          fail++;
+        }
+
+      /* Differ at last position */
+
+      g_buf2[size - 1] = '~';
+      if (strncmp(g_buf1, g_buf2, size) >= 0)
+        {
+          printf("  FAIL less: size=%d\n", size);
+          fail++;
+        }
+
+      /* Equal when n is smaller */
+
+      fill_pattern(g_buf2, size);
+      g_buf2[size] = '\0';
+      g_buf2[size - 1] = '~';
+      if (size > 1 && strncmp(g_buf1, g_buf2, size - 1) != 0)
+        {
+          printf("  FAIL partial: size=%d\n", size);
+          fail++;
+        }
+
+      /* Zero count */
+
+      if (strncmp(g_buf1, g_buf2, 0) != 0)
+        {
+          printf("  FAIL zero: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("strncmp: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strncmp(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  fill_pattern(g_buf2, 128);
+  g_buf2[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = strncmp(g_buf1, g_buf2, 128);
+    }
+
+  end = perf_gettime();
+  printf("strncmp(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strnlen
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRNLEN
+static int test_strnlen(void)
+{
+  int size;
+  int fail = 0;
+
+  printf("Testing strnlen...\n");
+  for (size = 0; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+
+      /* maxlen >= actual length */
+
+      if ((int)strnlen(g_buf1, size + 10) != size)
+        {
+          printf("  FAIL full: size=%d\n", size);
+          fail++;
+        }
+
+      /* maxlen < actual length */
+
+      if (size > 0 && (int)strnlen(g_buf1, size - 1) != size - 1)
+        {
+          printf("  FAIL trunc: size=%d\n", size);
+          fail++;
+        }
+
+      /* maxlen == 0 */
+
+      if (strnlen(g_buf1, 0) != 0)
+        {
+          printf("  FAIL zero: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("strnlen: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strnlen(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = strnlen(g_buf1, 256);
+    }
+
+  end = perf_gettime();
+  printf("strnlen(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strncpy
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRNCPY
+static int test_strncpy(void)
+{
+  int align;
+  int size;
+  int i;
+  int fail = 0;
+
+  printf("Testing strncpy...\n");
+  for (align = 0; align < 8; align++)
+    {
+      for (size = 1; size <= 64; size++)
+        {
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+
+          /* n > strlen: should copy and zero-fill */
+
+          memset(g_buf2, 0xaa, sizeof(g_buf2));
+          strncpy(g_buf2 + align, g_buf1 + align, size + 4);
+          if (strcmp(g_buf2 + align, g_buf1 + align) != 0)
+            {
+              printf("  FAIL copy: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Check zero-fill */
+
+          for (i = 0; i < 4; i++)
+            {
+              if (g_buf2[align + size + i] != '\0')
+                {
+                  printf("  FAIL zfill: align=%d size=%d\n", align, size);
+                  fail++;
+                  break;
+                }
+            }
+
+          /* n < strlen: should truncate without NUL */
+
+          if (size > 1)
+            {
+              memset(g_buf2, 0xaa, sizeof(g_buf2));
+              strncpy(g_buf2 + align, g_buf1 + align, size - 1);
+              if (memcmp(g_buf2 + align, g_buf1 + align, size - 1) != 0)
+                {
+                  printf("  FAIL trunc: align=%d size=%d\n", align, size);
+                  fail++;
+                }
+            }
+        }
+    }
+
+  printf("strncpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strncpy(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)strncpy(g_buf2, g_buf1, 128);
+    }
+
+  end = perf_gettime();
+  printf("strncpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_stpcpy
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STPCPY
+static int test_stpcpy(void)
+{
+  int align;
+  int size;
+  int fail = 0;
+  FAR char *p;
+
+  printf("Testing stpcpy...\n");
+  for (align = 0; align < 8; align++)
+    {
+      for (size = 1; size <= 64; size++)
+        {
+          fill_pattern(g_buf1 + align, size);
+          g_buf1[align + size] = '\0';
+          memset(g_buf2, 0, sizeof(g_buf2));
+          p = stpcpy(g_buf2 + align, g_buf1 + align);
+
+          /* Check content */
+
+          if (strcmp(g_buf2 + align, g_buf1 + align) != 0)
+            {
+              printf("  FAIL copy: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          /* Check return value points to NUL */
+
+          if (p != g_buf2 + align + size)
+            {
+              printf("  FAIL retval: align=%d size=%d\n", align, size);
+              fail++;
+            }
+
+          if (*p != '\0')
+            {
+              printf("  FAIL nul: align=%d size=%d\n", align, size);
+              fail++;
+            }
+        }
+    }
+
+  printf("stpcpy: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_stpcpy(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)stpcpy(g_buf2, g_buf1);
+    }
+
+  end = perf_gettime();
+  printf("stpcpy(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strcat
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCAT
+static int test_strcat(void)
+{
+  int size;
+  int fail = 0;
+
+  printf("Testing strcat...\n");
+  for (size = 1; size <= 64; size++)
+    {
+      /* Build expected: "ABCD..." + "ABCD..." */
+
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+
+      memset(g_buf2, 0, sizeof(g_buf2));
+      fill_pattern(g_buf2, size);
+      g_buf2[size] = '\0';
+
+      strcat(g_buf2, g_buf1);
+
+      /* Check total length */
+
+      if ((int)strlen(g_buf2) != size * 2)
+        {
+          printf("  FAIL len: size=%d got=%d\n", size,
+                 (int)strlen(g_buf2));
+          fail++;
+        }
+
+      /* Check second half matches */
+
+      if (memcmp(g_buf2 + size, g_buf1, size) != 0)
+        {
+          printf("  FAIL content: size=%d\n", size);
+          fail++;
+        }
+
+      /* Test cat to empty string */
+
+      g_buf2[0] = '\0';
+      strcat(g_buf2, g_buf1);
+      if (strcmp(g_buf2, g_buf1) != 0)
+        {
+          printf("  FAIL empty: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("strcat: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strcat(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 64);
+  g_buf1[64] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_buf2[0] = '\0';
+      g_sink = (uintptr_t)strcat(g_buf2, g_buf1);
+    }
+
+  end = perf_gettime();
+  printf("strcat(64) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
+#endif
+
+/****************************************************************************
+ * Name: test_strrchr
+ ****************************************************************************/
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRRCHR
+static int test_strrchr(void)
+{
+  int size;
+  int fail = 0;
+  FAR char *p;
+
+  printf("Testing strrchr...\n");
+  for (size = 1; size <= 128; size++)
+    {
+      fill_pattern(g_buf1, size);
+      g_buf1[size] = '\0';
+
+      /* Find last occurrence of first char (repeats every 26) */
+
+      p = strrchr(g_buf1, 'A');
+      if (p == NULL)
+        {
+          printf("  FAIL found: size=%d\n", size);
+          fail++;
+        }
+      else
+        {
+          /* 'A' appears at 0, 26, 52, ... — last one <= size-1 */
+
+          int expected = ((size - 1) / 26) * 26;
+          if (p != g_buf1 + expected)
+            {
+              printf("  FAIL pos: size=%d expected=%d got=%d\n",
+                     size, expected, (int)(p - g_buf1));
+              fail++;
+            }
+        }
+
+      /* Find NUL */
+
+      p = strrchr(g_buf1, '\0');
+      if (p != g_buf1 + size)
+        {
+          printf("  FAIL nul: size=%d\n", size);
+          fail++;
+        }
+
+      /* Not found */
+
+      p = strrchr(g_buf1, 0x01);
+      if (p != NULL)
+        {
+          printf("  FAIL notfound: size=%d\n", size);
+          fail++;
+        }
+    }
+
+  printf("strrchr: %s\n", fail ? "FAILED" : "PASSED");
+  return fail;
+}
+
+static void speed_strrchr(void)
+{
+  clock_t start;
+  clock_t end;
+  int i;
+
+  fill_pattern(g_buf1, 128);
+  g_buf1[128] = '\0';
+  start = perf_gettime();
+  for (i = 0; i < TEST_REPEAT; i++)
+    {
+      g_sink = (uintptr_t)strrchr(g_buf1, g_buf1[127]);
+    }
+
+  end = perf_gettime();
+  printf("strrchr(128) avg cycles: %ju\n",
+         (uintmax_t)(end - start) / TEST_REPEAT);
+}
 #endif
 
 /****************************************************************************
@@ -242,11 +1039,70 @@ int arch_libc_strcpy_speed(void)
 
 int main(int argc, FAR char *argv[])
 {
+  int fail = 0;
+
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCPY
+  fail += test_memcpy();
+  speed_memcpy();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMMOVE
+  fail += test_memmove();
+  speed_memmove();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMSET
+  fail += test_memset();
+  speed_memset();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCMP
+  fail += test_memcmp();
+  speed_memcmp();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_MEMCHR
+  fail += test_memchr();
+  speed_memchr();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRLEN
+  fail += test_strlen();
+  speed_strlen();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCMP
+  fail += test_strcmp();
+  speed_strcmp();
+#endif
 #ifdef CONFIG_TESTING_ARCH_LIBC_STRCPY
-  arch_libc_test_strcpy();
-  arch_libc_strcpy_speed();
+  fail += test_strcpy();
+  speed_strcpy();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCHR
+  fail += test_strchr();
+  speed_strchr();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRNCMP
+  fail += test_strncmp();
+  speed_strncmp();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRNLEN
+  fail += test_strnlen();
+  speed_strnlen();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRNCPY
+  fail += test_strncpy();
+  speed_strncpy();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STPCPY
+  fail += test_stpcpy();
+  speed_stpcpy();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRCAT
+  fail += test_strcat();
+  speed_strcat();
+#endif
+#ifdef CONFIG_TESTING_ARCH_LIBC_STRRCHR
+  fail += test_strrchr();
+  speed_strrchr();
 #endif
 
-  return 0;
+  printf("arch_libc_test %s\n", fail ? "Failed" : "Passed");
+  return fail ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 

--- a/testing/libc/arch_libc/arch_libc_test_main.c
+++ b/testing/libc/arch_libc/arch_libc_test_main.c
@@ -193,14 +193,21 @@ static int test_memmove(void)
               fail++;
             }
 
-          /* Adjacent (no overlap): dst = src + size */
+          /* Adjacent (no overlap): dst = src + size.
+           * The destination tail reaches align + 2*size, so the base
+           * offset must satisfy align + 2*size <= sizeof(g_buf1); a
+           * fixed +64 base overflows g_buf1 for the larger boundary
+           * sizes (e.g. size=255, align=0 writes 45 bytes past the
+           * end), which AddressSanitizer flags as a global-buffer-
+           * overflow.  Start from g_buf1 + align instead.
+           */
 
-          fill_pattern(g_buf1 + align + 64, size);
-          memcpy(g_buf2 + align + 64, g_buf1 + align + 64, size);
-          memmove(g_buf1 + align + 64 + size,
-                  g_buf1 + align + 64, size);
-          if (memcmp(g_buf1 + align + 64 + size,
-                     g_buf2 + align + 64, size) != 0)
+          fill_pattern(g_buf1 + align, size);
+          memcpy(g_buf2 + align, g_buf1 + align, size);
+          memmove(g_buf1 + align + size,
+                  g_buf1 + align, size);
+          if (memcmp(g_buf1 + align + size,
+                     g_buf2 + align, size) != 0)
             {
               printf("  FAIL adjacent: align=%d size=%d\n", align, size);
               fail++;


### PR DESCRIPTION
## Summary

`apps/testing/libc/arch_libc` only exercised `strcpy()`, so the architecture
optimized implementations of every other string and memory routine were never
covered by the test suite.  This series turns it into a full correctness and
speed harness for the whole string/memory family, which is the prerequisite for
landing architecture optimized assembly with confidence.

Four commits:

1. **`Add tests for all string/memory functions.`**
   Adds a correctness test (sweeping buffer alignment and transfer size) and a
   speed test (average cycles via `perf_gettime()`) for `memcpy`, `memmove`,
   `memset`, `memcmp`, `memchr`, `strlen`, `strcmp`, `strchr`, `strncmp`,
   `strnlen`, `strncpy`, `stpcpy`, `strcat` and `strrchr`.  Each test is
   selected by its own `CONFIG_TESTING_ARCH_LIBC_<FUNC>` option (default y) so
   a target can drop the ones it does not need.

2. **`Add strchrnul test and sweep size boundaries.`**
   Adds `strchrnul` coverage, and sweeps alignment 0..7 together with the
   boundary sizes {0, 1, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128,
   129, 255, 256, 257} in the scan function tests and in `memmove`.  Those
   sizes sit on the 8/16-byte chunk edges and on the sub-word tails, so
   vectorized (NEON/MVE) and word-at-a-time implementations are stressed
   exactly at their alignment and size boundaries.  `memmove` is additionally
   exercised across four overlap layouts: forward, backward, contained and
   adjacent.

3. **`Fix out-of-bounds write in memmove test.`**
   The adjacent overlap layout introduced by (2) started at a fixed
   `g_buf1 + align + 64`, so the destination tail ran past `g_buf1` for the
   largest swept sizes (AddressSanitizer reported a global-buffer-overflow).
   Start the layout at `g_buf1 + align` instead.

4. **`Cover unaligned src/dst copy paths.`**
   `strcpy`/`strncpy`/`stpcpy` applied the same offset to source and
   destination, so the two pointers always shared the same word congruence and
   the byte prologue plus shift-merge path of optimized copy routines was never
   reached.  Vary both offsets independently over 0..7.  Also drops the
   `ARCH_TOOLCHAIN_GNU` dependency from `TESTING_ARCH_LIBC`: the test only uses
   standard C string functions and `perf_gettime()`, with no GNU specific
   construct, so it builds with non-GNU toolchains such as TASKING as well.

Commit 3 is a fix for commit 2 rather than a squash because the two commits
have different authors; each commit still builds and runs standalone
(see Testing).

## Impact

* Test code only.  Nothing is built unless `CONFIG_TESTING_ARCH_LIBC`
  (default n) is selected, so no existing board configuration or defconfig
  changes, and no size impact on any shipped build.
* New Kconfig options `TESTING_ARCH_LIBC_{MEMCHR,MEMCMP,MEMCPY,MEMMOVE,MEMSET,
  STRCHR,STRCMP,STRCPY,STRLEN,STRNCMP,STRNLEN,STRNCPY,STPCPY,STRCAT,STRRCHR,
  STRCHRNUL}`, all default y inside `TESTING_ARCH_LIBC`.
* Dropping the `ARCH_TOOLCHAIN_GNU` dependency only widens the set of
  toolchains that may select the test; no existing configuration changes
  behaviour.
* No user API/ABI, hardware, security or documentation impact.

## Testing

Host: Ubuntu 24.04 x86_64, gcc 13.3.0
Target: `sim:nsh` with `CONFIG_TESTING_ARCH_LIBC=y` (all 16 function options
enabled) and `CONFIG_TESTING_ARCH_LIBC_VERBOSE=y`

Every commit of the series was built and run standalone; no build warnings, and
all enabled functions report `PASSED`:

| commit | functions PASSED | result |
| --- | --- | --- |
| 1 `Add tests for all string/memory functions.` | 15 | `arch_libc_test Passed` |
| 2 `Add strchrnul test and sweep size boundaries.` | 16 | `arch_libc_test Passed` |
| 3 `Fix out-of-bounds write in memmove test.` | 16 | `arch_libc_test Passed` |
| 4 `Cover unaligned src/dst copy paths.` | 16 | `arch_libc_test Passed` |

A build with only `CONFIG_TESTING_ARCH_LIBC_STRCPY=y` (every other function
test disabled) was also checked to make sure the reduced configurations stay
warning free.

**Before** (`apache/master`, only `strcpy` is covered):

```
NuttShell (NSH) NuttX-10.4.0
nsh> arch_libctest
arch_libc_test_strcpy Test Passed
strcpy total(run 25 times) cpu cycles 1749
strcpy average cpu cycles 69
nsh> exit
```

**After** (this series):

```
NuttShell (NSH) NuttX-10.4.0
nsh> arch_libctest
Testing memcpy...
memcpy: PASSED
memcpy(128) avg cycles: 96
Testing memmove...
memmove: PASSED
memmove(128) avg cycles: 4
Testing memset...
memset: PASSED
memset(128) avg cycles: 53
Testing memcmp...
memcmp: PASSED
memcmp(128) avg cycles: 121
Testing memchr...
memchr: PASSED
memchr(128) avg cycles: 12
Testing strlen...
strlen: PASSED
strlen(128) avg cycles: 50
Testing strcmp...
strcmp: PASSED
strcmp(128) avg cycles: 133
Testing strcpy...
strcpy: PASSED
strcpy(128) avg cycles: 234
Testing strchr...
strchr: PASSED
strchr(128) avg cycles: 54
Testing strncmp...
strncmp: PASSED
strncmp(128) avg cycles: 469
Testing strnlen...
strnlen: PASSED
strnlen(128) avg cycles: 281
Testing strncpy...
strncpy: PASSED
strncpy(128) avg cycles: 142
Testing stpcpy...
stpcpy: PASSED
stpcpy(128) avg cycles: 68
Testing strcat...
strcat: PASSED
strcat(64) avg cycles: 37
Testing strrchr...
strrchr: PASSED
strrchr(128) avg cycles: 65
Testing strchrnul...
strchrnul: PASSED
strchrnul(128) avg cycles: 18
arch_libc_test Passed
nsh> exit
```

`tools/checkpatch.sh -c -u -m -g apache/master..HEAD` reports
`All checks pass.` for the series.
