### PR TITLE
nshlib/ifconfig: apply only requested settings and support "up|down"

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -296,7 +296,7 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("ifconfig", cmd_ifconfig, 1, 12,
     "[interface [mtu <len>]|[address_family] [[add|del] <ip-address>|dhcp]]"
     "[dr|gw|gateway <dr-address>] [netmask <net-mask>|prefixlen <len>] "
-    "[dns <dns-address>] [hw <hw-mac>]"),
+    "[dns <dns-address>] [hw <hw-mac>] [up|down]"),
 #  endif
 #  if defined(CONFIG_NET_VLAN) && !defined(CONFIG_NSH_DISABLE_VCONFIG)
   CMD_MAP("vconfig", cmd_vconfig, 3, 5,

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -584,6 +584,8 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #endif
   bool missingarg = true;
   bool badarg = false;
+  bool ifup = false;
+  bool ifdown = false;
 #ifdef CONFIG_NET_ARP
   arp_cfg_e arpflag = ARP_DEFAULT;
 #endif
@@ -766,6 +768,14 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
               arpflag = ARP_DISABLE;
             }
 #endif
+          else if (!strcmp(tmp, "up"))
+            {
+              ifup = true;
+            }
+          else if (!strcmp(tmp, "down"))
+            {
+              ifdown = true;
+            }
           else if (hostip == NULL && i <= 4)
             {
               /* Let first non-option be host ip, to support inet/inet6
@@ -1078,6 +1088,17 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       netlib_ifnoarp(ifname);
     }
 #endif
+
+  /* Bring the interface up or down once everything else is in place. */
+
+  if (ifup)
+    {
+      netlib_ifup(ifname);
+    }
+  else if (ifdown)
+    {
+      netlib_ifdown(ifname);
+    }
 
 #if !defined(CONFIG_NET_IPv4) && !defined(CONFIG_NET_IPv6)
   UNUSED(hostip);

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -557,7 +557,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv4
   struct in_addr addr;
   in_addr_t gip = INADDR_ANY;
-  in_addr_t mip;
+  in_addr_t mip = INADDR_ANY;
 #endif
 #ifdef CONFIG_NET_IPv6
   struct in6_addr addr6;
@@ -809,7 +809,6 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (mtu != 0)
     {
       netlib_set_mtu(ifname, mtu);
-      return OK;
     }
 
   /* Set IP address */
@@ -839,11 +838,11 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
               nsh_error(vtbl, g_fmtarginvalid, argv[0]);
               return ERROR;
             }
-        }
 
 #ifndef CONFIG_NETDEV_MULTIPLE_IPv6
-      netlib_set_ipv6addr(ifname, &addr6);
+          netlib_set_ipv6addr(ifname, &addr6);
 #endif
+        }
     }
 #endif /* CONFIG_NET_IPv6 */
 
@@ -851,31 +850,25 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv6
   else
 #endif
+  if (hostip != NULL)
     {
-      if (hostip != NULL)
-        {
 #if defined(CONFIG_NETUTILS_DHCPC)
-          if (strcmp(hostip, "dhcp") == 0)
-            {
-              /* Set DHCP addr */
+      if (strcmp(hostip, "dhcp") == 0)
+        {
+          /* Set DHCP addr */
 
-              ninfo("DHCPC Mode\n");
-              addr.s_addr = 0;
-              gip         = 0;
-            }
-          else
-#endif
-            {
-              /* Set host IP address */
-
-              ninfo("Host IP: %s\n", hostip);
-              addr.s_addr = inet_addr(hostip);
-              gip         = addr.s_addr;
-            }
+          ninfo("DHCPC Mode\n");
+          addr.s_addr = 0;
+          gip         = 0;
         }
       else
+#endif
         {
-          addr.s_addr = 0;
+          /* Set host IP address */
+
+          ninfo("Host IP: %s\n", hostip);
+          addr.s_addr = inet_addr(hostip);
+          gip         = addr.s_addr;
         }
 
       netlib_set_ipv4addr(ifname, &addr);
@@ -908,33 +901,39 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
           ninfo("Prefixlen: %s\n", preflen);
           netlib_prefix2ipv6netmask(atoi(preflen), &mask6);
         }
-      else
+      else if (hostip != NULL)
         {
           ninfo("Netmask: Default\n");
           inet_pton(AF_INET6, "ffff:ffff:ffff:ffff::", &mask6);
         }
 
 #ifdef CONFIG_NETDEV_MULTIPLE_IPv6
-      plen = netlib_ipv6netmask2prefix(mask6.in6_u.u6_addr16);
-      if (remove)
+      if (hostip != NULL)
         {
-          ret = netlib_del_ipv6addr(ifname, &addr6, plen);
-        }
-      else
-        {
-          ret = netlib_add_ipv6addr(ifname, &addr6, plen);
-        }
+          plen = netlib_ipv6netmask2prefix(mask6.in6_u.u6_addr16);
+          if (remove)
+            {
+              ret = netlib_del_ipv6addr(ifname, &addr6, plen);
+            }
+          else
+            {
+              ret = netlib_add_ipv6addr(ifname, &addr6, plen);
+            }
 
-      if (ret < 0)
-        {
-          perror("Failed to manage IPv6 address");
+          if (ret < 0)
+            {
+              perror("Failed to manage IPv6 address");
 
-          /* REVISIT: Should we return ERROR or just let it go? */
+              /* REVISIT: Should we return ERROR or just let it go? */
 
-          return ERROR;
+              return ERROR;
+            }
         }
 #else
-      netlib_set_ipv6netmask(ifname, &mask6);
+      if (mask != NULL || preflen != NULL || hostip != NULL)
+        {
+          netlib_set_ipv6netmask(ifname, &mask6);
+        }
 #endif /* CONFIG_NETDEV_MULTIPLE_IPv6 */
     }
 #endif /* CONFIG_NET_IPv6 */
@@ -943,6 +942,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv6
   else
 #endif
+  if (mask != NULL || hostip != NULL)
     {
       if (mask != NULL)
         {
@@ -989,6 +989,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv6
   else
 #endif
+  if (gwip != NULL || hostip != NULL)
     {
       if (gwip != NULL)
         {
@@ -1030,14 +1031,14 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
               nsh_error(vtbl, g_fmtarginvalid, argv[0]);
               return ERROR;
             }
+
+          netlib_set_ipv6dnsaddr(&addr6);
         }
-      else
+      else if (hostip != NULL)
         {
           ninfo("DNS: Default\n");
-          addr6 = gip6;
+          netlib_set_ipv6dnsaddr(&gip6);
         }
-
-      netlib_set_ipv6dnsaddr(&addr6);
     }
 #endif /* CONFIG_NET_IPv6 */
 
@@ -1045,6 +1046,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #ifdef CONFIG_NET_IPv6
   else
 #endif
+  if (dns != NULL || hostip != NULL)
     {
       if (dns != NULL)
         {
@@ -1063,8 +1065,7 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 #endif /* CONFIG_NETDB_DNSCLIENT */
 
 #if defined(CONFIG_NETUTILS_DHCPC)
-
-  if (!gip)
+  if (hostip != NULL && strcmp(hostip, "dhcp") == 0)
     {
       netlib_obtain_ipv4addr(ifname);
     }

--- a/nshlib/nsh_netcmds.c
+++ b/nshlib/nsh_netcmds.c
@@ -623,163 +623,160 @@ int cmd_ifconfig(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
    *    ifconfig ifname [ip_address] [named options]
    */
 
-  if (argc > 2)
+  for (i = 1; i < argc; i++)
     {
-      for (i = 1; i < argc; i++)
+      if (i == 1)
         {
-          if (i == 1)
+          ifname = argv[i];
+          missingarg = false;
+        }
+      else
+        {
+          tmp = argv[i];
+
+          if (!strcmp(tmp, "dr") || !strcmp(tmp, "gw") ||
+              !strcmp(tmp, "gateway"))
             {
-              ifname = argv[i];
-              missingarg = false;
-            }
-          else
-            {
-              tmp = argv[i];
-
-              if (!strcmp(tmp, "dr") || !strcmp(tmp, "gw") ||
-                  !strcmp(tmp, "gateway"))
+              if (argc - 1 >= i + 1)
                 {
-                  if (argc - 1 >= i + 1)
-                    {
-                      gwip = argv[i + 1];
-                      i++;
-                    }
-                  else
-                    {
-                      badarg = true;
-                    }
-                }
-              else if (!strcmp(tmp, "netmask"))
-                {
-                  if (argc - 1 >= i + 1)
-                    {
-                      mask = argv[i + 1];
-                      i++;
-                    }
-                  else
-                    {
-                      badarg = true;
-                    }
-                }
-              else if (!strcmp(tmp, "inet"))
-                {
-#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-                  inet6 = false;
-#elif !defined(CONFIG_NET_IPv4)
-                  badarg = true;
-#endif
-                }
-              else if (!strcmp(tmp, "inet6"))
-                {
-#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-                  inet6 = true;
-#elif !defined(CONFIG_NET_IPv6)
-                  badarg = true;
-#endif
-                }
-
-#ifdef CONFIG_NET_IPv6
-              else if (!strcmp(tmp, "prefixlen"))
-                {
-                  if (argc - 1 >= i + 1)
-                    {
-                      preflen = argv[i + 1];
-                      i++;
-                    }
-                  else
-                    {
-                      badarg = true;
-                    }
-                }
-#endif
-
-#ifdef HAVE_HWADDR
-              /* REVISIT: How will we handle Ethernet and SLIP together? */
-
-              else if (!strcmp(tmp, "hw"))
-                {
-                  if (argc - 1 >= i + 1)
-                    {
-                      hw = argv[i + 1];
-                      i++;
-
-                      badarg = nsh_addrconv(hw, &macaddr);
-                    }
-                  else
-                    {
-                      badarg = true;
-                    }
-                }
-#endif
-
-#ifdef CONFIG_NETDB_DNSCLIENT
-              else if (!strcmp(tmp, "dns"))
-                {
-                  if (argc - 1 >= i + 1)
-                    {
-                      dns = argv[i + 1];
-                      i++;
-                    }
-                  else
-                    {
-                      badarg = true;
-                    }
-                }
-#endif
-              else if (!strcmp(tmp, "add"))
-                {
-#if defined(CONFIG_NET_IPv6) && defined(CONFIG_NETDEV_MULTIPLE_IPv6)
-                  remove = false;
-                  continue;
-                }
-              else if (!strcmp(tmp, "del"))
-                {
-                  remove = true;
-#endif
-                  continue;
-                }
-              else if (!strcmp(tmp, "mtu"))
-                {
-                  if (argc - 1 >= i + 1)
-                    {
-                      mtu = atoi(argv[i + 1]);
-                      i++;
-                      if (mtu < 1280)
-                        {
-                          mtu = 1280;
-                        }
-                    }
-                  else
-                    {
-                      badarg = true;
-                    }
-                }
-#ifdef CONFIG_NET_ARP
-              else if (!strcmp(tmp, "arp"))
-                {
-                  /* Enable arp function on interface */
-
-                  arpflag = ARP_ENABLE;
-                }
-              else if (!strcmp(tmp, "-arp"))
-                {
-                  /* Disable arp function on interface */
-
-                  arpflag = ARP_DISABLE;
-                }
-#endif
-              else if (hostip == NULL && i <= 4)
-                {
-                  /* Let first non-option be host ip, to support inet/inet6
-                   * options before address.
-                   */
-
-                  hostip = tmp;
+                  gwip = argv[i + 1];
+                  i++;
                 }
               else
                 {
                   badarg = true;
                 }
+            }
+          else if (!strcmp(tmp, "netmask"))
+            {
+              if (argc - 1 >= i + 1)
+                {
+                  mask = argv[i + 1];
+                  i++;
+                }
+              else
+                {
+                  badarg = true;
+                }
+            }
+          else if (!strcmp(tmp, "inet"))
+            {
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+              inet6 = false;
+#elif !defined(CONFIG_NET_IPv4)
+              badarg = true;
+#endif
+            }
+          else if (!strcmp(tmp, "inet6"))
+            {
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+              inet6 = true;
+#elif !defined(CONFIG_NET_IPv6)
+              badarg = true;
+#endif
+            }
+
+#ifdef CONFIG_NET_IPv6
+          else if (!strcmp(tmp, "prefixlen"))
+            {
+              if (argc - 1 >= i + 1)
+                {
+                  preflen = argv[i + 1];
+                  i++;
+                }
+              else
+                {
+                  badarg = true;
+                }
+            }
+#endif
+
+#ifdef HAVE_HWADDR
+          /* REVISIT: How will we handle Ethernet and SLIP together? */
+
+          else if (!strcmp(tmp, "hw"))
+            {
+              if (argc - 1 >= i + 1)
+                {
+                  hw = argv[i + 1];
+                  i++;
+
+                  badarg = nsh_addrconv(hw, &macaddr);
+                }
+              else
+                {
+                  badarg = true;
+                }
+            }
+#endif
+
+#ifdef CONFIG_NETDB_DNSCLIENT
+          else if (!strcmp(tmp, "dns"))
+            {
+              if (argc - 1 >= i + 1)
+                {
+                  dns = argv[i + 1];
+                  i++;
+                }
+              else
+                {
+                  badarg = true;
+                }
+            }
+#endif
+          else if (!strcmp(tmp, "add"))
+            {
+#if defined(CONFIG_NET_IPv6) && defined(CONFIG_NETDEV_MULTIPLE_IPv6)
+              remove = false;
+              continue;
+            }
+          else if (!strcmp(tmp, "del"))
+            {
+              remove = true;
+#endif
+              continue;
+            }
+          else if (!strcmp(tmp, "mtu"))
+            {
+              if (argc - 1 >= i + 1)
+                {
+                  mtu = atoi(argv[i + 1]);
+                  i++;
+                  if (mtu < 1280)
+                    {
+                      mtu = 1280;
+                    }
+                }
+              else
+                {
+                  badarg = true;
+                }
+            }
+#ifdef CONFIG_NET_ARP
+          else if (!strcmp(tmp, "arp"))
+            {
+              /* Enable arp function on interface */
+
+              arpflag = ARP_ENABLE;
+            }
+          else if (!strcmp(tmp, "-arp"))
+            {
+              /* Disable arp function on interface */
+
+              arpflag = ARP_DISABLE;
+            }
+#endif
+          else if (hostip == NULL && i <= 4)
+            {
+              /* Let first non-option be host ip, to support inet/inet6
+               * options before address.
+               */
+
+              hostip = tmp;
+            }
+          else
+            {
+              badarg = true;
             }
         }
     }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Fixes and extends `ifconfig` in nshlib. Three commits:

1. **only apply the settings that were asked for** — `cmd_ifconfig()`
   previously pushed *every* setting to the device on each call, whether or
   not it was on the command line, and stopped parsing at `mtu`. So
   `ifconfig eth0 hw <mac>` also silently cleared the address, netmask,
   gateway and resolver and kicked off DHCP; `ifconfig eth0 mtu 1500 dns ...`
   dropped the `dns`. Now each setting is written only when the user provides
   it, matching how Linux net-tools walks the argument vector (each keyword is
   an independent, idempotent operation).

2. **drop the redundant "argc > 2" check** — the function returns early for
   `argc <= 2`, so the check in the argument loop is dead code. Removed and the
   loop unindented. No functional change.

3. **support "ifconfig \<iface\> up|down"** — previously `ifconfig eth0 up`
   fell through to host-IP parsing, where `inet_addr("up")` returns
   `INADDR_NONE`, silently setting the address to 255.255.255.255. Recognize
   `up`/`down` as explicit keywords and apply them via
   `netlib_ifup()`/`netlib_ifdown()` after the rest of the config, so up/down
   is just another argument as in Linux `ifconfig`.

## Impact

- User: `ifconfig` no longer clobbers unrelated interface settings; new
  `ifconfig <iface> up|down` keyword supported (help text updated).
- Backward compatible: existing invocations that set a full config behave the
  same; only the unintended side effects are removed.
- No build, hardware, security or dependency changes. up/down works
  regardless of `CONFIG_NSH_DISABLE_IFUPDOWN`.

## Testing
```
core1> ifconfig eth0 172.16.1.201 up

core1> ifconfig eth0
eth0    Link encap:Ethernet HWaddr **:**:**:**:**:** at RUNNING mtu 1500
        inet addr:172.16.1.201 DRaddr:172.16.1.1 Mask:255.255.255.0

        RX: Received Fragment Errors   Bytes
            00000000 00000000 00000000 0
            IPv4     ARP      Dropped
            00000000 00000000 00000000
        TX: Queued   Sent     Errors   Timeouts Bytes
            00000000 00000000 00000000 00000000 0
        Total Errors: 00000000

core1>
```