### PR TITLE
kconfig: Fix Kconfig style

### DIFF
--- a/examples/smf/Kconfig
+++ b/examples/smf/Kconfig
@@ -4,34 +4,33 @@
 #
 
 config EXAMPLES_SMF
-  tristate "State Machine Framework PSICC2 demo (HSM)"
-  default n
-  depends on NSH_BUILTIN_APPS
-  depends on SYSTEM_SMF
-  depends on SYSTEM_SMF_ANCESTOR_SUPPORT
-  depends on SYSTEM_SMF_INITIAL_TRANSITION
+	tristate "State Machine Framework PSICC2 demo (HSM)"
+	default n
+	depends on NSH_BUILTIN_APPS
+	depends on SYSTEM_SMF
+	depends on SYSTEM_SMF_ANCESTOR_SUPPORT
+	depends on SYSTEM_SMF_INITIAL_TRANSITION
 
 if EXAMPLES_SMF
 
 config EXAMPLES_SMF_PROGNAME
-  string "Program name"
-  default "hsm_psicc2"
+	string "Program name"
+	default "hsm_psicc2"
 
 config EXAMPLES_SMF_PRIORITY
-  int "Priority"
-  default 100
+	int "Priority"
+	default 100
 
 config EXAMPLES_SMF_STACKSIZE
-  int "Stack size"
-  default 2048
+	int "Stack size"
+	default 2048
 
 config EXAMPLES_SMF_EVENT_QUEUE_SIZE
-  int "Event queue size"
-  default 10
+	int "Event queue size"
+	default 10
 
 config EXAMPLES_SMF_MQ_NAME
-  string "Message queue name"
-  default "/hsm_psicc2_mq"
+	string "Message queue name"
+	default "/hsm_psicc2_mq"
 
-endif
-
+endif # EXAMPLES_SMF

--- a/games/NXDoom/Kconfig
+++ b/games/NXDoom/Kconfig
@@ -78,7 +78,7 @@ config GAMES_NXDOOM_NET_MAXPLAYERS
 	int "Maximum number of players"
 	default 6
 	---help---
-        The maximum number of players, multiplayer/networking.
+		The maximum number of players, multiplayer/networking.
 		This is the maximum supported by the networking code; individual games
 		have their own values for MAXPLAYERS that can be smaller.
 		ChocolateDOOM default was 8.

--- a/math/gemmlowp/Kconfig
+++ b/math/gemmlowp/Kconfig
@@ -1,22 +1,7 @@
-############################################################################
-# apps/math/gemmlowp/Kconfig
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-############################################################################
 
 config MATH_GEMMLOWP
 	bool "Gemmlowp"

--- a/math/kissfft/Kconfig
+++ b/math/kissfft/Kconfig
@@ -1,22 +1,7 @@
-############################################################################
-# apps/math/kissfft/Kconfig
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-############################################################################
 
 config MATH_KISSFFT
 	bool "kissfft"

--- a/math/ruy/Kconfig
+++ b/math/ruy/Kconfig
@@ -1,22 +1,7 @@
-############################################################################
-# apps/math/ruy/Kconfig
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-############################################################################
 
 config MATH_RUY
 	bool "Ruy"

--- a/mlearning/cmsis-nn/Kconfig
+++ b/mlearning/cmsis-nn/Kconfig
@@ -1,22 +1,7 @@
-############################################################################
-# apps/mlearning/cmsis-nn/Kconfig
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-############################################################################
 
 config MLEARNING_CMSIS_NN
 	bool "CMSIS_NN Library"

--- a/mlearning/tflite-micro/Kconfig
+++ b/mlearning/tflite-micro/Kconfig
@@ -1,22 +1,7 @@
-############################################################################
-# apps/mlearning/tflite-micro/Kconfig
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-############################################################################
 
 config TFLITEMICRO
 	bool "TFLiteMicro"

--- a/netutils/paho_mqtt/Kconfig
+++ b/netutils/paho_mqtt/Kconfig
@@ -1,17 +1,6 @@
 #
-# Copyright (C) 2020 Xiaomi Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
 
 config LIB_MQTT5
@@ -34,4 +23,5 @@ config UTILS_MQTT5_PRIORITY
 config UTILS_MQTT5_STACKSIZE
 	int "mqtt utility statcksize"
 	default 16384
-endif
+
+endif # UTILS_MQTT5

--- a/system/flatbuffers/Kconfig
+++ b/system/flatbuffers/Kconfig
@@ -1,22 +1,7 @@
-############################################################################
-# apps/system/flatbuffers/Kconfig
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.  The
-# ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-############################################################################
 
 config SYSTEM_FLATBUFFERS
 	bool "flatbuffers"

--- a/system/smf/Kconfig
+++ b/system/smf/Kconfig
@@ -3,10 +3,10 @@
 # For syntax reference, see kconfig-language.txt in the NuttX tools repository.
 
 config SYSTEM_SMF
-  bool "(SMF) support"
-  default n
-  ---help---
-    Enables the State Machine Framework (SMF) for implementing state machines
+	bool "(SMF) support"
+	default n
+	---help---
+		Enables the State Machine Framework (SMF) for implementing state machines
 
 if SYSTEM_SMF
 
@@ -14,15 +14,15 @@ config SYSTEM_SMF_ANCESTOR_SUPPORT
 	bool "Enable ancestor/parent state support"
 	default n
 	---help---
-	  Enables support for parent/ancestor relationships between SMF states.
-	  Required for hierarchical state machines.
+		Enables support for parent/ancestor relationships between SMF states.
+		Required for hierarchical state machines.
 
 config SYSTEM_SMF_INITIAL_TRANSITION
 	bool "Enable initial transition support"
 	default n
 	depends on SYSTEM_SMF_ANCESTOR_SUPPORT
 	---help---
-	  Enables support for initial transitions in hierarchical states.
-	  Depends on ancestor/parent state support.
+		Enables support for initial transitions in hierarchical states.
+		Depends on ancestor/parent state support.
 
 endif # SYSTEM_SMF

--- a/tee/optee_client/Kconfig
+++ b/tee/optee_client/Kconfig
@@ -1,40 +1,24 @@
-############################################################################
-# apps/tee/optee_client/Kconfig
 #
-# SPDX-License-Identifier: Apache-2.0
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
-# Copyright (C) 2023 Xiaomi Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-############################################################################
 
 config LIBTEEC
 	bool "TEE client library (libteec)"
 	default n
 	---help---
-	        Enable libteec from https://github.com/OP-TEE/optee_client. This
-	        is OP-TEE project's implementation of GlobalPlatform's TEE client
-	        API specification v1.0 (GPD_SPE_007):
-	         https://globalplatform.org/specs-library/?filter-committee=tee
-	        The TEE Client API describes and defines how a client running in
-	        a rich operating environment (REE, in this case NuttX) should
-	        communicate with the Trusted Execution Environment (TEE) and its
-	        Trusted Applications (TAs). The library provides a
-	        well-established and easy-to-use interface abstracting away much
-	        of the details of the underlying subsystems. For more information
-	        please refer to:
-	        https://optee.readthedocs.io/en/latest/architecture/globalplatform_api.html#tee-client-api
+		Enable libteec from https://github.com/OP-TEE/optee_client. This
+		is OP-TEE project's implementation of GlobalPlatform's TEE client
+		API specification v1.0 (GPD_SPE_007):
+		https://globalplatform.org/specs-library/?filter-committee=tee
+		The TEE Client API describes and defines how a client running in
+		a rich operating environment (REE, in this case NuttX) should
+		communicate with the Trusted Execution Environment (TEE) and its
+		Trusted Applications (TAs). The library provides a
+		well-established and easy-to-use interface abstracting away much
+		of the details of the underlying subsystems. For more information
+		please refer to:
+		https://optee.readthedocs.io/en/latest/architecture/globalplatform_api.html#tee-client-api
 
 if LIBTEEC
 

--- a/testing/drivers/crypto/Kconfig
+++ b/testing/drivers/crypto/Kconfig
@@ -1,3 +1,8 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
 config TESTING_CRYPTO
 	tristate "crypto test"
 	default n
@@ -62,30 +67,30 @@ config TESTING_CRYPTO_HASH_DISABLE_SHA512
 
 config TESTING_CRYPTO_HASH_DISABLE_UNALIGNED_MD5
 	bool "disable unaligned md5 tests"
-        depends on !TESTING_CRYPTO_HASH_DISABLE_MD5
+	depends on !TESTING_CRYPTO_HASH_DISABLE_MD5
 	default n
 
 config TESTING_CRYPTO_HASH_DISABLE_UNALIGNED_SHA1
 	bool "disable unaligned sha1 tests"
-        depends on !TESTING_CRYPTO_HASH_DISABLE_SHA1
+	depends on !TESTING_CRYPTO_HASH_DISABLE_SHA1
 	default n
 
 config TESTING_CRYPTO_HASH_DISABLE_UNALIGNED_SHA224
 	bool "disable unaligned sha224 tests"
-        depends on !TESTING_CRYPTO_HASH_DISABLE_SHA224
+	depends on !TESTING_CRYPTO_HASH_DISABLE_SHA224
 	default n
 
 config TESTING_CRYPTO_HASH_DISABLE_UNALIGNED_SHA256
 	bool "disable unaligned sha256 tests"
-        depends on !TESTING_CRYPTO_HASH_DISABLE_SHA256
+	depends on !TESTING_CRYPTO_HASH_DISABLE_SHA256
 	default n
 
 config TESTING_CRYPTO_HASH_DISABLE_UNALIGNED_SHA512
 	bool "disable unaligned sha512 tests"
-        depends on !TESTING_CRYPTO_HASH_DISABLE_SHA512
+	depends on !TESTING_CRYPTO_HASH_DISABLE_SHA512
 	default n
 
-endif
+endif # TESTING_CRYPTO_HASH
 
 config TESTING_CRYPTO_CRC32
 	bool "crc32 crypto test"
@@ -119,4 +124,4 @@ config TESTING_CRYPTO_STACKSIZE
 	int "crypto test stack size"
 	default DEFAULT_TASK_STACKSIZE
 
-endif
+endif # TESTING_CRYPTO

--- a/videoutils/x264/Kconfig
+++ b/videoutils/x264/Kconfig
@@ -1,17 +1,6 @@
 #
-# Copyright (C) 2023 Xiaomi Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
 #
 
 config VIDEOUTILS_LIBX264


### PR DESCRIPTION
## Summary

- Remove spaces from Kconfig

- Add TABs

- Fixed the header file

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

only style changes