### PR TITLE
{bp-3529}examples/rng90: add RNG90 example

### DIFF
--- a/examples/rng90/CMakeLists.txt
+++ b/examples/rng90/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ##############################################################################
+# apps/examples/rng90/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_RNG90)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_RNG90_PROGNAME}
+    PRIORITY
+    ${CONFIG_EXAMPLES_RNG90_PRIORITY}
+    STACKSIZE
+    ${CONFIG_EXAMPLES_RNG90_STACKSIZE}
+    MODULE
+    ${CONFIG_EXAMPLES_RNG90}
+    SRCS
+    rng90_main.c)
+endif()

--- a/examples/rng90/Kconfig
+++ b/examples/rng90/Kconfig
@@ -1,0 +1,37 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_RNG90
+	tristate "Microchip RNG90 TRNG example"
+	default n
+	depends on DEV_RNG90
+	---help---
+		Enable the RNG90 example.  It opens the RNG90 character device,
+		runs the built-in self-test and reads random bytes from it.
+
+if EXAMPLES_RNG90
+
+config EXAMPLES_RNG90_PROGNAME
+	string "Program name"
+	default "rng90"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_RNG90_DEVPATH
+	string "RNG90 device path"
+	default "/dev/rng0"
+	---help---
+		The default path of the RNG90 character device.
+
+config EXAMPLES_RNG90_PRIORITY
+	int "RNG90 task priority"
+	default 100
+
+config EXAMPLES_RNG90_STACKSIZE
+	int "RNG90 stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/rng90/Make.defs
+++ b/examples/rng90/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/rng90/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_RNG90),)
+CONFIGURED_APPS += $(APPDIR)/examples/rng90
+endif

--- a/examples/rng90/Makefile
+++ b/examples/rng90/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/examples/rng90/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Microchip RNG90 TRNG example built-in application info
+
+PROGNAME = $(CONFIG_EXAMPLES_RNG90_PROGNAME)
+PRIORITY = $(CONFIG_EXAMPLES_RNG90_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_RNG90_STACKSIZE)
+MODULE = $(CONFIG_EXAMPLES_RNG90)
+
+# Microchip RNG90 TRNG example
+
+MAINSRC = rng90_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/rng90/rng90_main.c
+++ b/examples/rng90/rng90_main.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * apps/examples/rng90/rng90_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <nuttx/crypto/rng90.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_EXAMPLES_RNG90_DEVPATH
+#  define CONFIG_EXAMPLES_RNG90_DEVPATH "/dev/rng0"
+#endif
+
+#define RNG90_MAX_BYTES 32
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: print_hex
+ *
+ * Description:
+ *   Dump a buffer as a hex string, 16 bytes per line.
+ *
+ ****************************************************************************/
+
+static void print_hex(FAR const uint8_t *buf, size_t len)
+{
+  size_t i;
+
+  for (i = 0; i < len; i++)
+    {
+      printf("%02x", buf[i]);
+      if ((i & 0x0f) == 0x0f)
+        {
+          printf("\n");
+        }
+      else
+        {
+          printf(" ");
+        }
+    }
+
+  if ((len & 0x0f) != 0)
+    {
+      printf("\n");
+    }
+}
+
+/****************************************************************************
+ * Name: usage
+ ****************************************************************************/
+
+static void usage(FAR const char *progname)
+{
+  printf("Usage: %s [<devpath>] [<count>]\n", progname);
+  printf("  <devpath>  RNG90 device (default %s)\n",
+         CONFIG_EXAMPLES_RNG90_DEVPATH);
+  printf("  <count>    number of random bytes to read, 1..%d (default %d)\n",
+         RNG90_MAX_BYTES, RNG90_MAX_BYTES);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * rng90_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  FAR const char *devpath = CONFIG_EXAMPLES_RNG90_DEVPATH;
+  int count = RNG90_MAX_BYTES;
+  uint8_t buf[RNG90_MAX_BYTES];
+  int fd;
+  int ret;
+
+  /* Parse the optional command line arguments */
+
+  if (argc > 1)
+    {
+      if (argv[1][0] == '-')
+        {
+          usage(argv[0]);
+          return EXIT_FAILURE;
+        }
+
+      devpath = argv[1];
+    }
+
+  if (argc > 2)
+    {
+      count = atoi(argv[2]);
+      if (count < 1 || count > RNG90_MAX_BYTES)
+        {
+          printf("Invalid count %d, clamping to %d\n", count,
+                 RNG90_MAX_BYTES);
+          count = RNG90_MAX_BYTES;
+        }
+    }
+
+  /* Opening the device wakes the RNG90 up; closing puts it to sleep. */
+
+  fd = open(devpath, O_RDONLY);
+  if (fd < 0)
+    {
+      printf("ERROR: Failed to open %s: %d\n", devpath, errno);
+      return EXIT_FAILURE;
+    }
+
+  printf("RNG90 example: device %s\n", devpath);
+
+  /* Read random bytes from the device */
+
+  ret = read(fd, buf, (size_t)count);
+  if (ret < 0)
+    {
+      printf("ERROR: read failed: %d\n", errno);
+      close(fd);
+      return EXIT_FAILURE;
+    }
+
+  printf("Read %d random byte(s):\n", ret);
+  print_hex(buf, (size_t)ret);
+
+  close(fd);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add a new RNG90 example application that opens the RNG90 character device, reads random bytes, and prints them in hexadecimal format.

The example supports optional command-line arguments for device path and byte count and integrates with Kconfig, Make, and CMake build flows.

## Impact

RELEASE

## Testing

CI