### PR TITLE
system/nxinit: add property-based action triggers

### DIFF
--- a/system/nxinit/CMakeLists.txt
+++ b/system/nxinit/CMakeLists.txt
@@ -24,6 +24,8 @@ if(CONFIG_SYSTEM_NXINIT)
 
   set(CSRCS init.c action.c builtin.c import.c parser.c service.c)
 
+  list(APPEND CSRCS property_simple.c)
+
   nuttx_add_application(
     MODULE
     ${CONFIG_SYSTEM_NXINIT}

--- a/system/nxinit/Kconfig
+++ b/system/nxinit/Kconfig
@@ -53,7 +53,7 @@ config SYSTEM_NXINIT_ACTION_CMD_ARGS_MAX
 		Maximum number of command arguments.
 		Form:
 		```
-		on <trigger>
+		on <event> [&& <event>]*
 		   <command>
 		   <command>
 		   <command>
@@ -67,16 +67,18 @@ config SYSTEM_NXINIT_ACTION_WARN_SLOW
 	---help---
 		Warning if command took more than `SYSTEM_NXINIT_ACTION_WARN_SLOW` ms.
 
-config SYSTEM_NXINIT_ACTION_MANAGER_EVENT_MAX
-	int "Max number of action manager events"
-	default 32
+config SYSTEM_NXINIT_ACTION_EVENTS_MAX
+	int "Max number of events"
+	default 1
+	range 1 64
 	---help---
-		Maximum number of action manager events.
+		Maximum number of event and action events.
+		See action.h:
 		```
-		struct action_manager_s
+		struct action_s
 		{
 		  ...
-		  FAR char *events[CONFIG_SYSTEM_NXINIT_ACTION_MANAGER_EVENT_MAX];
+		  struct action_event_s events[CONFIG_SYSTEM_NXINIT_ACTION_EVENTS_MAX];
 		  ...
 		};
 		```

--- a/system/nxinit/Makefile
+++ b/system/nxinit/Makefile
@@ -30,6 +30,7 @@ CSRCS += parser.c
 CSRCS += action.c
 CSRCS += service.c
 CSRCS += import.c
+CSRCS += property_simple.c
 
 PROGNAME = $(CONFIG_SYSTEM_NXINIT_PROGNAME)
 PRIORITY = $(CONFIG_SYSTEM_NXINIT_PRIORITY)

--- a/system/nxinit/action.c
+++ b/system/nxinit/action.c
@@ -32,21 +32,32 @@
 #include <sys/types.h>
 #include <sys/param.h>
 #include <unistd.h>
+#include <fnmatch.h>
 #include <nuttx/clock.h>
 
 #include "action.h"
 #include "builtin.h"
 #include "init.h"
+#include "property.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Maximum number of parameters for the action trigger.
- * Format: `on <trigger>`
- */
+#define ACTION_SECTION_PROP_PREFIX "property:"
+#define ACTION_SECTION_AND_PREFIX  "&&"
 
-#define ACTION_ARGUMENTS_MAX 2
+#define ACTION_PROP_KEY_DEFAULT    "default"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct event_arg_s
+{
+  FAR const char *key;
+  FAR const char *value;
+};
 
 /****************************************************************************
  * Private Function Prototypes
@@ -66,9 +77,21 @@ static void init_dump_action(FAR struct action_s *action);
 static void init_dump_action(FAR struct action_s *action)
 {
   FAR struct action_cmd_s *cmd;
+  size_t i;
 
   init_debug("Action %p", action);
-  init_debug("  event trigger: '%s'", action->event ? action->event : "");
+  for (i = 0; i < nitems(action->events); i++)
+    {
+      if (!action->events[i].key)
+        {
+          continue;
+        }
+
+      init_debug("  %s%s%s", action->events[i].key,
+                 action->events[i].invert ? "!=" : "==",
+                 action->events[i].value);
+    }
+
   list_for_every_entry(&action->cmds, cmd, struct action_cmd_s, node)
     {
       init_dump_args(cmd->argc, cmd->argv);
@@ -94,8 +117,8 @@ static void add_ready(FAR struct action_manager_s *am,
     {
       if (ready == a)
         {
-          init_debug("Action %p(%s) already on the queue", a,
-                     a->event ? a->event : "");
+          init_debug("Event %p(%s:%s) already on the queue", a,
+                     a->events[0].key, a->events[0].value);
           init_dump_action(a);
           return;
         }
@@ -104,69 +127,148 @@ static void add_ready(FAR struct action_manager_s *am,
   list_add_tail(&am->ready_actions, &a->ready_node);
 }
 
-static void update_ready(FAR struct action_manager_s *am)
+static int parse_event(FAR char *buf, FAR struct action_event_s *events,
+                       size_t count)
 {
+  FAR char *value;
+  FAR char *key;
   size_t i;
 
-  /* Actions with event trigger */
-
-  for (i = 0; i < nitems(am->events); i++)
+  value = strchr(buf, '=');
+  if (!value || !*(value + 1))
     {
-      if (!am->events[i])
+      return -EINVAL;
+    }
+
+  *(value++) = '\0';
+  key = strchr(buf, ':');
+  if (!key || !*(key + 1))
+    {
+      return -EINVAL;
+    }
+
+  *(key++) = '\0';
+  for (i = 0; i < count; i++)
+    {
+      if (events[i].key)
         {
           continue;
         }
 
-      am->current = list_prepare_entry(am->current, &am->actions,
-                                       struct action_s, node);
-      list_for_every_entry_continue(am->current, &am->actions,
-                                    struct action_s, node)
+      if (key[strlen(key) - 1] == '!')
         {
-          if (am->current->event && !strcmp(am->current->event,
-                                            am->events[i]))
+          events[i].invert = true;
+          key[strlen(key) - 1] = '\0';  /* Skip '!' */
+        }
+      else
+        {
+          events[i].invert = false;
+        }
+
+      events[i].key = strdup(key);
+      events[i].value = strdup(value);
+
+      if (events[i].key && events[i].value)
+        {
+          init_debug("Added action event key:%s value:%s", events[i].key,
+                     events[i].value);
+          return 0;
+        }
+
+      for (; i >= 0; i--)
+        {
+          if (events[i].key)
             {
-              add_ready(am, am->current);
-              return;
+              free((FAR void *)events[i].key);
+              events[i].key = NULL;
+            }
+
+          if (events[i].value)
+            {
+              free(events[i].value);
             }
         }
 
-      init_debug("Remove event [%zu] '%s'", i, am->events[i]);
-      am->current = NULL;
-      free(am->events[i]);
-      am->events[i] = NULL;
+      return -errno;
     }
+
+  init_err("Dropped action event key:%s value:%s", key, value);
+  return -ENOBUFS;
+}
+
+static int event_callback(FAR struct action_manager_s *am,
+                          FAR struct action_s *a,
+                          FAR struct action_event_s *event,
+                          FAR void *argument)
+{
+  struct event_arg_s *arg = argument;
+
+  if (strcmp(arg->key, event->key))
+    {
+      return 0;
+    }
+
+  if (event->invert != fnmatch(event->value, arg->value, 0))
+    {
+      event->pending = false;
+    }
+  else if (!event->pending)
+    {
+      event->pending = true;
+      init_debug("Trigger %s%s%s", event->key,
+                 event->invert ? "!=" : "==",
+                 event->value);
+    }
+
+  return event->pending;
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
+int init_action_foreach_event(FAR struct action_manager_s *am,
+                              init_action_event_cb cb,
+                              FAR void *arg)
+{
+  FAR struct action_s *a;
+  size_t i;
+  int ret = 0;
+
+  list_for_every_entry(&am->actions, a, struct action_s, node)
+    {
+      for (i = 0; i < nitems(a->events) && a->events[i].key; i++)
+        {
+          ret = cb(am, a, &a->events[i], arg);
+          if (ret < 0)
+            {
+              break;
+            }
+          else if (ret > 0)
+            {
+              add_ready(am, a);
+            }
+        }
+    }
+
+  return ret;
+}
+
+void init_action_trigger_event(FAR struct action_manager_s *am,
+                               FAR const char *key,
+                               FAR const char *value)
+{
+  struct event_arg_s arg;
+
+  arg.key = key;
+  arg.value = value;
+  init_action_foreach_event(am, event_callback, &arg);
+}
+
 int init_action_add_event(FAR struct action_manager_s *am,
                           FAR const char *event)
 {
-  int ret = -ENOBUFS;
-  size_t i;
-
-  for (i = 0; i < nitems(am->events); i++)
-    {
-      if (am->events[i])
-        {
-          continue;
-        }
-
-      am->events[i] = strdup(event);
-      if (am->events[i])
-        {
-          init_debug("Add event [%zu] '%s'", i, am->events[i]);
-          return 0;
-        }
-
-      ret = -errno;
-      break;
-    }
-
-  init_warn("Drop event '%s' %d", event, ret);
-  return ret;
+  return init_property_set(am->prop, ACTION_PROP_KEY_DEFAULT, event);
 }
 
 /****************************************************************************
@@ -195,7 +297,6 @@ int init_action_run_command(FAR struct action_manager_s *am)
       return INT_MAX;
     }
 
-  update_ready(am);
   if (list_is_empty(&am->ready_actions))
     {
       return INT_MAX;
@@ -271,7 +372,7 @@ int init_action_parse(FAR const struct parser_s *parser,
                       bool create, FAR char *buf)
 {
   FAR struct action_manager_s *am = parser->priv;
-  FAR char *argv[ACTION_ARGUMENTS_MAX];
+  FAR char *argv[2 * CONFIG_SYSTEM_NXINIT_ACTION_EVENTS_MAX];
   FAR struct action_cmd_s *cmd;
   FAR struct action_s *a;
   int ret;
@@ -294,12 +395,35 @@ int init_action_parse(FAR const struct parser_s *parser,
 
       list_initialize(&a->cmds);
 
-      a->event = strdup(argv[--ret]);
-      if (a->event == NULL)
+      while (--ret > 0)
         {
-          init_err("Event trigger");
-          free(a);
-          return -errno;
+          if (!strncmp(argv[ret], ACTION_SECTION_PROP_PREFIX,
+                       strlen(ACTION_SECTION_PROP_PREFIX)))
+            {
+              ret = parse_event(argv[ret], a->events,
+                                nitems(a->events));
+              if (ret < 0)
+                {
+                  free(a);
+                  return ret;
+                }
+            }
+          else if (strncmp(argv[ret], ACTION_SECTION_AND_PREFIX,
+                           strlen(ACTION_SECTION_AND_PREFIX)))
+            {
+              char tmp[CONFIG_SYSTEM_NXINIT_RC_LINE_MAX];
+
+              sprintf(tmp, ":%s=%s", ACTION_PROP_KEY_DEFAULT, argv[ret]);
+              ret = parse_event(tmp, a->events,
+                                nitems(a->events));
+              if (ret < 0)
+                {
+                  free(a);
+                  return ret;
+                }
+
+              break;
+            }
         }
 
       list_add_tail(&am->actions, &a->node);

--- a/system/nxinit/action.c
+++ b/system/nxinit/action.c
@@ -176,7 +176,7 @@ static int parse_event(FAR char *buf, FAR struct action_event_s *events,
           return 0;
         }
 
-      for (; i >= 0; i--)
+      while (i-- > 0)
         {
           if (events[i].key)
             {

--- a/system/nxinit/action.c
+++ b/system/nxinit/action.c
@@ -397,15 +397,16 @@ int init_action_parse(FAR const struct parser_s *parser,
 
       while (--ret > 0)
         {
+          int n;
+
           if (!strncmp(argv[ret], ACTION_SECTION_PROP_PREFIX,
                        strlen(ACTION_SECTION_PROP_PREFIX)))
             {
-              ret = parse_event(argv[ret], a->events,
-                                nitems(a->events));
-              if (ret < 0)
+              n = parse_event(argv[ret], a->events, nitems(a->events));
+              if (n < 0)
                 {
                   free(a);
-                  return ret;
+                  return n;
                 }
             }
           else if (strncmp(argv[ret], ACTION_SECTION_AND_PREFIX,
@@ -414,12 +415,11 @@ int init_action_parse(FAR const struct parser_s *parser,
               char tmp[CONFIG_SYSTEM_NXINIT_RC_LINE_MAX];
 
               sprintf(tmp, ":%s=%s", ACTION_PROP_KEY_DEFAULT, argv[ret]);
-              ret = parse_event(tmp, a->events,
-                                nitems(a->events));
-              if (ret < 0)
+              n = parse_event(tmp, a->events, nitems(a->events));
+              if (n < 0)
                 {
                   free(a);
-                  return ret;
+                  return n;
                 }
 
               break;

--- a/system/nxinit/action.c
+++ b/system/nxinit/action.c
@@ -216,6 +216,7 @@ static int event_callback(FAR struct action_manager_s *am,
           init_debug("Trigger %s%s%s", event->key,
                      event->invert ? "!=" : "==",
                      event->value);
+          return EVENT_STATE_TRIGGERED;
         }
     }
 
@@ -237,20 +238,18 @@ int init_action_foreach_event(FAR struct action_manager_s *am,
 
   list_for_every_entry(&am->actions, a, struct action_s, node)
     {
-      for (i = 0, m = 0; i < nitems(a->events) && a->events[i].key; i++)
+      for (i = 0, m = 1; i < nitems(a->events) && a->events[i].key; i++)
         {
           ret = cb(am, a, &a->events[i], arg);
           if (ret < 0)
             {
               break;
             }
-          else if (ret > 0)
-            {
-              m++;
-            }
+
+          m = MIN(m * ret, EVENT_STATE_TRIGGERED);
         }
 
-      if (i > 0 && i == m)
+      if (m == EVENT_STATE_TRIGGERED)
         {
           add_ready(am, a);
         }

--- a/system/nxinit/action.c
+++ b/system/nxinit/action.c
@@ -167,6 +167,7 @@ static int parse_event(FAR char *buf, FAR struct action_event_s *events,
 
       events[i].key = strdup(key);
       events[i].value = strdup(value);
+      events[i].pending = false;
 
       if (events[i].key && events[i].value)
         {
@@ -203,21 +204,19 @@ static int event_callback(FAR struct action_manager_s *am,
 {
   struct event_arg_s *arg = argument;
 
-  if (strcmp(arg->key, event->key))
+  if (!strcmp(arg->key, event->key))
     {
-      return 0;
-    }
-
-  if (event->invert != fnmatch(event->value, arg->value, 0))
-    {
-      event->pending = false;
-    }
-  else if (!event->pending)
-    {
-      event->pending = true;
-      init_debug("Trigger %s%s%s", event->key,
-                 event->invert ? "!=" : "==",
-                 event->value);
+      if (event->invert != fnmatch(event->value, arg->value, 0))
+        {
+          event->pending = false;
+        }
+      else if (!event->pending)
+        {
+          event->pending = true;
+          init_debug("Trigger %s%s%s", event->key,
+                     event->invert ? "!=" : "==",
+                     event->value);
+        }
     }
 
   return event->pending;
@@ -233,11 +232,12 @@ int init_action_foreach_event(FAR struct action_manager_s *am,
 {
   FAR struct action_s *a;
   size_t i;
+  size_t m;
   int ret = 0;
 
   list_for_every_entry(&am->actions, a, struct action_s, node)
     {
-      for (i = 0; i < nitems(a->events) && a->events[i].key; i++)
+      for (i = 0, m = 0; i < nitems(a->events) && a->events[i].key; i++)
         {
           ret = cb(am, a, &a->events[i], arg);
           if (ret < 0)
@@ -246,8 +246,13 @@ int init_action_foreach_event(FAR struct action_manager_s *am,
             }
           else if (ret > 0)
             {
-              add_ready(am, a);
+              m++;
             }
+        }
+
+      if (i > 0 && i == m)
+        {
+          add_ready(am, a);
         }
     }
 

--- a/system/nxinit/action.h
+++ b/system/nxinit/action.h
@@ -71,6 +71,8 @@ struct action_manager_s
   struct timespec time_run;
 #endif
   FAR struct service_manager_s *sm;
+
+  FAR struct init_poller_s *prop;
 };
 
 /****************************************************************************

--- a/system/nxinit/action.h
+++ b/system/nxinit/action.h
@@ -44,15 +44,19 @@ struct action_cmd_s
   FAR char *argv[CONFIG_SYSTEM_NXINIT_ACTION_CMD_ARGS_MAX];
 };
 
+struct action_event_s
+{
+  FAR const char *key;
+  FAR char *value;
+  bool invert;
+  bool pending;
+};
+
 struct action_s
 {
   struct list_node node;          /* Action list node */
   struct list_node ready_node;    /* Ready list node */
-
-  /* Event trigger */
-
-  FAR const char *event;
-
+  struct action_event_s events[CONFIG_SYSTEM_NXINIT_ACTION_EVENTS_MAX];
   struct list_node cmds;          /* Command header, struct action_cmd_s */
 };
 
@@ -61,7 +65,6 @@ struct action_manager_s
   struct list_node actions;       /* Action header, struct action_s */
   struct list_node ready_actions; /* Ready header, struct action_s */
 
-  FAR char *events[CONFIG_SYSTEM_NXINIT_ACTION_MANAGER_EVENT_MAX];
   FAR struct action_s *current;
 
   FAR struct action_cmd_s *running;
@@ -75,6 +78,11 @@ struct action_manager_s
   FAR struct init_poller_s *prop;
 };
 
+typedef CODE int (*init_action_event_cb)(FAR struct action_manager_s *,
+                                         FAR struct action_s *,
+                                         FAR struct action_event_s *,
+                                         FAR void *arg);
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -85,6 +93,12 @@ int  init_action_run_command(FAR struct action_manager_s *am);
 void init_action_reap_command(FAR struct action_manager_s *am);
 int  init_action_parse(FAR const struct parser_s *parser,
                        bool create, FAR char *buf);
+int  init_action_foreach_event(FAR struct action_manager_s *am,
+                               init_action_event_cb cb,
+                               FAR void *arg);
+void init_action_trigger_event(FAR struct action_manager_s *am,
+                               FAR const char *key,
+                               FAR const char *value);
 #ifdef CONFIG_SYSTEM_NXINIT_DEBUG
 void init_dump_actions(FAR struct list_node *head);
 #else

--- a/system/nxinit/action.h
+++ b/system/nxinit/action.h
@@ -78,6 +78,18 @@ struct action_manager_s
   FAR struct init_poller_s *prop;
 };
 
+/* Event evaluation result reported by init_action_event_cb.
+ * TRIGGERED means the event is satisfied and its key is the one that just
+ * changed, SATISFIED means it stays satisfied from an earlier change.
+ */
+
+enum action_event_state_e
+{
+  EVENT_STATE_UNSATISFIED = 0,
+  EVENT_STATE_SATISFIED,
+  EVENT_STATE_TRIGGERED,
+};
+
 typedef CODE int (*init_action_event_cb)(FAR struct action_manager_s *,
                                          FAR struct action_s *,
                                          FAR struct action_event_s *,

--- a/system/nxinit/builtin.c
+++ b/system/nxinit/builtin.c
@@ -33,6 +33,7 @@
 
 #include "builtin.h"
 #include "init.h"
+#include "property.h"
 #include "service.h"
 
 /****************************************************************************
@@ -59,6 +60,10 @@ static int cmd_start(FAR struct action_manager_s *am,
                      int argc, FAR char **argv);
 static int cmd_stop(FAR struct action_manager_s *am,
                     int argc, FAR char **argv);
+#if CONFIG_SYSTEM_NXINIT_ACTION_EVENTS_MAX > 1
+static int cmd_setprop(FAR struct action_manager_s *am,
+                       int argc, FAR char **argv);
+#endif
 static int cmd_exec(FAR struct action_manager_s *am,
                     int argc, FAR char **argv);
 static int cmd_class_start(FAR struct action_manager_s *am,
@@ -76,6 +81,9 @@ static const struct cmd_map_s g_builtin[] =
   {"class_stop", 2, 2, cmd_class_stop},
   {"exec", 3, 99, cmd_exec},
   {"exec_start", 2, 2, cmd_exec_start},
+#if CONFIG_SYSTEM_NXINIT_ACTION_EVENTS_MAX > 1
+  {"setprop", 3, 3, cmd_setprop},
+#endif
   {"start", 2, 2, cmd_start},
   {"stop", 2, 2, cmd_stop},
   {"trigger", 2, 2, cmd_trigger},
@@ -135,6 +143,14 @@ static int cmd_stop(FAR struct action_manager_s *am,
 
   return init_service_stop(service);
 }
+
+#if CONFIG_SYSTEM_NXINIT_ACTION_EVENTS_MAX > 1
+static int cmd_setprop(FAR struct action_manager_s *am, int argc,
+                       FAR char **argv)
+{
+  return init_property_set(am->prop, argv[1], argv[2]);
+}
+#endif
 
 static int cmd_trigger(FAR struct action_manager_s *am,
                        int argc, FAR char **argv)

--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -38,6 +38,7 @@
 #include "builtin.h"
 #include "init.h"
 #include "import.h"
+#include "property.h"
 #include "service.h"
 
 /****************************************************************************
@@ -48,21 +49,6 @@
           ((ms) == INT_MAX ? NULL \
                            : ((ts)->tv_sec = (ms) / 1000, \
                               (ts)->tv_nsec = ((ms) % 1000) * 1000000, (ts)))
-
-/****************************************************************************
- * Private Types
- ****************************************************************************/
-
-struct init_event_s
-{
-  FAR struct pollfd *pfd;
-  FAR void *priv;
-  FAR struct service_manager_s *sm;
-  FAR struct action_manager_s *am;
-  CODE int  (*init)   (FAR struct init_event_s *);
-  CODE void (*handle) (FAR struct init_event_s *);
-  CODE void (*deinit) (FAR struct init_event_s *);
-};
 
 /****************************************************************************
  * Private Functions
@@ -154,11 +140,16 @@ int main(int argc, FAR char *argv[])
       {NULL},
     };
 
-  struct init_event_s ev[] =
+  struct init_poller_s poller[] =
     {
+      {
+        .init = init_property_init,
+        .handle = init_property_handler,
+        .deinit = init_property_deinit,
+      },
     };
 
-  struct pollfd pfds[nitems(ev)];
+  struct pollfd pfds[nitems(poller)];
   sigset_t mask;
   size_t i;
   int r;
@@ -176,12 +167,12 @@ int main(int argc, FAR char *argv[])
   usbtrace_enable(TRACE_BITSET);
 #endif
 
-  for (i = 0; i < nitems(ev); i++)
+  for (i = 0; i < nitems(poller); i++)
     {
-      ev[i].sm = &sm;
-      ev[i].am = &am;
-      ev[i].pfd = &pfds[i];
-      r = ev[i].init(&ev[i]);
+      poller[i].sm = &sm;
+      poller[i].am = &am;
+      poller[i].pfd = &pfds[i];
+      r = poller[i].init(&poller[i]);
       if (r < 0)
         {
           init_err("Init event %zu", i);
@@ -237,11 +228,11 @@ int main(int argc, FAR char *argv[])
           break;
         }
 
-      for (i = 0; i < nitems(ev); i++)
+      for (i = 0; i < nitems(poller); i++)
         {
-          if (ev[i].pfd->revents & ev[i].pfd->events)
+          if (poller[i].pfd->revents & poller[i].pfd->events)
             {
-              ev[i].handle(&ev[i]);
+              poller[i].handle(&poller[i]);
             }
         }
 
@@ -251,9 +242,9 @@ int main(int argc, FAR char *argv[])
 out:
   while (i--)
     {
-      if (ev[i].deinit)
+      if (poller[i].deinit)
         {
-          ev[i].deinit(&ev[i]);
+          poller[i].deinit(&poller[i]);
         }
     }
 

--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -125,7 +125,6 @@ int main(int argc, FAR char *argv[])
     {
       .actions = LIST_INITIAL_VALUE(am.actions),
       .ready_actions = LIST_INITIAL_VALUE(am.ready_actions),
-      .events = { 0 },
       .current = NULL,
       .running = NULL,
       .pid_running = -1,

--- a/system/nxinit/init.h
+++ b/system/nxinit/init.h
@@ -27,6 +27,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <poll.h>
 #include <syslog.h>
 
 /****************************************************************************
@@ -89,5 +90,20 @@
               } \
           } \
         while (0)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct init_poller_s
+{
+  FAR struct pollfd *pfd;
+  FAR void *priv;
+  FAR struct service_manager_s *sm;
+  FAR struct action_manager_s *am;
+  CODE int  (*init)   (FAR struct init_poller_s *);
+  CODE void (*handle) (FAR struct init_poller_s *);
+  CODE void (*deinit) (FAR struct init_poller_s *);
+};
 
 #endif /* __APPS_SYSTEM_NXINIT_INIT_H */

--- a/system/nxinit/property.h
+++ b/system/nxinit/property.h
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * apps/system/nxinit/property.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_NXINIT_PROPERTY_H
+#define __APPS_SYSTEM_NXINIT_PROPERTY_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "init.h"
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* Steps to enable action events
+ *
+ * - Define all init_property_*() interfaces declared in this file.
+ * - Data structures or functions that will likely be used:
+ *   - struct action_event_s
+ *   - init_action_foreach_event()
+ */
+
+void init_property_handler(FAR struct init_poller_s *ctx);
+void init_property_deinit(FAR struct init_poller_s *ctx);
+int  init_property_init(FAR struct init_poller_s *ctx);
+int  init_property_set(FAR struct init_poller_s *ctx,
+                       FAR const char *key, FAR const char *value);
+#endif /* __APPS_SYSTEM_NXINIT_PROPERTY_H */

--- a/system/nxinit/property_simple.c
+++ b/system/nxinit/property_simple.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * apps/system/nxinit/property_simple.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "action.h"
+#include "property.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int init_property_set(FAR struct init_poller_s *ctx,
+                      FAR const char *key, FAR const char *value)
+{
+  init_debug("Setprop key:%s value:%s", key, value);
+  init_action_trigger_event(ctx->am, key, value);
+  return 0;
+}
+
+void init_property_handler(FAR struct init_poller_s *ctx)
+{
+  UNUSED(ctx);
+}
+
+void init_property_deinit(FAR struct init_poller_s *ctx)
+{
+  UNUSED(ctx);
+}
+
+int init_property_init(FAR struct init_poller_s *ctx)
+{
+  ctx->am->prop = ctx;
+  ctx->pfd->fd = -1;
+  return 0;
+}


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Extend init actions from bare event names to a property-based trigger model:

```
on <event> [&& <event>]*
```

`<event>` is a name or `property:key=value` (fnmatch, `!=` inverts). Adds a
`setprop` builtin and a pluggable poller backend (`property_simple.c`). Bare
names map to `default==<name>`, so existing `on <event>` rc files keep working.
Includes three fixes to the new parser and matcher: event parsing loss,
multi-event AND semantics, and size_t index underflow.

## Impact

- rc files: new `on property:...` syntax and `setprop`; old `on <event>` unchanged.
- Kconfig: `..._ACTION_MANAGER_EVENT_MAX` (32) → `..._ACTION_EVENTS_MAX` (default 1, range 1..64); configs setting the old symbol must be updated.
- Build: adds `property_simple.c`. No hardware or security impact.

## Testing

```
on boot
   setprop key_test
   setprop key_test value_test  /* property changed and matched */
   trigger event_test

on event_test && property:key_test=value_test
   echo "on event_test, property changed!"

on property:key_test=value_test
   echo "property changed!"
```

`tools/checkpatch.sh -f` passes on all changed files.