### PR TITLE
nshlib: apply privilege prompt markers only after real login

### DIFF
--- a/nshlib/nsh_prompt.c
+++ b/nshlib/nsh_prompt.c
@@ -218,8 +218,11 @@ void nsh_update_prompt(void)
  * Name: nsh_update_prompt_after_login
  *
  * Description:
- *   Enable privilege markers in the prompt and refresh it.  Boot and
- *   no-login sessions keep NSH_PROMPT_STRING (for example, "nsh> ").
+ *   Enable privilege markers in the prompt and refresh it.  Call this
+ *   after a successful console/telnet login or su.  nsh_consolemain
+ *   always passes NSH_LOGIN_LOCAL, so this must not run merely because
+ *   the session type is local.  Boot and no-login sessions keep
+ *   NSH_PROMPT_STRING (for example, "nsh> ").
  *
  ****************************************************************************/
 

--- a/nshlib/nsh_session.c
+++ b/nshlib/nsh_session.c
@@ -87,6 +87,15 @@ int nsh_session(FAR struct console_stdio_s *pstate,
           nsh_exit(vtbl, 1);
           return -1; /* nsh_exit does not return */
         }
+
+#ifdef CONFIG_SCHED_USER_IDENTITY
+      /* nsh_consolemain always passes NSH_LOGIN_LOCAL, even when console
+       * login is disabled.  Apply #/$ markers only after a real login
+       * so CI/NTFC still sees CONFIG_NSH_PROMPT_STRING at boot.
+       */
+
+      nsh_update_prompt_after_login();
+#endif
     }
   else
 #endif /* CONFIG_NSH_CONSOLE_LOGIN */
@@ -100,15 +109,12 @@ int nsh_session(FAR struct console_stdio_s *pstate,
           nsh_exit(vtbl, 1);
           return -1; /* nsh_exit does not return */
         }
-    }
-#endif /* CONFIG_NSH_TELNET_LOGIN */
 
 #ifdef CONFIG_SCHED_USER_IDENTITY
-  if (login != NSH_LOGIN_NONE)
-    {
       nsh_update_prompt_after_login();
-    }
 #endif
+    }
+#endif /* CONFIG_NSH_TELNET_LOGIN */
 
   if (login != NSH_LOGIN_NONE)
     {


### PR DESCRIPTION
## Summary

- Emergency CI / NTFC is failing after https://github.com/apache/nuttx-apps/pull/3714 with `TimeoutError: device boot timeout` on `sim/citest` and `qemu-rv/citest`.
- `nsh_consolemain()` always starts the session with `NSH_LOGIN_LOCAL`, even when `CONFIG_NSH_CONSOLE_LOGIN` is disabled. PR 3714 treated any non-`NONE` session as a login and rewrote `nsh>` to `nsh#` whenever `CONFIG_SCHED_USER_IDENTITY` was enabled.
- NTFC detects boot by looking for `CONFIG_NSH_PROMPT_STRING` (`nsh>`), so those citest configs (USER_IDENTITY on, console login off) never come up.
- Apply `#`/`$` markers only after a successful console or telnet login (or `su`). No-login boot keeps `nsh>`.

## Impact

- `CONFIG_SCHED_USER_IDENTITY` boards without NSH login keep the configured prompt at boot (CI/NTFC compatible).
- Login-enabled sessions and `su` still get `nsh#` / `nsh$`.
- No change when `CONFIG_SCHED_USER_IDENTITY` is disabled.

## Testing

Build host: Linux WSL2, `sim:nsh` with `CONFIG_SCHED_USER_IDENTITY=y` and console login disabled (same prompt path as `sim/citest` / `qemu-rv/citest`).

No-login boot keeps `CONFIG_NSH_PROMPT_STRING` (`nsh>`), so NTFC boot detection can succeed. After `su`, root becomes `nsh#`:

```
NuttShell (NSH) NuttX-13.0.0
nsh> id
uid=0(root) gid=0(root)
nsh> su
nsh# id
uid=0(root) gid=0(root)
nsh# whoami
root
nsh# 
```