### PR TITLE
ci: do not trigger Build on PR description edits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,99 +14,24 @@ name: Build
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
   push:
     branches:
       - 'releases/*'
     tags:
 
+# pull-requests read: Fetch-Source re-reads the PR description so that a
+# manual re-run picks up Depends-On lines edited after the run was created.
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
-  # Edited runs do not request cancellation of an active code build.
-  # GitHub may still replace an older pending run in this concurrency group.
-  cancel-in-progress: ${{ github.event.action != 'edited' }}
+  cancel-in-progress: true
 
 jobs:
-  # Gate heavy CI on dependency-changing edits.
-  Changes:
-    runs-on: ubuntu-latest
-    outputs:
-      should_build: ${{ steps.gate.outputs.should_build }}
-    steps:
-      # Do not let PR code control its own edit gate.
-      - name: Checkout base-branch CI scripts
-        if: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' }}
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          sparse-checkout: .github/scripts
-          sparse-checkout-cone-mode: false
-          fetch-depth: 1
-          path: base-ci
-        continue-on-error: true
-      - name: Checkout PR CI scripts (fallback)
-        if: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' }}
-        uses: actions/checkout@v7
-        with:
-          sparse-checkout: .github/scripts
-          sparse-checkout-cone-mode: false
-          fetch-depth: 1
-          path: pr-ci
-      - name: Decide whether to run CI
-        id: gate
-        shell: bash
-        env:
-          ACTION: ${{ github.event.action }}
-          NEW_BODY: ${{ github.event.pull_request.body }}
-          OLD_BODY: ${{ github.event.changes.body.from }}
-          BODY_CHANGE: ${{ toJSON(github.event.changes.body) }}
-          BASE_CHANGE: ${{ toJSON(github.event.changes.base) }}
-        run: |
-          set -euo pipefail
-
-          if [ "${ACTION:-}" != "edited" ]; then
-            echo "Event '${ACTION:-push}': running CI."
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$BASE_CHANGE" != "null" ]; then
-            echo "::notice::PR base branch changed; running CI."
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$BODY_CHANGE" = "null" ]; then
-            echo "::notice::PR edited but body unchanged; no code/dependency change, skipping CI."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PARSER="pr-ci/.github/scripts/depends_on.py"
-          if [ -f "base-ci/.github/scripts/depends_on.py" ]; then
-            PARSER="base-ci/.github/scripts/depends_on.py"
-            echo "Using base-branch parser for the gate."
-          else
-            echo "::notice::Base branch has no depends_on.py yet; using PR parser for the gate (bootstrap)."
-          fi
-
-          # Include status so invalid declarations also retrigger reporting.
-          NEW_STATE="$(PR_BODY="$NEW_BODY" python3 "$PARSER" --print-state)"
-          OLD_STATE="$(PR_BODY="$OLD_BODY" python3 "$PARSER" --print-state)"
-          if [ "$NEW_STATE" != "$OLD_STATE" ]; then
-            echo "depends-on state changed; running CI."
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::No depends-on change on this edit; no code change, skipping CI."
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # Fetch the source from nuttx and nuttx-apps repos
   Fetch-Source:
-    needs: Changes
-    if: ${{ needs.Changes.outputs.should_build == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI scripts
@@ -119,6 +44,7 @@ jobs:
         id: gittargets
         shell: bash
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -126,6 +52,17 @@ jobs:
         run: |
           OS_REF=""
           APPS_REF=""
+
+          # The event payload keeps the PR description from when the run was
+          # created; re-read it so a manual re-run picks up an edited
+          # Depends-On line. Keep the payload copy if the API call fails.
+          if [ -n "${PR_NUMBER:-}" ]; then
+            if LIVE_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')"; then
+              PR_BODY="$LIVE_BODY"
+            else
+              echo "::warning::Could not re-read the PR description; using the copy from the event payload."
+            fi
+          fi
 
           REF=$GITHUB_REF
 


### PR DESCRIPTION
## Summary
  
The Depends-On feature (commit 2aebae740) made the Build workflow
trigger on PR description edits. A gate job checks whether the edit
changed any Depends-On declaration: if yes, the build jobs run again
with the new dependencies; on any other edit the gate skips all build
jobs.
    
The gate has a side effect that breaks PR check results. Skipped jobs
still register check results on the PR, and the PR checks view shows
the newest check run of each name. So after any description edit the
PR shows "skipped" for every build check instead of the pass/fail
from the real run. Re-running that newest run only repeats the skip,
so the real results never come back. This can also hide a red X from
a failed build.
    
Fix by not triggering Build on description edits at all: remove the
"edited" event type and the gate job.
    
Depends-On keeps working: dependencies are read from the description
at the start of every run against master, as before. Fetch-Source now
re-reads the description through the API instead of using the copy
stored in the event payload, so every run uses the current Depends-On
state no matter how it was triggered.
    
After editing a Depends-On line, retrigger CI by any of:
    - pushing new or rebased commits to the PR branch
    - closing and reopening the PR
    - pressing "Re-run all jobs" on the existing Build run
    
A description edit alone no longer triggers anything, which is
exactly the behavior that corrupted the PR check results.

## Impact

try to fix https://github.com/apache/nuttx-apps/pull/3690#issuecomment-5301179168

## Testing

none, must be checked upstream


