### PR TITLE
graphics/pdcurs34: Build fixes for wide characters code path

### DIFF
--- a/graphics/pdcurs34/pdcurses/pdc_getstr.c
+++ b/graphics/pdcurs34/pdcurses/pdc_getstr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/graphics/pdcurses/pdc_getstr.c
+ * apps/graphics/pdcurs34/pdcurses/pdc_getstr.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -273,7 +273,6 @@ int wgetnstr(WINDOW *win, char *str, int n)
             }
 
           break;
-
         }
 
       wrefresh(win);
@@ -378,7 +377,7 @@ int wgetn_wstr(WINDOW *win, wint_t *wstr, int n)
   int num;
   int x;
   int chars;
-  char *p;
+  wint_t *p;
   bool stop;
   bool oldecho;
   bool oldcbreak;

--- a/graphics/pdcurs34/pdcurses/pdc_keyname.c
+++ b/graphics/pdcurs34/pdcurses/pdc_keyname.c
@@ -61,7 +61,7 @@
  * Private Data
  ****************************************************************************/
 
-static const char *key_name[] =
+static const char *names[] =
 {
   "KEY_BREAK", "KEY_DOWN", "KEY_UP", "KEY_LEFT", "KEY_RIGHT",
   "KEY_HOME", "KEY_BACKSPACE", "KEY_F0", "KEY_F(1)", "KEY_F(2)",
@@ -138,7 +138,7 @@ const char *keyname(int key)
       return unctrl((chtype) key);
     }
 
-  return has_key(key) ? key_name[key - KEY_MIN] : "UNKNOWN KEY";
+  return has_key(key) ? names[key - KEY_MIN] : "UNKNOWN KEY";
 }
 
 bool has_key(int key)

--- a/graphics/pdcurs34/pdcurses/pdc_slk.c
+++ b/graphics/pdcurs34/pdcurses/pdc_slk.c
@@ -55,7 +55,7 @@
  *       These functions manipulate a window that contain Soft Label Keys
  *       (SLK). To use the SLK functions, a call to slk_init() must be
  *       made BEFORE initscr() or newterm(). slk_init() removes 1 or 2
- *       lines from the useable screen, depending on the format selected.
+ *       lines from the usable screen, depending on the format selected.
  *
  *       The line(s) removed from the screen are used as a separate
  *       window, in which SLKs are displayed.
@@ -362,7 +362,7 @@ char *slk_label(int labnum)
 #ifdef CONFIG_PDCURSES_WIDE
   wchar_t *wtemp = slk_wlabel(labnum);
 
-  PDC_wcstombs(temp, wtemp, 32);
+  PDC_wcstombs(slk_temp2, wtemp, 32);
 #else
   chtype *p;
   int i;

--- a/graphics/pdcurs34/pdcurses/pdc_util.c
+++ b/graphics/pdcurs34/pdcurses/pdc_util.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/graphics/pdcurses/util.c
+ * apps/graphics/pdcurs34/pdcurses/pdc_util.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -114,7 +114,10 @@ char *unctrl(chtype c)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #else
-  static char strbuf[3] = { 0, 0, 0 };
+  static char strbuf[3] =
+  {
+    0, 0, 0
+  };
 #endif
 
   chtype ic;
@@ -210,7 +213,10 @@ wchar_t *wunctrl(cchar_t *wc)
 #ifdef CONFIG_PDCURSES_MULTITHREAD
   FAR struct pdc_context_s *ctx = PDC_ctx();
 #else
-  static wchar_t strbuf2[3] = { 0, 0, 0 };
+  static wchar_t strbuf2[3] =
+  {
+    0, 0, 0
+  };
 #endif
 
   cchar_t ic;
@@ -223,7 +229,7 @@ wchar_t *wunctrl(cchar_t *wc)
     {
       strbuf2[0] = (wchar_t) ic;
       strbuf2[1] = L'\0';
-      return strbuf;
+      return strbuf2;
     }
 
   strbuf2[0] = '^';              /* '^' prefix */


### PR DESCRIPTION
## Summary

Fixed pdcurses build failures when wide character support is enabled. Some code paths had diverged from upstream pdcurses and did not compile correctly. Updated them to match the upstream.

## Impact

This change does not affect users who do not enable wide character support in pdcurses.

## Testing

Tested on a Radxa Orion O6 ARM64 host with a RISC-V `rv-virt` target running under RVVM.

