### PR TITLE
nshlib: fix builtin_isavail() index 0 check under CONFIG_NSH_BUILTIN_AS_COMMAND

### DIFF
--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -1274,7 +1274,7 @@ int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[])
 
   index = builtin_isavail(cmd);
 
-  if (index > 0)
+  if (index >= 0)
     {
       /* Get the builtin structure by index */
 


### PR DESCRIPTION
## Summary

builtin_isavail() returns 0-based index on success and negative errno on failure. The condition 'index > 0' incorrectly rejects valid index 0, making the first builtin app (index 0) unusable as an NSH command under CONFIG_NSH_BUILTIN_AS_COMMAND.

## Impact

Fix by changing to 'index >= 0'.

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


