### PR TITLE
apps: replace atomic_fetch_xxx with atomic_xxx

### DIFF
--- a/crypto/openssl_mbedtls_wrapper/mbedtls/ssl_lib.c
+++ b/crypto/openssl_mbedtls_wrapper/mbedtls/ssl_lib.c
@@ -1023,7 +1023,7 @@ SSL_SESSION *SSL_get1_session(SSL *ssl)
 {
   SSL_ASSERT2(ssl);
 
-  atomic_fetch_add(&ssl->session->references, 1);
+  atomic_add(&ssl->session->references, 1);
   return ssl->session;
 }
 
@@ -1031,7 +1031,7 @@ void SSL_SESSION_free(SSL_SESSION *session)
 {
   SSL_ASSERT3(session);
 
-  if (atomic_fetch_sub(&session->references, 1) == 1)
+  if (atomic_sub(&session->references, 1) == 1)
     {
       X509_free(session->peer);
       ssl_mem_free(session);

--- a/testing/libc/atomic/atomic_main.c
+++ b/testing/libc/atomic/atomic_main.c
@@ -43,25 +43,25 @@ if ((value) != (expected))                                  \
     atomic_##type object = init;                            \
     atomic_##type expected = 2;                             \
                                                             \
-    atomic_##type old_value = atomic_fetch_add(&object, 1); \
+    atomic_##type old_value = atomic_add(&object, 1);       \
     ATOMIC_CHECK(old_value, 1);                             \
     ATOMIC_CHECK(object, 2);                                \
                                                             \
-    atomic_store(&object, 1);                               \
+    atomic_set(&object, 1);                                 \
     ATOMIC_CHECK(object, 1);                                \
                                                             \
-    old_value = atomic_load(&object);                       \
+    old_value = atomic_read(&object);                       \
     ATOMIC_CHECK(object, 1)                                 \
                                                             \
-    old_value = atomic_fetch_or(&object, 4);                \
+    old_value = atomic_or(&object, 4);                      \
     ATOMIC_CHECK(old_value, 1);                             \
     ATOMIC_CHECK(object, 5);                                \
                                                             \
-    old_value = atomic_fetch_xor(&object, 7);               \
+    old_value = atomic_xor(&object, 7);                     \
     ATOMIC_CHECK(old_value, 5);                             \
     ATOMIC_CHECK(object, 2);                                \
                                                             \
-    old_value = atomic_fetch_and(&object, 3);               \
+    old_value = atomic_and(&object, 3);                     \
     ATOMIC_CHECK(old_value, 2);                             \
     ATOMIC_CHECK(object, 2);                                \
                                                             \
@@ -69,7 +69,7 @@ if ((value) != (expected))                                  \
     ATOMIC_CHECK(old_value, 2);                             \
     ATOMIC_CHECK(object, 5);                                \
                                                             \
-    old_value = atomic_fetch_sub(&object, 3);               \
+    old_value = atomic_sub(&object, 3);                     \
     ATOMIC_CHECK(old_value, 5);                             \
     ATOMIC_CHECK(object, 2);                                \
                                                             \

--- a/testing/ostest/roundrobin.c
+++ b/testing/ostest/roundrobin.c
@@ -134,7 +134,7 @@ static FAR void *get_primes_thread(FAR void *parameter)
   for (i = 0; i < CONFIG_TESTING_OSTEST_RR_RUNS; i++)
     {
       get_primes(&count, &last);
-      g_rr_values[atomic_fetch_add(&g_rr_value_index, 1)] = id;
+      g_rr_values[atomic_add(&g_rr_value_index, 1)] = id;
     }
 
   printf("get_primes_thread id=%d finished, found %d primes, "

--- a/testing/ostest/spinlock.c
+++ b/testing/ostest/spinlock.c
@@ -86,7 +86,7 @@ FAR static void * lock_type##_test_thread(FAR void *arg) \
   uint32_t i; \
   FAR struct spinlock_pub_args_s *pub = param->pub; \
   FAR lock_type *l = (FAR lock_type *)pub->lock; \
-  atomic_fetch_add(&pub->barrier, 1); \
+  atomic_add(&pub->barrier, 1); \
   while (atomic_read(&pub->barrier) != pub->thread_num) \
     { \
       sched_yield(); \


### PR DESCRIPTION
## Summary

Rename `atomic_fetch_xxx` to `atomic_xxx` (e.g., `atomic_fetch_add` -> `atomic_add`) and `atomic_store`/`atomic_load` to `atomic_set`/`atomic_read`, to match the `<nuttx/atomic.h>` API rename in the companion nuttx PR.

The `atomic_fetch_xxx` naming is reserved by the C/C++ standard and conflicts with standard library declarations when `<atomic>`/`<stdatomic.h>` is included by third-party code.

## Files changed
- `crypto/openssl_mbedtls_wrapper/mbedtls/ssl_lib.c`
- `testing/libc/atomic/atomic_main.c`
- `testing/ostest/roundrobin.c`
- `testing/ostest/spinlock.c`
