### PR TITLE
interpreters/python: fix build for x86_64 targets built with the host gcc

### DIFF
--- a/interpreters/python/Makefile
+++ b/interpreters/python/Makefile
@@ -140,10 +140,10 @@ endif
 
 $(SETUP_LOCAL):
 	$(Q) ( cp $(SETUP_LOCAL).in $(SETUP_LOCAL))
-# _posixsubprocess is the fork-then-exec path, so vfork() is enough for it;
-# os.fork() itself needs a real fork() and is governed by ac_cv_func_fork
-# above.
-ifeq ($(CONFIG_ARCH_HAVE_FORK)$(CONFIG_ARCH_HAVE_VFORK),)
+# _posixsubprocess needs a real fork(): its vfork() support is only an
+# optimization and the fork() fallback path is compiled unconditionally
+# (PyOS_BeforeFork/PyOS_AfterFork_* are declared only under HAVE_FORK).
+ifneq ($(CONFIG_ARCH_HAVE_FORK),y)
 	@echo "_posixsubprocess" >> $@
 endif
 ifneq ($(CONFIG_LIBC_DLFCN),y)
@@ -163,6 +163,10 @@ endif
 # Also, use -O0 for OPT because -Os is causing problems in
 # Python/Modules/getpath.c (issue will be filed soon to track this
 # problem).
+#
+# CPPFLAGS carries the -D/-U macro flags from CFLAGS so preprocessor-only
+# probes (Misc/platform_triplet.c) do not see the build host's __linux__
+# when NuttX is built with the native gcc (x86_64).
 
 ifneq ($(CONFIG_NET),y)
 PYTHON_CONFIGURE_EXTRAS = --disable-ipv6
@@ -182,6 +186,7 @@ $(TARGETBUILD)/Makefile: $(HOSTPYTHON) $(CONFIG_SITE) $(SETUP_LOCAL)
 			ARCH="$${ARCH//-/}"; \
 			ARCH_CHIP="$${ARCH_CHIP//-/}"; \
 			CFLAGS="$$(echo "$${CFLAGS}" | sed 's/-Os //')" \
+			CPPFLAGS="$$(echo "$${CFLAGS}" | tr ' ' '\n' | grep -E '^-[DU]' | tr '\n' ' ')" \
 			CC="$(CC)" \
 			CXX="$(CXX)" \
 			AR="$(AR)" \

--- a/interpreters/python/Setup.local.in
+++ b/interpreters/python/Setup.local.in
@@ -11,8 +11,13 @@ _codecs_iso2022
 _codecs_jp
 _codecs_kr
 _codecs_tw
+_curses
+_curses_panel
+_dbm
 _decimal
 _elementtree
+_gdbm
+_hashlib
 _heapq
 _interpchannels
 _interpqueues
@@ -29,6 +34,7 @@ _testclinic_limited
 _testexternalinspection
 _testinternalcapi
 _testlimitedcapi
+_tkinter
 _uuid
 _xxtestfuzz
 _zoneinfo

--- a/interpreters/python/config.site.in
+++ b/interpreters/python/config.site.in
@@ -35,3 +35,9 @@ export ac_cv_func_ffi_prep_cif_var="yes"
 export ac_cv_func_ffi_prep_closure_loc="yes"
 export ac_cv_func_ffi_closure_alloc="yes"
 export ac_cv_func_utimes="no"
+# NuttX provides neither header; without the overrides a native toolchain
+# (x86_64) resolves them against the host /usr/include, dragging host
+# ioctl macros into posixmodule and enabling xattr support that cannot
+# link.
+export ac_cv_header_linux_random_h="no"
+export ac_cv_header_sys_xattr_h="no"


### PR DESCRIPTION
## Summary

NuttX x86_64 (qemu-intel64) builds with the native host gcc, which exposed several host-environment leaks in the CPython cross build:

- Pass the -D/-U macro flags from CFLAGS as CPPFLAGS so preprocessor-only configure probes (Misc/platform_triplet.c) do not see the host's __linux__ and misdetect the platform as x86_64-linux-gnu, enabling Linux-only code such as the perf trampoline.

- Force linux/random.h and sys/xattr.h probes to no in config.site: NuttX provides neither, but a native toolchain resolves them against the host /usr/include.  The former drags host ioctl macros into posixmodule, the latter enables os xattr support with no xattr syscalls to link against.

- Disable _curses, _curses_panel, _dbm, _gdbm, _hashlib and _tkinter: their host libraries are discovered via pkg-config when the target compiler can compile host headers.  hashlib keeps working through the built-in HACL implementations.

- Only build _posixsubprocess when the arch has a real fork(): its vfork() support is only an optimization and the fork() fallback path (PyOS_BeforeFork/PyOS_AfterFork_*) is compiled unconditionally but declared only under HAVE_FORK.  This also fixes rv-virt:python, which became vfork-only after the fork/vfork split.

## Impact

python on intel64 works

## Testing

qemu intel64 with:

```
qemu-system-x86_64 -m 2G -cpu host -enable-kvm -smp 4 \
      -kernel nuttx -nographic -serial mon:stdio \
      -device e1000,netdev=u0 -netdev user,id=u0 
```
      
<img width="1220" height="1500" alt="image" src="https://github.com/user-attachments/assets/721ad7b1-4668-41ac-8381-e8f639ef741e" />

not tested yet on bare-metal intel64 HW.

rv-virt:python tested with the same python commands.




