### PR TITLE
system/nxinit: improve init.rc parser (per-cpu configs, --option fix)

### DIFF
--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -179,7 +179,7 @@ int main(int argc, FAR char *argv[])
         }
     }
 
-  r = init_parse_config_file(parser, CONFIG_SYSTEM_NXINIT_RC_FILE_PATH);
+  r = init_parse_configs(parser);
   if (r < 0)
     {
       goto out;

--- a/system/nxinit/parser.c
+++ b/system/nxinit/parser.c
@@ -60,7 +60,8 @@ int init_parse_arguments(FAR char *buf, bool dup, int argc, FAR char **argv)
           buf++;
         }
 
-      if (*buf == '-' && *(buf + 1) == '-')
+      if (*buf == '-' && *(buf + 1) == '-'
+          && (isblank(*(buf + 2)) || *(buf + 2) == '\0'))
         {
           argv[i++] = buf;
           if (i >= argc || *(buf += 2) == '\0')

--- a/system/nxinit/parser.c
+++ b/system/nxinit/parser.c
@@ -26,6 +26,7 @@
 
 #include <ctype.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -255,54 +256,37 @@ out:
   return ret;
 }
 
-int init_parse_configs(FAR const struct parser_s *parser,
-                       FAR const char *path)
+int init_parse_configs(FAR const struct parser_s *parser)
 {
-  FAR struct dirent *entry;
+  FAR const char *path = CONFIG_SYSTEM_NXINIT_RC_FILE_PATH;
+  FAR const char *ext;
   char file[PATH_MAX];
-  struct stat sb;
-  FAR DIR *dir;
-  int ret = 0;
-  size_t i;
+  int ret;
 
-  if (stat(path, &sb) < 0)
+  ret = init_parse_config_file(parser, path);
+  if (ret < 0)
     {
-      init_err("Stat %s", path);
-      return -errno;
+      return ret;
     }
 
-  if (S_ISDIR(sb.st_mode))
-    {
-      dir = opendir(path);
-      if (dir == NULL)
-        {
-          init_err("Opening directory %s", path);
-          return -errno;
-        }
+  /* Parse the optional cpu-specific config derived from the rc path, e.g.
+   * "/etc/init.d/init.rc" -> "/etc/init.d/init.cpu0.rc".
+   */
 
-      while ((entry = readdir(dir)) != NULL)
-        {
-          if (DIRENT_ISFILE(entry->d_type))
-            {
-              i = strlen(entry->d_name);
-              if (i >= 3 && !strcmp(entry->d_name + i - 3, ".rc"))
-                {
-                  snprintf(file, sizeof(file), "%s/%s", path, entry->d_name);
-                  ret = init_parse_config_file(parser, file);
-                  if (ret < 0)
-                    {
-                      break;
-                    }
-                }
-            }
-        }
-
-      closedir(dir);
-    }
-  else if (S_ISREG(sb.st_mode))
+  ext = strrchr(path, '.');
+  if (ext == NULL)
     {
-      ret = init_parse_config_file(parser, path);
+      return 0;
     }
 
-  return ret;
+  snprintf(file, sizeof(file), "%.*s.cpu%d%s",
+           (int)(ext - path), path, sched_getcpu(), ext);
+
+  if (access(file, F_OK) < 0)
+    {
+      init_debug("skipping non-exist file %s", file);
+      return 0;
+    }
+
+  return init_parse_config_file(parser, file);
 }

--- a/system/nxinit/parser.h
+++ b/system/nxinit/parser.h
@@ -53,8 +53,7 @@ struct parser_s
  ****************************************************************************/
 
 int init_parse_arguments(FAR char *buf, bool dup, int argc, FAR char **argv);
-int init_parse_configs(FAR const struct parser_s *parser,
-                       FAR const char *path);
+int init_parse_configs(FAR const struct parser_s *parser);
 int init_parse_config_file(FAR const struct parser_s *parser,
                            FAR const char *file);
 #endif


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This series improves the `system/nxinit` init.rc parser. It contains two
self-contained, independent commits:

1. **parse default cpu-specific configs** — On top of the configured rc file
   (`CONFIG_SYSTEM_NXINIT_RC_FILE_PATH`, e.g. `/etc/init.d/init.rc`),
   `init_parse_configs()` now also loads an optional per-cpu config derived
   from that path (`<rc-path>.cpu${CPUID}`, e.g. `/etc/init.d/init.cpu0.rc`).
   The configurable rc path support is preserved and the unused directory
   scanning path is dropped.

2. **fix argument parser treating --option as -- separator** —
   `init_parse_arguments()` only compared the first two characters when
   detecting the `--` separator, so options like `--system` / `--nofork` were
   mistaken for the standalone `--` separator and the remaining arguments were
   truncated. Add an `isblank()` check on the third character so only a
   standalone `--` followed by whitespace triggers the separator logic.

Both commits are independent parser improvements and can be reviewed in any
order.

## Impact

- **Users**: `nxinit` gains optional per-cpu init.rc support and correctly
  passes through long options (e.g. `--system`) to services/actions. Existing
  single-file init.rc setups are unaffected (the per-cpu file is optional).
- **Build**: No new Kconfig options; no build-flag changes. Only
  `system/nxinit/{parser.c,parser.h,init.c}` are touched.
- **Hardware / compatibility**: No ABI or on-flash format change. Behavior for
  configs that do not use per-cpu files or `--`-style options is unchanged.
- **Documentation / security**: None.

## Testing

Host:
- OS: Linux (x86_64)
- Compiler: xtensa-esp32s3-elf-gcc (ESP toolchain)

Target:
- arch: xtensa
- board:config: `lckfb-szpi-esp32s3:adb`

Verification:
- `./tools/checkpatch.sh -f` passes cleanly on all touched files
  (`parser.c`, `parser.h`, `init.c`) — `All checks pass.`
- The full nxinit series (of which this is the first batch) builds and boots on
  the target above; init.rc is parsed and services start as expected.
