### PR TITLE
apps/system/grep: Add standalone grep with regexp support

### DIFF
--- a/system/grep/CMakeLists.txt
+++ b/system/grep/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ##############################################################################
+# apps/system/grep/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_GREP)
+  nuttx_add_application(
+    MODULE
+    ${CONFIG_SYSTEM_GREP}
+    NAME
+    ${CONFIG_SYSTEM_GREP_PROGNAME}
+    STACKSIZE
+    ${CONFIG_SYSTEM_GREP_STACKSIZE}
+    PRIORITY
+    ${CONFIG_SYSTEM_GREP_PRIORITY}
+    SRCS
+    grep_main.c)
+
+endif()

--- a/system/grep/Kconfig
+++ b/system/grep/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config SYSTEM_GREP
+	tristate "system 'grep' command"
+	default n
+	depends on LIBC_REGEX
+	---help---
+		Enable support for the system 'grep' command (regex-based search).
+
+if SYSTEM_GREP
+
+config SYSTEM_GREP_PROGNAME
+	string "grep program name"
+	default "grep"
+	---help---
+		This is the name of the program that will be used when the grep
+		program is installed.
+
+config SYSTEM_GREP_PRIORITY
+	int "grep task priority"
+	default 100
+
+config SYSTEM_GREP_STACKSIZE
+	int "grep stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/system/grep/Make.defs
+++ b/system/grep/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/system/grep/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_GREP),)
+CONFIGURED_APPS += $(APPDIR)/system/grep
+endif

--- a/system/grep/Makefile
+++ b/system/grep/Makefile
@@ -1,0 +1,36 @@
+############################################################################
+# apps/system/grep/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# Standalone grep command
+
+PROGNAME  = $(CONFIG_SYSTEM_GREP_PROGNAME)
+PRIORITY  = $(CONFIG_SYSTEM_GREP_PRIORITY)
+STACKSIZE = $(CONFIG_SYSTEM_GREP_STACKSIZE)
+MODULE    = $(CONFIG_SYSTEM_GREP)
+
+# Files
+
+MAINSRC = grep_main.c
+
+include $(APPDIR)/Application.mk

--- a/system/grep/grep_main.c
+++ b/system/grep/grep_main.c
@@ -1,0 +1,307 @@
+/****************************************************************************
+ * apps/system/grep/grep_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <errno.h>
+#include <regex.h>
+#include <limits.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define GREP_F_INVERT  (1u << 0)   /* -v: invert match               */
+#define GREP_F_ICASE   (1u << 1)   /* -i: case-insensitive           */
+#define GREP_F_LINENO  (1u << 2)   /* -n: print line number          */
+#define GREP_F_RECURSE (1u << 3)   /* -r: recurse into directories   */
+#define GREP_F_NAME    (1u << 4)   /* -H: always print filename      */
+#define GREP_F_NONAME  (1u << 5)   /* -h: never print filename       */
+
+#define GREP_LINE_MAX  512
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int grep_stream(FILE *in, FAR const char *label,
+                       FAR const regex_t *re, unsigned int flags)
+{
+  char line[GREP_LINE_MAX];
+  unsigned long lineno = 0;
+  int matched = 0;
+
+  while (fgets(line, sizeof(line), in) != NULL)
+    {
+      size_t n = strlen(line);
+      int hit;
+
+      if (n > 0 && line[n - 1] == '\n')
+        {
+          line[n - 1] = '\0';
+        }
+
+      lineno++;
+
+      hit = (regexec(re, line, 0, NULL, 0) == 0);
+      if (flags & GREP_F_INVERT)
+        {
+          hit = !hit;
+        }
+
+      if (hit)
+        {
+          matched = 1;
+          if (label != NULL && !(flags & GREP_F_NONAME))
+            {
+              printf("%s:", label);
+            }
+
+          if (flags & GREP_F_LINENO)
+            {
+              printf("%lu:", lineno);
+            }
+
+          printf("%s\n", line);
+        }
+    }
+
+  return matched ? 0 : 1;
+}
+
+static int grep_file(FAR const char *path, FAR const regex_t *re,
+                     unsigned int flags, int multi)
+{
+  FILE *f = fopen(path, "r");
+  FAR const char *label = (multi || (flags & GREP_F_NAME)) ? path : NULL;
+  int rc;
+
+  if (f == NULL)
+    {
+      fprintf(stderr, "grep: %s: %s\n", path, strerror(errno));
+      return 2;
+    }
+
+  rc = grep_stream(f, label, re, flags);
+  fclose(f);
+  return rc;
+}
+
+static int grep_dir(FAR const char *path, FAR const regex_t *re,
+                    unsigned int flags, int multi)
+{
+  FAR DIR *d = opendir(path);
+  char full[PATH_MAX];
+  int rc = 1;
+  FAR struct dirent *e;
+
+  if (d == NULL)
+    {
+      fprintf(stderr, "grep: %s: %s\n", path, strerror(errno));
+      return 2;
+    }
+
+  while ((e = readdir(d)) != NULL)
+    {
+      struct stat st;
+
+      if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
+        {
+          continue;
+        }
+
+      snprintf(full, sizeof(full), "%s/%s", path, e->d_name);
+
+      if (stat(full, &st) != 0)
+        {
+          continue;
+        }
+
+      if (S_ISDIR(st.st_mode))
+        {
+          if (flags & GREP_F_RECURSE)
+            {
+              int r = grep_dir(full, re, flags, multi);
+
+              if (r == 0)
+                {
+                  rc = 0;
+                }
+              else if (r == 2 && rc != 0)
+                {
+                  rc = 2;
+                }
+            }
+        }
+      else if (S_ISREG(st.st_mode))
+        {
+          int r = grep_file(full, re, flags, multi);
+
+          if (r == 0)
+            {
+              rc = 0;
+            }
+        }
+    }
+
+  closedir(d);
+  return rc;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char **argv)
+{
+  unsigned int flags = 0;
+  FAR const char *pattern;
+  int idx;
+  int cflags = REG_NOSUB;
+  int nfiles;
+  int multi;
+  int rc = 1;
+  regex_t re;
+  int err;
+
+  for (idx = 1; idx < argc; idx++)
+    {
+      FAR const char *p;
+
+      if (argv[idx][0] != '-' || argv[idx][1] == '\0')
+        {
+          break;
+        }
+
+      for (p = argv[idx] + 1; *p != '\0'; p++)
+        {
+          switch (*p)
+            {
+              case 'i':
+                flags |= GREP_F_ICASE;
+                break;
+              case 'v':
+                flags |= GREP_F_INVERT;
+                break;
+              case 'n':
+                flags |= GREP_F_LINENO;
+                break;
+              case 'r':
+                flags |= GREP_F_RECURSE;
+                break;
+              case 'H':
+                flags |= GREP_F_NAME;
+                break;
+              case 'h':
+                flags |= GREP_F_NONAME;
+                break;
+              default:
+                fprintf(stderr, "grep: invalid option -%c\n", *p);
+                return 2;
+            }
+        }
+    }
+
+  if (idx >= argc)
+    {
+      fprintf(stderr, "usage: grep [-invrHh] <pattern> [<file>...]\n");
+      return 2;
+    }
+
+  pattern = argv[idx++];
+
+  if (flags & GREP_F_ICASE)
+    {
+      cflags |= REG_ICASE;
+    }
+
+  err = regcomp(&re, pattern, cflags);
+  if (err != 0)
+    {
+      char errbuf[128];
+
+      regerror(err, &re, errbuf, sizeof(errbuf));
+      fprintf(stderr, "grep: %s\n", errbuf);
+      return 2;
+    }
+
+  nfiles = argc - idx;
+  multi  = (nfiles > 1) || (flags & GREP_F_RECURSE);
+
+  if (nfiles == 0)
+    {
+      rc = grep_stream(stdin, NULL, &re, flags);
+    }
+  else
+    {
+      for (; idx < argc; idx++)
+        {
+          struct stat st;
+          int r;
+
+          if (stat(argv[idx], &st) != 0)
+            {
+              fprintf(stderr, "grep: %s: %s\n", argv[idx], strerror(errno));
+              rc = 2;
+              continue;
+            }
+
+          if (S_ISDIR(st.st_mode))
+            {
+              if (flags & GREP_F_RECURSE)
+                {
+                  r = grep_dir(argv[idx], &re, flags, multi);
+                }
+              else
+                {
+                  fprintf(stderr, "grep: %s: Is a directory\n", argv[idx]);
+                  r = 2;
+                }
+            }
+          else
+            {
+              r = grep_file(argv[idx], &re, flags, multi);
+            }
+
+          if (r == 0)
+            {
+              rc = 0;
+            }
+        }
+    }
+
+  regfree(&re);
+  return rc;
+}


### PR DESCRIPTION
## Summary

Add a standalone `grep` application under `apps/system/grep/`, registered as a built-in NSH app via `nuttx_add_application`.

The implementation uses the NuttX libc regex library (`regcomp` / `regexec`) rather than substring matching, so it supports real regular expressions including anchors and character classes. Supported options:
- `-i` (case-insensitive), `-n` (line numbers), `-v` (invert match),
- `-r` (recursive directory search), `-H` (always print filename) and
- `-h` (never print filename), plus reading from stdin when no file is given. Exit codes follow POSIX grep: `0` on match, `1` on no match,
- `2` on error.

`SYSTEM_GREP` does `select LIBC_REGEX`, so enabling `CONFIG_SYSTEM_GREP=y` alone is sufficient -- the regex dependency and its `ALLOW_MIT_COMPONENTS` gate are pulled in automatically by Kconfig, avoiding a link-time `undefined reference to regcomp` if a user enables grep without the regex library.

## Impact

- **Users**: Adds a new `grep` builtin command to NSH; no existing command or behavior is changed.
- **Build**: Adds a new `apps/system/grep/` app discovered via the existing `system/*/Make.defs` wildcard; no shared build files are modified. New `CONFIG_SYSTEM_GREP` Kconfig option (default `n`).
- **Hardware**: None -- host-side `sim` and any board with NSH + a filesystem.
- **Documentation**: None -- usage follows standard grep conventions.
- **Security & Compatibility**: None -- opt-in (default `n`), no change to existing symbols or behavior.

## Testing

Built and ran on `sim:nsh` (Ubuntu 22.04 host, gcc):
```
cd nuttx
tools/configure.sh sim:nsh
enable CONFIG_SYSTEM_GREP=y

make olddefconfig
make -j
./nuttx
```
`help` lists `grep` among the builtin apps:

Builtin Apps:
```
    dd  gcov  grep  nsh  sh
```

Functional matrix verified inside NSH against a 4-line test file:

| command | result |
|---------|--------|
| `grep error` | case-sensitive match only |
| `grep -i error` | case-insensitive, both cases |
| `grep -in error` | matches with line numbers |
| `grep -v error` | inverted, non-matching lines |
| `grep "^ERR"` | regex anchor, line-head only |
| `grep nomatch` | no output, exit code 1 |

Pipe usage verified with real NSH commands -- grep works as a pipe consumer reading stdin from other commands:
```
nsh> 
nsh> 
nsh> 
nsh> 
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069584 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 sim_loop_wq 0x7f4d736003f0 0x7f4d73600470
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067472 hpwork 0x40170fe0 0x40171060
    4     4     0 100 FIFO     Task      - Running            0000000000000000 0067496 nsh_main
nsh> 
nsh> 
nsh> 
nsh> ps | grep work
sh [7:100]
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067472 hpwork 0x40170fe0 0x40171060
    8     8     4 100 FIFO     Task      - Ready              0000000000000000 0067488 grep work
nsh> 
nsh> 
nsh> 
nsh> ps | grep sim
sh [9:100]
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067448 sim_loop_wq 0x7f4d736003f0 0x7f4d73600470
   10    10     4 100 FIFO     Task      - Ready              0000000000000000 0067488 grep sim
nsh> 
nsh> 
nsh> uname -a
NuttX 12.13.0 0790b52e64 Aug 20 2026 23:30:32 sim sim
nsh> 
nsh> help
help usage:  help [-v] [<cmd>]

    .           dirname     free        mount       set         umount      
    [           date        help        mv          kill        unset       
    ?           df          hexdump     pidof       pkill       uptime      
    alias       dmesg       losetup     poweroff    sleep       watch       
    unalias     echo        ln          quit        usleep      xd          
    basename    env         ls          printf      source      wait        
    break       exec        du          ps          test        
    cat         exit        mkdir       pwd         time        
    cd          expr        mkfatfs     readlink    true        
    cp          false       mkfifo      rm          truncate    
    cmp         fdinfo      mkrd        rmdir       uname       

Builtin Apps:
    dd           gcov         grep         nsh          sh           
    dumpstack    gpio         hello        ostest       
nsh> 
```

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>