### PR TITLE
system/expat: add reusable XML parser package

### DIFF
--- a/system/expat/.gitignore
+++ b/system/expat/.gitignore
@@ -1,0 +1,2 @@
+/libexpat
+/R_*.tar.gz

--- a/system/expat/CMakeLists.txt
+++ b/system/expat/CMakeLists.txt
@@ -1,0 +1,62 @@
+# ##############################################################################
+# apps/system/expat/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LIB_EXPAT)
+  set(EXPAT_DIR ${CMAKE_CURRENT_LIST_DIR}/libexpat)
+
+  if(NOT EXISTS ${EXPAT_DIR})
+    string(REPLACE "." "_" EXPAT_TAG ${CONFIG_LIB_EXPAT_VERSION})
+    string(CONCAT EXPAT_URL
+                  "https://codeload.github.com/libexpat/libexpat/tar.gz/"
+                  "refs/tags/R_${EXPAT_TAG}")
+    FetchContent_Declare(
+      expat_fetch
+      URL ${EXPAT_URL} SOURCE_DIR ${EXPAT_DIR} BINARY_DIR
+          ${NUTTX_BINARY_DIR}/apps/system/expat/libexpat
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+    FetchContent_GetProperties(expat_fetch)
+
+    if(NOT expat_fetch_POPULATED)
+      FetchContent_Populate(expat_fetch)
+    endif()
+  endif()
+
+  set(EXPAT_INCDIR ${EXPAT_DIR}/expat/lib)
+  set(EXPAT_SRCS
+      ${EXPAT_INCDIR}/xmlparse.c ${EXPAT_INCDIR}/xmlrole.c
+      ${EXPAT_INCDIR}/xmltok.c ${EXPAT_INCDIR}/random_arc4random_buf.c)
+
+  set(EXPAT_FLAGS -DXML_STATIC -Wno-shadow)
+  if(CONFIG_LIB_EXPAT_DTD)
+    list(APPEND EXPAT_FLAGS -DXML_DTD)
+  endif()
+
+  nuttx_add_library(expat STATIC)
+  target_sources(expat PRIVATE ${EXPAT_SRCS})
+  target_include_directories(
+    expat
+    PUBLIC ${EXPAT_INCDIR}
+    PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+  target_compile_options(expat PRIVATE ${EXPAT_FLAGS})
+  nuttx_export_header(TARGET expat INCLUDE_DIRECTORIES ${EXPAT_INCDIR})
+endif()

--- a/system/expat/Kconfig
+++ b/system/expat/Kconfig
@@ -1,0 +1,43 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config LIB_EXPAT
+	tristate "Expat XML parser"
+	default n
+	depends on ALLOW_MIT_COMPONENTS
+	---help---
+		Enable the Expat stream-oriented XML parser.  The selected version is
+		downloaded when the applications tree is configured.
+
+if LIB_EXPAT
+
+config LIB_EXPAT_VERSION
+	string "Expat version"
+	default "2.8.2"
+
+config LIB_EXPAT_CONTEXT_BYTES
+	int "Input context bytes"
+	default 1024
+	range 0 65536
+	---help---
+		Number of input bytes retained around the current parse point.  Set
+		this to zero to disable XML_GetInputContext().
+
+config LIB_EXPAT_GENERAL_ENTITIES
+	bool "General entity support"
+	default n
+	---help---
+		Enable expansion of general entities.  Keep this disabled when XML
+		inputs are not fully trusted.
+
+config LIB_EXPAT_DTD
+	bool "DTD support"
+	default n
+	select LIB_EXPAT_GENERAL_ENTITIES
+	---help---
+		Enable DTD and parameter entity parsing support.  This also enables
+		general entities.
+
+endif # LIB_EXPAT

--- a/system/expat/Make.defs
+++ b/system/expat/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# apps/system/expat/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_LIB_EXPAT),)
+CONFIGURED_APPS += $(APPDIR)/system/expat
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/system/expat/libexpat/expat/lib
+CXXFLAGS += ${INCDIR_PREFIX}$(APPDIR)/system/expat/libexpat/expat/lib
+endif

--- a/system/expat/Makefile
+++ b/system/expat/Makefile
@@ -1,0 +1,64 @@
+############################################################################
+# apps/system/expat/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+EXPAT_VERSION = $(patsubst "%",%,$(CONFIG_LIB_EXPAT_VERSION))
+EXPAT_TAG = R_$(subst .,_,$(EXPAT_VERSION))
+EXPAT_ARCHIVE = $(EXPAT_TAG).tar.gz
+EXPAT_ARCHIVES = $(wildcard R_*.tar.gz)
+EXPAT_SRCDIR = libexpat
+EXPAT_URL ?= https://codeload.github.com/libexpat/libexpat/tar.gz/refs/tags
+
+CSRCS += $(EXPAT_SRCDIR)/expat/lib/xmlparse.c
+CSRCS += $(EXPAT_SRCDIR)/expat/lib/xmlrole.c
+CSRCS += $(EXPAT_SRCDIR)/expat/lib/xmltok.c
+CSRCS += $(EXPAT_SRCDIR)/expat/lib/random_arc4random_buf.c
+
+CFLAGS += ${INCDIR_PREFIX}$(CURDIR)
+CFLAGS += ${INCDIR_PREFIX}$(EXPAT_SRCDIR)/expat/lib
+CFLAGS += -DXML_STATIC -Wno-shadow
+
+ifeq ($(CONFIG_LIB_EXPAT_DTD),y)
+CFLAGS += -DXML_DTD
+endif
+
+ifeq ($(wildcard $(EXPAT_SRCDIR)/.git),)
+$(EXPAT_ARCHIVE):
+	@echo "Downloading: $(EXPAT_ARCHIVE)"
+	$(Q) curl -o $(EXPAT_ARCHIVE) -L \
+		$(EXPAT_URL)/$(EXPAT_TAG)
+
+$(EXPAT_SRCDIR): $(EXPAT_ARCHIVE)
+	$(Q) tar -xf $(EXPAT_ARCHIVE)
+	$(Q) mv libexpat-$(EXPAT_TAG) $(EXPAT_SRCDIR)
+
+context:: $(EXPAT_SRCDIR)
+
+distclean::
+	$(call DELDIR, $(EXPAT_SRCDIR))
+	$(call DELFILE, $(EXPAT_ARCHIVES))
+endif
+
+MODULE = $(CONFIG_LIB_EXPAT)
+
+include $(APPDIR)/Application.mk

--- a/system/expat/expat_config.h
+++ b/system/expat/expat_config.h
@@ -1,0 +1,68 @@
+/****************************************************************************
+ * apps/system/expat/expat_config.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_EXPAT_EXPAT_CONFIG_H
+#define __APPS_SYSTEM_EXPAT_EXPAT_CONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_ENDIAN_BIG
+#  define BYTEORDER 4321
+#  define WORDS_BIGENDIAN 1
+#else
+#  define BYTEORDER 1234
+#endif
+
+#define HAVE_ARC4RANDOM_BUF 1
+#define HAVE_FCNTL_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_MEMORY_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_UNISTD_H 1
+#define PACKAGE "expat"
+#define PACKAGE_NAME "expat"
+#define PACKAGE_STRING "expat " CONFIG_LIB_EXPAT_VERSION
+#define PACKAGE_TARNAME "expat"
+#define PACKAGE_URL "https://libexpat.github.io/"
+#define PACKAGE_VERSION CONFIG_LIB_EXPAT_VERSION
+#define STDC_HEADERS 1
+#define XML_CONTEXT_BYTES CONFIG_LIB_EXPAT_CONTEXT_BYTES
+#ifdef CONFIG_LIB_EXPAT_GENERAL_ENTITIES
+#  define XML_GE 1
+#else
+#  define XML_GE 0
+#endif
+#define XML_NS 1
+
+#endif /* __APPS_SYSTEM_EXPAT_EXPAT_CONFIG_H */


### PR DESCRIPTION
## Summary

system/expat: add reusable XML parser package

Dependency for S2OPC port.

The doc will be updated together with the doc for S2OPC later

## Impact

new feature

## Testing

tested with S2OPC port (not yet upstream)

