### PR TITLE
examples/nxterm: add full-screen window option

### DIFF
--- a/examples/nxterm/Kconfig
+++ b/examples/nxterm/Kconfig
@@ -57,6 +57,13 @@ config EXAMPLES_NXTERM_WCOLOR
 	hex "Window color"
 	default 0xcf1f
 
+config EXAMPLES_NXTERM_FULLSCREEN
+	bool "Full-screen window"
+	default n
+	---help---
+		Size the NXTerm window to cover the complete display instead of
+		centering it at three quarters of the display size.
+
 config EXAMPLES_NXTERM_TOOLBAR_HEIGHT
 	int "Toolbar height"
 	default 16

--- a/examples/nxterm/nxterm_main.c
+++ b/examples/nxterm/nxterm_main.c
@@ -268,6 +268,13 @@ int main(int argc, FAR char *argv[])
 
   /* Determine the size and position of the window */
 
+#ifdef CONFIG_EXAMPLES_NXTERM_FULLSCREEN
+  g_nxterm_vars.wndo.wsize.w = g_nxterm_vars.xres;
+  g_nxterm_vars.wndo.wsize.h = g_nxterm_vars.yres;
+
+  g_nxterm_vars.wpos.x       = 0;
+  g_nxterm_vars.wpos.y       = 0;
+#else
   g_nxterm_vars.wndo.wsize.w = g_nxterm_vars.xres / 2 +
                                g_nxterm_vars.xres / 4;
   g_nxterm_vars.wndo.wsize.h = g_nxterm_vars.yres / 2 +
@@ -275,6 +282,7 @@ int main(int argc, FAR char *argv[])
 
   g_nxterm_vars.wpos.x       = g_nxterm_vars.xres / 8;
   g_nxterm_vars.wpos.y       = g_nxterm_vars.yres / 8;
+#endif
 
   /* Set the window position */
 


### PR DESCRIPTION
## Summary

Use the full framebuffer instead of the example's centered three-quarter window.

## Impact

new feature for nxterm

## Testing

intel64 with console on display


