### PR TITLE
netutils/paho_mqtt: improvements for use as a dependency for other packages

### DIFF
--- a/netutils/paho_mqtt/.gitignore
+++ b/netutils/paho_mqtt/.gitignore
@@ -1,0 +1,2 @@
+/paho_mqtt
+/v*.zip

--- a/netutils/paho_mqtt/CMakeLists.txt
+++ b/netutils/paho_mqtt/CMakeLists.txt
@@ -117,6 +117,11 @@ if(CONFIG_LIB_MQTT5)
 
   target_compile_options(mqtt5 PRIVATE ${MQTT5_FLAGS})
 
+  if(CONFIG_LIB_MQTT5_HIGH_PERFORMANCE)
+    target_compile_definitions(mqtt5 PRIVATE HIGH_PERFORMANCE=1)
+    target_compile_options(mqtt5 PRIVATE -Wno-unused-but-set-variable)
+  endif()
+
   if(CONFIG_UTILS_MQTT5)
 
     set(MQTT_PUB_FLAGS

--- a/netutils/paho_mqtt/CMakeLists.txt
+++ b/netutils/paho_mqtt/CMakeLists.txt
@@ -81,8 +81,8 @@ if(CONFIG_LIB_MQTT5)
       execute_process(
         COMMAND
           sh -c
-          "patch -p1 --forward --ignore-whitespace < ${CMAKE_CURRENT_LIST_DIR}/paho_mqtt_01.patch || true"
-        WORKING_DIRECTORY ${PAHO_MQTT_DIR})
+          "patch -p1 --forward --ignore-whitespace < ${CMAKE_CURRENT_LIST_DIR}/paho_mqtt_01.patch"
+        WORKING_DIRECTORY ${PAHO_MQTT_DIR} COMMAND_ERROR_IS_FATAL ANY)
       message("paho_mqtt_01 patching done")
     endif()
 

--- a/netutils/paho_mqtt/Kconfig
+++ b/netutils/paho_mqtt/Kconfig
@@ -16,6 +16,15 @@ config LIB_MQTT5_THREAD_STACKSIZE
 	---help---
 		Stack size used by threads created by the Paho MQTT library.
 
+config LIB_MQTT5_HIGH_PERFORMANCE
+	bool "Enable Paho high-performance mode"
+	default y
+	depends on LIB_MQTT5
+	---help---
+		Disable Paho heap-allocation tracking and function call-stack
+		tracing to reduce runtime and memory overhead. Disable this option
+		when debugging the Paho MQTT library.
+
 config UTILS_MQTT5
 	tristate "Enable mqtt5 tool"
 	depends on LIB_MQTT5

--- a/netutils/paho_mqtt/Kconfig
+++ b/netutils/paho_mqtt/Kconfig
@@ -9,6 +9,13 @@ config LIB_MQTT5
 	---help---
 		A library for accessing mqtt5 client services through C libraries calls in a simple manner.
 
+config LIB_MQTT5_THREAD_STACKSIZE
+	int "MQTT library thread stack size"
+	default 16384
+	depends on LIB_MQTT5
+	---help---
+		Stack size used by threads created by the Paho MQTT library.
+
 config UTILS_MQTT5
 	tristate "Enable mqtt5 tool"
 	depends on LIB_MQTT5

--- a/netutils/paho_mqtt/Makefile
+++ b/netutils/paho_mqtt/Makefile
@@ -34,6 +34,8 @@ PAHO_MQTT_UNPACK  = paho_mqtt
 
 SRCDIR = $(APPDIR)/netutils/paho_mqtt/$(PAHO_MQTT_UNPACK)/src
 
+CFLAGS += $(INCDIR_PREFIX)$(SRCDIR)
+
 ifeq ($(CONFIG_LIB_MQTT5), y)
 
 # Check if paho_mqtt directory exists, if not download and extract
@@ -49,15 +51,10 @@ $(PAHO_MQTT_UNPACK): $(PAHO_MQTT_ZIP)
 	$(Q) rm -f $(PAHO_MQTT_ZIP)
 	$(Q) if [ -f paho_mqtt_01.patch ]; then \
 		echo "Applying paho_mqtt_01 patch to $(PAHO_MQTT_UNPACK)"; \
-		cd $(PAHO_MQTT_UNPACK) && patch -p1 --forward --ignore-whitespace < ../paho_mqtt_01.patch || true; \
+		cd $(PAHO_MQTT_UNPACK) && patch -p1 --forward --ignore-whitespace < ../paho_mqtt_01.patch; \
 	fi
 	$(Q) touch $(PAHO_MQTT_UNPACK)
 
-context:: $(PAHO_MQTT_UNPACK)
-
-distclean::
-	$(call DELFILE, $(PAHO_MQTT_ZIP))
-	$(call DELDIR, $(PAHO_MQTT_UNPACK))
 endif
 
 ifeq ($(CONFIG_OPENSSL_MBEDTLS_WRAPPER), y)
@@ -80,8 +77,8 @@ MQTT5_VERSION = $(SRCDIR)/VersionInfo.h
 
 SED_COMMANDS = $(foreach var,$(VARS),-e 's/@$(var)@/$($(var))/g')
 
-$(MQTT5_VERSION): $(SRCDIR)/VersionInfo.h.in
-	sed $(SED_COMMANDS) $< > $@
+$(MQTT5_VERSION): $(PAHO_MQTT_UNPACK)
+	sed $(SED_COMMANDS) $(SRCDIR)/VersionInfo.h.in > $@
 
 context:: $(MQTT5_VERSION)
 
@@ -106,6 +103,12 @@ $(SRCDIR)/samples/paho_c_pub.c_CFLAGS += -Dcfinish=mqtt_pub_cfinish
 $(SRCDIR)/samples/paho_c_pub.c_CFLAGS += -Dtrace_callback=mqtt_pub_trace_callback
 endif
 
+endif
+
+ifeq ($(wildcard $(PAHO_MQTT_UNPACK)/.git),)
+distclean::
+	$(call DELFILE, $(wildcard v*.zip))
+	$(call DELDIR, $(PAHO_MQTT_UNPACK))
 endif
 
 include $(APPDIR)/Application.mk

--- a/netutils/paho_mqtt/Makefile
+++ b/netutils/paho_mqtt/Makefile
@@ -38,6 +38,11 @@ CFLAGS += $(INCDIR_PREFIX)$(SRCDIR)
 
 ifeq ($(CONFIG_LIB_MQTT5), y)
 
+ifeq ($(CONFIG_LIB_MQTT5_HIGH_PERFORMANCE),y)
+CFLAGS += -DHIGH_PERFORMANCE=1
+CFLAGS += -Wno-unused-but-set-variable
+endif
+
 # Check if paho_mqtt directory exists, if not download and extract
 ifeq ($(wildcard $(PAHO_MQTT_UNPACK)/src),)
 $(PAHO_MQTT_ZIP):

--- a/netutils/paho_mqtt/paho_mqtt_01.patch
+++ b/netutils/paho_mqtt/paho_mqtt_01.patch
@@ -122,7 +122,7 @@ index f4d43fb..52f810a 100644
  #else
  	pthread_attr_init(&attr);
  	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-+	pthread_attr_setstacksize(&attr, CONFIG_UTILS_MQTT5_STACKSIZE);
++	pthread_attr_setstacksize(&attr, CONFIG_LIB_MQTT5_THREAD_STACKSIZE);
  	if (pthread_create(&thread, &attr, fn, parameter) != 0)
  		thread = 0;
  	pthread_attr_destroy(&attr);

--- a/netutils/paho_mqtt/paho_mqtt_01.patch
+++ b/netutils/paho_mqtt/paho_mqtt_01.patch
@@ -6,7 +6,6 @@ Subject: [PATCH] paho_mqtt: Fix mqtt compile warning
 Signed-off-by: zhangshuai39 <zhangshuai39@xiaomi.com>
 ---
  src/MQTTAsync.c          |  2 +-
- src/MQTTPacket.h         |  2 ++
  src/SHA1.c               |  2 +-
  src/Socket.c             | 16 +++++++++++++++-
  src/Socket.h             |  1 +
@@ -16,7 +15,7 @@ Signed-off-by: zhangshuai39 <zhangshuai39@xiaomi.com>
  src/WebSocket.h          |  2 +-
  src/samples/paho_c_pub.c | 29 ++++++++++++++++++-----------
  src/samples/paho_c_sub.c |  4 +++-
- 11 files changed, 45 insertions(+), 18 deletions(-)
+ 10 files changed, 43 insertions(+), 18 deletions(-)
 
 diff --git a/src/MQTTAsync.c b/src/MQTTAsync.c
 index c548ae3..2487d69 100644
@@ -31,20 +30,6 @@ index c548ae3..2487d69 100644
  {
  	thread_id_type thread_id = Paho_thread_getid();
  	return thread_id == sendThread_id || thread_id == receiveThread_id;
-diff --git a/src/MQTTPacket.h b/src/MQTTPacket.h
-index fd384ae..c833d0c 100644
---- a/src/MQTTPacket.h
-+++ b/src/MQTTPacket.h
-@@ -28,7 +28,9 @@
- #include "LinkedList.h"
- #include "Clients.h"
- 
-+#ifndef bool
- typedef unsigned int bool;
-+#endif
- typedef void* (*pf)(int, unsigned char, char*, size_t);
- 
- #include "MQTTProperties.h"
 diff --git a/src/SHA1.c b/src/SHA1.c
 index a1b2c3d..e4f5g6h 100644
 --- a/src/SHA1.c
@@ -311,4 +296,3 @@ index 85875c9..1fe18ce 100644
  	return EXIT_SUCCESS;
 -- 
 2.34.1
-


### PR DESCRIPTION
## Summary

- netutils/paho_mqtt: make package preparation reliable 
- netutils/paho_mqtt: separate library worker stack size 
- netutils/paho_mqtt: configure embedded runtime mode 

## Impact

dependency for S2OPC

## Testing

paho works as dependency for S2OPC and with `CONFIG_UTILS_MQTT5=y`


