### PR TITLE
system/nxinit: refactor parser and fix event/board init ordering

### DIFF
--- a/system/nxinit/builtin.c
+++ b/system/nxinit/builtin.c
@@ -25,9 +25,11 @@
  ****************************************************************************/
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <spawn.h>
+#include <sys/boardctl.h>
 #include <sys/param.h>
 #include <sys/wait.h>
 
@@ -70,6 +72,10 @@ static int cmd_class_start(FAR struct action_manager_s *am,
                            int argc, FAR char **argv);
 static int cmd_class_stop(FAR struct action_manager_s *am,
                           int argc, FAR char **argv);
+#ifdef CONFIG_BOARDCTL_BOOT_IMAGE
+static int cmd_boot(FAR struct action_manager_s *am,
+                    int argc, FAR char **argv);
+#endif
 
 /****************************************************************************
  * Private Data
@@ -77,6 +83,9 @@ static int cmd_class_stop(FAR struct action_manager_s *am,
 
 static const struct cmd_map_s g_builtin[] =
 {
+#ifdef CONFIG_BOARDCTL_BOOT_IMAGE
+  {"boot", 1, 3, cmd_boot},
+#endif
   {"class_start", 2, 2, cmd_class_start},
   {"class_stop", 2, 2, cmd_class_stop},
   {"exec", 3, 99, cmd_exec},
@@ -92,6 +101,32 @@ static const struct cmd_map_s g_builtin[] =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_BOOT_IMAGE
+static int cmd_boot(FAR struct action_manager_s *am,
+                    int argc, FAR char **argv)
+{
+  struct boardioc_boot_info_s info;
+
+  UNUSED(am);
+  memset(&info, 0, sizeof(info));
+
+  if (argc > 1)
+    {
+      info.path = argv[1];
+    }
+
+  if (argc > 2)
+    {
+      info.header_size = strtoul(argv[2], NULL, 0);
+    }
+
+  boardctl(BOARDIOC_BOOT_IMAGE, (uintptr_t)&info);
+  init_err("boot image '%s' %" PRIu32 "", info.path ? info.path : "",
+           info.header_size);
+  return -ENOENT;
+}
+#endif
 
 static int cmd_class_start(FAR struct action_manager_s *am,
                            int argc, FAR char **argv)

--- a/system/nxinit/builtin.c
+++ b/system/nxinit/builtin.c
@@ -33,6 +33,8 @@
 #include <sys/param.h>
 #include <sys/wait.h>
 
+#include <netutils/netinit.h>
+
 #include "builtin.h"
 #include "init.h"
 #include "property.h"
@@ -81,6 +83,10 @@ static int cmd_boot(FAR struct action_manager_s *am,
 static int cmd_start_cpu(FAR struct action_manager_s *am,
                          int argc, FAR char **argv);
 #endif
+#ifdef CONFIG_NETUTILS_NETINIT
+static int cmd_netinit(FAR struct action_manager_s *am,
+                       int argc, FAR char **argv);
+#endif
 
 /****************************************************************************
  * Private Data
@@ -93,6 +99,9 @@ static const struct cmd_map_s g_builtin[] =
 #endif
 #ifdef CONFIG_BOARDCTL_START_CPU
   {"start_cpu", 1, 3, cmd_start_cpu},
+#endif
+#ifdef CONFIG_NETUTILS_NETINIT
+  {"netinit", 1, 1, cmd_netinit},
 #endif
   {"class_start", 2, 2, cmd_class_start},
   {"class_stop", 2, 2, cmd_class_stop},
@@ -149,6 +158,15 @@ static int cmd_start_cpu(FAR struct action_manager_s *am,
 
   init_info("start cpu %d", cpuid);
   return boardctl(BOARDIOC_START_CPU, cpuid);
+}
+#endif
+
+#ifdef CONFIG_NETUTILS_NETINIT
+static int cmd_netinit(FAR struct action_manager_s *am,
+                       int argc, FAR char **argv)
+{
+  UNUSED(am);
+  return netinit_bringup();
 }
 #endif
 

--- a/system/nxinit/builtin.c
+++ b/system/nxinit/builtin.c
@@ -77,6 +77,11 @@ static int cmd_boot(FAR struct action_manager_s *am,
                     int argc, FAR char **argv);
 #endif
 
+#ifdef CONFIG_BOARDCTL_START_CPU
+static int cmd_start_cpu(FAR struct action_manager_s *am,
+                         int argc, FAR char **argv);
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -85,6 +90,9 @@ static const struct cmd_map_s g_builtin[] =
 {
 #ifdef CONFIG_BOARDCTL_BOOT_IMAGE
   {"boot", 1, 3, cmd_boot},
+#endif
+#ifdef CONFIG_BOARDCTL_START_CPU
+  {"start_cpu", 1, 3, cmd_start_cpu},
 #endif
   {"class_start", 2, 2, cmd_class_start},
   {"class_stop", 2, 2, cmd_class_stop},
@@ -125,6 +133,22 @@ static int cmd_boot(FAR struct action_manager_s *am,
   init_err("boot image '%s' %" PRIu32 "", info.path ? info.path : "",
            info.header_size);
   return -ENOENT;
+}
+#endif
+
+#ifdef CONFIG_BOARDCTL_START_CPU
+static int cmd_start_cpu(FAR struct action_manager_s *am,
+                         int argc, FAR char **argv)
+{
+  int cpuid = 0;
+
+  if (argc > 1)
+    {
+      cpuid = strtol(argv[1], NULL, 0);
+    }
+
+  init_info("start cpu %d", cpuid);
+  return boardctl(BOARDIOC_START_CPU, cpuid);
 }
 #endif
 

--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -29,10 +29,7 @@
 #include <errno.h>
 #include <poll.h>
 #include <sys/param.h>
-#include <sys/boardctl.h>
 #include <sys/wait.h>
-
-#include <netutils/netinit.h>
 
 #include "action.h"
 #include "builtin.h"
@@ -189,17 +186,6 @@ int main(int argc, FAR char *argv[])
   init_dump_services(&sm.services);
 
   init_action_add_event(&am, "boot");
-
-  init_action_add_event(&am, "init");
-
-#ifdef CONFIG_NETUTILS_NETINIT
-  netinit_bringup();
-  init_action_add_event(&am, "netinit");
-#endif
-
-#ifdef CONFIG_SYSTEM_NXINIT_FINALINIT
-  init_action_add_event(&am, "finalinit");
-#endif
 
   for (; ; )
     {

--- a/system/nxinit/parser.c
+++ b/system/nxinit/parser.c
@@ -331,10 +331,33 @@ out:
 
 int init_parse_configs(FAR const struct parser_s *parser)
 {
+  static const char preset[] =
+    "on boot\n"
+    "   trigger init\n"
+#if defined(CONFIG_NETUTILS_NETINIT) || defined(CONFIG_SYSTEM_NXINIT_FINALINIT)
+    "on init\n"
+#ifdef CONFIG_NETUTILS_NETINIT
+    "   trigger netinit\n"
+#endif
+#ifdef CONFIG_SYSTEM_NXINIT_FINALINIT
+    "   trigger finalinit\n"
+#endif
+#endif
+#ifdef CONFIG_NETUTILS_NETINIT
+    "on netinit\n"
+    "   netinit\n"
+#endif
+    ;
   FAR const char *path = CONFIG_SYSTEM_NXINIT_RC_FILE_PATH;
   FAR const char *ext;
   char file[PATH_MAX];
   int ret;
+
+  ret = init_parse_config_buffer(parser, preset, sizeof(preset));
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   ret = init_parse_config_file(parser, path);
   if (ret < 0)

--- a/system/nxinit/parser.c
+++ b/system/nxinit/parser.c
@@ -139,6 +139,18 @@ static int init_parse_config_buffer(FAR const struct parser_s *parser,
         }
     }
 
+  for (n = 0; parser[n].key; n++)
+    {
+      if (parser[n].check)
+        {
+          ret = parser[n].check(&parser[n]);
+          if (ret < 0)
+            {
+              return ret;
+            }
+        }
+    }
+
   return 0;
 }
 

--- a/system/nxinit/parser.c
+++ b/system/nxinit/parser.c
@@ -32,10 +32,115 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/param.h>
 #include <unistd.h>
 
 #include "init.h"
 #include "parser.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int init_parse_config_lines(FAR const struct parser_s *parser,
+                                   FAR const struct parser_s **cur,
+                                   FAR size_t *line,
+                                   FAR char *buf, FAR size_t *len)
+{
+  bool create = false;
+  FAR char *nl;
+  int ret;
+
+  while ((nl = memchr(buf, '\n', *len)))
+    {
+      *(nl++) = '\0';
+      *len -= nl - buf;
+      init_debug("Line %-3zu '%s'", ++*line, buf);
+      if (*buf == '\0')
+        {
+          continue;
+        }
+
+      /* Skip empty lines and lines containing only whitespace */
+
+      for (ret = 0; buf[ret] && isblank(buf[ret]); ret++);
+
+      if (buf[ret] == '\0')
+        {
+          memmove(buf, nl, *len);
+          continue;
+        }
+
+      for (ret = 0; parser[ret].key; ret++)
+        {
+          if (!strncmp(parser[ret].key, buf, strlen(parser[ret].key)))
+            {
+              create = true;
+              *cur = &parser[ret];
+              init_debug("New section (%s)", parser[ret].key);
+              break;
+            }
+        }
+
+      if (*cur == NULL)
+        {
+          return -EINVAL;
+        }
+
+      ret = (*cur)->parse(*cur, create, buf);
+      create = false;
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      memmove(buf, nl, *len);
+    }
+
+  return 0;
+}
+
+static int init_parse_config_buffer(FAR const struct parser_s *parser,
+                                    FAR const char *buf, size_t len)
+{
+  char tmp[CONFIG_SYSTEM_NXINIT_RC_LINE_MAX];
+  FAR const struct parser_s *cur = NULL;
+  size_t line = 0;
+  size_t off = 0;
+  size_t n = 0;
+  size_t r;
+  int ret;
+
+  for (; ; )
+    {
+      r = MIN(len - off, sizeof(tmp));
+      memcpy(&tmp[n], &buf[off], r);
+      if (r == 0)
+        {
+          if (n == 0)
+            {
+              break;
+            }
+
+          tmp[n++] = '\n';
+        }
+
+      n += r;
+      off += r;
+      ret = init_parse_config_lines(parser, &cur, &line, tmp, &n);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      if (n == sizeof(tmp))
+        {
+          return -E2BIG;
+        }
+    }
+
+  return 0;
+}
 
 /****************************************************************************
  * Public Functions
@@ -139,14 +244,10 @@ int init_parse_config_file(FAR const struct parser_s *parser,
 {
   char buf[CONFIG_SYSTEM_NXINIT_RC_LINE_MAX];
   FAR const struct parser_s *cur = NULL;
-  bool create = false;
-  FAR char *nl;
+  size_t line = 0;
   size_t n = 0;
   int ret = 0;
   int fd;
-#ifdef CONFIG_SYSTEM_NXINIT_DEBUG
-  int line = 0;
-#endif
 
   init_debug("Parsing %s", file);
 
@@ -181,51 +282,10 @@ int init_parse_config_file(FAR const struct parser_s *parser,
         }
 
       n += r;
-      while ((nl = memchr(buf, '\n', n)))
+      ret = init_parse_config_lines(parser, &cur, &line, buf, &n);
+      if (ret < 0)
         {
-          *(nl++) = '\0';
-          n -= nl - buf;
-          init_debug("Line %3d: '%s'", ++line, buf);
-          if (*buf == '\0')
-            {
-              continue;
-            }
-
-          /* Skip empty lines and lines containing only whitespace */
-
-          for (ret = 0; buf[ret] && isblank(buf[ret]); ret++);
-
-          if (buf[ret] == '\0')
-            {
-              memmove(buf, nl, n);
-              continue;
-            }
-
-          for (ret = 0; parser[ret].key; ret++)
-            {
-              if (!strncmp(parser[ret].key, buf, strlen(parser[ret].key)))
-                {
-                  create = true;
-                  cur = &parser[ret];
-                  init_debug("New section (%s)", parser[ret].key);
-                  break;
-                }
-            }
-
-          if (cur == NULL)
-            {
-              ret = -EINVAL;
-              goto out;
-            }
-
-          ret = cur->parse(cur, create, buf);
-          create = false;
-          if (ret < 0)
-            {
-              goto out;
-            }
-
-          memmove(buf, nl, n);
+          goto out;
         }
 
       if (n == sizeof(buf))


### PR DESCRIPTION
## Summary
- Extract init_parse_config_buffer() out of init_parse_config_file()
  so an in-memory buffer (not just a file) can be parsed with the
  same section/validation logic.
- Add a post-parse check() loop to init_parse_config_buffer(),
  mirroring the existing validation already done for file-based
  parsing.
- Add "boot" and "start_cpu" builtin actions (depend on
  BOARDCTL_BOOT_IMAGE / BOARDCTL_START_CPU respectively), letting
  init.rc trigger firmware boot / secondary CPU bring-up.
- Fix event/board init timing: move the boot event chain into a
  preset config buffer so "init" and the optional "netinit"/
  "finalinit" events are triggered as a serialized chain instead of
  being queued back-to-back in main(). Adds a "netinit" builtin that
  calls netinit_bringup(), driven by
  on init -> trigger netinit -> on netinit -> netinit
  instead of calling netinit_bringup() directly in main(), restoring
  the auto network bring-up that nsh provided (see nshlib/nsh_init.c).
  finalinit remains a pure event for user-defined services to hook.
  BOARDIOC_INIT/BOARDIOC_FINALINIT are not reintroduced since
  BOARDIOC_INIT was already removed upstream in favor of
  CONFIG_BOARD_LATE_INITIALIZE.

## Impact
- User: minor behavior change — when CONFIG_NETUTILS_NETINIT is set,
  the network is now brought up automatically during boot again
  (previously the event fired but nothing consumed it).
- Build: no new required config; "boot"/"start_cpu" builtins are
  gated by existing BOARDCTL_BOOT_IMAGE/BOARDCTL_START_CPU.
- Hardware: NO.
- Documentation: NO.
- Compatibility: NO break to existing init.rc files.

## Testing
Build Host: Linux x86_64, gcc 13.4.0
Target: xtensa / ESP32-S3 / esp32s3-lckfb (adb config), toolchain
        xtensa-esp32s3-elf-gcc 12.2.0

- tools/nxstyle on parser.c / builtin.c / init.c -> clean (exit 0)
- make -j8 -> Generated: nuttx.bin (link OK)
- Flashed and boot-verified on lckfb-szpi-esp32s3 hardware
  (MAC a0:85:e3:f4:43:30) via esptool + adb:
```
  $ esptool.py -c esp32s3 -p /dev/ttyUSB0 chip_id
  Chip is ESP32-S3 (QFN56) (revision v0.2)
  MAC: a0:85:e3:f4:43:30

  $ make flash ESPTOOL_PORT=/dev/ttyUSB0
  Wrote 287192 bytes (150626 compressed) at 0x00000000 in 2.9 seconds
  Hash of data verified.

  $ adb -s 1234 shell uname -a
  NuttX 13.0.1-RC0 95a292de9ab-dirty Aug 24 2026 11:13:50 xtensa lckfb-szpi-esp32s3

  $ adb -s 1234 shell ps
    TID   PID  PPID ... COMMAND
      3     3     0 ... init_main    <- nxinit as system init
      4     4     3 ... sh           <- init.rc: service console sh
      5     5     3 ... adbd         <- init.rc: service adbd adbd
```
  init_main (nxinit, PID 3) boots and starts sh/adbd as services per
  /etc/init.d/init.rc; confirmed reproducible across an adb reboot
  cycle (same uname/ps output after reboot).

  Note: this board's current config has BOARDCTL_BOOT_IMAGE,
  BOARDCTL_START_CPU and NETUTILS_NETINIT unset, so the new "boot"/
  "start_cpu"/"netinit" builtins are compiled out on this target and
  were not exercised at runtime here. Their compile-time correctness
  was separately verified against a NETUTILS_NETINIT-enabled config
  (fastboot_tcp), where parser.c/builtin.c build and link cleanly.