### PR TITLE
netutils/libshvc: implement headers export and update shv-libs4c

### DIFF
--- a/netutils/libshvc/Make.defs
+++ b/netutils/libshvc/Make.defs
@@ -24,11 +24,10 @@ ifeq ($(CONFIG_NETUTILS_LIBSHVC),y)
 CONFIGURED_APPS += $(APPDIR)/netutils/libshvc
 
 SHVDIR = shv-libs4c
-REL_PATH_TO_INC = $(SHVDIR)/_compiled/include
+SHV_REL_PATH_TO_INC = $(SHVDIR)/_compiled/include
 
 # Make <shv/tree/...> and <shv/chainpack/...> visible
 
-CFLAGS   +=  $(INCDIR_PREFIX)$(APPDIR)/netutils/libshvc/$(REL_PATH_TO_INC)
-CXXFLAGS +=  $(INCDIR_PREFIX)$(APPDIR)/netutils/libshvc/$(REL_PATH_TO_INC)
+EXPORTED_INCLUDES += ${INCDIR_PREFIX}$(APPDIR)/netutils/libshvc/$(SHV_REL_PATH_TO_INC)
 
 endif

--- a/netutils/libshvc/Makefile
+++ b/netutils/libshvc/Makefile
@@ -25,7 +25,7 @@ include $(APPDIR)/Make.defs
 SHVDIR := shv-libs4c
 
 # Commit hash of the supported shv-libs4c revision
-SHV_LIBS4C_COMMIT_HASH := 149cf26b71c73b9d5f59b5b21d5b079b1a1150c1
+SHV_LIBS4C_COMMIT_HASH := cbb2c0ed57d3ec0396b6ce4d1b17ac054999b299
 
 SHV_LIBS4C_TARGZ := shv-libs4c-$(SHV_LIBS4C_COMMIT_HASH).tar.gz
 

--- a/netutils/libulut/Make.defs
+++ b/netutils/libulut/Make.defs
@@ -23,10 +23,9 @@
 ifeq ($(CONFIG_NETUTILS_LIBULUT),y)
 CONFIGURED_APPS += $(APPDIR)/netutils/libulut
 
-ULUTDIT = ulut
-REL_PATH_TO_INC = $(ULUTDIT)/_compiled/include
+ULUTDIR = ulut
+ULUT_REL_PATH_TO_INC = $(ULUTDIR)/_compiled/include
 
-CFLAGS   +=  $(INCDIR_PREFIX)$(APPDIR)/netutils/libulut/$(REL_PATH_TO_INC)
-CXXFLAGS +=  $(INCDIR_PREFIX)$(APPDIR)/netutils/libulut/$(REL_PATH_TO_INC)
+EXPORTED_INCLUDES += ${INCDIR_PREFIX}$(APPDIR)/netutils/libulut/$(ULUT_REL_PATH_TO_INC)
 
 endif


### PR DESCRIPTION
## Summary

The uLUt and libshvc declare headers intended for make export by EXPORTED_INCLUDES mechanism implemented during 2026 Micowindows GSoC. The shv-libs4c has been updated as well to support newer pyshv versions and that way firmware updates when shv-nxboot-updater is used through pyshv based shvflasher.py and related GUI.

For pyshv see https://github.com/silicon-heaven/pyshv

New commits from shv-libs4c project

  https://github.com/silicon-heaven/shv-libs4c

- shv_com_common: shv_unpack_discard and shv_unpack_skip

   required to skip additional parameters and query requests
   introduced introduced by newer silicon-heaven protocol
   and pyshv. Incorrect skipping was a bug even against
   previous protocol version but did not present itself because
   older pyshv did not send additional requests which need
   to be ignored.

- shv_file_node: small, but crucial unpack change

  Ignore any other messages than PARAM in file node's write unpack
  function. Other different states should be handled, too.

- shv_file_node: fix the CRC unpack method too

  Any other messages than PARAM are ignored.

- shv_com: add a method to close a connection only

- shv_dotdevice_node.c: close the conn with the other side when resetted

- shv_com.h: use array designators for error strings

- libshvtree: move shv_con_errno_strs to the C file to not waste space by copies

- shvtree/shv_clayer_posix: provide alternative socketpair notification support

  This allows to use shv-libs4c and related pysimCoder support on RTEMS system which does not provide functional pipe directive/system call but BSD networking supported local/UNIX socket pair is fully supported.

## Impact

The update fixes shv-nxboot-updater to work when latest pyshv is used with NuttX included scripts

  https://github.com/apache/nuttx-apps/tree/master/examples/shv-nxboot-updater/update-script

and allows to use SHV from NuttX build from applications build against NuttX export.

## Testing

Only build and `make export` has been examined at this time, but newer shv-libs4c is used and was crucial update for https://github.com/robertobucher/pysimCoder delivery to https://utia.cas.cz/en/ in December 2025 and it has been used there from pysimCoder with NuttX export without SHV enabled (it would not work with pysimCoder due missing EXPORTED_INCLUDES ). Newer shv-libs4c version has been used locally updated NuttX builds of minimal image with shv-nxboot-updater from that time as well. It is time to move forward, as EXPORTED_INCLUDES is implemented and integrated into NuttX mainline.