### PR TITLE
fs: rename PSEUDOFS_SOFTLINKS to FS_LINKS

### DIFF
--- a/examples/tlpi/Makefile
+++ b/examples/tlpi/Makefile
@@ -124,7 +124,7 @@ MAINSRC += $(TLPIDIR)/dirs_links/file_type_stats.c \
            $(TLPIDIR)/dirs_links/nftw_dir_tree.c \
            $(TLPIDIR)/dirs_links/t_unlink.c \
            $(TLPIDIR)/dirs_links/t_dirbasename.c
-ifneq ($(CONFIG_PSEUDOFS_SOFTLINKS),)
+ifneq ($(CONFIG_FS_LINKS),)
 MAINSRC += $(TLPIDIR)/dirs_links/bad_symlink.c \
            $(TLPIDIR)/dirs_links/view_symlink.c
 endif

--- a/interpreters/luamodules/luv/Kconfig
+++ b/interpreters/luamodules/luv/Kconfig
@@ -14,7 +14,7 @@ config LUA_LUV_MODULE
 	depends on NET_SOCKOPTS
 	depends on NET_TCP
 	depends on NET_UDP
-	depends on PSEUDOFS_SOFTLINKS
+	depends on FS_LINKS
 	depends on SCHED_HAVE_PARENT
 	---help---
 		Bare libuv bindings for Lua

--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -108,7 +108,7 @@ config INTERPRETERS_WAMR_BUILD_MODULES_FOR_NUTTX
 
 config INTERPRETERS_WAMR_LIBC_WASI
 	bool "Enable WASI libc"
-	select PSEUDOFS_SOFTLINKS
+	select FS_LINKS
 	default n
 	---help---
 		Note: As of writing this, this works only with main branch of

--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -158,7 +158,7 @@ config INTERPRETERS_WAMR_STACK_GUARD_SIZE
 
 		The default value here (1024) was chosen to match the default value on
 		the majority of other platforms, including Linux. It also matches
-		the expections in the WAMR AoT compiler.
+		the exceptions in the WAMR AoT compiler.
 		On the other hand, it might be a bit larger than what's strictly
 		necessary, especially for typical NuttX targets.
 
@@ -241,7 +241,7 @@ config INTERPRETERS_WAMR_GLOBAL_HEAP_POOL_SIZE
 endif # INTERPRETERS_WAMR_GLOBAL_HEAP_POOL
 
 config INTERPRETERS_WAMR_CONFIGUABLE_BOUNDS_CHECKS
-	bool "Configuable bounds checks"
+	bool "Configurable bounds checks"
 	default n
 	---help---
 		Bounds checks enabled by default. With this option, you can

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -509,7 +509,7 @@ config NSH_DISABLE_LOMTD
 config NSH_DISABLE_LN
 	bool "Disable ln"
 	default DEFAULT_SMALL
-	depends on PSEUDOFS_SOFTLINKS
+	depends on FS_LINKS
 
 config NSH_DISABLE_LS
 	bool "Disable ls"
@@ -636,7 +636,7 @@ config NSH_DISABLE_PWD
 config NSH_DISABLE_READLINK
 	bool "Disable readlink"
 	default DEFAULT_SMALL
-	depends on PSEUDOFS_SOFTLINKS
+	depends on FS_LINKS
 
 config NSH_DISABLE_SWITCHBOOT
 	bool "Switch boot partition"

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -992,7 +992,7 @@ int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #ifndef CONFIG_NSH_DISABLE_HEXDUMP
   int cmd_hexdump(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
-#if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
+#if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_FS_LINKS)
   int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #ifndef CONFIG_NSH_DISABLE_LS
@@ -1004,7 +1004,7 @@ int cmd_irqinfo(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #if defined(CONFIG_SYSLOG_DEVPATH) && !defined(CONFIG_NSH_DISABLE_DMESG)
   int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
-#if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
+#if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_FS_LINKS)
   int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv);
 #endif
 #if !defined(CONFIG_NSH_DISABLESCRIPT) && !defined(CONFIG_NSH_DISABLE_SOURCE)

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -351,7 +351,7 @@ static const struct cmdmap_s g_cmdmap[] =
 #  endif
 #endif
 
-#if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
+#if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_FS_LINKS)
   CMD_MAP("ln",       cmd_ln,       3, 4, "[-s] <target> <link>"),
 #endif
 
@@ -508,7 +508,7 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP("pwd",      cmd_pwd,      1, 1, NULL),
 #endif
 
-#if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
+#if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_FS_LINKS)
   CMD_MAP("readlink", cmd_readlink, 2, 2, "<link>"),
 #endif
 

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -397,7 +397,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
                       FAR struct dirent *entryp, FAR void *pvarg)
 {
   unsigned int lsflags = (unsigned int)((uintptr_t)pvarg);
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
+#ifdef CONFIG_FS_LINKS
   bool isdir = false;
 #endif
   int ret;
@@ -435,7 +435,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
         {
           char details[] = "----------";
 
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
+#ifdef CONFIG_FS_LINKS
           if (S_ISLNK(buf.st_mode))
             {
               details[0] = 'l';  /* Takes precedence over type of the target */
@@ -621,7 +621,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
     {
       nsh_output(vtbl, " %s", entryp->d_name);
 
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
+#ifdef CONFIG_FS_LINKS
       if (DIRENT_ISLINK(entryp->d_type))
         {
           FAR char *fullpath;
@@ -1660,7 +1660,7 @@ errout_with_paths:
  * Name: cmd_ln
  ****************************************************************************/
 
-#if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
+#if !defined(CONFIG_NSH_DISABLE_LN) && defined(CONFIG_FS_LINKS)
 int cmd_ln(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   FAR char *linkpath;
@@ -2528,7 +2528,7 @@ errout_with_oldpath:
  * Name: cmd_readlink
  ****************************************************************************/
 
-#if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_PSEUDOFS_SOFTLINKS)
+#if !defined(CONFIG_NSH_DISABLE_READLINK) && defined(CONFIG_FS_LINKS)
 int cmd_readlink(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
 {
   UNUSED(argc);

--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -415,6 +415,7 @@ static int ls_handler(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
       if (entryp != NULL)
         {
           FAR char *fullpath = nsh_getdirpath(vtbl, dirpath, entryp->d_name);
+
           ret = stat(fullpath, &buf);
           free(fullpath);
         }
@@ -688,6 +689,7 @@ static int ls_recursive(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
       /* Yes.. */
 
       FAR char *newpath;
+
       newpath = nsh_getdirpath(vtbl, dirpath, entryp->d_name);
 
       /* List the directory contents */
@@ -872,6 +874,7 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (argc == 1)
     {
       char *buf = malloc(BUFSIZ);
+
       if (buf == NULL)
         {
           return -ENOMEM;
@@ -989,6 +992,7 @@ int cmd_chown(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (*endptr == ':')
     {
       FAR const char *gidstr = endptr + 1;
+
       if (*gidstr != '\0')
         {
           value = strtol(gidstr, &endptr, 10);
@@ -1043,29 +1047,29 @@ int cmd_dmesg(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   if (argc > 1 && (option = getopt(argc, argv, "cC:")) != ERROR)
     {
       switch (option)
-      {
-        case 'c':
-          ret = nsh_catfile(vtbl, argv[0], CONFIG_SYSLOG_DEVPATH);
+        {
+          case 'c':
+            ret = nsh_catfile(vtbl, argv[0], CONFIG_SYSLOG_DEVPATH);
 
-          /* Go through */
+            /* Go through */
 
-        case 'C':
-          fd = open(CONFIG_SYSLOG_DEVPATH, O_RDONLY);
-          if (fd < 0)
-            {
-              nsh_error(vtbl, g_fmtcmdfailed, argv[0], "open", NSH_ERRNO);
-              return fd;
-            }
+          case 'C':
+            fd = open(CONFIG_SYSLOG_DEVPATH, O_RDONLY);
+            if (fd < 0)
+              {
+                nsh_error(vtbl, g_fmtcmdfailed, argv[0], "open", NSH_ERRNO);
+                return fd;
+              }
 
-          ret = ioctl(fd, BIOC_FLUSH, 0);
-          if (ret < 0)
-            {
-              nsh_error(vtbl, g_fmtcmdfailed, argv[0], "ioctl", NSH_ERRNO);
-            }
+            ret = ioctl(fd, BIOC_FLUSH, 0);
+            if (ret < 0)
+              {
+                nsh_error(vtbl, g_fmtcmdfailed, argv[0], "ioctl", NSH_ERRNO);
+              }
 
-          close(fd);
-          break;
-      }
+            close(fd);
+            break;
+        }
     }
   else
     {
@@ -1180,28 +1184,28 @@ int cmd_losetup(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     {
       switch (option)
         {
-        case 'd':
-          loopdev  = nsh_getfullpath(vtbl, optarg);
-          teardown = true;
-          break;
+          case 'd':
+            loopdev  = nsh_getfullpath(vtbl, optarg);
+            teardown = true;
+            break;
 
-        case 'o':
-          offset = atoi(optarg);
-          break;
+          case 'o':
+            offset = atoi(optarg);
+            break;
 
-        case 'r':
-          readonly = true;
-          break;
+          case 'r':
+            readonly = true;
+            break;
 
-        case 'b':
-          sectsize = atoi(optarg);
-          break;
+          case 'b':
+            sectsize = atoi(optarg);
+            break;
 
-        case '?':
-        default:
-          nsh_error(vtbl, g_fmtarginvalid, argv[0]);
-          badarg = true;
-          break;
+          case '?':
+          default:
+            nsh_error(vtbl, g_fmtarginvalid, argv[0]);
+            badarg = true;
+            break;
         }
     }
 
@@ -1343,36 +1347,36 @@ int cmd_losmart(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     {
       switch (option)
         {
-        case 'd':
-          loopdev  = nsh_getfullpath(vtbl, optarg);
-          teardown = true;
-          break;
+          case 'd':
+            loopdev  = nsh_getfullpath(vtbl, optarg);
+            teardown = true;
+            break;
 
-        case 'e':
-          erasesize = atoi(optarg);
-          break;
+          case 'e':
+            erasesize = atoi(optarg);
+            break;
 
-        case 'm':
-          minor = atoi(optarg);
-          break;
+          case 'm':
+            minor = atoi(optarg);
+            break;
 
-        case 'o':
-          offset = atoi(optarg);
-          break;
+          case 'o':
+            offset = atoi(optarg);
+            break;
 
-        case 'r':
-          readonly = true;
-          break;
+          case 'r':
+            readonly = true;
+            break;
 
-        case 's':
-          sectsize = atoi(optarg);
-          break;
+          case 's':
+            sectsize = atoi(optarg);
+            break;
 
-        case '?':
-        default:
-          nsh_error(vtbl, g_fmtarginvalid, argv[0]);
-          badarg = true;
-          break;
+          case '?':
+          default:
+            nsh_error(vtbl, g_fmtarginvalid, argv[0]);
+            badarg = true;
+            break;
         }
     }
 
@@ -1518,34 +1522,34 @@ int cmd_lomtd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
     {
       switch (option)
         {
-        case 'd':
-          loopdev  = nsh_getfullpath(vtbl, optarg);
-          teardown = true;
-          break;
+          case 'd':
+            loopdev  = nsh_getfullpath(vtbl, optarg);
+            teardown = true;
+            break;
 
-        case 'e':
-          erasesize = atoi(optarg);
-          break;
+          case 'e':
+            erasesize = atoi(optarg);
+            break;
 
-        case 'o':
-          offset = atoi(optarg);
-          break;
+          case 'o':
+            offset = atoi(optarg);
+            break;
 
-        case 'b':
-          sectsize = atoi(optarg);
-          break;
+          case 'b':
+            sectsize = atoi(optarg);
+            break;
 
 #  ifndef CONFIG_MTD_CONFIG_NONE
-        case 'c':
-          configdata = atoi(optarg);
-          break;
+          case 'c':
+            configdata = atoi(optarg);
+            break;
 #  endif
 
-        case '?':
-        default:
-          nsh_error(vtbl, g_fmtarginvalid, argv[0]);
-          badarg = true;
-          break;
+          case '?':
+          default:
+            nsh_error(vtbl, g_fmtarginvalid, argv[0]);
+            badarg = true;
+            break;
         }
     }
 
@@ -1746,6 +1750,7 @@ int cmd_ls(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   /* Get the ls options */
 
   int option;
+
   while ((option = getopt(argc, argv, "lRsh")) != ERROR)
     {
       switch (option)
@@ -2144,7 +2149,7 @@ int cmd_mkdir(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
             {
               break;
             }
-         }
+        }
 
       nsh_freefullpath(fullpath);
     }
@@ -2185,7 +2190,7 @@ int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
               }
             break;
 
-         case 'r':
+          case 'r':
             rootdirentries = atoi(optarg);
             if (rootdirentries >= 0)
               {
@@ -2198,7 +2203,7 @@ int cmd_mkfatfs(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
               }
             break;
 
-         case ':':
+          case ':':
             nsh_error(vtbl, g_fmtargrequired, argv[0]);
             badarg = true;
             break;
@@ -2301,6 +2306,7 @@ int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
   /* Get the mkrd options */
 
   int option;
+
   while ((option = getopt(argc, argv, ":m:s:")) != ERROR)
     {
       switch (option)
@@ -2323,7 +2329,7 @@ int cmd_mkrd(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
               }
             break;
 
-         case ':':
+          case ':':
             nsh_error(vtbl, g_fmtargrequired, argv[0]);
             badarg = true;
             break;
@@ -2670,6 +2676,7 @@ int cmd_rm(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (recursive)
         {
           FAR char *buf = lib_get_pathbuffer();
+
           strlcpy(buf, fullpath, PATH_MAX);
           ret = unlink_recursive(buf, &stat);
           lib_put_pathbuffer(buf);
@@ -2899,6 +2906,7 @@ int cmd_truncate(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       if (errval == ENOENT)
         {
           int fd = creat(fullpath, 0666);
+
           if (fd < 0)
             {
               nsh_error(vtbl, g_fmtcmdfailed, argv[0], "stat", NSH_ERRNO);

--- a/system/adb/Kconfig
+++ b/system/adb/Kconfig
@@ -164,8 +164,8 @@ config ADBD_FILE_SERVICE
 config ADBD_FILE_SYMLINK
 	bool "File service symlink support"
 	depends on ADBD_FILE_SERVICE
-	depends on PSEUDOFS_SOFTLINKS
-	default PSEUDOFS_SOFTLINKS
+	depends on FS_LINKS
+	default FS_LINKS
 	---help---
 		Enable fs symlink support.
 

--- a/testing/testsuites/Kconfig
+++ b/testing/testsuites/Kconfig
@@ -29,7 +29,7 @@ config TESTS_TESTSUITES_STACKSIZE
 config CM_FS_TEST
 	bool "enable fs test"
 	default n
-	depends on PSEUDOFS_SOFTLINKS
+	depends on FS_LINKS
 
 config CM_SCHED_TEST
 	bool "enable schedule test"
@@ -56,7 +56,7 @@ config CM_SOCKET_TEST
 config CM_SYSCALL_TEST
 	bool "enable syscall test"
 	default n
-	depends on PIPES && SCHED_HAVE_PARENT && FS_TMPFS && ARCH_SETJMP_H && PSEUDOFS_SOFTLINKS
+	depends on PIPES && SCHED_HAVE_PARENT && FS_TMPFS && ARCH_SETJMP_H && FS_LINKS
 
 config CM_MUTEX_TEST
 	bool "enable mutex test"


### PR DESCRIPTION
## Summary

Update all nuttx-apps references to the kernel filesystem-link config
option, which is renamed from PSEUDOFS_SOFTLINKS to FS_LINKS in the
companion NuttX PR. The link support is no longer limited to the pseudo
filesystem and now covers both soft (symbolic) and hard links across the
VFS, so the more accurate name FS_LINKS is used.

Affected areas: nshlib (ln/readlink/ls), interpreters (luv, wamr), adb,
tlpi example, and the testsuites — 18 references across 9 files.

## Impact

- Build-time only. No runtime/ABI/behavior change.
- Must be merged together with the NuttX kernel-side rename; on its own
  each repository's build would break because the config symbol only
  exists under one name at a time.

## Testing

- tools/checkpatch.sh passes on all changed lines.

Note: The kernel-side dependency (apache/nuttx#19949) has already been merged into master.
