### PR TITLE
examples/lvglterm: fix wrong dependency on PSEUDOTERM

### DIFF
--- a/examples/lvglterm/Kconfig
+++ b/examples/lvglterm/Kconfig
@@ -7,7 +7,7 @@ menuconfig EXAMPLES_LVGLTERM
 	tristate "LVGL Terminal"
 	default n
 	depends on GRAPHICS_LVGL
-	select PSEUDOTERM
+	depends on PSEUDOTERM
 	---help---
 		Enable LVGL Terminal
 


### PR DESCRIPTION
Changes PSEUDOTERM dependency from 'select' to 'depends on' which was missing from the initial pull request.

## Summary

This change was missing from PR #3742. Related change on `nuttx` main repo has already been merged.
Makes [nuttx #19963](https://github.com/apache/nuttx/pull/19963) unnecessary. Issue lready taken care of in [nuttx #19952] (https://github.com/apache/nuttx/pull/19952).

## Impact

Changes the requirement for enabling the example.


