### PR TITLE
system/fastboot: Add serial (UART) transport backend

### DIFF
--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -8,32 +8,50 @@ menuconfig SYSTEM_FASTBOOTD
 	default n
 	depends on USBFASTBOOT || (NET_TCP && NET_TCPBACKLOG)
 	---help---
-		Enable Fastboot daemon.
+		Fastboot daemon supporting multiple transports concurrently.
+		Enable at least one transport (USB, TCP).
 		The USB transport depends on USBFASTBOOT.
 		The TCP network transport depends on NET_TCP and NET_TCPBACKLOG.
+		Each transport can be individually disabled via
+		SYSTEM_FASTBOOTD_USB / SYSTEM_FASTBOOTD_TCP below.
 
 if SYSTEM_FASTBOOTD
 
 config SYSTEM_FASTBOOTD_PRIORITY
-	int "USB-fastboot task priority"
+	int "fastboot task priority"
 	default 100
 
 config SYSTEM_FASTBOOTD_STACKSIZE
-	int "USB-fastboot stack size"
+	int "fastboot stack size"
 	default DEFAULT_TASK_STACKSIZE
 
 config SYSTEM_FASTBOOTD_DOWNLOAD_MAX
-	int "USB-fastboot download buffer size"
+	int "fastboot download buffer size"
 	default 40960
+
+config SYSTEM_FASTBOOTD_USB
+	bool "Fastboot USB transport"
+	default y
+	depends on USBFASTBOOT
+	---help---
+		Enable USB transport for fastboot daemon.
 
 config SYSTEM_FASTBOOTD_USB_BOARDCTL
 	bool "USB Board Control"
 	default n
 	depends on BOARDCTL
 	depends on BOARDCTL_USBDEVCTRL
-	depends on USBFASTBOOT
+	depends on SYSTEM_FASTBOOTD_USB
 	---help---
 		Connect usbdev before running fastboot daemon.
+
+config SYSTEM_FASTBOOTD_TCP
+	bool "Fastboot TCP transport"
+	default y
+	depends on NET_TCP
+	depends on NET_TCPBACKLOG
+	---help---
+		Enable TCP network transport for fastboot daemon.
 
 config SYSTEM_FASTBOOTD_SHELL
 	bool "Execute custom commands"
@@ -48,6 +66,7 @@ config SYSTEM_FASTBOOTD_SHELL
 config SYSTEM_FASTBOOTD_NET_INIT
 	bool "Network initialization"
 	default n
+	depends on SYSTEM_FASTBOOTD_TCP
 	select NETUTILS_NETINIT
 	---help---
 		This option enables/disables all network initialization in fastboot server.

--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -6,12 +6,13 @@
 menuconfig SYSTEM_FASTBOOTD
 	bool "fastbootd"
 	default n
-	depends on USBFASTBOOT || (NET_TCP && NET_TCPBACKLOG)
+	depends on USBFASTBOOT || (NET_TCP && NET_TCPBACKLOG) || SERIAL
 	---help---
 		Fastboot daemon supporting multiple transports concurrently.
-		Enable at least one transport (USB, TCP).
+		Enable at least one transport (USB, TCP, Serial).
 		The USB transport depends on USBFASTBOOT.
 		The TCP network transport depends on NET_TCP and NET_TCPBACKLOG.
+		The Serial transport depends on SERIAL.
 		Each transport can be individually disabled via
 		SYSTEM_FASTBOOTD_USB / SYSTEM_FASTBOOTD_TCP below.
 
@@ -70,5 +71,19 @@ config SYSTEM_FASTBOOTD_NET_INIT
 	select NETUTILS_NETINIT
 	---help---
 		This option enables/disables all network initialization in fastboot server.
+
+config SYSTEM_FASTBOOTD_SERIAL
+	bool "Fastboot serial transport"
+	default n
+	depends on SERIAL
+	---help---
+		Enable serial (UART) transport for fastboot daemon.
+		Reuses TCP v1 wire framing (FB01 handshake + 8-byte length prefix).
+		The host side can use socat to bridge the UART to a TCP socket.
+
+config SYSTEM_FASTBOOTD_SERIAL_PORT
+	string "Serial device path"
+	default "/dev/ttyS1"
+	depends on SYSTEM_FASTBOOTD_SERIAL
 
 endif # SYSTEM_FASTBOOTD

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -1362,7 +1362,7 @@ static ssize_t fastboot_read_all(int fd, FAR void *buf, size_t len)
   size_t total = 0;
   ssize_t nread;
 
-  while (total < len)
+  while (len > 0)
     {
       nread = fastboot_read(fd, buf, len);
       if (nread <= 0)
@@ -1375,6 +1375,8 @@ static ssize_t fastboot_read_all(int fd, FAR void *buf, size_t len)
           break;
         }
 
+      buf = (FAR char *)buf + nread;
+      len -= nread;
       total += nread;
     }
 

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -347,6 +347,7 @@ static FAR void *fastboot_memset32(FAR void *m, uint32_t val, size_t count)
 static ssize_t fastboot_read(int fd, FAR void *buf, size_t len)
 {
   ssize_t r = read(fd, buf, len);
+
   return r < 0 ? -errno : r;
 }
 
@@ -357,6 +358,7 @@ static int fastboot_write(int fd, FAR const void *buf, size_t len)
   while (len > 0)
     {
       ssize_t r = write(fd, data, len);
+
       if (r < 0)
         {
           return -errno;
@@ -404,6 +406,7 @@ static void fastboot_okay(FAR struct fastboot_ctx_s *ctx,
 static int fastboot_flash_open(FAR const char *name)
 {
   int fd = open(name, O_RDWR | O_CLOEXEC);
+
   if (fd < 0)
     {
       fb_err("Open %s error\n", name);
@@ -529,6 +532,7 @@ static int fastboot_flash_program(FAR struct fastboot_ctx_s *ctx, int fd)
           case FASTBOOT_CHUNK_RAW:
             {
               uint32_t chunk_size = chunk->chunk_sz * sparse->blk_sz;
+
               ret = fastboot_flash_write(fd, ctx->download_offset,
                                          chunk_ptr, chunk_size);
               if (ret < 0)
@@ -544,6 +548,7 @@ static int fastboot_flash_program(FAR struct fastboot_ctx_s *ctx, int fd)
             {
               uint32_t fill_data = be32toh(*(FAR uint32_t *)chunk_ptr);
               uint32_t chunk_size = chunk->chunk_sz * sparse->blk_sz;
+
               ret = ffastboot_flash_fill(fd, ctx->download_offset, fill_data,
                                          sparse->blk_sz, chunk->chunk_sz);
               if (ret < 0)
@@ -693,6 +698,7 @@ static void fastboot_download(FAR struct fastboot_ctx_s *ctx,
   while (len > 0)
     {
       ssize_t r = ctx->ops->read(ctx, download, len);
+
       if (r < 0)
         {
           if (errno == EAGAIN)
@@ -851,6 +857,7 @@ static int fastboot_filedump_upload(FAR struct fastboot_ctx_s *ctx)
     {
       ssize_t nread = fastboot_read(fd, ctx->download_buffer,
                                     MIN(size, ctx->download_max));
+
       if (nread == 0)
         {
           break;
@@ -1036,6 +1043,7 @@ static void fastboot_oem(FAR struct fastboot_ctx_s *ctx, FAR const char *arg)
   for (index = 0; index < ncmds; index++)
     {
       size_t len = strlen(g_oem_cmd[index].prefix);
+
       if (memcmp(arg, g_oem_cmd[index].prefix, len) == 0)
         {
           arg += len;
@@ -1105,6 +1113,7 @@ static int fastboot_command_loop(FAR struct fastboot_ctx_s *ctx,
         {
           c = (FAR struct fastboot_ctx_s *)ev[n].data.ptr;
           ssize_t r = c->ops->read(c, buffer, FASTBOOT_MSG_LEN);
+
           if (r <= 0)
             {
               n--;
@@ -1115,6 +1124,7 @@ static int fastboot_command_loop(FAR struct fastboot_ctx_s *ctx,
           for (index = 0; index < ncmds; index++)
             {
               size_t len = strlen(g_fast_cmd[index].prefix);
+
               if (memcmp(buffer, g_fast_cmd[index].prefix, len) == 0)
                 {
                   g_fast_cmd[index].handle(c, buffer + len);
@@ -1221,9 +1231,9 @@ static int fastboot_usbdev_initialize(FAR struct fastboot_ctx_s *ctx)
 #ifdef CONFIG_SYSTEM_FASTBOOTD_USB_BOARDCTL
   struct boardioc_usbdev_ctrl_s ctrl;
 #  ifdef CONFIG_USBDEV_COMPOSITE
-    uint8_t dev = BOARDIOC_USBDEV_COMPOSITE;
+  uint8_t dev = BOARDIOC_USBDEV_COMPOSITE;
 #  else
-    uint8_t dev = BOARDIOC_USBDEV_FASTBOOT;
+  uint8_t dev = BOARDIOC_USBDEV_FASTBOOT;
 #  endif
   int ret;
 

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -233,7 +233,7 @@ static void fastboot_switchboot(FAR struct fastboot_ctx_s *context,
 
 /* USB transport */
 
-#ifdef CONFIG_USBFASTBOOT
+#ifdef CONFIG_SYSTEM_FASTBOOTD_USB
 static int     fastboot_usbdev_initialize(FAR struct fastboot_ctx_s *ctx);
 static void    fastboot_usbdev_deinit(FAR struct fastboot_ctx_s *ctx);
 static ssize_t fastboot_usbdev_read(FAR struct fastboot_ctx_s *ctx,
@@ -244,7 +244,7 @@ static int     fastboot_usbdev_write(FAR struct fastboot_ctx_s *ctx,
 
 /* TCP transport */
 
-#ifdef CONFIG_NET_TCP
+#ifdef CONFIG_SYSTEM_FASTBOOTD_TCP
 static int     fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx);
 static void    fastboot_tcp_deinit(FAR struct fastboot_ctx_s *ctx);
 static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
@@ -290,7 +290,7 @@ static const struct memory_region_s g_memory_region[] =
 
 static const struct fastboot_transport_ops_s g_tran_ops[] =
 {
-#ifdef CONFIG_USBFASTBOOT
+#ifdef CONFIG_SYSTEM_FASTBOOTD_USB
   {
     .init    = fastboot_usbdev_initialize,
     .deinit  = fastboot_usbdev_deinit,
@@ -298,7 +298,7 @@ static const struct fastboot_transport_ops_s g_tran_ops[] =
     .write   = fastboot_usbdev_write,
   },
 #endif
-#ifdef CONFIG_NET_TCP
+#ifdef CONFIG_SYSTEM_FASTBOOTD_TCP
   {
     .init    = fastboot_tcp_initialize,
     .deinit  = fastboot_tcp_deinit,
@@ -1170,7 +1170,7 @@ static void fastboot_free_publish(FAR struct fastboot_ctx_s *ctx,
     }
 }
 
-#ifdef CONFIG_USBFASTBOOT
+#ifdef CONFIG_SYSTEM_FASTBOOTD_USB
 static int fastboot_open_usb(int index, int flags)
 {
   int try = FASTBOOT_EP_RETRY_TIMES;
@@ -1301,7 +1301,7 @@ static int fastboot_usbdev_write(FAR struct fastboot_ctx_s *ctx,
 }
 #endif
 
-#ifdef CONFIG_NET_TCP
+#ifdef CONFIG_SYSTEM_FASTBOOTD_TCP
 static int fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx)
 {
   struct sockaddr_in addr;

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -1383,63 +1383,55 @@ static ssize_t fastboot_read_all(int fd, FAR void *buf, size_t len)
   return total;
 }
 
-static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
-                                 FAR void *buf, size_t len)
+static ssize_t fastboot_framed_read(FAR struct fastboot_ctx_s *ctx,
+                                    int fd, FAR void *buf, size_t len,
+                                    bool detect_handshake)
 {
-  char handshake[FASTBOOT_TCP_HANDSHAKE_LEN];
-  uint64_t data_size;
+  union
+    {
+      char handshake[FASTBOOT_TCP_HANDSHAKE_LEN];
+      uint64_t data_size;
+    } u;
+
   ssize_t nread;
 
-  if (ctx->tran_fd[1] == -1)
+  while (ctx->left == 0)
     {
-      while (1)
+      if (detect_handshake)
         {
-          /* Accept a connection, not care the address of the peer socket */
-
-          ctx->tran_fd[1] = accept(ctx->tran_fd[0], NULL, 0);
-          if (ctx->tran_fd[1] < 0)
+          nread = fastboot_read_all(fd, &u, FASTBOOT_TCP_HANDSHAKE_LEN);
+          if (nread != FASTBOOT_TCP_HANDSHAKE_LEN)
             {
+              return nread < 0 ? nread : -EIO;
+            }
+
+          if (memcmp(u.handshake, FASTBOOT_TCP_HANDSHAKE,
+                     FASTBOOT_TCP_HANDSHAKE_LEN) == 0)
+            {
+              fastboot_write(fd, FASTBOOT_TCP_HANDSHAKE,
+                             FASTBOOT_TCP_HANDSHAKE_LEN);
               continue;
             }
 
-          /* Handshake */
-
-          memset(handshake, 0, sizeof(handshake));
-          if (fastboot_read_all(ctx->tran_fd[1], handshake,
-                                sizeof(handshake)) != sizeof(handshake) ||
-              strncmp(handshake, FASTBOOT_TCP_HANDSHAKE,
-                      sizeof(handshake)) != 0 ||
-              fastboot_write(ctx->tran_fd[1], handshake,
-                             sizeof(handshake)) < 0)
+          nread = fastboot_read_all(fd,
+                      (FAR char *)&u + FASTBOOT_TCP_HANDSHAKE_LEN,
+                      sizeof(u.data_size) - FASTBOOT_TCP_HANDSHAKE_LEN);
+          if (nread != (ssize_t)(sizeof(u.data_size) -
+                                 FASTBOOT_TCP_HANDSHAKE_LEN))
             {
-              fb_err("%s err handshake %d 0x%" PRIx32, __func__, errno,
-                     *(FAR uint32_t *)handshake);
-              fastboot_tcp_disconn(ctx);
-              continue;
+              return nread < 0 ? nread : -EIO;
             }
-
-          break;
         }
-    }
-
-  if (ctx->left == 0)
-    {
-      nread =
-          fastboot_read_all(ctx->tran_fd[1], &data_size, sizeof(data_size));
-      if (nread != sizeof(data_size))
+      else
         {
-          /* As normal, end of file if client has closed the connection */
-
-          if (nread != 0)
+          nread = fastboot_read_all(fd, &u.data_size, sizeof(u.data_size));
+          if (nread != (ssize_t)sizeof(u.data_size))
             {
-              fb_err("%s err read data_size %zd %d", __func__, nread, errno);
+              return nread < 0 ? nread : -EIO;
             }
-
-          fastboot_tcp_disconn(ctx);
-          return nread;
         }
 
-      ctx->left = be64toh(data_size);
+      ctx->left = be64toh(u.data_size);
     }
 
   if (len > ctx->left)
@@ -1447,15 +1439,37 @@ static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
       len = ctx->left;
     }
 
-  nread = fastboot_read(ctx->tran_fd[1], buf, len);
+  nread = fastboot_read(fd, buf, len);
+  if (nread <= 0)
+    {
+      ctx->left = 0;
+      return nread;
+    }
+
+  ctx->left -= nread;
+  return nread;
+}
+
+static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
+                                 FAR void *buf, size_t len)
+{
+  ssize_t nread;
+
+  if (ctx->tran_fd[1] == -1)
+    {
+      ctx->tran_fd[1] = accept(ctx->tran_fd[0], NULL, 0);
+      if (ctx->tran_fd[1] < 0)
+        {
+          return -errno;
+        }
+
+      return fastboot_framed_read(ctx, ctx->tran_fd[1], buf, len, true);
+    }
+
+  nread = fastboot_framed_read(ctx, ctx->tran_fd[1], buf, len, false);
   if (nread <= 0)
     {
       fastboot_tcp_disconn(ctx);
-      ctx->left = 0;
-    }
-  else
-    {
-      ctx->left -= nread;
     }
 
   return nread;

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <syslog.h>
+#include <termios.h>
 #include <unistd.h>
 
 #include <netinet/in.h>
@@ -155,10 +156,10 @@ struct fastboot_ctx_s
 {
   /* Transport file descriptors
    *
-   * | idx |    USB   |      TCP      | poll |
-   * |-----|----------|---------------|------|
-   * |   0 |usbdev in |TCP socket     |  Y   |
-   * |   1 |usbdev out|accepted socket|  N   |
+   * | idx |    USB   |      TCP      |  Serial  | poll |
+   * |-----|----------|---------------|----------|------|
+   * |   0 |usbdev in |TCP socket     |serial fd |  Y   |
+   * |   1 |usbdev out|accepted socket|serial fd |  N   |
    */
 
   int tran_fd[2];
@@ -253,6 +254,17 @@ static int     fastboot_tcp_write(FAR struct fastboot_ctx_s *ctx,
                                   FAR const void *buf, size_t len);
 #endif
 
+/* Serial transport */
+
+#ifdef CONFIG_SYSTEM_FASTBOOTD_SERIAL
+static int     fastboot_serial_initialize(FAR struct fastboot_ctx_s *ctx);
+static void    fastboot_serial_deinit(FAR struct fastboot_ctx_s *ctx);
+static ssize_t fastboot_serial_read(FAR struct fastboot_ctx_s *ctx,
+                                    FAR void *buf, size_t len);
+static int     fastboot_serial_write(FAR struct fastboot_ctx_s *ctx,
+                                     FAR const void *buf, size_t len);
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -304,6 +316,14 @@ static const struct fastboot_transport_ops_s g_tran_ops[] =
     .deinit  = fastboot_tcp_deinit,
     .read    = fastboot_tcp_read,
     .write   = fastboot_tcp_write,
+  },
+#endif
+#ifdef CONFIG_SYSTEM_FASTBOOTD_SERIAL
+  {
+    .init    = fastboot_serial_initialize,
+    .deinit  = fastboot_serial_deinit,
+    .read    = fastboot_serial_read,
+    .write   = fastboot_serial_write,
   },
 #endif
 };
@@ -1301,62 +1321,7 @@ static int fastboot_usbdev_write(FAR struct fastboot_ctx_s *ctx,
 }
 #endif
 
-#ifdef CONFIG_SYSTEM_FASTBOOTD_TCP
-static int fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx)
-{
-  struct sockaddr_in addr;
-
-#ifdef CONFIG_SYSTEM_FASTBOOTD_NET_INIT
-  /* Bring up the network */
-
-  netinit_bringup();
-#endif
-
-  ctx->tran_fd[0] = socket(AF_INET,
-                           SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK,
-                           0);
-  if (ctx->tran_fd[0] < 0)
-    {
-      fb_err("create socket failed %d", errno);
-      return -errno;
-    }
-
-  memset(&addr, 0, sizeof(addr));
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  addr.sin_port = htons(FASTBOOT_TCP_PORT);
-  if (bind(ctx->tran_fd[0], (struct sockaddr *) &addr, sizeof(addr)) < 0)
-    {
-      fb_err("bind() failed %d", errno);
-      goto error;
-    }
-
-  if (listen(ctx->tran_fd[0], 1) < 0)
-    {
-      fb_err("listen() failed %d", errno);
-      goto error;
-    }
-
-  return 0;
-error:
-  close(ctx->tran_fd[0]);
-  ctx->tran_fd[0] = -1;
-  return -errno;
-}
-
-static void fastboot_tcp_disconn(FAR struct fastboot_ctx_s *ctx)
-{
-  close(ctx->tran_fd[1]);
-  ctx->tran_fd[1] = -1;
-}
-
-static void fastboot_tcp_deinit(FAR struct fastboot_ctx_s *ctx)
-{
-  fastboot_tcp_disconn(ctx);
-  close(ctx->tran_fd[0]);
-  ctx->tran_fd[0] = -1;
-}
-
+#if defined(CONFIG_SYSTEM_FASTBOOTD_TCP) || defined(CONFIG_SYSTEM_FASTBOOTD_SERIAL)
 static ssize_t fastboot_read_all(int fd, FAR void *buf, size_t len)
 {
   size_t total = 0;
@@ -1449,6 +1414,63 @@ static ssize_t fastboot_framed_read(FAR struct fastboot_ctx_s *ctx,
   ctx->left -= nread;
   return nread;
 }
+#endif
+
+#ifdef CONFIG_SYSTEM_FASTBOOTD_TCP
+static int fastboot_tcp_initialize(FAR struct fastboot_ctx_s *ctx)
+{
+  struct sockaddr_in addr;
+
+#ifdef CONFIG_SYSTEM_FASTBOOTD_NET_INIT
+  /* Bring up the network */
+
+  netinit_bringup();
+#endif
+
+  ctx->tran_fd[0] = socket(AF_INET,
+                           SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK,
+                           0);
+  if (ctx->tran_fd[0] < 0)
+    {
+      fb_err("create socket failed %d", errno);
+      return -errno;
+    }
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(FASTBOOT_TCP_PORT);
+  if (bind(ctx->tran_fd[0], (struct sockaddr *) &addr, sizeof(addr)) < 0)
+    {
+      fb_err("bind() failed %d", errno);
+      goto error;
+    }
+
+  if (listen(ctx->tran_fd[0], 1) < 0)
+    {
+      fb_err("listen() failed %d", errno);
+      goto error;
+    }
+
+  return 0;
+error:
+  close(ctx->tran_fd[0]);
+  ctx->tran_fd[0] = -1;
+  return -errno;
+}
+
+static void fastboot_tcp_disconn(FAR struct fastboot_ctx_s *ctx)
+{
+  close(ctx->tran_fd[1]);
+  ctx->tran_fd[1] = -1;
+}
+
+static void fastboot_tcp_deinit(FAR struct fastboot_ctx_s *ctx)
+{
+  fastboot_tcp_disconn(ctx);
+  close(ctx->tran_fd[0]);
+  ctx->tran_fd[0] = -1;
+}
 
 static ssize_t fastboot_tcp_read(FAR struct fastboot_ctx_s *ctx,
                                  FAR void *buf, size_t len)
@@ -1488,6 +1510,68 @@ static int fastboot_tcp_write(FAR struct fastboot_ctx_s *ctx,
     }
 
   return fastboot_write(ctx->tran_fd[1], buf, len);
+}
+#endif
+
+#ifdef CONFIG_SYSTEM_FASTBOOTD_SERIAL
+static int fastboot_serial_initialize(FAR struct fastboot_ctx_s *ctx)
+{
+  int fd;
+
+  fd = open(CONFIG_SYSTEM_FASTBOOTD_SERIAL_PORT,
+            O_RDWR | O_CLOEXEC | O_NONBLOCK);
+  if (fd < 0)
+    {
+      fb_err("serial: open %s failed %d\n",
+             CONFIG_SYSTEM_FASTBOOTD_SERIAL_PORT, errno);
+      return -errno;
+    }
+
+#ifdef CONFIG_SERIAL_TERMIOS
+  struct termios tio;
+
+  if (tcgetattr(fd, &tio) == 0)
+    {
+      cfmakeraw(&tio);
+      tcsetattr(fd, TCSANOW, &tio);
+    }
+#endif
+
+  ctx->tran_fd[0] = fd;
+  ctx->tran_fd[1] = fd;
+  fb_info("serial: opened %s\n", CONFIG_SYSTEM_FASTBOOTD_SERIAL_PORT);
+  return 0;
+}
+
+static void fastboot_serial_deinit(FAR struct fastboot_ctx_s *ctx)
+{
+  if (ctx->tran_fd[0] >= 0)
+    {
+      close(ctx->tran_fd[0]);
+      ctx->tran_fd[0] = -1;
+      ctx->tran_fd[1] = -1;
+    }
+}
+
+static ssize_t fastboot_serial_read(FAR struct fastboot_ctx_s *ctx,
+                                    FAR void *buf, size_t len)
+{
+  return fastboot_framed_read(ctx, ctx->tran_fd[0], buf, len, true);
+}
+
+static int fastboot_serial_write(FAR struct fastboot_ctx_s *ctx,
+                                 FAR const void *buf, size_t len)
+{
+  uint64_t data_size = htobe64(len);
+  int ret;
+
+  ret = fastboot_write(ctx->tran_fd[0], &data_size, sizeof(data_size));
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return fastboot_write(ctx->tran_fd[0], buf, len);
 }
 #endif
 


### PR DESCRIPTION
## Summary

Add a serial (UART) transport backend to the fastboot daemon, alongside
the existing USB and TCP transports. This enables fastboot on devices
where neither USB nor network is available — only a UART port is needed.

The serial backend reuses the TCP v1 wire framing (FB01 handshake +
8-byte big-endian length prefix), so the host side needs no new tool:
socat bridges the UART to a TCP socket and the standard fastboot client
connects via `tcp:`.

## Changes
-  fix a bug where read_all did not advance the buffer pointer.
-  allow individual transport enable/disable (SYSTEM_FASTBOOTD_USB, SYSTEM_FASTBOOTD_TCP).
-  factor out the 8-byte length-prefix frame parsing shared by TCP and Serial.
- the new serial transport implementation

## Impact

- **Features**: New serial transport for fastboot; USB and TCP transports can now be individually enabled/disabled via Kconfig
- **User Experience**: Enables fastboot on UART-only devices
- **Build**: New Kconfig options (SYSTEM_FASTBOOTD_SERIAL, SYSTEM_FASTBOOTD_USB, SYSTEM_FASTBOOTD_TCP); no breaking changes to existing configs
- **Compatibility**: Fully backward compatible; existing USB/TCP behavior unchanged

## Testing

All tests based on `sim:nsh`.
```
cmake -B build -DBOARD_CONFIG=sim:nsh -GNinja
# Apply transport-specific configs via menuconfig
cmake --build build
```
###  Configuration
 **Core**
```
CONFIG_SYSTEM_FASTBOOTD=y
CONFIG_SYSTEM_FASTBOOTD_DOWNLOAD_MAX=65536
```
**Flash Support (enabled on sim:nsh)**
```
CONFIG_FS_FAT=y
CONFIG_ETC_ROMFS=y               # auto-creates /dev/ram0/1/2
CONFIG_ETC_ROMFSDEVNO=1          # /dev/ram1
CONFIG_ETC_FATDEVNO=2            # /dev/ram2 (usable for flash test)
```
**Transport Layer (Select one from USB, TCP, or Serial; multiple selections allowed)**
```
── Serial ──
CONFIG_SYSTEM_FASTBOOTD_SERIAL=y
CONFIG_SYSTEM_FASTBOOTD_SERIAL_PORT="/dev/ttyFB"
CONFIG_SERIAL_TERMIOS=y
CONFIG_SIM_UART_NUMBER=1
CONFIG_SIM_UART_PTY=y
CONFIG_SIM_UART0_NAME="/dev/ttyFB"

── TCP ──
CONFIG_SYSTEM_FASTBOOTD_TCP=y
CONFIG_NET=y
CONFIG_NET_TCP=y
CONFIG_NET_TCPBACKLOG=y
CONFIG_SYSTEM_FASTBOOTD_NET_INIT=y
CONFIG_SIM_NETDEV=y
CONFIG_SIM_NETDEV_TAP=y
CONFIG_NETINIT_IPADDR=0x0a000002             # 10.0.0.2
CONFIG_NETINIT_DRIPADDR=0x0a000001           # 10.0.0.1 (host bridge)

── USB ──
CONFIG_SYSTEM_FASTBOOTD_USB=y
CONFIG_USBADB=y
CONFIG_USBFASTBOOT=y
CONFIG_USBDEV_FS=y
CONFIG_USBDEV_DUALSPEED=y
CONFIG_SIM_USB_DEV=y
CONFIG_SIM_USB_RAW_GADGET=y
CONFIG_SIM_LOOP_INTERVAL=1
```
### Verification
**1. Serial Transport**
Setup:
```
# Terminal 1: socat bridge (UART PTY ↔ TCP socket)
sudo socat -t 0 PTY,link=/dev/ttyFB,raw,echo=0  TCP-LISTEN:5556,reuseaddr,fork,nodelay &
sudo chmod 777 /dev/ttyFB

# Terminal 2: NuttX sim
cd build_fastboot_serial && sudo ./nuttx
nsh> fastbootd &
```
Test output
```
# 1. Query device info
$ fastboot -s tcp:127.0.0.1:5556 getvar version                                       
version: 13.0.1
Finished. Total time: 0.010s
$ fastboot -s tcp:127.0.0.1:5556 getvar max-download-size                             
max-download-size: 65536
Finished. Total time: 0.010s

# 2. Download (within max-download-size)
$ fastboot -s tcp:127.0.0.1:5556 stage /tmp/test_64k.bin                       
Sending '/tmp/test_64k.bin' (64 KB)                OKAY [  0.012s]
Finished. Total time: 0.022s

# 3. Flash with sparse split (payload > max-download-size)
$ fastboot -s tcp:127.0.0.1:5556 flash ram2 /tmp/test_128k.bin                         
Invalid sparse file format at header magic
Sending sparse 'ram2' 1/3 (60 KB)                  OKAY [  0.022s]
Writing 'ram2'                                     OKAY [  0.008s]
Sending sparse 'ram2' 2/3 (60 KB)                  OKAY [  0.030s]
Writing 'ram2'                                     OKAY [  0.010s]
Sending sparse 'ram2' 3/3 (8 KB)                   OKAY [  0.060s]
Writing 'ram2'                                     OKAY [  0.010s]
Finished. Total time: 0.170s

# 4. Erase partition
$ fastboot -s tcp:127.0.0.1:5556 erase ram2                                         
Erasing 'ram2'                                     OKAY [  0.011s]
Finished. Total time: 0.031s

```
**2. TCP Transport**
Setup:
```
# Terminal 1: create host bridge (one-time)
sudo ip link add nuttx0 type bridge
sudo ip addr add 10.0.0.1/24 dev nuttx0
sudo ip link set nuttx0 up

# Terminal 2: NuttX sim (TAP auto-joins bridge on boot)
cd build_fastboot_tcp && sudo ./nuttx
nsh> fastbootd &
```
Test output
```
# 1. Query device info
$ fastboot -s tcp:10.0.0.2:5554 getvar version                   
version: 13.0.1
Finished. Total time: 0.060s

$ fastboot -s tcp:10.0.0.2:5554 getvar max-download-size                    
max-download-size: 65536
Finished. Total time: 0.060s

# 2. Download (within max-download-size)
$ fastboot -s tcp:10.0.0.2:5554 stage /tmp/test_64k.bin                           
Sending '/tmp/test_64k.bin' (64 KB)                OKAY [  0.120s]
Finished. Total time: 0.180s

# 3. Flash with sparse split (payload > max-download-size)
$ fastboot -s tcp:10.0.0.2:5554 flash ram2 /tmp/test_128k.bin            
Invalid sparse file format at header magic
Sending sparse 'ram2' 1/3 (60 KB)                  OKAY [  0.120s]
Writing 'ram2'                                     OKAY [  0.060s]
Sending sparse 'ram2' 2/3 (60 KB)                  OKAY [  0.120s]
Writing 'ram2'                                     OKAY [  0.060s]
Sending sparse 'ram2' 3/3 (8 KB)                   OKAY [  0.120s]
Writing 'ram2'                                     OKAY [  0.060s]
Finished. Total time: 0.720s

# 4. Erase partition
$ fastboot -s tcp:10.0.0.2:5554 erase ram2                                
Erasing 'ram2'                                     OKAY [  0.060s]
Finished. Total time: 0.180s
```

**3. USB Transport**
Setup:
```
# Terminal 1: load kernel modules (one-time)
sudo modprobe raw_gadget
sudo modprobe dummy_hcd

# Terminal 2: NuttX sim
cd build_fastboot_usb && sudo ./nuttx
nsh> fastbootd &

```
Test output
```
$ fastboot devices                                                                     
1234	fastboot

# 1. Query device info
$ sudo fastboot getvar version                                                   
version: 13.0.1
Finished. Total time: 0.007s

$ sudo fastboot getvar max-download-size                                         
max-download-size: 65536
Finished. Total time: 0.004s

# 2. Download (within max-download-size)
$ sudo fastboot stage /tmp/test_64k.bin                                              
Sending '/tmp/test_64k.bin' (64 KB)                OKAY [  0.650s]
Finished. Total time: 0.653s

# 3. Flash with sparse split (payload > max-download-size)
$ sudo fastboot flash ram2 /tmp/test_128k.bin                                       
Invalid sparse file format at header magic
Sending sparse 'ram2' 1/3 (60 KB)                  OKAY [  0.620s]
Writing 'ram2'                                     OKAY [  0.010s]
Sending sparse 'ram2' 2/3 (60 KB)                  OKAY [  0.620s]
Writing 'ram2'                                     OKAY [  0.010s]
Sending sparse 'ram2' 3/3 (8 KB)                   OKAY [  0.100s]
Writing 'ram2'                                     OKAY [  0.010s]
Finished. Total time: 1.398s

# 4. Erase partition
$ sudo fastboot erase ram2                                                         
Erasing 'ram2'                                     OKAY [  0.011s]
Finished. Total time: 0.026s
```