### PR TITLE
system/nxinit: add rptun/unlink builtins and service fallback option

### DIFF
--- a/system/nxinit/builtin.c
+++ b/system/nxinit/builtin.c
@@ -323,7 +323,7 @@ static int cmd_rptun(FAR struct action_manager_s *am,
     }
 
   close(fd);
-  return ret;
+  return ret < 0 ? ret : 0;
 }
 #endif
 

--- a/system/nxinit/builtin.c
+++ b/system/nxinit/builtin.c
@@ -25,15 +25,22 @@
  ****************************************************************************/
 
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <spawn.h>
+#include <unistd.h>
 #include <sys/boardctl.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/wait.h>
 
 #include <netutils/netinit.h>
+
+#ifdef CONFIG_RPTUN
+#include <nuttx/rptun/rptun.h>
+#endif
 
 #include "builtin.h"
 #include "init.h"
@@ -91,6 +98,12 @@ static int cmd_start_cpu(FAR struct action_manager_s *am,
 static int cmd_netinit(FAR struct action_manager_s *am,
                        int argc, FAR char **argv);
 #endif
+#ifdef CONFIG_RPTUN
+static int cmd_rptun(FAR struct action_manager_s *am,
+                     int argc, FAR char **argv);
+#endif
+static int cmd_unlink(FAR struct action_manager_s *am,
+                      int argc, FAR char **argv);
 
 /****************************************************************************
  * Private Data
@@ -120,6 +133,10 @@ static const struct cmd_map_s g_builtin[] =
   {"start", 2, 2, cmd_start},
   {"stop", 2, 2, cmd_stop},
   {"trigger", 2, 2, cmd_trigger},
+#ifdef CONFIG_RPTUN
+  {"rptun", 3, 3, cmd_rptun},
+#endif
+  {"unlink", 2, 2, cmd_unlink},
 };
 
 /****************************************************************************
@@ -267,6 +284,63 @@ static int cmd_exec(FAR struct action_manager_s *am,
     }
 
   return -EINVAL;
+}
+
+#ifdef CONFIG_RPTUN
+static int cmd_rptun(FAR struct action_manager_s *am,
+                     int argc, FAR char **argv)
+{
+  int fd;
+  int ret;
+
+  UNUSED(am);
+
+  fd = open(argv[2], O_WRONLY | O_CLOEXEC);
+  if (fd < 0)
+    {
+      init_err("rptun %s: open '%s' failed: %d",
+               argv[1], argv[2], errno);
+      return -errno;
+    }
+
+  if (!strcmp(argv[1], "start"))
+    {
+      ret = ioctl(fd, RPTUNIOC_START, 0);
+    }
+  else if (!strcmp(argv[1], "stop"))
+    {
+      ret = ioctl(fd, RPTUNIOC_STOP, 0);
+    }
+  else
+    {
+      init_err("rptun: unknown command '%s'", argv[1]);
+      ret = -EINVAL;
+    }
+
+  if (ret < 0)
+    {
+      init_err("rptun %s: failed: %d", argv[1], errno);
+    }
+
+  close(fd);
+  return ret;
+}
+#endif
+
+static int cmd_unlink(FAR struct action_manager_s *am,
+                      int argc, FAR char **argv)
+{
+  int ret;
+
+  UNUSED(am);
+
+  ret = unlink(argv[1]);
+  if (ret < 0)
+    {
+      init_err("unlink '%s' failed: %d", argv[1], errno);
+    }
+
+  return ret;
 }
 
 /****************************************************************************

--- a/system/nxinit/service.c
+++ b/system/nxinit/service.c
@@ -96,6 +96,8 @@ static int option_gentle_kill(FAR struct service_manager_s *sm,
                               int argc, FAR char **argv);
 static int option_restart_period(FAR struct service_manager_s *sm,
                                  int argc, FAR char **argv);
+static int option_fallback(FAR struct service_manager_s *sm,
+                           int argc, FAR char **argv);
 static int option_override(FAR struct service_manager_s *sm,
                            int argc, FAR char **argv);
 static int option_oneshot(FAR struct service_manager_s *sm,
@@ -114,6 +116,7 @@ static const struct cmd_map_s g_option[] =
   {"class", 2, NXINIT_ACTION_CMD_ARGS_MAX, option_class},
   {"gentle_kill", 1, 1, option_gentle_kill},
   {"restart_period", 2, 2, option_restart_period},
+  {"fallback", 1, 1, option_fallback},
   {"override", 1, 1, option_override},
   {"oneshot", 1, 1, option_oneshot},
 #ifdef CONFIG_BOARDCTL_RESET
@@ -131,6 +134,7 @@ static const struct flag_str_s g_flag_str[] =
   {SVC_GENTLE_KILL, "gentle_kill"},
   {SVC_REMOVE, "remove"},
   {SVC_SIGKILL, "sigkill"},
+  {SVC_FALLBACK, "fallback"},
   {SVC_OVERRIDE, "override"},
 };
 #endif
@@ -253,6 +257,16 @@ static int option_restart_period(FAR struct service_manager_s *sm,
   return 0;
 }
 
+static int option_fallback(FAR struct service_manager_s *sm,
+                           int argc, FAR char **argv)
+{
+  FAR struct service_s *s = list_last_entry(&sm->services, struct service_s,
+                                            node);
+
+  add_flags(s, SVC_FALLBACK);
+  return 0;
+}
+
 static int option_override(FAR struct service_manager_s *sm,
                            int argc, FAR char **argv)
 {
@@ -279,6 +293,7 @@ static int option_reboot_on_failure(FAR struct service_manager_s *sm,
 {
   FAR struct service_s *s = list_last_entry(&sm->services, struct service_s,
                                             node);
+
   s->reset_reason = atoi(argv[1]);
   return 0;
 }
@@ -649,17 +664,31 @@ int init_service_check(FAR const struct parser_s *parser)
         {
           if (!strcmp(s->argv[1], tmp->argv[1]))
             {
-              if (!check_flags(tmp, SVC_OVERRIDE))
+              if (check_flags(tmp, SVC_OVERRIDE))
+                {
+                  init_info("override: remove old service '%s'",
+                            s->argv[1]);
+                  add_flags(s, SVC_DISABLED | SVC_REMOVE);
+                }
+              else if (check_flags(tmp, SVC_FALLBACK))
+                {
+                  init_info("fallback: ignore new service '%s'",
+                            tmp->argv[1]);
+                  add_flags(tmp, SVC_DISABLED | SVC_REMOVE);
+                }
+              else if (check_flags(s, SVC_FALLBACK))
+                {
+                  init_info("fallback: replace old service '%s'",
+                            s->argv[1]);
+                  add_flags(s, SVC_DISABLED | SVC_REMOVE);
+                }
+              else
                 {
                   init_err("Redefined service '%s'", tmp->argv[1]);
                   init_dump_service(s);
                   init_dump_service(tmp);
                   return -EEXIST;
                 }
-
-              init_info("Remove duplicate definition of service '%s'",
-                        tmp->argv[1]);
-              add_flags(s, SVC_DISABLED | SVC_REMOVE);
             }
         }
     }

--- a/system/nxinit/service.h
+++ b/system/nxinit/service.h
@@ -54,6 +54,10 @@
 /* Flags below are new added.
  */
 
+/* Fallback: silently ignored if a service with the same name exists */
+
+#define SVC_FALLBACK    (1 << 28)
+
 /* Override the previous definition for a service with the same name */
 
 #define SVC_OVERRIDE    (1 << 29)


### PR DESCRIPTION
## Summary

1. **rptun / unlink builtin commands.** Some products drive early bring-up
   entirely from `init.rc` rather than NSH, so the NSH `rptun` command is
   not available there. Add `rptun` as an init builtin (guarded by
   `CONFIG_RPTUN`) supporting `start`/`stop`, plus a generic `unlink`
   builtin (always available) for removing device nodes, e.g.:

   ```
   rptun stop /dev/rptun/proc
   unlink /dev/rptun/proc
   rptun start /dev/rptun/proc
   ```

   `RPTUNIOC_START` returns the pid of the rptun kernel thread in async
   mode (`CONFIG_RPTUN_START_SYNC` unset). That thread is a detached
   kthread, never a child of init, so returning a positive value would
   make the action engine `waitpid()` on it and block the whole action
   queue (and `on init` / console would never run). A successful start is
   normalized to 0.

2. **`fallback` service option.** Add an `SVC_FALLBACK` flag and a
   `fallback` service option — the semantic opposite of `override` — to
   resolve same-name service conflicts. `override` makes the new
   definition replace the old; `fallback` makes the definition marked
   fallback yield to the other one, so a board-level `init.rc` can provide
   a default service that is silently dropped when another `init.rc`
   defines a service with the same name (and vice versa). If neither flag
   is set, duplicate service names still produce `-EEXIST` as before.

## Impact

- Only touches `system/nxinit/{builtin.c,service.c,service.h}`. No change
  to existing builtins/options; new behavior is opt-in via the new
  `rptun`/`unlink` commands and the `fallback` option.
- `rptun` builtin is compiled only when `CONFIG_RPTUN` is enabled;
  `unlink` and `fallback` are always available.
- No new Kconfig symbols.

## Testing

Built and verified locally with the `sim` target (host gcc). `nxstyle`
clean on all three touched files.

`fallback` verified at runtime on `sim` + nxinit with an `init.rc` that
declares two services named `console` (A/B against the same config
without the flag):

```
# without "fallback":
Error Redefined service 'console'          # parse fails (-EEXIST)

# with "fallback" on the second definition:
nsh> ps
  TID  PID PPID ... COMMAND
    4    4    0 ... init_main               # nxinit is init
    5    5    4 ... sh                       # the non-fallback console starts;
                                             # the fallback one is silently ignored, no error
```

`unlink` is always compiled in and `rptun` compiles under `CONFIG_RPTUN`;
both build cleanly. The `sim` target has no rptun device, so the rptun
runtime path is not exercised here — the concurrency fix (normalizing a
successful async `RPTUNIOC_START` to 0 so the action engine does not
`waitpid()` on the detached rptun kthread) is a targeted one-line change
verified by build + code review.

cc @wyr-7 