### PR TITLE
.github/workflows/build.yml: bump nuttx-ntfc-testing to release-0.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,7 +354,7 @@ jobs:
             # get NTFC test cases
             cd external
             for i in 1 2 3 4 5; do
-              git clone -b release-0.0.1 https://github.com/apache/nuttx-ntfc-testing && break
+              git clone -b release-0.0.2 https://github.com/apache/nuttx-ntfc-testing && break
               if [ "$i" -eq 5 ]; then
                 echo "Failed to clone nuttx-ntfc-testing after $i attempts"
                 exit 1


### PR DESCRIPTION
## Summary

`nuttx-ntfc-testing` release-0.0.1's `ntfc.yaml` pins the `sim/citest`
requirement to `CONFIG_INIT_ENTRYPOINT=nsh_main`. Any `sim/citest`
defconfig that switches its init entrypoint (e.g. to `nxinit`'s
`init_main`, as in apache/nuttx#19984) then fails `ntfc` with:

```
OSError: Missing kconfig dependency: ['CONFIG_INIT_ENTRYPOINT', 'nsh_main']
```

Maintainer raiden00pl cut `nuttx-ntfc-testing` `release-0.0.2`, which
drops that `CONFIG_INIT_ENTRYPOINT` requirement, and asked that both
`nuttx` and `nuttx-apps` workflows be bumped to it:
https://github.com/apache/nuttx-ntfc-testing/issues/7#issuecomment-5480486089

This PR only changes the `git clone -b release-0.0.1` line in
`.github/workflows/build.yml`; the unrelated `ntfc==0.0.1` PyPI
package version pin is untouched.

Companion PR in nuttx: apache/nuttx#20025

## Impact
CI only (`.github/workflows/build.yml`), no runtime/code impact.

## Testing Build Host(s)
N/A - workflow-only change.

## Testing

Diff:
```diff
-              git clone -b release-0.0.1 https://github.com/apache/nuttx-ntfc-testing && break
+              git clone -b release-0.0.2 https://github.com/apache/nuttx-ntfc-testing && break
```

Note on CI: GitHub Actions runs `pull_request`-triggered workflows
using the workflow file from the base branch, so verification that
`nuttx-apps` CI still passes with `release-0.0.2` is only meaningful
after this merges to `master`.