### PR TITLE
system/nxinit: add CONFIG_SYSTEM_NXINIT_STDOUT for printf-based log output

### DIFF
--- a/system/nxinit/Kconfig
+++ b/system/nxinit/Kconfig
@@ -168,4 +168,12 @@ config SYSTEM_NXINIT_DEBUG
 	bool "Enable debug log"
 	depends on SYSTEM_NXINIT_INFO
 
+config SYSTEM_NXINIT_STDOUT
+	bool "Output log to stdout (printf)"
+	default n
+	---help---
+		Debug option: redirect all init logs to stdout via printf
+		instead of syslog. Useful when syslog is not available or
+		serial console has no output during early boot.
+
 endif

--- a/system/nxinit/init.h
+++ b/system/nxinit/init.h
@@ -28,6 +28,7 @@
  ****************************************************************************/
 
 #include <poll.h>
+#include <stdio.h>
 #include <syslog.h>
 
 /****************************************************************************
@@ -36,8 +37,14 @@
 
 #define TIMESPEC2MS(t) (((t).tv_sec * 1000) + (t).tv_nsec / 1000000)
 
+#ifdef CONFIG_SYSTEM_NXINIT_STDOUT
+#define init_log_output(level, fmt, ...) printf(fmt "\n", ##__VA_ARGS__)
+#else
+#define init_log_output(level, ...) syslog(level, ##__VA_ARGS__)
+#endif
+
 #ifdef CONFIG_SYSTEM_NXINIT_DEBUG
-#define init_debug(...) syslog(LOG_USER, ##__VA_ARGS__)
+#define init_debug(...) init_log_output(LOG_USER, ##__VA_ARGS__)
 #define init_dump_args(argc, argv) \
           { \
             int _i; \
@@ -52,19 +59,19 @@
 #endif
 
 #ifdef CONFIG_SYSTEM_NXINIT_INFO
-#define init_info(...) syslog(LOG_INFO, ##__VA_ARGS__)
+#define init_info(...) init_log_output(LOG_INFO, ##__VA_ARGS__)
 #else
 #define init_info(...)
 #endif
 
 #ifdef CONFIG_SYSTEM_NXINIT_WARN
-#define init_warn(...) syslog(LOG_WARNING, ##__VA_ARGS__)
+#define init_warn(...) init_log_output(LOG_WARNING, ##__VA_ARGS__)
 #else
 #define init_warn(...)
 #endif
 
 #ifdef CONFIG_SYSTEM_NXINIT_ERR
-#define init_err(f, ...) syslog(LOG_ERR, "Error " f, ##__VA_ARGS__)
+#define init_err(f, ...) init_log_output(LOG_ERR, "Error " f, ##__VA_ARGS__)
 #else
 #define init_err(...)
 #endif


### PR DESCRIPTION
## Summary

`system/nxinit` currently logs everything through `syslog()`. On
products where `syslog` is routed through a userspace service (e.g.
DFX), that channel may not be usable yet during early boot, or may
not be visible at all if the service itself is what's failing (e.g.
a service start failure, or an exception inside the DFX consumer).
When that happens, `init_debug/info/warn/err` output is silently
lost and there is no way to see why `init` failed to bring up a
service.

Add a debug-only Kconfig option `SYSTEM_NXINIT_STDOUT` that redirects
all four log macros to `printf()` (with an appended newline) instead
of `syslog()`, selected at compile time via a new `init_log_output()`
macro. Default is `n` (unchanged `syslog` behavior).

## Impact

- Only touches `system/nxinit/{Kconfig,init.h}`. No behavior change
  when `SYSTEM_NXINIT_STDOUT` is left at its default (`n`).
- No new dependencies; `stdio.h` is already transitively available.

## Testing

Built with the `sim:nsh` target (host gcc, `nxinit-qemu-sim-all-nsh-defconfigs`
branch of `nuttx` which enables `CONFIG_SYSTEM_NXINIT`). `nxstyle`
clean on both touched files.

Verified the actual failure mode this fixes: pointed
`CONFIG_SYSTEM_NXINIT_RC_FILE_PATH` at a nonexistent file so `init`
hits its own `init_err()` path on boot, and disabled
`CONFIG_SYSLOG_DEFAULT` so `syslog()` has no console channel at all
(simulating "syslog not available/not visible"):

```
# CONFIG_SYSTEM_NXINIT_STDOUT is not set, CONFIG_SYSLOG_DEFAULT is not set
$ ./nuttx
nsh>                     # no init_err output at all - the bug this fixes

# CONFIG_SYSTEM_NXINIT_STDOUT=y, CONFIG_SYSLOG_DEFAULT still not set
$ ./nuttx
Error Opening /etc/init.d/init.rc.MISSING 2
nsh>                     # init_err output now visible via printf
```

With `CONFIG_SYSTEM_NXINIT_STDOUT` left unset (default), behavior is
unchanged from before this patch (verified boot log is identical to
`apache/master`).
