### PR TITLE
system/nxinit: use TRACE_DEVERROR_BIT|TRACE_CLSERROR_BIT, not TRACE_BITSET

### DIFF
--- a/system/nxinit/init.c
+++ b/system/nxinit/init.c
@@ -35,6 +35,8 @@
 #include <sys/param.h>
 #include <sys/wait.h>
 
+#include <nuttx/usb/usbdev_trace.h>
+
 #include "action.h"
 #include "builtin.h"
 #include "init.h"
@@ -235,7 +237,7 @@ int main(int argc, FAR char *argv[])
     }
 
 #ifdef CONFIG_USBDEV_TRACE
-  usbtrace_enable(TRACE_BITSET);
+  usbtrace_enable(TRACE_DEVERROR_BIT | TRACE_CLSERROR_BIT);
 #endif
 
   for (i = 0; i < nitems(poller); i++)


### PR DESCRIPTION
## Summary

`system/nxinit/init.c` calls `usbtrace_enable(TRACE_BITSET)` under
`#ifdef CONFIG_USBDEV_TRACE`, but the block was copied from NSH's
`CONFIG_USBDEV_TRACE` path without also copying NSH's local
`#define TRACE_BITSET` or the `<nuttx/usb/usbdev_trace.h>` include it
needs. `TRACE_BITSET` is not a built-in macro; every other
`CONFIG_USBDEV_TRACE` caller in the tree (nsh, composite, cdcacm,
usbmsc) defines its own. This compiled fine only while
`CONFIG_SYSTEM_NXINIT` and `CONFIG_USBDEV_TRACE` were never enabled
together for the same board. As soon as both are on, `init.c` fails to
build with `'TRACE_BITSET' undeclared`.

This PR adds the missing `<nuttx/usb/usbdev_trace.h>` include and
replaces `TRACE_BITSET` with the explicit error-only bitset
`TRACE_DEVERROR_BIT | TRACE_CLSERROR_BIT` — the same fallback the other
callers use when none of their granular trace Kconfig options are
enabled, since `system/nxinit` has no such granular Kconfig of its own.

One file changed, +3/-1.

## Impact

- Fixes a build break when `CONFIG_SYSTEM_NXINIT=y` and
  `CONFIG_USBDEV_TRACE=y` are enabled together.
- No functional change to any existing configuration: when
  `CONFIG_USBDEV_TRACE` is off the code path is unchanged; when on, USB
  trace still enables device+class error tracing.

## Testing

Built `sim:nsh` with `CONFIG_SYSTEM_NXINIT=y`, `CONFIG_USBDEV=y`,
`CONFIG_USBDEV_TRACE=y` (the combination that triggers the bug) on
Linux x86_64.

Before (reverting to `TRACE_BITSET`):

```
CC:  init.c
init.c:239:3: warning: implicit declaration of function 'usbtrace_enable' [-Wimplicit-function-declaration]
init.c:239:19: error: 'TRACE_BITSET' undeclared (first use in this function)
  239 |   usbtrace_enable(TRACE_BITSET);
make[2]: *** [Application.mk:348: ...init.c...o] Error 1
```

After (this PR):

```
CC:  init.c
CC:  usbdev/usbdev_trace.c
...
LD:  nuttx
```

`nxstyle system/nxinit/init.c` passes with no warnings.

Note: verified via the arch-independent `sim` host build because this
is portable apps-layer code; no target-specific behaviour is involved.
