### PR TITLE
graphics/microwindiws: Update microwindows commit hash

### DIFF
--- a/graphics/microwindows/Makefile
+++ b/graphics/microwindows/Makefile
@@ -31,7 +31,7 @@ MICROWINDOWS_DIR_NAME = microwindows
 
 WD := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 
-MICROWINDOWS_COMMIT_HASH := f9c2980fe085de87acc085980ffd672bc2d20cff
+MICROWINDOWS_COMMIT_HASH := 19d1890f67f7e099c17b2fd4529c5160327eedba
 
 CONFIG_GRAPH_MICROWINDOWS_URL ?= https://codeload.github.com/ghaerr/microwindows/zip/$(MICROWINDOWS_COMMIT_HASH)
 


### PR DESCRIPTION
## Summary

This update introduces the following changes in mw:
- Fixed some -Werror warnings in CI as mentioned in https://github.com/apache/nuttx/pull/19912
- Fixed the issue where the backspace key was not working in QEMU https://github.com/ghaerr/microwindows/pull/199

## Impact

- Users can use backspace in microwindows demos in nuttx.
- Except for the Mixed Style errors, all other CI issues in nuttx-apps should be fixed.



## Testing

Tested under [qemu-intel64:nanox](https://github.com/apache/nuttx/pull/19912/changes/ccc7c1216fd30a5783e3cd953a615e411b100957) configurations.


