### PR TITLE
testing/nettest: add checksum zero-length regression test

### DIFF
--- a/testing/nettest/CMakeLists.txt
+++ b/testing/nettest/CMakeLists.txt
@@ -77,7 +77,8 @@ if(CONFIG_TESTING_NET_TEST)
     set(SRCS
         ${CMAKE_CURRENT_LIST_DIR}/others/test_others.c
         ${CMAKE_CURRENT_LIST_DIR}/others/test_others_common.c
-        ${CMAKE_CURRENT_LIST_DIR}/others/test_others_bufpool.c)
+        ${CMAKE_CURRENT_LIST_DIR}/others/test_others_bufpool.c
+        ${CMAKE_CURRENT_LIST_DIR}/others/test_others_chksum.c)
 
     nuttx_add_application(
       NAME

--- a/testing/nettest/Makefile
+++ b/testing/nettest/Makefile
@@ -54,7 +54,8 @@ endif
 ifeq ($(CONFIG_TESTING_NET_OTHERS),y)
 MAINSRC  += others/test_others.c
 PROGNAME += cmocka_net_others
-CSRCS    += others/test_others_common.c others/test_others_bufpool.c
+CSRCS    += others/test_others_common.c others/test_others_bufpool.c \
+            others/test_others_chksum.c
 endif
 
 endif

--- a/testing/nettest/others/test_others.c
+++ b/testing/nettest/others/test_others.c
@@ -39,6 +39,7 @@ int main(int argc, FAR char *argv[])
   const struct CMUnitTest others_tests[] =
     {
       cmocka_unit_test(test_others_bufpool),
+      cmocka_unit_test(test_others_chksum),
     };
 
   return cmocka_run_group_tests(others_tests, test_others_group_setup,

--- a/testing/nettest/others/test_others.h
+++ b/testing/nettest/others/test_others.h
@@ -48,5 +48,6 @@ int test_others_group_teardown(FAR void **state);
  ****************************************************************************/
 
 void test_others_bufpool(FAR void **state);
+void test_others_chksum(FAR void **state);
 
 #endif /* __APPS_TESTING_NETTEST_OTHERS_TEST_OTHERS_H */

--- a/testing/nettest/others/test_others_chksum.c
+++ b/testing/nettest/others/test_others_chksum.c
@@ -1,0 +1,76 @@
+/****************************************************************************
+ * apps/testing/nettest/others/test_others_chksum.c
+ *
+ * Included Files
+ ****************************************************************************/
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/netdev.h>
+
+#include "test_others.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void test_others_chksum(FAR void **state)
+{
+  struct iob_s iob1;
+  struct iob_s iob2;
+  struct iob_s iob3;
+  uint8_t data1[] =
+    {
+      0xaa, 0xbb, 0xcc
+    };
+
+  uint8_t data2[] =
+    {
+      0xdd, 0xee
+    };
+
+  uint8_t data[] =
+    {
+      0xaa, 0xbb, 0xcc, 0xdd, 0xee
+    };
+
+  uint16_t chained_sum;
+  uint16_t reference_sum;
+
+  memset(&iob1, 0, sizeof(iob1));
+  memset(&iob2, 0, sizeof(iob2));
+  memset(&iob3, 0, sizeof(iob3));
+
+  /* First IOB: odd number of bytes */
+
+  memcpy(iob1.io_data, data1, sizeof(data1));
+  iob1.io_len = sizeof(data1);
+  iob1.io_offset = 0;
+  iob1.io_flink = &iob2;
+
+  /* Second IOB: zero-length */
+
+  iob2.io_data[0] = 0xdd;
+  iob2.io_len = 0;
+  iob2.io_offset = 0;
+  iob2.io_flink = &iob3;
+
+  /* Third IOB: remaining bytes */
+
+  memcpy(iob3.io_data, data2, sizeof(data2));
+  iob3.io_len = sizeof(data2);
+  iob3.io_offset = 0;
+  iob3.io_flink = NULL;
+
+  chained_sum = chksum_iob(0, &iob1, 0);
+  reference_sum = chksum(0, data, sizeof(data));
+
+  assert_int_equal(chained_sum, reference_sum);
+}
+


### PR DESCRIPTION
## Summary

Add a CMocka regression test for the zero-length fragment handling issue in
`checksum()` reported in Apache NuttX issue #20010.

When `checksum()` is called with `len == 0` while an odd byte is pending, the
previous implementation could read `data[0]` even though the current fragment
contained no valid bytes. It could also clear the pending odd-byte state.

The regression test covers this through the public `chksum_iob()` path using:

`AA BB CC | empty fragment | DD EE`

and verifies that the chained checksum matches the checksum of the equivalent
contiguous data:

`AA BB CC DD EE`

This verifies that an empty fragment does not affect the checksum and that
the pending odd-byte state is preserved across the empty fragment.

## Changes

- Add `test_others_chksum()` regression test.
- Register the test in `testing/nettest/others/test_others.c`.
- Add its declaration to `testing/nettest/others/test_others.h`.
- Add the test source to `testing/nettest/Makefile`.
- Add the test source to `testing/nettest/CMakeLists.txt`.

## Impact

This change only adds a regression test to `nuttx-apps`.
It does not change runtime behavior or production code.
## Validation

### Regression test with the buggy implementation

The regression test was verified against the implementation without the
zero-length guard and failed as expected:

```text
[ RUN      ] test_others_chksum
[ ERROR    ] --- 30617 != 30396
[ LINE     ] --- others/test_others_chksum.c:52
[  FAILED  ] test_others_chksum
Regression test with the fix applied
````
With the len == 0 handling fix restored, the test passed:

```text
nsh: mount: mount failed: 20
nsh> cmocka_net_others
[==========] others_tests: Running 2 test(s).
[ RUN      ] test_others_bufpool
[       OK ] test_others_bufpool
[ RUN      ] test_others_chksum
[       OK ] test_others_chksum
[==========] others_tests: 2 test(s) run.
[  PASSED  ] 2 test(s).
````
The mount failed: 20 message occurs during simulator startup and did not
prevent cmocka_net_others from running successfully.

Checkpatch

The corresponding NuttX fix was checked with the CI-style command:

Used config files:
````text
    1: .codespellrc
✔️ All checks pass.
````

