### PR TITLE
 mlearning/tflite-micro: Register DEPTHWISE_CONV_2D in tflm_tool resolver.

### DIFF
--- a/mlearning/tflite-micro/tflm_tool.cc
+++ b/mlearning/tflite-micro/tflm_tool.cc
@@ -110,8 +110,9 @@ extern "C" int main(int argc, FAR char* argv[])
 
   /* HACK: can change operators here. */
 
-  tflite::MicroMutableOpResolver<8> resolver;
+  tflite::MicroMutableOpResolver<9> resolver;
   resolver.AddConv2D(tflite::Register_CONV_2D_INT8());
+  resolver.AddDepthwiseConv2D(tflite::Register_DEPTHWISE_CONV_2D_INT8());
   resolver.AddMaxPool2D(tflite::Register_MAX_POOL_2D_INT8());
   resolver.AddQuantize(tflite::Register_QUANTIZE_FLOAT32_INT8());
   resolver.AddDequantize(tflite::Register_DEQUANTIZE_INT8());


### PR DESCRIPTION


## Summary

* MicroMutableOpResolver<8> in tflm_tool.cc only registered 8 ops, missing DEPTHWISE_CONV_2D — required by any depthwise-separable CNN (MobileNet-style, DS-CNN keyword-spotting models).
* This wires in the already-existing upstream kernel (Register_DEPTHWISE_CONV_2D_INT8() in tensorflow/lite/micro/kernels/depthwise_conv.h) and bumps the resolver template to <9>.

## Impact

* Is new feature added? Is existing feature changed? NO — adds a missing op registration, no existing behavior changed.
* Impact on user (will user need to adapt to change)? YES — models using DEPTHWISE_CONV_2D (MobileNet/DS-CNN style) now work with tflm_tool where they previously failed with "Didn't find op for builtin opcode 'DEPTHWISE_CONV_2D'".
* Impact on build (will build process change)? NO.
* Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO — sim-only host tool, no board target exists for tflm_tool.
* Impact on documentation (is update required / provided)? NO.
* Impact on security (any sort of implications)? NO.
* Impact on compatibility (backward/forward/interoperability)? NO — purely additive, no existing op registrations changed.
* Anything else to consider or add? None.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): Linux (Ubuntu), x86_64, GCC
* Target(s): sim:tflm

Test model: micro_speech_quantized.tflite (from tensorflow/tflite-micro's own examples repo), which uses RESHAPE, DEPTHWISE_CONV_2D, FULLY_CONNECTED, SOFTMAX.

Before change:
nsh> tflm -i /data/micro_speech_quantized.tflite -o /data/out.cc -E -a 20000
Didn't find op for builtin opcode 'DEPTHWISE_CONV_2D'
Failed to get registration from op code DEPTHWISE_CONV_2D

"Event","Tag","Ticks"
"Unique Tag","Total ticks across all events with that tag."
"total number of ticks", 0
nxai done!

After change:
nsh> tflm -i /data/micro_speech_quantized.tflite -o /data/out.cc -E -a 20000
0 (id=0): size=4000, offset=0, first_used=2 last_used=3
1 (id=1): size=1968, offset=0, first_used=0 last_used=1
2 (id=2): size=1968, offset=4000, first_used=1 last_used=2
3 (id=3): size=16, offset=4000, first_used=3 last_used=4
4 (id=4): size=16, offset=0, first_used=4 last_used=4
0: 11111111111111111111111111...................................................... (2k)
1: 11111111111111111111111111...........................222222222222222222222222222 (4k)
2: 00000000000000000000000000000000000000000000000000000222222222222222222222222222 (6k)
3: 00000000000000000000000000000000000000000000000000000........................... (4k)
4: ................................................................................ (1k)
"Event","Tag","Ticks"
0,RESHAPE,0
1,DEPTHWISE_CONV_2D,0
2,FULLY_CONNECTED,0
3,SOFTMAX,0
"Unique Tag","Total ticks across all events with that tag."
RESHAPE, 0
DEPTHWISE_CONV_2D, 0
FULLY_CONNECTED, 0
SOFTMAX, 0
"total number of ticks", 0
nxai done!

## PR verification Self-Check

* [x] This PR introduces only one functional change.
* [x] I have updated all required description fields above.
* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [ ] My PR is still work in progress (not ready for review).
* [x] My PR is ready for review and can be safely merged into a codebase.


