### PR TITLE
{bp-3684} audioutils/lame: pin the checkout and build its AVX-512 sources

### DIFF
--- a/audioutils/lame/CMakeLists.txt
+++ b/audioutils/lame/CMakeLists.txt
@@ -36,11 +36,20 @@ if(CONFIG_AUDIOUTILS_LAME)
     list(APPEND CFG_CMDS "--cross-prefix=${CROSSDEV}")
   endif()
 
+  # The revision to check out.  See the comment in Makefile: an unpinned
+  # checkout stops linking on the day lame's trunk grows its next vector tier.
+  # Raise this deliberately, together with the vector source list below.
+
+  if(NOT DEFINED LAME_VERSION)
+    set(LAME_VERSION 6720)
+  endif()
+
   # # Download lame if no lame/configure found
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lame/configure")
     execute_process(
-      COMMAND "svn" "checkout" "https://svn.code.sf.net/p/lame/svn/trunk/lame"
-              "lame" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+      COMMAND "svn" "checkout" "-r" "${LAME_VERSION}"
+              "https://svn.code.sf.net/p/lame/svn/trunk/lame" "lame"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 
   # Set source path
@@ -95,7 +104,10 @@ if(CONFIG_AUDIOUTILS_LAME)
       "${SRC_PATH}/libmp3lame/vector/xmm_quantize_lines.c"
       "${SRC_PATH}/libmp3lame/vector/xmm_calc_sfb_noise.c"
       "${SRC_PATH}/libmp3lame/vector/avx2_choose_table.c"
-      "${SRC_PATH}/libmp3lame/vector/avx2_quantize_lines.c")
+      "${SRC_PATH}/libmp3lame/vector/avx2_quantize_lines.c"
+      "${SRC_PATH}/libmp3lame/vector/avx512_choose_table.c"
+      "${SRC_PATH}/libmp3lame/vector/avx512_quantize_lines.c"
+      "${SRC_PATH}/libmp3lame/vector/avx512_calc_sfb_noise.c")
   endif()
 
   # Add custom target to generate config_h

--- a/audioutils/lame/Makefile
+++ b/audioutils/lame/Makefile
@@ -20,10 +20,19 @@
 #
 ############################################################################
 
+# The revision to check out.  lame's trunk grows vector tiers over time --
+# SSE2, then AVX2, then AVX-512 -- and each one adds sources that this file
+# and CMakeLists.txt have to name, so an unpinned checkout stops linking on
+# the day upstream adds the next one.  Raise this deliberately, together with
+# the vector source list below.
+
+LAME_VERSION ?= 6720
+
 # Download lame if no lame/configure found
 lame-svn:
 	$(Q) echo "svn checkout lame ..."
-	$(Q) svn checkout https://svn.code.sf.net/p/lame/svn/trunk/lame lame
+	$(Q) svn checkout -r $(LAME_VERSION) \
+		https://svn.code.sf.net/p/lame/svn/trunk/lame lame
 
 ifeq ($(wildcard lame/configure),)
 context:: lame-svn
@@ -72,7 +81,6 @@ CSRCS += $(SRC_PATH)/libmp3lame/bitstream.c \
          $(SRC_PATH)/libmp3lame/newmdct.c \
          $(SRC_PATH)/libmp3lame/psymodel.c \
          $(SRC_PATH)/libmp3lame/quantize.c \
-         $(SRC_PATH)/libmp3lame/vector/xmm_quantize_sub.c \
          $(SRC_PATH)/libmp3lame/quantize_pvt.c \
          $(SRC_PATH)/libmp3lame/set_get.c \
          $(SRC_PATH)/libmp3lame/vbrquantize.c \
@@ -83,6 +91,23 @@ CSRCS += $(SRC_PATH)/libmp3lame/bitstream.c \
          $(SRC_PATH)/libmp3lame/VbrTag.c \
          $(SRC_PATH)/libmp3lame/version.c \
          $(SRC_PATH)/libmp3lame/presets.c
+
+# lame's configure enables the SSE2, AVX2 and AVX-512 dispatch paths whenever
+# the host compiler accepts their per-function target attributes, and the
+# scalar code then calls into them, so the whole group has to be built on an
+# x86 host.  Other hosts keep lame's scalar implementation.
+
+ifneq ($(CONFIG_HOST_X86)$(CONFIG_HOST_X86_64),)
+CSRCS += $(SRC_PATH)/libmp3lame/vector/xmm_quantize_sub.c \
+         $(SRC_PATH)/libmp3lame/vector/xmm_choose_table.c \
+         $(SRC_PATH)/libmp3lame/vector/xmm_quantize_lines.c \
+         $(SRC_PATH)/libmp3lame/vector/xmm_calc_sfb_noise.c \
+         $(SRC_PATH)/libmp3lame/vector/avx2_choose_table.c \
+         $(SRC_PATH)/libmp3lame/vector/avx2_quantize_lines.c \
+         $(SRC_PATH)/libmp3lame/vector/avx512_choose_table.c \
+         $(SRC_PATH)/libmp3lame/vector/avx512_quantize_lines.c \
+         $(SRC_PATH)/libmp3lame/vector/avx512_calc_sfb_noise.c
+endif
 
 LAME_CONFIG_SCRIPT := $(CURDIR)$(DELIM)lame$(DELIM)configure
 


### PR DESCRIPTION
## Summary

The bundled encoder was checked out from lame's trunk with no revision, so every build took whatever trunk happened to be at that moment.  lame's trunk grows vector tiers over time, and each one adds sources that the two build files have to name:  r6655 offered AVX2 to the vector routines on 2026-07-25, and r6718 and r6720 added an AVX-512 tier on 2026-07-30.  The AVX-512 sources were never listed, so sim:alsa stopped linking on x86 hosts:

  takehiro.c:332:    undefined reference to `quantize_lines_xrpow_avx512'
  takehiro.c:533:    undefined reference to `ix_max_avx512'
  takehiro.c:569:    undefined reference to `count_bit_esc_avx512'
  vbrquantize.c:261: undefined reference to `calc_sfb_noise_x34_avx512'

Pin the checkout to r6720 through a LAME_VERSION variable, as the rest of apps/ pins its third-party sources, and list the three AVX-512 files that revision provides.  The pin is what keeps the two in step:  the source list is maintained by hand, so it can only be correct for a known revision.

The checkout is also only performed when lame/configure is absent and is never updated afterwards, so before this an unpinned tree was frozen at whatever trunk was on the day it was first built.  Anyone who checked out before 2026-07-30 still links and cannot reproduce the failure, which is why this surfaced only in CI.

Makefile named just vector/xmm_quantize_sub.c and none of the other vector sources, so a Make build on an x86 host fails the same way with a longer list of symbols, from SSE2 upwards.  CI builds sim:alsa through CMake only, so that half was latent rather than visible.  Both files now list the same nine sources under the same host condition.

## Impact

RELEASE

## Testing

CI