### PR TITLE
system/nxinit: add a per-service "console" option

### DIFF
--- a/system/nxinit/Kconfig
+++ b/system/nxinit/Kconfig
@@ -111,6 +111,20 @@ config SYSTEM_NXINIT_SERVICE_RESTART_PERIOD
 	int "Service restart period in ms"
 	default 5000
 
+config SYSTEM_NXINIT_CONSOLE_DEV
+	string "Default console device of a service"
+	default "/dev/console"
+	---help---
+		The device used as stdin/stdout/stderr of a service declared with the
+		option "console" and no explicit device, i.e. "console" rather than
+		"console <device>".
+
+		This is needed by services which expect a controlling terminal but do
+		not open one themselves (e.g. plain "sh"), and is the only way to get
+		a console when the console device is not available at the time the
+		file descriptors of the idle task are set up, as is the case for a USB
+		gadget console.
+
 comment "NXInit Testing"
 
 config SYSTEM_NXINIT_TEST

--- a/system/nxinit/service.c
+++ b/system/nxinit/service.c
@@ -323,7 +323,11 @@ int init_service_refresh(FAR struct service_manager_s *sm)
           ms = TIMESPEC2MS(diff);
           if (ms >= service->restart_period)
             {
-              init_service_start(service);
+              if (init_service_start(service) < 0)
+                {
+                  min = MIN(min, service->restart_period);
+                }
+
               continue;
             }
 
@@ -466,6 +470,8 @@ int init_service_start(FAR struct service_s *service)
       return -ret;
     }
 
+  clock_gettime(CLOCK_MONOTONIC, &service->time_started);
+
   ret = posix_spawnp(&pid, service->argv[2], NULL, &attr, &service->argv[2],
                      environ);
   posix_spawnattr_destroy(&attr);
@@ -477,7 +483,6 @@ int init_service_start(FAR struct service_s *service)
     }
 
   service->pid = pid;
-  clock_gettime(CLOCK_MONOTONIC, &service->time_started);
   add_flags(service, SVC_RUNNING);
   remove_flags(service, SVC_RESTARTING);
   remove_flags(service, SVC_DISABLED);

--- a/system/nxinit/service.c
+++ b/system/nxinit/service.c
@@ -279,6 +279,7 @@ static int option_reboot_on_failure(FAR struct service_manager_s *sm,
 {
   FAR struct service_s *s = list_last_entry(&sm->services, struct service_s,
                                             node);
+
   s->reset_reason = atoi(argv[1]);
   return 0;
 }

--- a/system/nxinit/service.c
+++ b/system/nxinit/service.c
@@ -29,12 +29,14 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
 #include <signal.h>
 #include <spawn.h>
 #include <sys/param.h>
+#include <unistd.h>
 
 #include "init.h"
 #include "parser.h"
@@ -100,6 +102,8 @@ static int option_override(FAR struct service_manager_s *sm,
                            int argc, FAR char **argv);
 static int option_oneshot(FAR struct service_manager_s *sm,
                           int argc, FAR char **argv);
+static int option_console(FAR struct service_manager_s *sm,
+                          int argc, FAR char **argv);
 #ifdef CONFIG_BOARDCTL_RESET
 static int option_reboot_on_failure(FAR struct service_manager_s *sm,
                                     int argc, FAR char **argv);
@@ -116,6 +120,7 @@ static const struct cmd_map_s g_option[] =
   {"restart_period", 2, 2, option_restart_period},
   {"override", 1, 1, option_override},
   {"oneshot", 1, 1, option_oneshot},
+  {"console", 1, 2, option_console},
 #ifdef CONFIG_BOARDCTL_RESET
   {"reboot_on_failure", 2, 2, option_reboot_on_failure},
 #endif
@@ -128,6 +133,7 @@ static const struct flag_str_s g_flag_str[] =
   {SVC_ONESHOT, "oneshot"},
   {SVC_RUNNING, "running"},
   {SVC_RESTARTING, "restarting"},
+  {SVC_CONSOLE, "console"},
   {SVC_GENTLE_KILL, "gentle_kill"},
   {SVC_REMOVE, "remove"},
   {SVC_SIGKILL, "sigkill"},
@@ -197,6 +203,7 @@ static void remove_service(FAR struct service_s *service)
       free(service->argv[i]);
     }
 
+  free(service->console);
   list_delete(&service->node);
   free(service);
 }
@@ -270,6 +277,43 @@ static int option_oneshot(FAR struct service_manager_s *sm,
                                             node);
 
   add_flags(s, SVC_ONESHOT);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: option_console
+ *
+ * Description:
+ *   Handle the service option "console [<device>]".  The service is given
+ *   'device' (CONFIG_SYSTEM_NXINIT_CONSOLE_DEV if omitted) as its stdin,
+ *   stdout and stderr, so that a service which does not open a console
+ *   device on its own still gets a working console.
+ *
+ ****************************************************************************/
+
+static int option_console(FAR struct service_manager_s *sm,
+                          int argc, FAR char **argv)
+{
+  FAR struct service_s *s = list_last_entry(&sm->services, struct service_s,
+                                            node);
+
+  add_flags(s, SVC_CONSOLE);
+
+  if (argc > 1)
+    {
+      /* 'argv' points into the parser line buffer, which is reused for the
+       * next line, so the device name must be duplicated here.
+       */
+
+      free(s->console);
+      s->console = strdup(argv[1]);
+      if (s->console == NULL)
+        {
+          init_err("Alloc console device");
+          return -ENOMEM;
+        }
+    }
+
   return 0;
 }
 
@@ -430,8 +474,59 @@ void init_service_reap(FAR struct service_s *service, int status)
     }
 }
 
+/****************************************************************************
+ * Name: console_file_actions
+ *
+ * Description:
+ *   Build the spawn file actions which redirect the stdio of a service
+ *   flagged SVC_CONSOLE to its console device.  The actions are performed
+ *   in the context of the new task, so the stdio of NxInit itself is left
+ *   untouched.
+ *
+ ****************************************************************************/
+
+static int console_file_actions(FAR posix_spawn_file_actions_t *actions,
+                               FAR struct service_s *service)
+{
+  FAR const char *dev = service->console ?
+                        service->console : CONFIG_SYSTEM_NXINIT_CONSOLE_DEV;
+  int ret;
+
+  ret = posix_spawn_file_actions_init(actions);
+  if (ret != 0)
+    {
+      init_err("posix_spawn_file_actions_init %d", ret);
+      return -ret;
+    }
+
+  ret = posix_spawn_file_actions_addopen(actions, STDIN_FILENO, dev,
+                                        O_RDWR, 0);
+  if (ret == 0)
+    {
+      ret = posix_spawn_file_actions_adddup2(actions, STDIN_FILENO,
+                                             STDOUT_FILENO);
+    }
+
+  if (ret == 0)
+    {
+      ret = posix_spawn_file_actions_adddup2(actions, STDIN_FILENO,
+                                             STDERR_FILENO);
+    }
+
+  if (ret != 0)
+    {
+      init_err("Add console '%s' file action %d", dev, ret);
+      posix_spawn_file_actions_destroy(actions);
+      return -ret;
+    }
+
+  return 0;
+}
+
 int init_service_start(FAR struct service_s *service)
 {
+  FAR posix_spawn_file_actions_t *pactions = NULL;
+  posix_spawn_file_actions_t actions;
   posix_spawnattr_t attr;
   sigset_t mask;
   int ret;
@@ -472,9 +567,27 @@ int init_service_start(FAR struct service_s *service)
 
   clock_gettime(CLOCK_MONOTONIC, &service->time_started);
 
-  ret = posix_spawnp(&pid, service->argv[2], NULL, &attr, &service->argv[2],
-                     environ);
+  if (check_flags(service, SVC_CONSOLE))
+    {
+      ret = console_file_actions(&actions, service);
+      if (ret < 0)
+        {
+          posix_spawnattr_destroy(&attr);
+          init_service_reap(service, -ret);
+          return ret;
+        }
+
+      pactions = &actions;
+    }
+
+  ret = posix_spawnp(&pid, service->argv[2], pactions, &attr,
+                     &service->argv[2], environ);
   posix_spawnattr_destroy(&attr);
+  if (pactions != NULL)
+    {
+      posix_spawn_file_actions_destroy(pactions);
+    }
+
   if (ret != 0)
     {
       init_err("Starting service '%s': %d", service->argv[1], ret);

--- a/system/nxinit/service.h
+++ b/system/nxinit/service.h
@@ -44,6 +44,7 @@
 #define SVC_ONESHOT     (1 << 1)  /* do not restart on exit */
 #define SVC_RUNNING     (1 << 2)  /* currently active */
 #define SVC_RESTARTING  (1 << 3)  /* waiting to restart */
+#define SVC_CONSOLE     (1 << 4)  /* requires a console as its stdio */
 
 /* This service should be stopped with SIGTERM instead of SIGKILL.
  * Will still be SIGKILLed after timeout period of 200 ms.
@@ -104,6 +105,12 @@ struct service_s
   struct timespec time_kill;
   int restart_period;
   pid_t pid;
+
+  /* The device given by the service option "console".  NULL means that the
+   * default console device is used.  Only meaningful with SVC_CONSOLE.
+   */
+
+  FAR char *console;
 
   /* The "target" of service option "reboot_on_failure" */
 

--- a/system/nxinit/test/test_nxinit.c
+++ b/system/nxinit/test/test_nxinit.c
@@ -58,6 +58,7 @@ int main(int argc, FAR char *argv[])
       cmocka_unit_test(test_nxinit_service_duplicate_conflict),
       cmocka_unit_test(test_nxinit_service_override_replaces_duplicate),
       cmocka_unit_test(test_nxinit_service_args_max_boundary),
+      cmocka_unit_test(test_nxinit_service_console_option),
     };
 
   return cmocka_run_group_tests(nxinit_tests, test_nxinit_group_setup,

--- a/system/nxinit/test/test_nxinit.h
+++ b/system/nxinit/test/test_nxinit.h
@@ -77,5 +77,6 @@ void test_nxinit_action_event_and_semantics(FAR void **state);
 void test_nxinit_service_duplicate_conflict(FAR void **state);
 void test_nxinit_service_override_replaces_duplicate(FAR void **state);
 void test_nxinit_service_args_max_boundary(FAR void **state);
+void test_nxinit_service_console_option(FAR void **state);
 
 #endif /* __APPS_SYSTEM_NXINIT_TEST_TEST_NXINIT_H */

--- a/system/nxinit/test/test_nxinit_service.c
+++ b/system/nxinit/test/test_nxinit_service.c
@@ -80,6 +80,7 @@ static void service_manager_free_all(FAR struct service_manager_s *sm)
           free(s->argv[i]);
         }
 
+      free(s->console);
       list_delete(&s->node);
       free(s);
     }
@@ -248,4 +249,66 @@ void test_nxinit_service_args_max_boundary(FAR void **state)
 #endif
 
 #undef NARGS_AT_LIMIT
+}
+
+/****************************************************************************
+ * Name: test_nxinit_service_console_option
+ *
+ * Description:
+ *   The "console" option flags the service with SVC_CONSOLE.  Without an
+ *   argument the default console device is used (console == NULL); with an
+ *   argument the device name is duplicated into the service, since the
+ *   parser reuses its line buffer for the next line.
+ ****************************************************************************/
+
+void test_nxinit_service_console_option(FAR void **state)
+{
+  struct service_manager_s sm;
+  struct parser_s parser =
+    {
+      "service", init_service_parse, init_service_check, &sm
+    };
+
+  char decl1[] = "service console1 /bin/sh";
+  char opt_default[] = "  console";
+  char decl2[] = "service console2 /bin/sh";
+  char opt_device[] = "  console /dev/ttyACM0";
+  char decl3[] = "service plain /bin/sh";
+  FAR struct service_s *s;
+
+  service_manager_init(&sm);
+
+  /* "console" without an argument: flagged, default device. */
+
+  assert_int_equal(init_service_parse(&parser, true, decl1), 0);
+  assert_int_equal(init_service_parse(&parser, false, opt_default), 0);
+
+  s = list_last_entry(&sm.services, struct service_s, node);
+  assert_int_equal(s->flags & SVC_CONSOLE, SVC_CONSOLE);
+  assert_null(s->console);
+
+  /* "console <device>": flagged, device duplicated (not aliased into the
+   * caller's line buffer, which is reused for the next line).
+   */
+
+  assert_int_equal(init_service_parse(&parser, true, decl2), 0);
+  assert_int_equal(init_service_parse(&parser, false, opt_device), 0);
+
+  s = list_last_entry(&sm.services, struct service_s, node);
+  assert_int_equal(s->flags & SVC_CONSOLE, SVC_CONSOLE);
+  assert_non_null(s->console);
+  assert_string_equal(s->console, "/dev/ttyACM0");
+  assert_ptr_not_equal(s->console, opt_device + 10);
+
+  /* A service without the option keeps its stdio untouched. */
+
+  assert_int_equal(init_service_parse(&parser, true, decl3), 0);
+
+  s = list_last_entry(&sm.services, struct service_s, node);
+  assert_int_equal(s->flags & SVC_CONSOLE, 0);
+  assert_null(s->console);
+
+  assert_int_equal(init_service_check(&parser), 0);
+
+  service_manager_free_all(&sm);
 }


### PR DESCRIPTION
## Summary

Adds a per-service `"console [<device>]"` option to nxinit's init.rc
service syntax, plus two small robustness fixes uncovered while adding
it.

Services started by nxinit (e.g. plain `"sh"`) do not open a console
device on their own, unlike `nsh_main`, which explicitly does so via
`nsh_consolemain()`/`nsh_waitusbready()` for USB gadget consoles
(CDC-ACM/PL2303). When a board switches its top-level init from
`nsh_main` to nxinit, no code path ever registers/connects a USB
console gadget, and a service that just execs a plain `"sh"` inherits
whatever (invalid, for a gadget console not yet opened) stdio nxinit
itself has. This was the actual root cause of a real-hardware
regression reported on esp32s3-xiao (board hangs, no USB console) —
see the companion apache/nuttx PR for the board-side fix that uses
this option.

A service declared with `console [<device>]` gets the given device
(`CONFIG_SYSTEM_NXINIT_CONSOLE_DEV`, `"/dev/console"` by default, if no
device is given) opened and dup'd onto its stdin, stdout and stderr via
`posix_spawn_file_actions` before it is spawned. This does not depend
on nsh being enabled at all — for a USB gadget console, boards are
expected to bring the gadget up themselves before any service using
`"console"` starts (e.g. via an `exec -- sercon` init.rc action, since
`apps/system/cdcacm` already implements exactly that and depends on
neither nxinit nor nsh either).

Two commits unrelated to the option itself, split out for review:

- `system/nxinit: fix missing blank line after declaration in
  service.c` — pre-existing nxstyle nit in `option_reboot_on_failure()`,
  unrelated to this change but in a file this PR already touches.
- `system/nxinit: retry a service whose spawn failed` —
  `init_service_refresh()` ignored the return value of
  `init_service_start()`; a service whose spawn fails stayed
  `SVC_RESTARTING` with nothing left to arm this function's own poll
  timeout, and (being a failed spawn) no `SIGCHLD` either to wake the
  event loop some other way. If it were the only pending timer, the
  loop would block indefinitely and the service would never be
  attempted again. Also moves the `time_started` update in
  `init_service_start()` from after a successful spawn to before the
  spawn is even attempted, so a failure doesn't leave a stale timestamp
  behind (which would otherwise make a repeatedly failing service look
  permanently "overdue" and get retried on every unrelated wakeup,
  bypassing its own `restart_period`).

## Impact

- New `"console"` service option in nxinit's init.rc syntax; existing
  init.rc files using services without it are unaffected.
- `init_service_refresh()`/`init_service_start()` behavior change is a
  pure bug fix (previously-ignored failure case); no change to the
  successful-spawn path.

## Testing

Covered by a new unit test, `test_nxinit_service_console_option`
(`system/nxinit/test/test_nxinit_service.c`), exercising the option
with and without an explicit device, and confirming services without
the option are left untouched.

Build-verified against `esp32s3-xiao:usbnsh`/`combo` (apache/nuttx)
with the option actually wired up via the companion board-side PR:

```
$ ./tools/configure.sh -l esp32s3-xiao:usbnsh && make -j8
...
MKIMAGE: ESP32-S3 binary
Successfully created esp32s3 image.
Generated: nuttx.bin

$ tools/checkpatch.sh -g <each of the 3 commits>
✔️ All checks pass.
```

End-to-end hardware verification on real Seeed XIAO ESP32-S3 Sense
(`usbnsh`): a real physical reset (`dmesg` shows a clean USB
disconnect/reconnect, not a software-triggered one) now enumerates the
NuttX CDC-ACM console gadget instead of leaving USB dark:

```
usb 1-2.3: USB disconnect, device number 97
usb 1-2.3: New USB device found, idVendor=0525, idProduct=a4a7
usb 1-2.3: Product: CDC/ACM Serial
usb 1-2.3: Manufacturer: NuttX
```

Serial console over that device, showing `init_main` (nxinit) as PID 2
and the `console` service's `sh` as its child (PID 4), i.e. the
`"console"` option actually connected `sh`'s stdio to the gadget:

```
nsh> uname -a
NuttX 13.0.1-RC0 7cc6707a76b-dirty Sep  8 2026 10:53:53 xtensa esp32s3-xiao
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003040 Idle_Task
    2     2     0 100 RR       Task      - Waiting  Semaphore 0000000000000000 0008120 init_main
    4     4     2 100 RR       Task      - Running            0000000000000000 0008144 sh
nsh> ls /etc
/etc:
 init.d/
```

Before this option existed (plain `service console sh`, no `console`
line, no `exec -- sercon`), the same hardware reproduced the original
regression exactly: after a real reset the USB device disappears
entirely and never re-enumerates.

More detail on the board-side setup (`init.rc`/defconfig changes, the
`exec -- sercon` step, and a from-scratch repro of the original hang)
is in the companion apache/nuttx#20088.