### PR TITLE
system/xrcedds: add eProsima Micro XRCE-DDS

### DIFF
--- a/examples/xrcedds/CMakeLists.txt
+++ b/examples/xrcedds/CMakeLists.txt
@@ -1,0 +1,38 @@
+# ##############################################################################
+# apps/examples/xrcedds/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_XRCEDDS_PUB)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_XRCEDDS_PUB_PROGNAME}
+    SRCS
+    xrcedds_pub_main.c
+    hello_world.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_XRCEDDS_PUB_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_XRCEDDS_PUB_PRIORITY}
+    MODULE
+    ${CONFIG_EXAMPLES_XRCEDDS_PUB}
+    DEPENDS
+    xrcedds)
+endif()

--- a/examples/xrcedds/HelloWorld.idl
+++ b/examples/xrcedds/HelloWorld.idl
@@ -1,0 +1,5 @@
+struct HelloWorld
+{
+  unsigned long index;
+  string message;
+};

--- a/examples/xrcedds/Kconfig
+++ b/examples/xrcedds/Kconfig
@@ -1,0 +1,29 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig EXAMPLES_XRCEDDS_PUB
+	tristate "XRCEDDS publisher demo"
+	default n
+	depends on SYSTEM_XRCEDDS && NET_UDP && NET_IPv4
+	---help---
+		Build the PublishHelloWorldClient command.  It connects to a
+		Micro XRCE-DDS Agent through the built-in UDP transport and
+		publishes HelloWorld samples.
+
+if EXAMPLES_XRCEDDS_PUB
+
+config EXAMPLES_XRCEDDS_PUB_PROGNAME
+	string "Publisher command name"
+	default "PublishHelloWorldClient"
+
+config EXAMPLES_XRCEDDS_PUB_PRIORITY
+	int "Publisher task priority"
+	default 100
+
+config EXAMPLES_XRCEDDS_PUB_STACKSIZE
+	int "Publisher task stack size"
+	default 4096
+
+endif

--- a/examples/xrcedds/Make.defs
+++ b/examples/xrcedds/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/xrcedds/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_XRCEDDS_PUB),)
+CONFIGURED_APPS += $(APPDIR)/examples/xrcedds
+endif

--- a/examples/xrcedds/Makefile
+++ b/examples/xrcedds/Makefile
@@ -1,0 +1,33 @@
+############################################################################
+# apps/examples/xrcedds/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_EXAMPLES_XRCEDDS_PUB_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_XRCEDDS_PUB_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_XRCEDDS_PUB_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_XRCEDDS_PUB)
+
+MAINSRC   = xrcedds_pub_main.c
+CSRCS    += hello_world.c
+
+include $(APPDIR)/Application.mk

--- a/examples/xrcedds/hello_world.c
+++ b/examples/xrcedds/hello_world.c
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * apps/examples/xrcedds/hello_world.c
+ *
+ * Implements the HelloWorld type described by HelloWorld.idl.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+#include <ucdr/microcdr.h>
+
+#include "hello_world.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+bool hello_world_serialize_topic(struct ucdrBuffer *writer,
+                                 const struct hello_world_s *topic)
+{
+  ucdr_serialize_uint32_t(writer, topic->index);
+  ucdr_serialize_string(writer, topic->message);
+
+  return !writer->error;
+}
+
+bool hello_world_deserialize_topic(struct ucdrBuffer *reader,
+                                   struct hello_world_s *topic)
+{
+  ucdr_deserialize_uint32_t(reader, &topic->index);
+  ucdr_deserialize_string(reader, topic->message, 255);
+
+  return !reader->error;
+}
+
+uint32_t hello_world_topic_size(const struct hello_world_s *topic,
+                                uint32_t size)
+{
+  uint32_t previous_size = size;
+
+  size += ucdr_alignment(size, 4) + 4;
+  size += ucdr_alignment(size, 4) + 4 + strlen(topic->message) + 1;
+
+  return size - previous_size;
+}

--- a/examples/xrcedds/hello_world.h
+++ b/examples/xrcedds/hello_world.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * apps/examples/xrcedds/hello_world.h
+ *
+ * Declares the HelloWorld type described by HelloWorld.idl.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_EXAMPLES_XRCEDDS_HELLO_WORLD_H
+#define __APPS_EXAMPLES_XRCEDDS_HELLO_WORLD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct hello_world_s
+{
+  uint32_t index;
+  char message[255];
+};
+
+struct ucdrBuffer;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+bool hello_world_serialize_topic(struct ucdrBuffer *writer,
+                                 const struct hello_world_s *topic);
+bool hello_world_deserialize_topic(struct ucdrBuffer *reader,
+                                   struct hello_world_s *topic);
+uint32_t hello_world_topic_size(const struct hello_world_s *topic,
+                                uint32_t size);
+
+#endif /* __APPS_EXAMPLES_XRCEDDS_HELLO_WORLD_H */

--- a/examples/xrcedds/xrcedds_pub_main.c
+++ b/examples/xrcedds/xrcedds_pub_main.c
@@ -1,0 +1,225 @@
+/****************************************************************************
+ * apps/examples/xrcedds/xrcedds_pub_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <uxr/client/client.h>
+#include <ucdr/microcdr.h>
+
+#include "hello_world.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define STREAM_HISTORY 8
+#define BUFFER_SIZE    (UXR_CONFIG_UDP_TRANSPORT_MTU * STREAM_HISTORY)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  uxrUDPTransport transport;
+  uxrSession session;
+  uxrStreamId reliable_out;
+  uint8_t out_stream_buffer[BUFFER_SIZE];
+  uint8_t in_stream_buffer[BUFFER_SIZE];
+  uxrObjectId participant_id;
+  uxrObjectId topic_id;
+  uxrObjectId publisher_id;
+  uxrObjectId datawriter_id;
+  const char *participant_xml;
+  const char *topic_xml;
+  const char *publisher_xml;
+  const char *datawriter_xml;
+  uint16_t participant_req;
+  uint16_t topic_req;
+  uint16_t publisher_req;
+  uint16_t datawriter_req;
+  uint8_t status[4];
+  uint16_t requests[4];
+  bool connected;
+  uint32_t count;
+  char *ip;
+  char *port;
+  uint32_t max_topics;
+
+  /* Parse the command line. */
+
+  if (argc < 3 || atoi(argv[2]) == 0)
+    {
+      printf("usage: %s ip port [<max_topics>]\n", argv[0]);
+      return 0;
+    }
+
+  ip = argv[1];
+  port = argv[2];
+  max_topics = argc == 4 ? atoi(argv[3]) : UINT32_MAX;
+
+  /* Create the UDP transport. */
+
+  if (!uxr_init_udp_transport(&transport, UXR_IPv4, ip, port))
+    {
+      printf("Error at create transport.\n");
+      return 1;
+    }
+
+  /* Create the session. */
+
+  uxr_init_session(&session, &transport.comm, 0xaaaabbbb);
+  if (!uxr_create_session(&session))
+    {
+      printf("Error at create session.\n");
+      return 1;
+    }
+
+  /* Create the reliable streams. */
+
+  reliable_out = uxr_create_output_reliable_stream(&session,
+                                                   out_stream_buffer,
+                                                   BUFFER_SIZE,
+                                                   STREAM_HISTORY);
+  uxr_create_input_reliable_stream(&session, in_stream_buffer,
+                                   BUFFER_SIZE, STREAM_HISTORY);
+
+  /* Create the DDS entities. */
+
+  participant_id = uxr_object_id(0x01, UXR_PARTICIPANT_ID);
+  participant_xml = "<dds>"
+                    "<participant>"
+                    "<rtps>"
+                    "<name>default_xrce_participant</name>"
+                    "</rtps>"
+                    "</participant>"
+                    "</dds>";
+  participant_req = uxr_buffer_create_participant_xml(&session, reliable_out,
+                                                      participant_id, 0,
+                                                      participant_xml,
+                                                      UXR_REPLACE);
+
+  topic_id = uxr_object_id(0x01, UXR_TOPIC_ID);
+  topic_xml = "<dds>"
+              "<topic>"
+              "<name>HelloWorldTopic</name>"
+              "<dataType>HelloWorld</dataType>"
+              "</topic>"
+              "</dds>";
+  topic_req = uxr_buffer_create_topic_xml(&session, reliable_out, topic_id,
+                                          participant_id, topic_xml,
+                                          UXR_REPLACE);
+
+  publisher_id = uxr_object_id(0x01, UXR_PUBLISHER_ID);
+  publisher_xml = "";
+  publisher_req = uxr_buffer_create_publisher_xml(&session, reliable_out,
+                                                  publisher_id,
+                                                  participant_id,
+                                                  publisher_xml,
+                                                  UXR_REPLACE);
+
+  datawriter_id = uxr_object_id(0x01, UXR_DATAWRITER_ID);
+  datawriter_xml = "<dds>"
+                   "<data_writer>"
+                   "<topic>"
+                   "<kind>NO_KEY</kind>"
+                   "<name>HelloWorldTopic</name>"
+                   "<dataType>HelloWorld</dataType>"
+                   "</topic>"
+                   "</data_writer>"
+                   "</dds>";
+  datawriter_req = uxr_buffer_create_datawriter_xml(&session, reliable_out,
+                                                    datawriter_id,
+                                                    publisher_id,
+                                                    datawriter_xml,
+                                                    UXR_REPLACE);
+
+  /* Send the create entities message and wait for its status. */
+
+  requests[0] = participant_req;
+  requests[1] = topic_req;
+  requests[2] = publisher_req;
+  requests[3] = datawriter_req;
+
+  if (!uxr_run_session_until_all_status(&session, 1000, requests, status, 4))
+    {
+      printf("Error at create entities: participant: %d topic: %d "
+             "publisher: %d datawriter: %d\n",
+             status[0], status[1], status[2], status[3]);
+      return 1;
+    }
+
+  /* Wait for the Agent to match the DataWriter before sending. */
+
+  sleep(3);
+
+  /* Publish samples until the requested number is reached or the session
+   * is disconnected.
+   */
+
+  connected = true;
+  count = 0;
+
+  while (connected && count < max_topics)
+    {
+      struct hello_world_s topic;
+      ucdrBuffer ub;
+      uint32_t topic_size;
+
+      topic.index = ++count;
+      strlcpy(topic.message, "Hello DDS world!",
+              sizeof(topic.message));
+
+      topic_size = hello_world_topic_size(&topic, 0);
+
+      uxr_prepare_output_stream(&session, reliable_out, datawriter_id, &ub,
+                                topic_size);
+      hello_world_serialize_topic(&ub, &topic);
+
+      printf("Send topic: %s, id: %" PRIu32 "\n", topic.message,
+             topic.index);
+      connected = uxr_run_session_time(&session, 1000);
+    }
+
+  /* Delete the session and close the transport. */
+
+  uxr_delete_session(&session);
+  uxr_close_udp_transport(&transport);
+
+  return 0;
+}

--- a/system/xrcedds/.gitignore
+++ b/system/xrcedds/.gitignore
@@ -1,0 +1,3 @@
+/Micro-XRCE-DDS-Client/
+/Micro-CDR/
+/*.tar.gz

--- a/system/xrcedds/CMakeLists.txt
+++ b/system/xrcedds/CMakeLists.txt
@@ -1,0 +1,88 @@
+# ##############################################################################
+# apps/system/xrcedds/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_SYSTEM_XRCEDDS)
+  set(XRCEDDS_VERSION 3.0.1)
+  set(MICROCDR_VERSION 2.0.2)
+  set(XRCEDDS_DIR ${CMAKE_CURRENT_LIST_DIR}/Micro-XRCE-DDS-Client)
+  set(MICROCDR_DIR ${CMAKE_CURRENT_LIST_DIR}/Micro-CDR)
+  set(XRCEDDS_URL https://github.com/eProsima/Micro-XRCE-DDS-Client/archive)
+  set(MICROCDR_URL https://github.com/eProsima/Micro-CDR/archive)
+
+  if(NOT EXISTS ${XRCEDDS_DIR})
+    FetchContent_Declare(
+      xrcedds_fetch
+      URL ${XRCEDDS_URL}/refs/tags/v${XRCEDDS_VERSION}.tar.gz SOURCE_DIR
+          ${XRCEDDS_DIR} BINARY_DIR
+          ${NUTTX_APPS_BINDIR}/system/xrcedds/xrcedds-client
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+    FetchContent_GetProperties(xrcedds_fetch)
+    if(NOT xrcedds_fetch_POPULATED)
+      FetchContent_Populate(xrcedds_fetch)
+    endif()
+  endif()
+
+  if(NOT EXISTS ${MICROCDR_DIR})
+    FetchContent_Declare(
+      microcdr_fetch
+      URL ${MICROCDR_URL}/refs/tags/v${MICROCDR_VERSION}.tar.gz SOURCE_DIR
+          ${MICROCDR_DIR} BINARY_DIR
+          ${NUTTX_APPS_BINDIR}/system/xrcedds/microcdr
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+    FetchContent_GetProperties(microcdr_fetch)
+    if(NOT microcdr_fetch_POPULATED)
+      FetchContent_Populate(microcdr_fetch)
+    endif()
+  endif()
+
+  file(
+    GLOB XRCEDDS_SRCS ${XRCEDDS_DIR}/src/c/core/serialization/*.c
+    ${XRCEDDS_DIR}/src/c/core/session/*.c
+    ${XRCEDDS_DIR}/src/c/core/session/stream/*.c ${XRCEDDS_DIR}/src/c/util/*.c)
+
+  list(APPEND XRCEDDS_SRCS
+       ${XRCEDDS_DIR}/src/c/profile/transport/ip/udp/udp_transport.c
+       ${XRCEDDS_DIR}/src/c/profile/transport/ip/udp/udp_transport_posix.c)
+
+  if(CONFIG_SYSTEM_XRCEDDS_STREAM_FRAMING)
+    file(GLOB XRCEDDS_FRAMING_SRCS
+         ${XRCEDDS_DIR}/src/c/profile/transport/stream_framing/*.c)
+    list(APPEND XRCEDDS_SRCS ${XRCEDDS_FRAMING_SRCS})
+  endif()
+
+  file(GLOB MICROCDR_SRCS ${MICROCDR_DIR}/src/c/*.c
+       ${MICROCDR_DIR}/src/c/types/*.c)
+
+  nuttx_add_library(xrcedds STATIC)
+  target_sources(xrcedds PRIVATE ${XRCEDDS_SRCS} ${MICROCDR_SRCS})
+  target_include_directories(
+    xrcedds PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include ${XRCEDDS_DIR}/include
+                    ${XRCEDDS_DIR}/src/c ${MICROCDR_DIR}/include)
+
+  set_property(
+    TARGET nuttx
+    APPEND
+    PROPERTY NUTTX_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/include
+             ${XRCEDDS_DIR}/include ${MICROCDR_DIR}/include)
+endif()

--- a/system/xrcedds/Kconfig
+++ b/system/xrcedds/Kconfig
@@ -1,0 +1,50 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig SYSTEM_XRCEDDS
+	bool "eProsima Micro XRCE-DDS"
+	default n
+	---help---
+		Enable a lightweight build of Micro XRCE-DDS Client 3.0.1 and
+		Micro-CDR 2.0.2.  Only the core client and the built-in UDP
+		transport are built; ROS 2, micro-ROS, discovery, and other
+		transports are not included.
+
+if SYSTEM_XRCEDDS
+
+config SYSTEM_XRCEDDS_STREAM_FRAMING
+	bool "Byte-stream transport framing"
+	default n
+	---help---
+		Enable HDLC framing for byte-stream transports such as UART.
+		The built-in UDP transport preserves packet boundaries, so this
+		is not needed for the UDP publisher demo.
+
+config SYSTEM_XRCEDDS_MTU
+	int "UDP transport MTU"
+	range 64 65535
+	default 512
+
+config SYSTEM_XRCEDDS_MAX_OUTPUT_BEST_EFFORT_STREAMS
+	int "Maximum output best-effort streams"
+	range 1 127
+	default 1
+
+config SYSTEM_XRCEDDS_MAX_OUTPUT_RELIABLE_STREAMS
+	int "Maximum output reliable streams"
+	range 1 127
+	default 1
+
+config SYSTEM_XRCEDDS_MAX_INPUT_BEST_EFFORT_STREAMS
+	int "Maximum input best-effort streams"
+	range 1 127
+	default 1
+
+config SYSTEM_XRCEDDS_MAX_INPUT_RELIABLE_STREAMS
+	int "Maximum input reliable streams"
+	range 1 127
+	default 1
+
+endif

--- a/system/xrcedds/Make.defs
+++ b/system/xrcedds/Make.defs
@@ -1,0 +1,35 @@
+############################################################################
+# apps/system/xrcedds/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_SYSTEM_XRCEDDS),)
+CONFIGURED_APPS += $(APPDIR)/system/xrcedds
+
+XRCEDDS_DIR := $(APPDIR)/system/xrcedds
+
+CFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_DIR)/include"
+CFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_DIR)/Micro-XRCE-DDS-Client/include"
+CFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_DIR)/Micro-CDR/include"
+
+CXXFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_DIR)/include"
+CXXFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_DIR)/Micro-XRCE-DDS-Client/include"
+CXXFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_DIR)/Micro-CDR/include"
+endif

--- a/system/xrcedds/Makefile
+++ b/system/xrcedds/Makefile
@@ -1,0 +1,106 @@
+############################################################################
+# apps/system/xrcedds/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+XRCEDDS_VERSION    := 3.0.1
+MICROCDR_VERSION   := 2.0.2
+XRCEDDS_TARBALL    := Micro-XRCE-DDS-Client-$(XRCEDDS_VERSION).tar.gz
+MICROCDR_TARBALL   := Micro-CDR-$(MICROCDR_VERSION).tar.gz
+XRCEDDS_UNPACK     := Micro-XRCE-DDS-Client
+MICROCDR_UNPACK    := Micro-CDR
+XRCEDDS_CSRC       := $(XRCEDDS_UNPACK)$(DELIM)src$(DELIM)c
+MICROCDR_CSRC      := $(MICROCDR_UNPACK)$(DELIM)src$(DELIM)c
+XRCEDDS_URL        := https://github.com/eProsima/Micro-XRCE-DDS-Client/archive
+MICROCDR_URL       := https://github.com/eProsima/Micro-CDR/archive
+
+CFLAGS += ${INCDIR_PREFIX}"$(XRCEDDS_CSRC)"
+
+XRCEDDS_CORE := $(XRCEDDS_CSRC)$(DELIM)core
+XRCEDDS_UTIL := $(XRCEDDS_CSRC)$(DELIM)util
+XRCEDDS_SESSION := $(XRCEDDS_CORE)$(DELIM)session
+XRCEDDS_STREAM := $(XRCEDDS_SESSION)$(DELIM)stream
+XRCEDDS_TRANSPORT := $(XRCEDDS_CSRC)$(DELIM)profile$(DELIM)transport
+XRCEDDS_UDP := $(XRCEDDS_TRANSPORT)$(DELIM)ip$(DELIM)udp
+
+CSRCS += $(XRCEDDS_CORE)$(DELIM)serialization$(DELIM)xrce_header.c
+CSRCS += $(XRCEDDS_CORE)$(DELIM)serialization$(DELIM)xrce_subheader.c
+CSRCS += $(XRCEDDS_CORE)$(DELIM)serialization$(DELIM)xrce_types.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)common_create_entities.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)create_entities_bin.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)create_entities_ref.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)create_entities_xml.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)object_id.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)read_access.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)session.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)session_info.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)submessage.c
+CSRCS += $(XRCEDDS_SESSION)$(DELIM)write_access.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)input_best_effort_stream.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)input_reliable_stream.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)output_best_effort_stream.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)output_reliable_stream.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)seq_num.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)stream_id.c
+CSRCS += $(XRCEDDS_STREAM)$(DELIM)stream_storage.c
+CSRCS += $(XRCEDDS_UTIL)$(DELIM)ping.c
+CSRCS += $(XRCEDDS_UTIL)$(DELIM)time.c
+
+CSRCS += $(XRCEDDS_UDP)$(DELIM)udp_transport.c
+CSRCS += $(XRCEDDS_UDP)$(DELIM)udp_transport_posix.c
+
+ifeq ($(CONFIG_SYSTEM_XRCEDDS_STREAM_FRAMING),y)
+XRCEDDS_FRAMING := $(XRCEDDS_TRANSPORT)$(DELIM)stream_framing
+CSRCS += $(XRCEDDS_FRAMING)$(DELIM)stream_framing_protocol.c
+endif
+
+CSRCS += $(MICROCDR_CSRC)$(DELIM)common.c
+CSRCS += $(MICROCDR_CSRC)$(DELIM)types$(DELIM)array.c
+CSRCS += $(MICROCDR_CSRC)$(DELIM)types$(DELIM)basic.c
+CSRCS += $(MICROCDR_CSRC)$(DELIM)types$(DELIM)sequence.c
+CSRCS += $(MICROCDR_CSRC)$(DELIM)types$(DELIM)string.c
+
+$(XRCEDDS_TARBALL):
+	$(Q) echo "Downloading Micro XRCE-DDS Client $(XRCEDDS_VERSION)"
+	$(Q) curl -L -o $@ $(XRCEDDS_URL)/refs/tags/v$(XRCEDDS_VERSION).tar.gz
+
+$(MICROCDR_TARBALL):
+	$(Q) echo "Downloading Micro-CDR $(MICROCDR_VERSION)"
+	$(Q) curl -L -o $@ $(MICROCDR_URL)/refs/tags/v$(MICROCDR_VERSION).tar.gz
+
+$(XRCEDDS_UNPACK): $(XRCEDDS_TARBALL)
+	$(Q) tar zxf $<
+	$(Q) mv Micro-XRCE-DDS-Client-$(XRCEDDS_VERSION) $@
+
+$(MICROCDR_UNPACK): $(MICROCDR_TARBALL)
+	$(Q) tar zxf $<
+	$(Q) mv Micro-CDR-$(MICROCDR_VERSION) $@
+
+context:: $(XRCEDDS_UNPACK) $(MICROCDR_UNPACK)
+
+distclean::
+	$(call DELFILE,$(XRCEDDS_TARBALL))
+	$(call DELFILE,$(MICROCDR_TARBALL))
+	$(call DELDIR,$(XRCEDDS_UNPACK))
+	$(call DELDIR,$(MICROCDR_UNPACK))
+
+include $(APPDIR)/Application.mk

--- a/system/xrcedds/include/ucdr/config.h
+++ b/system/xrcedds/include/ucdr/config.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * apps/system/xrcedds/include/ucdr/config.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_XRCEDDS_INCLUDE_UCDR_CONFIG_H
+#define __APPS_SYSTEM_XRCEDDS_INCLUDE_UCDR_CONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#define MICROCDR_VERSION_MAJOR 2
+#define MICROCDR_VERSION_MINOR 0
+#define MICROCDR_VERSION_MICRO 2
+#define MICROCDR_VERSION_STR "2.0.2"
+
+#ifdef CONFIG_ENDIAN_BIG
+#  define UCDR_MACHINE_ENDIANNESS UCDR_BIG_ENDIANNESS
+#else
+#  define UCDR_MACHINE_ENDIANNESS UCDR_LITTLE_ENDIANNESS
+#endif
+
+#endif /* __APPS_SYSTEM_XRCEDDS_INCLUDE_UCDR_CONFIG_H */

--- a/system/xrcedds/include/uxr/client/config.h
+++ b/system/xrcedds/include/uxr/client/config.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * apps/system/xrcedds/include/uxr/client/config.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ ****************************************************************************/
+
+#ifndef __APPS_SYSTEM_XRCEDDS_INCLUDE_UXR_CLIENT_CONFIG_H
+#define __APPS_SYSTEM_XRCEDDS_INCLUDE_UXR_CLIENT_CONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#define UXR_CLIENT_VERSION_MAJOR 3
+#define UXR_CLIENT_VERSION_MINOR 0
+#define UXR_CLIENT_VERSION_MICRO 1
+#define UXR_CLIENT_VERSION_STR "3.0.1"
+
+#define UCLIENT_PROFILE_UDP
+#define UCLIENT_PLATFORM_POSIX
+#define UCLIENT_TWEAK_XRCE_WRITE_LIMIT
+
+#ifdef CONFIG_SYSTEM_XRCEDDS_STREAM_FRAMING
+#  define UCLIENT_PROFILE_STREAM_FRAMING
+#endif
+
+#define UXR_CONFIG_MAX_OUTPUT_BEST_EFFORT_STREAMS \
+  CONFIG_SYSTEM_XRCEDDS_MAX_OUTPUT_BEST_EFFORT_STREAMS
+#define UXR_CONFIG_MAX_OUTPUT_RELIABLE_STREAMS \
+  CONFIG_SYSTEM_XRCEDDS_MAX_OUTPUT_RELIABLE_STREAMS
+#define UXR_CONFIG_MAX_INPUT_BEST_EFFORT_STREAMS \
+  CONFIG_SYSTEM_XRCEDDS_MAX_INPUT_BEST_EFFORT_STREAMS
+#define UXR_CONFIG_MAX_INPUT_RELIABLE_STREAMS \
+  CONFIG_SYSTEM_XRCEDDS_MAX_INPUT_RELIABLE_STREAMS
+
+#define UXR_CONFIG_MAX_SESSION_CONNECTION_ATTEMPTS 10
+#define UXR_CONFIG_MIN_SESSION_CONNECTION_INTERVAL 1000
+#define UXR_CONFIG_MIN_HEARTBEAT_TIME_INTERVAL 100
+
+#ifdef UCLIENT_PROFILE_UDP
+#  define UXR_CONFIG_UDP_TRANSPORT_MTU CONFIG_SYSTEM_XRCEDDS_MTU
+#endif
+
+#endif /* __APPS_SYSTEM_XRCEDDS_INCLUDE_UXR_CLIENT_CONFIG_H */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

~/nuttxspace/nuttx$ ./tools/configure.sh sim:xrcedds
~/nuttxspace/nuttx$ make
~/nuttxspace/nuttx$ sudo setcap cap_net_admin+ep ./nuttx
~/nuttxspace/nuttx$ ./nuttx
nsh> PublishHelloWorldClient 10.0.1.1 2026 10
Send topic: Hello DDS world!, id: 1
Send topic: Hello DDS world!, id: 2
Send topic: Hello DDS world!, id: 3
Send topic: Hello DDS world!, id: 4
Send topic: Hello DDS world!, id: 5
Send topic: Hello DDS world!, id: 6
Send topic: Hello DDS world!, id: 7
Send topic: Hello DDS world!, id: 8
Send topic: Hello DDS world!, id: 9
Send topic: Hello DDS world!, id: 10


~$ sudo ip addr replace 10.0.1.1/24 dev tap0
~$ sudo ip link set tap0 up
~$ MicroXRCEAgent udp4 -p 2026
~$ SubscribeHelloWorldClient 127.0.0.1 2026
Received topic: Hello DDS world!, id: 1
Received topic: Hello DDS world!, id: 2
Received topic: Hello DDS world!, id: 3
Received topic: Hello DDS world!, id: 4
Received topic: Hello DDS world!, id: 5
Received topic: Hello DDS world!, id: 6
Received topic: Hello DDS world!, id: 7
Received topic: Hello DDS world!, id: 8
Received topic: Hello DDS world!, id: 9
Received topic: Hello DDS world!, id: 10


CONFIG_ALLOW_BSD_COMPONENTS=y
CONFIG_ARCH="sim"
CONFIG_ARCH_BOARD="sim"
CONFIG_ARCH_BOARD_SIM=y
CONFIG_ARCH_CHIP="sim"
CONFIG_ARCH_SIM=y
CONFIG_BOARDCTL_POWEROFF=y
CONFIG_BUILTIN=y
CONFIG_DEBUG_SYMBOLS=y
CONFIG_ETC_ROMFS=y
CONFIG_EXPERIMENTAL=y
CONFIG_FS_BINFS=y
CONFIG_FS_HOSTFS=y
CONFIG_FS_PROCFS=y
CONFIG_FS_ROMFS=y
CONFIG_HAVE_CXX=y
CONFIG_HAVE_CXXINITIALIZE=y
CONFIG_IDLETHREAD_STACKSIZE=2048
CONFIG_INIT_ENTRYPOINT="init_main"
CONFIG_IOB_NBUFFERS=1024
CONFIG_IOB_NCHAINS=128
CONFIG_IOB_NOTIFIER=y
CONFIG_IOB_THROTTLE=16
CONFIG_LIBC_EXECFUNCS=y
CONFIG_LIBC_MAX_EXITFUNS=1
CONFIG_LIBC_NETDB=y
CONFIG_MM_REGIONS=2
CONFIG_MQ_MAXMSGSIZE=64
CONFIG_NET=y
CONFIG_NETDEV_LATEINIT=y
CONFIG_NETINIT_DRIPADDR=0x0a000101
CONFIG_NETINIT_IPADDR=0x0a000102
CONFIG_NET_UDP=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_FILE_APPS=y
CONFIG_NSH_READLINE=y
CONFIG_PREALLOC_TIMERS=4
CONFIG_PTHREAD_MUTEX_TYPES=y
CONFIG_READLINE_CMD_HISTORY=y
CONFIG_READLINE_TABCOMPLETION=y
CONFIG_SCHED_CHILD_STATUS=y
CONFIG_SCHED_HAVE_PARENT=y
CONFIG_SCHED_WAITPID=y
CONFIG_SERIAL_TERMIOS=y
CONFIG_SIG_DEFAULT=y
CONFIG_SIG_EVTHREAD=y
CONFIG_SIM_HOSTFS=y
CONFIG_SIM_NETDEV=y
CONFIG_STACK_COLORATION=y
CONFIG_SYSLOG_CONSOLE=y
CONFIG_SYSTEM_NSH=y
CONFIG_SYSTEM_NXINIT=y
CONFIG_SYSTEM_XRCEDDS=y
CONFIG_SYSTEM_XRCEDDS_PUBLISH_DEMO=y
CONFIG_SYSTEM_XRCEDDS_PUBLISH_DEMO_AGENT_IP="10.0.1.1"
CONFIG_TASK_NAME_SIZE=32
CONFIG_TLS_NCLEANUP=2
CONFIG_TTY_SIGINT=y

